### PR TITLE
Adds missing return types & fixes deprecations

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -9,6 +9,7 @@ doctrine:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: true
+        enable_lazy_ghost_objects: true
 #        mappings:
 #            App:
 #                is_bundle: false

--- a/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/DispatchSpecificDomainEventSubscriber.php
+++ b/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/DispatchSpecificDomainEventSubscriber.php
@@ -22,7 +22,7 @@ class DispatchSpecificDomainEventSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DomainEvent::class => ['dispatchDomainEventWithSpecificEventName', 0],

--- a/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/SetDomainEventUserSubscriber.php
+++ b/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/SetDomainEventUserSubscriber.php
@@ -24,7 +24,7 @@ class SetDomainEventUserSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DomainEvent::class => ['setDomainEventUser', 256],

--- a/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/StoreActivitySubscriber.php
+++ b/src/Sulu/Bundle/ActivityBundle/Application/Subscriber/StoreActivitySubscriber.php
@@ -22,7 +22,7 @@ class StoreActivitySubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             DomainEvent::class => ['storeActivity', -256],

--- a/src/Sulu/Bundle/AdminBundle/Command/DownloadLanguageCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/DownloadLanguageCommand.php
@@ -36,7 +36,7 @@ class DownloadLanguageCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addArgument('languages', InputArgument::IS_ARRAY, 'The languages to download', $this->defaultLanguages)
             ->addOption(

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
@@ -22,7 +22,7 @@ class AddAdminPass implements CompilerPassInterface
     public const ADMIN_POOL_DEFINITION_ID = 'sulu_admin.admin_pool';
     public const ADMIN_TAG = 'sulu.admin';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::ADMIN_POOL_DEFINITION_ID)) {
             return;

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddMetadataProviderPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddMetadataProviderPass.php
@@ -19,7 +19,7 @@ class AddMetadataProviderPass implements CompilerPassInterface
 {
     public const TAG = 'sulu_admin.metadata_provider';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $pool = $container->getDefinition('sulu_admin.metadata_provider_registry');
 

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -27,11 +27,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class SuluAdminExtension extends Extension implements PrependExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('framework')) {
             $publicDir = 'public';

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -51,9 +51,9 @@
             id="sulu_admin.form_metadata_provider"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider"
         >
-            <argument type="tagged" tag="sulu_admin.form_metadata_loader"/>
-            <argument type="tagged" tag="sulu_admin.form_metadata_visitor"/>
-            <argument type="tagged" tag="sulu_admin.typed_form_metadata_visitor"/>
+            <argument type="tagged_iterator" tag="sulu_admin.form_metadata_loader"/>
+            <argument type="tagged_iterator" tag="sulu_admin.form_metadata_visitor"/>
+            <argument type="tagged_iterator" tag="sulu_admin.typed_form_metadata_visitor"/>
             <argument>%sulu_core.fallback_locale%</argument>
 
             <tag name="sulu_admin.metadata_provider" type="form" />
@@ -92,8 +92,8 @@
             id="sulu_admin.list_metadata_provider"
             class="Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataProvider"
         >
-            <argument type="tagged" tag="sulu_admin.list_metadata_loader"/>
-            <argument type="tagged" tag="sulu_admin.list_metadata_visitor"/>
+            <argument type="tagged_iterator" tag="sulu_admin.list_metadata_loader"/>
+            <argument type="tagged_iterator" tag="sulu_admin.list_metadata_visitor"/>
 
             <tag name="sulu_admin.metadata_provider" type="list" />
         </service>
@@ -274,7 +274,7 @@
 
         <service id="sulu_admin.field_metadata_validator.chain"
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\ChainFieldMetadataValidator">
-            <argument type="tagged" tag="sulu_admin.field_metadata_validator"/>
+            <argument type="tagged_iterator" tag="sulu_admin.field_metadata_validator"/>
         </service>
 
         <service id="sulu_admin.field_metadata_validator.types_property"

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Handler/SchemaHandler.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Handler/SchemaHandler.php
@@ -19,7 +19,7 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 
 class SchemaHandler implements SubscribingHandlerInterface
 {
-    public static function getSubscribingMethods()
+    public static function getSubscribingMethods(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/DropdownToolbarActionSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/DropdownToolbarActionSubscriber.php
@@ -29,7 +29,7 @@ class DropdownToolbarActionSubscriber implements EventSubscriberInterface
         $this->translator = $translator;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/SaveWithFormDialogToolbarActionSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/SaveWithFormDialogToolbarActionSubscriber.php
@@ -29,7 +29,7 @@ class SaveWithFormDialogToolbarActionSubscriber implements EventSubscriberInterf
         $this->translator = $translator;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/TogglerToolbarActionSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/TogglerToolbarActionSubscriber.php
@@ -29,7 +29,7 @@ class TogglerToolbarActionSubscriber implements EventSubscriberInterface
         $this->translator = $translator;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Compiler/AddRulesPass.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Compiler/AddRulesPass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class AddRulesPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $ruleCollection = $container->getDefinition('sulu_audience_targeting.rules_collection');
         $taggedServices = $container->findTaggedServiceIds('sulu.audience_target_rule');

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/SuluAudienceTargetingExtension.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/SuluAudienceTargetingExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * Container extension for sulu audience targeting.
@@ -29,7 +29,7 @@ class SuluAudienceTargetingExtension extends Extension implements PrependExtensi
 {
     use PersistenceExtensionTrait;
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -73,7 +73,7 @@ class SuluAudienceTargetingExtension extends Extension implements PrependExtensi
         );
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/AudienceTargetingCacheListener.php
@@ -40,7 +40,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
 
     protected $hadValidTargetGroupCookie = false;
 
-    public function preHandle(CacheEvent $cacheEvent)
+    public function preHandle(CacheEvent $cacheEvent): void
     {
         $request = $cacheEvent->getRequest();
 
@@ -56,7 +56,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
         );
     }
 
-    public function postHandle(CacheEvent $cacheEvent)
+    public function postHandle(CacheEvent $cacheEvent): void
     {
         $request = $cacheEvent->getRequest();
 
@@ -84,7 +84,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
      *
      * @return bool
      */
-    private function setTargetGroupHeader(Request $request, CacheInvalidation $kernel)
+    private function setTargetGroupHeader(Request $request, CacheInvalidation $kernel): bool
     {
         $hadValidTargetGroup = true;
         $visitorTargetGroup = $request->cookies->get(static::TARGET_GROUP_COOKIE);
@@ -108,7 +108,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
      *
      * @return ?string
      */
-    private function requestTargetGroup(Request $request, CacheInvalidation $kernel, ?int $currentTargetGroup = null)
+    private function requestTargetGroup(Request $request, CacheInvalidation $kernel, ?int $currentTargetGroup = null): ?string
     {
         $targetGroupRequest = Request::create(
             static::TARGET_GROUP_URL,
@@ -140,7 +140,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
     /**
      * Set the cookie for the target group from the request. Should only be set in case the cookie was not set before.
      */
-    private function setTargetGroupCookie(Response $response, Request $request)
+    private function setTargetGroupCookie(Response $response, Request $request): void
     {
         $response->headers->setCookie(
             Cookie::create(
@@ -158,7 +158,7 @@ class AudienceTargetingCacheListener implements EventSubscriberInterface
         );
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PRE_HANDLE => ['preHandle', 512],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/DeviceDetectorSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/DeviceDetectorSubscriber.php
@@ -28,7 +28,7 @@ class DeviceDetectorSubscriber implements EventSubscriberInterface
         $this->deviceDetector = $deviceDetector;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [

--- a/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/EventListener/TargetGroupSubscriber.php
@@ -133,7 +133,7 @@ class TargetGroupSubscriber implements EventSubscriberInterface
         $this->visitorSessionCookie = $visitorSessionCookie;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Serializer/Subscriber/TargetGroupRuleSerializeSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Serializer/Subscriber/TargetGroupRuleSerializeSubscriber.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupRuleInterface;
 
 class TargetGroupRuleSerializeSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Serializer/Subscriber/TargetGroupSerializeSubscriber.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Serializer/Subscriber/TargetGroupSerializeSubscriber.php
@@ -22,7 +22,7 @@ use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupWebspaceInterface;
  */
 class TargetGroupSerializeSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
+++ b/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
@@ -33,7 +33,7 @@ class RecoverCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption(

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/DeprecationCompilerPass.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/DeprecationCompilerPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class DeprecationCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasParameter('sulu.model.category.class')) {
             $container->setParameter(

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/SuluCategoryExtension.php
@@ -28,13 +28,13 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class SuluCategoryExtension extends Extension implements PrependExtensionInterface
 {
     use PersistenceExtensionTrait;
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -59,7 +59,7 @@ class SuluCategoryExtension extends Extension implements PrependExtensionInterfa
         );
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('fos_rest')) {
             $container->prependExtensionConfig(

--- a/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
+++ b/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
@@ -33,7 +33,7 @@ class AccountRecoverCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOption(
             'force',

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -21,7 +21,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -35,7 +35,7 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
     /**
      * Allow an extension to prepend the extension configurations.
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_search')) {
             $container->prependExtensionConfig(
@@ -265,7 +265,7 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
         }
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $bundles = $container->getParameter('kernel.bundles');
 

--- a/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'sulu:build')]
 class SuluBuildCommand extends BuildCommand
 {
-    public function configure()
+    public function configure(): void
     {
         parent::configure();
         $this->addOption('destroy', null, InputOption::VALUE_NONE, 'Destroy existing data');

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/CsvHandlerCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/CsvHandlerCompilerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class CsvHandlerCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $id = 'fos_rest.view_handler';
         if (!$container->hasDefinition($id)) {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ListBuilderMetadataProviderCompilerPass.php
@@ -24,7 +24,7 @@ class ListBuilderMetadataProviderCompilerPass implements CompilerPassInterface
 
     public const PROVIDER_TAG_ID = 'sulu.list-builder.metadata.provider';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::CHAIN_PROVIDER_ID)) {
             return;

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterContentTypesCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterContentTypesCompilerPass.php
@@ -21,7 +21,7 @@ class RegisterContentTypesCompilerPass implements CompilerPassInterface
 {
     public const CONTENT_TYPE_TAG = 'sulu.content.type';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('sulu.content.type_manager')) {
             return;

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
@@ -21,7 +21,7 @@ class RegisterLocalizationProvidersPass implements CompilerPassInterface
 {
     public const LOCALIZATION_PROVIDER_TAG = 'sulu.localization_provider';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $localizationManager = $container->getDefinition('sulu.core.localization_manager');
 

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RemoveForeignContextServicesPass.php
@@ -22,7 +22,7 @@ class RemoveForeignContextServicesPass implements CompilerPassInterface
 {
     public const SULU_CONTEXT_TAG = 'sulu.context';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasParameter('sulu.context')) {
             return;

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ReplacersCompilerPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/ReplacersCompilerPass.php
@@ -39,7 +39,7 @@ class ReplacersCompilerPass implements CompilerPassInterface
      *
      * @api
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->loader = $container->get('sulu.content.path_cleaner.replacer_loader');
 

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -29,7 +29,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -38,7 +38,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class SuluCoreExtension extends Extension implements PrependExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         // process the configuration of SuluCoreExtension
         $configs = $container->getExtensionConfig($this->getAlias());
@@ -258,7 +258,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
     /**
      * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -181,7 +181,7 @@
             <argument>%sulu.content.language.namespace%</argument>
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
             <argument type="service" id="sulu_audience_targeting.target_group_store" on-invalid="null" />
-            <argument type="tagged" tag="sulu_content.block_visitor" />
+            <argument type="tagged_iterator" tag="sulu_content.block_visitor" />
             <tag name="sulu.content.type" alias="block"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/rest.xml
@@ -36,7 +36,7 @@
             class="Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry"
         >
             <argument
-                type="tagged"
+                type="tagged_iterator"
                 tag="sulu_core.list_builder_filter_type"
                 index-by="alias"
                 default-index-method="getDefaultIndexName"

--- a/src/Sulu/Bundle/CustomUrlBundle/DependencyInjection/SuluCustomUrlExtension.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/DependencyInjection/SuluCustomUrlExtension.php
@@ -31,7 +31,7 @@ class SuluCustomUrlExtension extends Extension implements PrependExtensionInterf
     /**
      * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $bundles = $container->getParameter('kernel.bundles');
 
@@ -49,7 +49,7 @@ class SuluCustomUrlExtension extends Extension implements PrependExtensionInterf
     /**
      * @return void
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(

--- a/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/EventListener/CustomUrlSerializeEventSubscriber.php
@@ -33,7 +33,7 @@ class CustomUrlSerializeEventSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/Serializer/Handler/ChildrenCollectionHandler.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/Serializer/Handler/ChildrenCollectionHandler.php
@@ -22,7 +22,7 @@ use Sulu\Component\DocumentManager\Collection\ChildrenCollection;
  */
 class ChildrenCollectionHandler implements SubscribingHandlerInterface
 {
-    public static function getSubscribingMethods()
+    public static function getSubscribingMethods(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/Serializer/Subscriber/ChildrenSubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/Serializer/Subscriber/ChildrenSubscriber.php
@@ -31,7 +31,7 @@ class ChildrenSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/Serializer/Subscriber/DocumentSubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/Serializer/Subscriber/DocumentSubscriber.php
@@ -35,7 +35,7 @@ class DocumentSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/Serializer/Subscriber/ProxySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/Serializer/Subscriber/ProxySubscriber.php
@@ -22,7 +22,7 @@ use Sulu\Component\DocumentManager\ClassNameInflector;
  */
 class ProxySubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/DocumentManagerBundle/Collector/DocumentDomainEventCollectorSubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Collector/DocumentDomainEventCollectorSubscriber.php
@@ -23,7 +23,7 @@ class DocumentDomainEventCollectorSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::CLEAR => ['onClear', -256],

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
@@ -40,7 +40,7 @@ class FixturesLoadCommand extends Command
         $this->fixtures = $fixtures ?: new \ArrayObject([]);
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption('group', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'The group which should be loaded.')

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/InitializeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/InitializeCommand.php
@@ -37,7 +37,7 @@ class InitializeCommand extends Command
         $this->questionHelper = $questionHelper ?: new QuestionHelper();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addOption('purge', null, InputOption::VALUE_NONE, 'Purge the content repository before initialization.')

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/SubscriberDebugCommand.php
@@ -31,7 +31,7 @@ class SubscriberDebugCommand extends Command
         parent::__construct();
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this->addArgument('event_name', InputArgument::OPTIONAL, 'Event name, without the sulu_document_manager. prefix');
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/DocumentFixturePass.php
@@ -23,7 +23,7 @@ class DocumentFixturePass implements CompilerPassInterface
     /**
      * @return void
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $tags) {
             $definition = $container->getDefinition($id);

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/InitializerPass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/InitializerPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class InitializerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('sulu_document_manager.initializer')) {
             return;

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/RegisterListenersPass.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Compiler/RegisterListenersPass.php
@@ -71,7 +71,7 @@ class RegisterListenersPass implements CompilerPassInterface
         return $this;
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition($this->dispatcherService) && !$container->hasAlias($this->dispatcherService)) {
             return;

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/SuluDocumentManagerExtension.php
@@ -31,7 +31,7 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
     /**
      * @return void
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $preview = $container->hasParameter('sulu.preview') ? $container->getParameter('sulu.preview') : false;
         $context = $container->getParameter('sulu.context');
@@ -122,7 +122,7 @@ class SuluDocumentManagerExtension extends Extension implements PrependExtension
     /**
      * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         /** @var array<string, class-string> $bundles */
         $bundles = $container->getParameter('kernel.bundles');

--- a/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
@@ -29,7 +29,7 @@ class SecuritySubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::CONFIGURE_OPTIONS => 'setDefaultUser',

--- a/src/Sulu/Bundle/DocumentManagerBundle/Session/Session.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Session/Session.php
@@ -11,8 +11,16 @@
 
 namespace Sulu\Bundle\DocumentManagerBundle\Session;
 
+use Iterator;
 use PHPCR\CredentialsInterface;
+use PHPCR\ItemInterface;
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use PHPCR\RepositoryInterface;
+use PHPCR\Retention\RetentionManagerInterface;
+use PHPCR\Security\AccessControlManagerInterface;
 use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
 
 /**
  * Used to wrap the PHPCR session and add some Sulu specific logic on top of it.
@@ -23,137 +31,137 @@ class Session implements SessionInterface
     {
     }
 
-    public function getRepository()
+    public function getRepository(): RepositoryInterface
     {
         return $this->inner->getRepository();
     }
 
-    public function getUserID()
+    public function getUserID(): string
     {
         return $this->inner->getUserID();
     }
 
-    public function getAttributeNames()
+    public function getAttributeNames(): array
     {
         return $this->inner->getAttributeNames();
     }
 
-    public function getAttribute($name)
+    public function getAttribute($name): mixed
     {
         return $this->inner->getAttribute($name);
     }
 
-    public function getWorkspace()
+    public function getWorkspace(): WorkspaceInterface
     {
         return $this->inner->getWorkspace();
     }
 
-    public function getRootNode()
+    public function getRootNode(): NodeInterface
     {
         return $this->inner->getRootNode();
     }
 
-    public function impersonate(CredentialsInterface $credentials)
+    public function impersonate(CredentialsInterface $credentials): SessionInterface
     {
         return $this->inner->impersonate($credentials);
     }
 
-    public function getNodeByIdentifier($id)
+    public function getNodeByIdentifier($id): NodeInterface
     {
         return $this->inner->getNodeByIdentifier($id);
     }
 
-    public function getNodesByIdentifier($ids)
+    public function getNodesByIdentifier($ids): Iterator
     {
         return $this->inner->getNodesByIdentifier($ids);
     }
 
-    public function getItem($absPath)
+    public function getItem($absPath): ItemInterface
     {
         return $this->inner->getItem($absPath);
     }
 
-    public function getNode($absPath, $depthHint = -1)
+    public function getNode($absPath, $depthHint = -1): NodeInterface
     {
         return $this->inner->getNode($absPath, $depthHint);
     }
 
-    public function getNodes($absPaths)
+    public function getNodes($absPaths): Iterator
     {
         return $this->inner->getNodes($absPaths);
     }
 
-    public function getProperty($absPath)
+    public function getProperty($absPath): PropertyInterface
     {
         return $this->inner->getProperty($absPath);
     }
 
-    public function getProperties($absPaths)
+    public function getProperties($absPaths): Iterator
     {
         return $this->inner->getProperties($absPaths);
     }
 
-    public function itemExists($absPath)
+    public function itemExists($absPath): bool
     {
         return $this->inner->itemExists($absPath);
     }
 
-    public function nodeExists($absPath)
+    public function nodeExists($absPath): bool
     {
         return $this->inner->nodeExists($absPath);
     }
 
-    public function propertyExists($absPath)
+    public function propertyExists($absPath): bool
     {
         return $this->inner->propertyExists($absPath);
     }
 
-    public function move($srcAbsPath, $destAbsPath)
+    public function move($srcAbsPath, $destAbsPath): void
     {
         $this->inner->move($srcAbsPath, $destAbsPath);
     }
 
-    public function removeItem($absPath)
+    public function removeItem($absPath): void
     {
         $this->inner->removeItem($absPath);
     }
 
-    public function save()
+    public function save(): void
     {
         $this->inner->save();
     }
 
-    public function refresh($keepChanges)
+    public function refresh($keepChanges): void
     {
         $this->inner->refresh($keepChanges);
     }
 
-    public function hasPendingChanges()
+    public function hasPendingChanges(): bool
     {
         return $this->inner->hasPendingChanges();
     }
 
-    public function hasPermission($absPath, $actions)
+    public function hasPermission($absPath, $actions): bool
     {
         return $this->inner->hasPermission($absPath, $actions);
     }
 
-    public function checkPermission($absPath, $actions)
+    public function checkPermission($absPath, $actions): void
     {
         $this->inner->checkPermission($absPath, $actions);
     }
 
-    public function hasCapability($methodName, $target, array $arguments)
+    public function hasCapability($methodName, $target, array $arguments): bool
     {
         return $this->inner->hasCapability($methodName, $target, $arguments);
     }
 
-    public function importXML($parentAbsPath, $uri, $uuidBehavior)
+    public function importXML($parentAbsPath, $uri, $uuidBehavior): void
     {
         $this->inner->importXML($parentAbsPath, $uri, $uuidBehavior);
     }
 
-    public function exportSystemView($absPath, $stream, $skipBinary, $noRecurse)
+    public function exportSystemView($absPath, $stream, $skipBinary, $noRecurse): void
     {
         $memoryStream = \fopen('php://memory', 'w+');
         $this->inner->exportSystemView($absPath, $memoryStream, $skipBinary, $noRecurse);
@@ -175,47 +183,47 @@ class Session implements SessionInterface
         \fwrite($stream, $document->saveXML());
     }
 
-    public function exportDocumentView($absPath, $stream, $skipBinary, $noRecurse)
+    public function exportDocumentView($absPath, $stream, $skipBinary, $noRecurse): void
     {
         $this->inner->exportDocumentView($absPath, $stream, $skipBinary, $noRecurse);
     }
 
-    public function setNamespacePrefix($prefix, $uri)
+    public function setNamespacePrefix($prefix, $uri): void
     {
         $this->inner->setNamespacePrefix($prefix, $uri);
     }
 
-    public function getNamespacePrefixes()
+    public function getNamespacePrefixes(): array
     {
         return $this->inner->getNamespacePrefixes();
     }
 
-    public function getNamespaceURI($prefix)
+    public function getNamespaceURI($prefix): string
     {
         return $this->inner->getNamespaceURI($prefix);
     }
 
-    public function getNamespacePrefix($uri)
+    public function getNamespacePrefix($uri): string
     {
         return $this->inner->getNamespacePrefix($uri);
     }
 
-    public function logout()
+    public function logout(): void
     {
         $this->inner->logout();
     }
 
-    public function isLive()
+    public function isLive(): bool
     {
         return $this->inner->isLive();
     }
 
-    public function getAccessControlManager()
+    public function getAccessControlManager(): AccessControlManagerInterface
     {
         return $this->inner->getAccessControlManager();
     }
 
-    public function getRetentionManager()
+    public function getRetentionManager(): RetentionManagerInterface
     {
         return $this->inner->getRetentionManager();
     }

--- a/src/Sulu/Bundle/HashBundle/DependencyInjection/SuluHashExtension.php
+++ b/src/Sulu/Bundle/HashBundle/DependencyInjection/SuluHashExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class SuluHashExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheExtension.php
@@ -15,14 +15,14 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * Container extension for sulu-http-cache bundle.
  */
 class SuluHttpCacheExtension extends Extension implements PrependExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         $configs = $container->getExtensionConfig($this->getAlias());
         $configuration = $this->getConfiguration($configs, $container);
@@ -75,12 +75,12 @@ class SuluHttpCacheExtension extends Extension implements PrependExtensionInterf
         $container->prependExtensionConfig('fos_http_cache', $fosHttpCacheConfig);
     }
 
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): Configuration
     {
         return new Configuration($container->getParameter('kernel.debug'));
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('event-subscribers.xml');

--- a/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/InvalidationSubscriber.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/InvalidationSubscriber.php
@@ -58,7 +58,7 @@ class InvalidationSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::CONFIGURE_OPTIONS => 'configureOptions',

--- a/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php
@@ -32,7 +32,7 @@ class TagsSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => ['addTags', 1024],

--- a/src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
+++ b/src/Sulu/Bundle/LocationBundle/DependencyInjection/SuluLocationExtension.php
@@ -16,14 +16,14 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class SuluLocationExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * @return void
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
@@ -44,7 +44,7 @@ class SuluLocationExtension extends Extension implements PrependExtensionInterfa
     /**
      * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/ParserCompilerPass.php
@@ -26,7 +26,7 @@ class ParserCompilerPass implements CompilerPassInterface
 
     public const TYPE_ATTRIBUTE = 'type';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::SERVICE_ID)) {
             return;

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/CompilerPass/TagCompilerPass.php
@@ -30,7 +30,7 @@ class TagCompilerPass implements CompilerPassInterface
 
     public const TYPE_ATTRIBUTE = 'type';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::SERVICE_ID)) {
             return;

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/SuluMarkupExtension.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/SuluMarkupExtension.php
@@ -14,14 +14,14 @@ namespace Sulu\Bundle\MarkupBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * Extends the container and initializes the markup bundle.
  */
 class SuluMarkupExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 

--- a/src/Sulu/Bundle/MarkupBundle/Listener/MailerListener.php
+++ b/src/Sulu/Bundle/MarkupBundle/Listener/MailerListener.php
@@ -26,7 +26,7 @@ class MailerListener implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             MessageEvent::class => 'onMessage',

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/swiftmailer.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/swiftmailer.xml
@@ -3,7 +3,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu_markup.swift_mailer_listener" class="Sulu\Bundle\MarkupBundle\Listener\SwiftMailerListener">
-            <argument type="tagged" tag="sulu_markup.parser" index-by="type"/>
+            <argument type="tagged_iterator" tag="sulu_markup.parser" index-by="type"/>
             <argument type="service" id="request_stack"/>
             <argument>%kernel.default_locale%</argument>
 

--- a/src/Sulu/Bundle/MediaBundle/Command/ClearCacheCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/ClearCacheCommand.php
@@ -26,7 +26,7 @@ class ClearCacheCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->addArgument('cache', InputArgument::OPTIONAL, 'Optional alias to clear the specific cache')

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheCleanupCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheCleanupCommand.php
@@ -34,7 +34,7 @@ class FormatCacheCleanupCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do nothing')
         ;

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/AbstractImageFormatCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/AbstractImageFormatCompilerPass.php
@@ -31,7 +31,7 @@ abstract class AbstractImageFormatCompilerPass implements CompilerPassInterface
      */
     private $globalOptions;
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $this->globalOptions = $container->getParameter('sulu_media.format_manager.default_imagine_options');
 

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/FormatCacheClearerCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/FormatCacheClearerCompilerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class FormatCacheClearerCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('sulu_media.format_cache_clearer')) {
             return;

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
@@ -24,7 +24,7 @@ class ImageTransformationCompilerPass implements CompilerPassInterface
 
     public const TAG = 'sulu_media.image.transformation';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::POOL_SERVICE_ID)) {
             return;

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/S3ClientCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/S3ClientCompilerPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class S3ClientCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (Configuration::STORAGE_S3 !== $container->getParameter('sulu_media.media.storage')) {
             return;

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -34,7 +34,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\Process\ExecutableFinder;
 
 class SuluMediaExtension extends Extension implements PrependExtensionInterface
@@ -51,7 +51,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
         $this->executableFinder = $executableFinder ?: new ExecutableFinder();
     }
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_search')) {
             $container->prependExtensionConfig(
@@ -217,7 +217,7 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         /** @var array<string, class-string> $bundles */
         $bundles = $container->getParameter('kernel.bundles');

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -247,7 +247,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
         return $queryBuilder->getQuery()->getArrayResult();
     }
 
-    public function count(array $filter)
+    public function count(array $filter): int
     {
         list($collection, $systemCollections, $types, $search) = $this->extractFilterVars($filter);
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -547,7 +547,7 @@
             id="sulu_media.file_inspector.subscriber"
             class="Sulu\Bundle\MediaBundle\FileInspector\UploadFileSubscriber"
         >
-            <argument type="tagged" tag="sulu_media.file_inspector"/>
+            <argument type="tagged_iterator" tag="sulu_media.file_inspector"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/MediaSearchSubscriber.php
@@ -50,7 +50,7 @@ class MediaSearchSubscriber implements EventSubscriberInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             SearchEvents::PRE_INDEX => 'handlePreIndex',

--- a/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
+++ b/src/Sulu/Bundle/MediaBundle/Search/Subscriber/StructureMediaSearchSubscriber.php
@@ -40,7 +40,7 @@ class StructureMediaSearchSubscriber implements EventSubscriberInterface
      *
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             SearchEvents::PRE_INDEX => 'handlePreIndex',

--- a/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
@@ -27,7 +27,7 @@ class MediaTwigExtension extends AbstractExtension
     {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('sulu_resolve_media', [$this, 'resolveMediaFunction']),

--- a/src/Sulu/Bundle/PageBundle/Command/CleanupHistoryCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/CleanupHistoryCommand.php
@@ -32,7 +32,7 @@ class CleanupHistoryCommand extends Command
         parent::__construct();
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this->setHelp(
             <<<'EOT'

--- a/src/Sulu/Bundle/PageBundle/Command/ContentLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ContentLocaleCopyCommand.php
@@ -44,7 +44,7 @@ class ContentLocaleCopyCommand extends Command
         parent::__construct();
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this->setHelp(
             <<<'EOT'

--- a/src/Sulu/Bundle/PageBundle/Command/ContentTypesDumpCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ContentTypesDumpCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'sulu:content:types:dump', description: 'Dumps all ContentTypes registered in the system')]
 class ContentTypesDumpCommand extends Command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition([

--- a/src/Sulu/Bundle/PageBundle/Command/ValidatePagesCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/ValidatePagesCommand.php
@@ -37,7 +37,7 @@ class ValidatePagesCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addArgument('webspaceKey', InputArgument::REQUIRED, 'Which webspace to search');
     }

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -67,7 +67,7 @@ class WebspaceCopyCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addArgument('source-webspace', InputArgument::REQUIRED)
             ->addArgument('source-locale', InputArgument::REQUIRED)

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceExportCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceExportCommand.php
@@ -28,7 +28,7 @@ class WebspaceExportCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addArgument('target', InputArgument::REQUIRED, 'export.xliff')
             ->addArgument('webspace', InputArgument::REQUIRED)

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceImportCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceImportCommand.php
@@ -38,7 +38,7 @@ class WebspaceImportCommand extends Command
         $this->logger = $logger ?: new NullLogger();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addArgument('file', InputArgument::REQUIRED, 'test.xliff')
             ->addArgument('webspace', InputArgument::REQUIRED)

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
@@ -24,7 +24,7 @@ class ContentExportCompilerPass implements CompilerPassInterface
 
     public const STRUCTURE_EXTENSION_TAG = 'sulu.content.export';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::CONTENT_EXPORT_SERVICE_ID)) {
             return;

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
@@ -24,7 +24,7 @@ class SmartContentDataProviderCompilerPass implements CompilerPassInterface
 
     public const STRUCTURE_EXTENSION_TAG = 'sulu.smart_content.data_provider';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::POOL_SERVICE_ID)) {
             return;

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/StructureExtensionCompilerPass.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/StructureExtensionCompilerPass.php
@@ -24,7 +24,7 @@ class StructureExtensionCompilerPass implements CompilerPassInterface
 
     public const STRUCTURE_EXTENSION_TAG = 'sulu.structure.extension';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::STRUCTURE_MANAGER_ID)) {
             return;

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/VersioningCompilerPass.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/VersioningCompilerPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class VersioningCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->getParameter('sulu_document_manager.versioning.enabled')) {
             return;

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/WebspacesPass.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/WebspacesPass.php
@@ -19,7 +19,7 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class WebspacesPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $directory = $container->getParameterBag()->resolveValue($container->getParameter('sulu_core.webspace.config_dir'));
 

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
@@ -25,11 +25,11 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class SuluPageExtension extends Extension implements PrependExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
@@ -254,7 +254,7 @@ class SuluPageExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         /** @var array<string, class-string> $bundles */
         $bundles = $container->getParameter('kernel.bundles');

--- a/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Document/Subscriber/PublishSubscriber.php
@@ -44,7 +44,7 @@ class PublishSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['createNodeInPublicWorkspace', -490],

--- a/src/Sulu/Bundle/PageBundle/EventListener/TeaserSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/EventListener/TeaserSerializeEventSubscriber.php
@@ -28,7 +28,7 @@ class TeaserSerializeEventSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/EventListener/WebspaceSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/EventListener/WebspaceSerializeEventSubscriber.php
@@ -42,7 +42,7 @@ class WebspaceSerializeEventSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/BlameTimestampSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/BlameTimestampSubscriber.php
@@ -35,7 +35,7 @@ class BlameTimestampSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             SearchEvents::PRE_INDEX => 'handleBlameTimestamp',

--- a/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Search/EventSubscriber/StructureSubscriber.php
@@ -35,7 +35,7 @@ class StructureSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['indexPersistedDocument', -10],

--- a/src/Sulu/Bundle/PageBundle/Serializer/Handler/ExtensionContainerHandler.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Handler/ExtensionContainerHandler.php
@@ -23,7 +23,7 @@ use Sulu\Component\Content\Document\Extension\ExtensionContainer;
  */
 class ExtensionContainerHandler implements SubscribingHandlerInterface
 {
-    public static function getSubscribingMethods()
+    public static function getSubscribingMethods(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Handler/StructureHandler.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Handler/StructureHandler.php
@@ -23,7 +23,7 @@ use Sulu\Component\Content\Document\Structure\Structure;
  */
 class StructureHandler implements SubscribingHandlerInterface
 {
-    public static function getSubscribingMethods()
+    public static function getSubscribingMethods(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/ExtensionContainerSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/ExtensionContainerSubscriber.php
@@ -21,7 +21,7 @@ use Sulu\Component\Content\Document\Extension\ExtensionContainer;
  */
 class ExtensionContainerSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/LocaleSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/LocaleSubscriber.php
@@ -32,7 +32,7 @@ class LocaleSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/ParentSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/ParentSubscriber.php
@@ -23,7 +23,7 @@ use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
  */
 class ParentSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/PathSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/PathSubscriber.php
@@ -30,7 +30,7 @@ class PathSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/RedirectTypeSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/RedirectTypeSubscriber.php
@@ -23,7 +23,7 @@ use Sulu\Component\Content\Document\RedirectType;
  */
 class RedirectTypeSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/ShadowLocaleSubscriber.php
@@ -30,7 +30,7 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/StructureSubscriber.php
@@ -32,7 +32,7 @@ class StructureSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/Serializer/Subscriber/WorkflowStageSubscriber.php
@@ -25,7 +25,7 @@ use Sulu\Component\Content\Document\WorkflowStage;
  */
 class WorkflowStageSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ActivateResolveTargetEntityResolverPass.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ActivateResolveTargetEntityResolverPass.php
@@ -23,7 +23,7 @@ class ActivateResolveTargetEntityResolverPass implements CompilerPassInterface
     /**
      * @return void
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         // TODO we should replace the SuluPersistenceBundle with configuring doctrine.orm.resolve_target_entities in the config
         //      else we need to keep the resolve target entity resolver uptodate ourself.

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Compiler/ResolveTargetEntitiesPass.php
@@ -29,7 +29,7 @@ class ResolveTargetEntitiesPass implements CompilerPassInterface
     /**
      * @return void
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('doctrine.orm.listeners.resolve_target_entity')) {
             throw new \RuntimeException('Cannot find Doctrine Target Entity Resolver Listener.');

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/SuluPersistenceExtension.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/SuluPersistenceExtension.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\PersistenceBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.

--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/SuluPreviewExtension.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/SuluPreviewExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * Extends the container and initializes the preview budle.

--- a/src/Sulu/Bundle/RouteBundle/Command/MovePageTreeCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/MovePageTreeCommand.php
@@ -34,7 +34,7 @@ class MovePageTreeCommand extends Command
         parent::__construct();
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this->addArgument('source-segment', InputArgument::REQUIRED)
             ->addArgument('destination-segment', InputArgument::REQUIRED)

--- a/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
@@ -34,7 +34,7 @@ class UpdateRouteCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addArgument('entity', InputArgument::REQUIRED)
             ->addArgument('locale', InputArgument::REQUIRED)

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/RouteGeneratorCompilerPass.php
@@ -26,7 +26,7 @@ class RouteGeneratorCompilerPass implements CompilerPassInterface
 
     public const PARAMETER_NAME = 'sulu_route.mappings';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(self::SERVICE_ID) || !$container->hasParameter(self::PARAMETER_NAME)) {
             return;

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/SuluRouteExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * Container extension for sulu-route-bundle.
@@ -27,7 +27,7 @@ class SuluRouteExtension extends Extension implements PrependExtensionInterface
 {
     use PersistenceExtensionTrait;
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
@@ -45,7 +45,7 @@ class SuluRouteExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sulu/Bundle/RouteBundle/Document/Subscriber/PageTreeRouteSubscriber.php
+++ b/src/Sulu/Bundle/RouteBundle/Document/Subscriber/PageTreeRouteSubscriber.php
@@ -41,7 +41,7 @@ class PageTreeRouteSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // should be called before the live resource-segment will be updated

--- a/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
+++ b/src/Sulu/Bundle/RouteBundle/Document/Subscriber/RoutableSubscriber.php
@@ -57,7 +57,7 @@ class RoutableSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => ['handleHydrate'],

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/SuluSearchExtension.php
@@ -15,11 +15,11 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class SuluSearchExtension extends Extension implements PrependExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
@@ -75,7 +75,7 @@ class SuluSearchExtension extends Extension implements PrependExtensionInterface
         ]);
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/DependencyInjection/TestExtension.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/DependencyInjection/TestExtension.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\SearchBundle\Tests\Resources\TestBundle\DependencyInjectio
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class TestExtension extends Extension
 {

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
@@ -35,7 +35,7 @@ class CreateRoleCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition(

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -52,7 +52,7 @@ class CreateUserCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setDefinition(

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/AccessControlProviderPass.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/AccessControlProviderPass.php
@@ -18,7 +18,7 @@ class AccessControlProviderPass implements CompilerPassInterface
 {
     public const ACCESS_CONTROL_TAG = 'sulu.access_control';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $accessControlManager = $container->getDefinition('sulu_security.access_control_manager');
 

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/AliasForSecurityEncoderCompilerPass.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Compiler/AliasForSecurityEncoderCompilerPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class AliasForSecurityEncoderCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasAlias('security.encoder_factory')) {
             // @deprecated Symfony 5.4 backward compatibility bridge

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
@@ -31,7 +31,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenExtractorInterface;
 use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
 
@@ -45,7 +45,7 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
     /**
      * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -141,7 +141,7 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
     /**
      * @return void
      */
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('scheb_two_factor') && \interface_exists(AuthCodeMailerInterface::class)) {
             $container->prependExtensionConfig(

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/AuhenticationFailureListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/AuhenticationFailureListener.php
@@ -31,14 +31,14 @@ class AuhenticationFailureListener implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             AuthenticationFailureEvent::class => 'onLoginFailure',
         ];
     }
 
-    public function onLoginFailure(AuthenticationFailureEvent $event)
+    public function onLoginFailure(AuthenticationFailureEvent $event): void
     {
         $previousException = $event->getAuthenticationException()->getPrevious();
         if ($previousException instanceof UsernameNotFoundException) {

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/LastLoginListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/LastLoginListener.php
@@ -32,14 +32,14 @@ class LastLoginListener implements EventSubscriberInterface
      *
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             SecurityEvents::INTERACTIVE_LOGIN => 'onSecurityInteractiveLogin',
         ];
     }
 
-    public function onSecurityInteractiveLogin(InteractiveLoginEvent $event)
+    public function onSecurityInteractiveLogin(InteractiveLoginEvent $event): void
     {
         $user = $event->getAuthenticationToken()->getUser();
         $this->updateLastLogin($user);
@@ -50,7 +50,7 @@ class LastLoginListener implements EventSubscriberInterface
      *
      * @param UserInterface $user
      */
-    protected function updateLastLogin($user)
+    protected function updateLastLogin($user): void
     {
         if ($user instanceof SuluUserInterface) {
             $user->setLastLogin(new \DateTime());

--- a/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
@@ -35,7 +35,7 @@ class SecuritySubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetExportCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetExportCommand.php
@@ -28,7 +28,7 @@ class SnippetExportCommand extends Command
         parent::__construct();
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this->addArgument('target', InputArgument::REQUIRED, 'Target for export (e.g. export_de.xliff)');
         $this->addArgument('locale', InputArgument::REQUIRED, 'Locale to export (e.g. de, en)');

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetImportCommand.php
@@ -37,7 +37,7 @@ class SnippetImportCommand extends Command
         $this->logger = $logger ?: new NullLogger();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addArgument('file', InputArgument::REQUIRED, 'test.xliff')
             ->addArgument('locale', InputArgument::REQUIRED)

--- a/src/Sulu/Bundle/SnippetBundle/Command/SnippetLocaleCopyCommand.php
+++ b/src/Sulu/Bundle/SnippetBundle/Command/SnippetLocaleCopyCommand.php
@@ -51,7 +51,7 @@ class SnippetLocaleCopyCommand extends Command
         parent::__construct();
     }
 
-    public function configure()
+    public function configure(): void
     {
         $this->setHelp(
             <<<'EOT'

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Compiler/SnippetAreaCompilerPass.php
@@ -24,7 +24,7 @@ class SnippetAreaCompilerPass implements CompilerPassInterface
     /**
      * @return void
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $structureFactory = $container->get('sulu_page.structure.factory');
         $structures = $structureFactory->getStructures(Structure::TYPE_SNIPPET);

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/SuluSnippetExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class SuluSnippetExtension extends Extension implements PrependExtensionInterface
 {
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
@@ -176,7 +176,7 @@ class SuluSnippetExtension extends Extension implements PrependExtensionInterfac
         }
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         /** @var array<string, class-string> $bundles */
         $bundles = $container->getParameter('kernel.bundles');

--- a/src/Sulu/Bundle/SnippetBundle/EventListener/CacheInvalidationSubscriber.php
+++ b/src/Sulu/Bundle/SnippetBundle/EventListener/CacheInvalidationSubscriber.php
@@ -36,7 +36,7 @@ class CacheInvalidationSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             WebspaceDefaultSnippetModifiedEvent::class => 'invalidateSnippetAreaOnAreaModified',

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * This is the class that loads and manages tag-bundle configuration.
@@ -27,7 +27,7 @@ class SuluTagExtension extends Extension implements PrependExtensionInterface
 {
     use PersistenceExtensionTrait;
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
@@ -73,7 +73,7 @@ class SuluTagExtension extends Extension implements PrependExtensionInterface
         }
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $bundles = $container->getParameter('kernel.bundles');
 

--- a/src/Sulu/Bundle/TestBundle/DependencyInjection/Compiler/ReplaceTestClientPass.php
+++ b/src/Sulu/Bundle/TestBundle/DependencyInjection/Compiler/ReplaceTestClientPass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ReplaceTestClientPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->hasDefinition('test.client')) {
             $container->getDefinition('test.client')->setClass(SuluKernelBrowser::class);

--- a/src/Sulu/Bundle/TestBundle/DependencyInjection/SuluTestExtension.php
+++ b/src/Sulu/Bundle/TestBundle/DependencyInjection/SuluTestExtension.php
@@ -14,11 +14,11 @@ namespace Sulu\Bundle\TestBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class SuluTestExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -83,7 +83,7 @@ class DumpSitemapCommand extends Command
         $this->defaultHost = $defaultHost;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->addOption('https', null, InputOption::VALUE_NONE, 'Use https scheme for url generation.')
             ->addOption('clear', null, InputOption::VALUE_NONE, 'Delete all file before start.');

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/DeregisterDefaultRouteListenerCompilerPass.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/DeregisterDefaultRouteListenerCompilerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class DeregisterDefaultRouteListenerCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $container->getDefinition('router_listener')->clearTag('kernel.event_subscriber');
     }

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Compiler/RouteProviderCompilerPass.php
@@ -23,7 +23,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RouteProviderCompilerPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (SuluKernel::CONTEXT_WEBSITE === $container->getParameter('sulu.context')) {
             $container->setDefinition(

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -31,7 +31,7 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
 {
     use PersistenceExtensionTrait;
 
-    public function prepend(ContainerBuilder $container)
+    public function prepend(ContainerBuilder $container): void
     {
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
@@ -83,7 +83,7 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
         ]);
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
@@ -62,7 +62,7 @@ class RedirectExceptionSubscriber implements EventSubscriberInterface
         $this->urlReplacer = $urlReplacer;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::EXCEPTION => [

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RouterListener.php
@@ -47,7 +47,7 @@ class RouterListener implements EventSubscriberInterface
      * Analyzes the request before passing the event to the default RouterListener from symfony and validates the result
      * afterwards.
      */
-    public function onKernelRequest(RequestEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
 
@@ -64,12 +64,12 @@ class RouterListener implements EventSubscriberInterface
     /**
      * Simply pass the event to the route listener, because we have nothing to add here.
      */
-    public function onKernelFinishRequest(FinishRequestEvent $event)
+    public function onKernelFinishRequest(FinishRequestEvent $event): void
     {
         $this->baseRouteListener->onKernelFinishRequest($event);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [['onKernelRequest', 32]],

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentCacheListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentCacheListener.php
@@ -21,7 +21,7 @@ class SegmentCacheListener implements EventSubscriberInterface
 
     public const SEGMENT_HEADER = 'X-Sulu-Segment';
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PRE_HANDLE => ['preHandle', 512],
@@ -29,7 +29,7 @@ class SegmentCacheListener implements EventSubscriberInterface
         ];
     }
 
-    public function preHandle(CacheEvent $cacheEvent)
+    public function preHandle(CacheEvent $cacheEvent): void
     {
         $request = $cacheEvent->getRequest();
 
@@ -38,7 +38,7 @@ class SegmentCacheListener implements EventSubscriberInterface
         $request->headers->set(static::SEGMENT_HEADER, (string) $segment);
     }
 
-    public function postHandle(CacheEvent $cacheEvent)
+    public function postHandle(CacheEvent $cacheEvent): void
     {
         $response = $cacheEvent->getResponse();
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentSubscriber.php
@@ -44,7 +44,7 @@ class SegmentSubscriber implements EventSubscriberInterface
         $this->segmentCookieName = $segmentCookieName;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => [

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/TranslatorListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/TranslatorListener.php
@@ -48,7 +48,7 @@ class TranslatorListener implements EventSubscriberInterface
         $this->translator->setLocale($localization->getLocale(Localization::LCID));
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // Set the translator locale in `de_AT` format instead of `de-at`

--- a/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/AnalyticsSerializeEventSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/AnalyticsSerializeEventSubscriber.php
@@ -23,7 +23,7 @@ use Sulu\Bundle\WebsiteBundle\Entity\AnalyticsInterface;
  */
 class AnalyticsSerializeEventSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/DomainEventEventSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/DomainEventEventSubscriber.php
@@ -43,7 +43,7 @@ class DomainEventEventSubscriber implements EventSubscriberInterface
         $this->webspaceManager = $webspaceManager;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::CACHE_CLEAR => 'onCacheClear',

--- a/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/GeneratorEventSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventSubscriber/GeneratorEventSubscriber.php
@@ -30,7 +30,7 @@ class GeneratorEventSubscriber implements EventSubscriberInterface
         $this->version = $version;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onResponse',

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu_website.sitemap.pool" class="Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderPool">
-            <argument type="tagged" tag="sulu.sitemap.provider"/>
+            <argument type="tagged_iterator" tag="sulu.sitemap.provider"/>
         </service>
 
         <service id="sulu_website.sitemap.xml_renderer" class="Sulu\Bundle\WebsiteBundle\Sitemap\XmlSitemapRenderer">

--- a/src/Sulu/Component/Content/Compat/Serializer/PageBridgeHandler.php
+++ b/src/Sulu/Component/Content/Compat/Serializer/PageBridgeHandler.php
@@ -32,7 +32,7 @@ class PageBridgeHandler implements SubscribingHandlerInterface
     ) {
     }
 
-    public static function getSubscribingMethods()
+    public static function getSubscribingMethods(): array
     {
         return [
             [

--- a/src/Sulu/Component/Content/Compat/Serializer/PageBridgeSubscriber.php
+++ b/src/Sulu/Component/Content/Compat/Serializer/PageBridgeSubscriber.php
@@ -22,7 +22,7 @@ use Sulu\Component\Content\Compat\Structure\PageBridge;
  */
 class PageBridgeSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
+++ b/src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
@@ -36,13 +36,13 @@ class ExtensionContainer implements \ArrayAccess, \Iterator
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->data;
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
@@ -58,13 +58,13 @@ class ExtensionContainer implements \ArrayAccess, \Iterator
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetSet($extensionName, $data)
+    public function offsetSet($extensionName, $data): void
     {
         $this->data[$extensionName] = $data;
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetUnset($extensionName)
+    public function offsetUnset($extensionName): void
     {
         unset($this->data[$extensionName]);
     }
@@ -94,7 +94,7 @@ class ExtensionContainer implements \ArrayAccess, \Iterator
     }
 
     #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return null !== isset($this->data);
     }

--- a/src/Sulu/Component/Content/Document/Extension/ManagedExtensionContainer.php
+++ b/src/Sulu/Component/Content/Document/Extension/ManagedExtensionContainer.php
@@ -75,12 +75,12 @@ class ManagedExtensionContainer extends ExtensionContainer
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetExists($extensionName)
+    public function offsetExists($extensionName): bool
     {
         return $this->extensionManager->hasExtension($this->structureType, $extensionName);
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         $result = [];
 

--- a/src/Sulu/Component/Content/Document/Subscriber/AuthorSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/AuthorSubscriber.php
@@ -37,7 +37,7 @@ class AuthorSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => 'setAuthorOnDocument',

--- a/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/BlameSubscriber.php
@@ -36,7 +36,7 @@ class BlameSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => 'setBlamesOnDocument',

--- a/src/Sulu/Component/Content/Document/Subscriber/Compat/ContentMapperSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/Compat/ContentMapperSubscriber.php
@@ -48,7 +48,7 @@ class ContentMapperSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::REMOVE => [

--- a/src/Sulu/Component/Content/Document/Subscriber/ExtensionSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ExtensionSubscriber.php
@@ -39,7 +39,7 @@ class ExtensionSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // persist should happen before content is mapped

--- a/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/FallbackLocalizationSubscriber.php
@@ -34,7 +34,7 @@ class FallbackLocalizationSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // needs to happen after the node and document has been initially registered

--- a/src/Sulu/Component/Content/Document/Subscriber/LastModifiedSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/LastModifiedSubscriber.php
@@ -37,7 +37,7 @@ class LastModifiedSubscriber implements EventSubscriberInterface
         $this->propertyEncoder = $propertyEncoder;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => 'setLastModifiedOnDocument',

--- a/src/Sulu/Component/Content/Document/Subscriber/NavigationContextSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/NavigationContextSubscriber.php
@@ -20,7 +20,7 @@ class NavigationContextSubscriber implements EventSubscriberInterface
 {
     public const FIELD = 'navContexts';
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::METADATA_LOAD => 'handleMetadataLoad',

--- a/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/OrderSubscriber.php
@@ -34,7 +34,7 @@ class OrderSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => 'handlePersist',

--- a/src/Sulu/Component/Content/Document/Subscriber/RedirectTypeSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RedirectTypeSubscriber.php
@@ -26,7 +26,7 @@ class RedirectTypeSubscriber implements EventSubscriberInterface
 
     public const EXTERNAL_FIELD = 'external';
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::METADATA_LOAD => 'handleMetadataLoad',

--- a/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ResourceSegmentSubscriber.php
@@ -47,7 +47,7 @@ class ResourceSegmentSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // persist should happen before content is mapped

--- a/src/Sulu/Component/Content/Document/Subscriber/RobotSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RobotSubscriber.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class RobotSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::METADATA_LOAD => 'handleMetadataLoad',

--- a/src/Sulu/Component/Content/Document/Subscriber/RouteSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/RouteSubscriber.php
@@ -45,7 +45,7 @@ class RouteSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => [

--- a/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/SecuritySubscriber.php
@@ -43,7 +43,7 @@ class SecuritySubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => [

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
@@ -46,7 +46,7 @@ class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['copyShadowProperties', -256],

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
@@ -36,7 +36,7 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::METADATA_LOAD => 'handleMetadataLoad',

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureRemoveSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureRemoveSubscriber.php
@@ -39,7 +39,7 @@ class StructureRemoveSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::REMOVE => ['handleRemove', 550],

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureSubscriber.php
@@ -49,7 +49,7 @@ class StructureSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => [

--- a/src/Sulu/Component/Content/Document/Subscriber/StructureTypeFilingSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/StructureTypeFilingSubscriber.php
@@ -21,7 +21,7 @@ use Sulu\Component\DocumentManager\Subscriber\Behavior\Path\AbstractFilingSubscr
  */
 class StructureTypeFilingSubscriber extends AbstractFilingSubscriber
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['handlePersist', 485],

--- a/src/Sulu/Component/Content/Document/Subscriber/TargetSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/TargetSubscriber.php
@@ -23,7 +23,7 @@ class TargetSubscriber implements EventSubscriberInterface
 {
     public const DOCUMENT_TARGET_FIELD = 'content';
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::METADATA_LOAD => 'handleMetadataLoad',

--- a/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/TitleSubscriber.php
@@ -27,7 +27,7 @@ class TitleSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             // should happen after content is hydrated

--- a/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WebspaceSubscriber.php
@@ -31,7 +31,7 @@ class WebspaceSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::COPY => ['deleteUnavailableLocales', 256],

--- a/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/WorkflowStageSubscriber.php
@@ -43,7 +43,7 @@ class WorkflowStageSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => 'setWorkflowStageOnDocument',

--- a/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
+++ b/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
@@ -36,7 +36,7 @@ class SerializerEventListener implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [
@@ -50,7 +50,7 @@ class SerializerEventListener implements EventSubscriberInterface
     /**
      * Add data for serialization of content objects.
      */
-    public function onPostSerialize(ObjectEvent $event)
+    public function onPostSerialize(ObjectEvent $event): void
     {
         /** @var Content $content */
         $content = $event->getObject();

--- a/src/Sulu/Component/CustomUrl/Document/Subscriber/CustomUrlSubscriber.php
+++ b/src/Sulu/Component/CustomUrl/Document/Subscriber/CustomUrlSubscriber.php
@@ -42,7 +42,7 @@ class CustomUrlSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => 'handlePersist',

--- a/src/Sulu/Component/CustomUrl/Document/Subscriber/InvalidationSubscriber.php
+++ b/src/Sulu/Component/CustomUrl/Document/Subscriber/InvalidationSubscriber.php
@@ -37,7 +37,7 @@ class InvalidationSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PUBLISH => ['invalidateDocumentBeforePublishing', 1024],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Audit/TimestampSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Audit/TimestampSubscriber.php
@@ -39,7 +39,7 @@ class TimestampSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => 'setTimestampsOnNodeForPersist',

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/ChildrenSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/ChildrenSubscriber.php
@@ -26,7 +26,7 @@ class ChildrenSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => 'handleHydrate',

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/LocaleSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/LocaleSubscriber.php
@@ -27,7 +27,7 @@ class LocaleSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => ['handleLocale', 410],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/MixinSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/MixinSubscriber.php
@@ -24,7 +24,7 @@ class MixinSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['setDocumentMixinsOnNode', 468],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/NodeNameSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/NodeNameSubscriber.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class NodeNameSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => 'setFinalNodeName',

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/ParentSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/ParentSubscriber.php
@@ -34,7 +34,7 @@ class ParentSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => 'handleHydrate',

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/PathSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/PathSubscriber.php
@@ -26,7 +26,7 @@ class PathSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => [

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/UuidSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Mapping/UuidSubscriber.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class UuidSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => 'handleUuid',

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AbstractFilingSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AbstractFilingSubscriber.php
@@ -29,7 +29,7 @@ abstract class AbstractFilingSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['handlePersist', 490],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AliasFilingSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AliasFilingSubscriber.php
@@ -38,7 +38,7 @@ class AliasFilingSubscriber extends AbstractFilingSubscriber
         $this->inflector = InflectorFactory::create()->build();
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['handlePersist', 490],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AutoNameSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/AutoNameSubscriber.php
@@ -52,7 +52,7 @@ class AutoNameSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::CONFIGURE_OPTIONS => 'configureOptions',

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/BasePathSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/BasePathSubscriber.php
@@ -29,7 +29,7 @@ class BasePathSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['handlePersist', 500],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/ExplicitSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/Path/ExplicitSubscriber.php
@@ -33,7 +33,7 @@ class ExplicitSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => ['handlePersist', 485],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Behavior/VersionSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Behavior/VersionSubscriber.php
@@ -56,7 +56,7 @@ class VersionSubscriber implements EventSubscriberInterface
         $this->versionManager = $this->defaultSession->getWorkspace()->getVersionManager();
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => [

--- a/src/Sulu/Component/DocumentManager/Subscriber/Core/InstantiatorSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Core/InstantiatorSubscriber.php
@@ -32,7 +32,7 @@ class InstantiatorSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => ['handleHydrate', 500],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Core/MappingSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Core/MappingSubscriber.php
@@ -36,7 +36,7 @@ class MappingSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => ['handleHydrate', -100],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Core/RegistratorSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Core/RegistratorSubscriber.php
@@ -33,7 +33,7 @@ class RegistratorSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::HYDRATE => [

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/FindSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/FindSubscriber.php
@@ -34,7 +34,7 @@ class FindSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::FIND => ['handleFind', 500],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/GeneralSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/GeneralSubscriber.php
@@ -37,7 +37,7 @@ class GeneralSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::MOVE => ['handleMove', 400],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/QuerySubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/QuerySubscriber.php
@@ -33,7 +33,7 @@ class QuerySubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::QUERY_CREATE => ['handleCreate', 500],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RefreshSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RefreshSubscriber.php
@@ -28,7 +28,7 @@ class RefreshSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::REFRESH => 'refreshDocument',

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RemoveSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/RemoveSubscriber.php
@@ -28,7 +28,7 @@ class RemoveSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::REMOVE => ['handleRemove', 500],

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/ReorderSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/ReorderSubscriber.php
@@ -26,7 +26,7 @@ class ReorderSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::REORDER => ['handleReorder', 500],

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentManagerTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentManagerTest.php
@@ -318,7 +318,7 @@ class TestDocumentManagerSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             Events::PERSIST => 'handlePersist',

--- a/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
+++ b/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
@@ -29,7 +29,7 @@ class HashSerializeEventSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ['event' => 'serializer.post_serialize', 'method' => 'onPostSerialize'],

--- a/src/Sulu/Component/Rest/Handler/DateHandler.php
+++ b/src/Sulu/Component/Rest/Handler/DateHandler.php
@@ -21,7 +21,7 @@ use JMS\Serializer\Visitor\SerializationVisitorInterface;
  */
 class DateHandler implements SubscribingHandlerInterface
 {
-    public static function getSubscribingMethods()
+    public static function getSubscribingMethods(): array
     {
         return [
             [

--- a/src/Sulu/Component/Route/RouteDefaultOptionsCompilerPass.php
+++ b/src/Sulu/Component/Route/RouteDefaultOptionsCompilerPass.php
@@ -24,7 +24,7 @@ class RouteDefaultOptionsCompilerPass implements CompilerPassInterface
     {
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('routing.loader')) {
             return;

--- a/src/Sulu/Component/Security/Serializer/Subscriber/SecuredEntitySubscriber.php
+++ b/src/Sulu/Component/Security/Serializer/Subscriber/SecuredEntitySubscriber.php
@@ -30,7 +30,7 @@ class SecuredEntitySubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ['event' => 'serializer.post_serialize', 'method' => 'onPostSerialize'],

--- a/src/Sulu/Component/Serializer/RepresentationSubscriber.php
+++ b/src/Sulu/Component/Serializer/RepresentationSubscriber.php
@@ -24,7 +24,7 @@ use Sulu\Component\Rest\ListBuilder\RepresentationInterface;
  */
 class RepresentationSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             [

--- a/src/Sulu/Component/Symfony/CompilerPass/TaggedServiceCollectorCompilerPass.php
+++ b/src/Sulu/Component/Symfony/CompilerPass/TaggedServiceCollectorCompilerPass.php
@@ -30,7 +30,7 @@ class TaggedServiceCollectorCompilerPass implements CompilerPassInterface
     {
     }
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition($this->serviceId)) {
             return;

--- a/src/Sulu/Component/Util/SuluVersionPass.php
+++ b/src/Sulu/Component/Util/SuluVersionPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 class SuluVersionPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $dir = \realpath($container->getParameter('kernel.project_dir'));
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

A basic setup of sulu (out of the box) causes ~ 350 deprecation log messages to pop up in profiler. The sheer amount makes it hard to distiguish between user- and framework-caused deprecations.

#### Why?

This PR fixes lots of deprecations by using different (new) interfaces and adding non-bc return types to EventSubscribers, kernel extensions, compiler passes, etc. I structured my changes in commits for each type. 

Now, after my improvements, my application gives me ~ 140 (210 less) deprecation log messages.

#### Testing

Locally, besides producing less deprecation messages, no difference in behaviour has been observed. Everything tested worked as expected.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
