### PR TITLE
Marking all Sulu `Extension`s as `final` classes.

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/SuluActivityBundle.php
+++ b/src/Sulu/Bundle/ActivityBundle/SuluActivityBundle.php
@@ -18,10 +18,13 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SuluActivityBundle extends Bundle
+final class SuluActivityBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
+    /**
+     * @internal
+     */
     public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
@@ -32,6 +35,9 @@ class SuluActivityBundle extends Bundle
         );
     }
 
+    /**
+     * @internal
+     */
     public function getContainerExtension(): ExtensionInterface
     {
         return new SuluActivityExtension();

--- a/src/Sulu/Bundle/ActivityBundle/SuluActivityBundle.php
+++ b/src/Sulu/Bundle/ActivityBundle/SuluActivityBundle.php
@@ -23,7 +23,7 @@ final class SuluActivityBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {
@@ -36,7 +36,7 @@ final class SuluActivityBundle extends Bundle
     }
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function getContainerExtension(): ExtensionInterface
     {

--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -17,10 +17,7 @@ use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ExposeResourceRoutesPas
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluAdminBundle extends Bundle
+final class SuluAdminBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 final class SuluAdminBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
@@ -30,7 +30,7 @@ final class SuluAudienceTargetingBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/SuluAudienceTargetingBundle.php
@@ -24,10 +24,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 /**
  * Sulu Audience Targeting Bundle is for managing target groups, their rules and conditions
  * and applying them to certain contents to delivery user specific content.
- *
- * @final
  */
-class SuluAudienceTargetingBundle extends Bundle
+final class SuluAudienceTargetingBundle extends Bundle
 {
     use PersistenceBundleTrait;
 

--- a/src/Sulu/Bundle/CategoryBundle/SuluCategoryBundle.php
+++ b/src/Sulu/Bundle/CategoryBundle/SuluCategoryBundle.php
@@ -24,7 +24,7 @@ final class SuluCategoryBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/CategoryBundle/SuluCategoryBundle.php
+++ b/src/Sulu/Bundle/CategoryBundle/SuluCategoryBundle.php
@@ -19,12 +19,7 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Entry point for the SuluCategoryBundle.
- *
- * @final
- */
-class SuluCategoryBundle extends Bundle
+final class SuluCategoryBundle extends Bundle
 {
     use PersistenceBundleTrait;
 

--- a/src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
+++ b/src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
@@ -17,10 +17,7 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluContactBundle extends Bundle
+final class SuluContactBundle extends Bundle
 {
     use PersistenceBundleTrait;
 

--- a/src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
+++ b/src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
@@ -22,7 +22,7 @@ final class SuluContactBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
+++ b/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
@@ -22,10 +22,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluCoreBundle extends Bundle
+final class SuluCoreBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
+++ b/src/Sulu/Bundle/CoreBundle/SuluCoreBundle.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 final class SuluCoreBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/CustomUrlBundle/SuluCustomUrlBundle.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/SuluCustomUrlBundle.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 final class SuluCustomUrlBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/CustomUrlBundle/SuluCustomUrlBundle.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/SuluCustomUrlBundle.php
@@ -16,12 +16,7 @@ use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRouteEnha
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Integrates custom-urls into sulu.
- *
- * @final
- */
-class SuluCustomUrlBundle extends Bundle
+final class SuluCustomUrlBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
@@ -18,10 +18,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluDocumentManagerBundle extends Bundle
+final class SuluDocumentManagerBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/SuluDocumentManagerBundle.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 final class SuluDocumentManagerBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/HashBundle/SuluHashBundle.php
+++ b/src/Sulu/Bundle/HashBundle/SuluHashBundle.php
@@ -13,6 +13,6 @@ namespace Sulu\Bundle\HashBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SuluHashBundle extends Bundle
+final class SuluHashBundle extends Bundle
 {
 }

--- a/src/Sulu/Bundle/HttpCacheBundle/SuluHttpCacheBundle.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/SuluHttpCacheBundle.php
@@ -13,6 +13,6 @@ namespace Sulu\Bundle\HttpCacheBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SuluHttpCacheBundle extends Bundle
+final class SuluHttpCacheBundle extends Bundle
 {
 }

--- a/src/Sulu/Bundle/LocationBundle/SuluLocationBundle.php
+++ b/src/Sulu/Bundle/LocationBundle/SuluLocationBundle.php
@@ -13,6 +13,6 @@ namespace Sulu\Bundle\LocationBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SuluLocationBundle extends Bundle
+final class SuluLocationBundle extends Bundle
 {
 }

--- a/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
+++ b/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
@@ -19,10 +19,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Integrates markup into symfony.
- *
- * @final
  */
-class SuluMarkupBundle extends Bundle
+final class SuluMarkupBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
+++ b/src/Sulu/Bundle/MarkupBundle/SuluMarkupBundle.php
@@ -17,13 +17,10 @@ use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Integrates markup into symfony.
- */
 final class SuluMarkupBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
+++ b/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
@@ -21,10 +21,7 @@ use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluMediaBundle extends Bundle
+final class SuluMediaBundle extends Bundle
 {
     use PersistenceBundleTrait;
 

--- a/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
+++ b/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
@@ -26,7 +26,7 @@ final class SuluMediaBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/PageBundle/SuluPageBundle.php
+++ b/src/Sulu/Bundle/PageBundle/SuluPageBundle.php
@@ -20,10 +20,7 @@ use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluPageBundle extends Bundle
+final class SuluPageBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/PageBundle/SuluPageBundle.php
+++ b/src/Sulu/Bundle/PageBundle/SuluPageBundle.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 final class SuluPageBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/PersistenceBundle/SuluPersistenceBundle.php
+++ b/src/Sulu/Bundle/PersistenceBundle/SuluPersistenceBundle.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 final class SuluPersistenceBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/PersistenceBundle/SuluPersistenceBundle.php
+++ b/src/Sulu/Bundle/PersistenceBundle/SuluPersistenceBundle.php
@@ -16,10 +16,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluPersistenceBundle extends Bundle
+final class SuluPersistenceBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
+++ b/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
@@ -24,7 +24,7 @@ final class SuluPreviewBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {
@@ -48,7 +48,7 @@ final class SuluPreviewBundle extends Bundle
     }
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function getContainerExtension(): ExtensionInterface
     {

--- a/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
+++ b/src/Sulu/Bundle/PreviewBundle/SuluPreviewBundle.php
@@ -19,12 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Integrates preview into symfony.
- *
- * @final
- */
-class SuluPreviewBundle extends Bundle
+final class SuluPreviewBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
@@ -52,6 +47,9 @@ class SuluPreviewBundle extends Bundle
         );
     }
 
+    /**
+     * @internal
+     */
     public function getContainerExtension(): ExtensionInterface
     {
         return new SuluPreviewExtension();

--- a/src/Sulu/Bundle/ReferenceBundle/SuluReferenceBundle.php
+++ b/src/Sulu/Bundle/ReferenceBundle/SuluReferenceBundle.php
@@ -25,7 +25,7 @@ final class SuluReferenceBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {
@@ -38,7 +38,7 @@ final class SuluReferenceBundle extends Bundle
     }
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function getContainerExtension(): ExtensionInterface
     {

--- a/src/Sulu/Bundle/ReferenceBundle/SuluReferenceBundle.php
+++ b/src/Sulu/Bundle/ReferenceBundle/SuluReferenceBundle.php
@@ -20,10 +20,13 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SuluReferenceBundle extends Bundle
+final class SuluReferenceBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
+    /**
+     * @internal
+     */
     public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
@@ -34,6 +37,9 @@ class SuluReferenceBundle extends Bundle
         );
     }
 
+    /**
+     * @internal
+     */
     public function getContainerExtension(): ExtensionInterface
     {
         return new SuluReferenceExtension();

--- a/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
+++ b/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
@@ -22,13 +22,14 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Entry point of sulu-route-bundle.
- *
- * @final
  */
-class SuluRouteBundle extends Bundle
+final class SuluRouteBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
+    /**
+     * @internal
+     */
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);

--- a/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
+++ b/src/Sulu/Bundle/RouteBundle/SuluRouteBundle.php
@@ -28,7 +28,7 @@ final class SuluRouteBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/SearchBundle/SuluSearchBundle.php
+++ b/src/Sulu/Bundle/SearchBundle/SuluSearchBundle.php
@@ -13,6 +13,6 @@ namespace Sulu\Bundle\SearchBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SuluSearchBundle extends Bundle
+final class SuluSearchBundle extends Bundle
 {
 }

--- a/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/TestBundle.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Resources/TestBundle/TestBundle.php
@@ -13,6 +13,6 @@ namespace Sulu\Bundle\SearchBundle\Tests\Resources\TestBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class TestBundle extends Bundle
+final class TestBundle extends Bundle
 {
 }

--- a/src/Sulu/Bundle/SecurityBundle/SuluSecurityBundle.php
+++ b/src/Sulu/Bundle/SecurityBundle/SuluSecurityBundle.php
@@ -27,7 +27,7 @@ final class SuluSecurityBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/SecurityBundle/SuluSecurityBundle.php
+++ b/src/Sulu/Bundle/SecurityBundle/SuluSecurityBundle.php
@@ -22,10 +22,7 @@ use Sulu\Component\Security\Authorization\AccessControl\AccessControlInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluSecurityBundle extends Bundle
+final class SuluSecurityBundle extends Bundle
 {
     use PersistenceBundleTrait;
 

--- a/src/Sulu/Bundle/SnippetBundle/SuluSnippetBundle.php
+++ b/src/Sulu/Bundle/SnippetBundle/SuluSnippetBundle.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 final class SuluSnippetBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/SnippetBundle/SuluSnippetBundle.php
+++ b/src/Sulu/Bundle/SnippetBundle/SuluSnippetBundle.php
@@ -16,10 +16,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluSnippetBundle extends Bundle
+final class SuluSnippetBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/TagBundle/SuluTagBundle.php
+++ b/src/Sulu/Bundle/TagBundle/SuluTagBundle.php
@@ -16,12 +16,7 @@ use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * Entry-point of tag-bundle.
- *
- * @final
- */
-class SuluTagBundle extends Bundle
+final class SuluTagBundle extends Bundle
 {
     use PersistenceBundleTrait;
 

--- a/src/Sulu/Bundle/TagBundle/SuluTagBundle.php
+++ b/src/Sulu/Bundle/TagBundle/SuluTagBundle.php
@@ -21,7 +21,7 @@ final class SuluTagBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/TestBundle/SuluTestBundle.php
+++ b/src/Sulu/Bundle/TestBundle/SuluTestBundle.php
@@ -15,10 +15,7 @@ use Sulu\Bundle\TestBundle\DependencyInjection\Compiler\ReplaceTestClientPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluTestBundle extends Bundle
+final class SuluTestBundle extends Bundle
 {
     /**
      * @internal

--- a/src/Sulu/Bundle/TestBundle/SuluTestBundle.php
+++ b/src/Sulu/Bundle/TestBundle/SuluTestBundle.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 final class SuluTestBundle extends Bundle
 {
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {
@@ -28,7 +28,7 @@ final class SuluTestBundle extends Bundle
     }
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public static function getConfigDir(): string
     {

--- a/src/Sulu/Bundle/TrashBundle/SuluTrashBundle.php
+++ b/src/Sulu/Bundle/TrashBundle/SuluTrashBundle.php
@@ -24,6 +24,9 @@ final class SuluTrashBundle extends Bundle
 {
     use PersistenceBundleTrait;
 
+    /**
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
+     */
     public function build(ContainerBuilder $container): void
     {
         $this->buildPersistence(
@@ -34,6 +37,9 @@ final class SuluTrashBundle extends Bundle
         );
     }
 
+    /**
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
+     */
     public function getContainerExtension(): ExtensionInterface
     {
         return new SuluTrashExtension();

--- a/src/Sulu/Bundle/TrashBundle/SuluTrashBundle.php
+++ b/src/Sulu/Bundle/TrashBundle/SuluTrashBundle.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class SuluTrashBundle extends Bundle
+final class SuluTrashBundle extends Bundle
 {
     use PersistenceBundleTrait;
 

--- a/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
+++ b/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
@@ -25,7 +25,7 @@ final class SuluWebsiteBundle extends Bundle
     use PersistenceBundleTrait;
 
     /**
-     * @internal
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
      */
     public function build(ContainerBuilder $container): void
     {

--- a/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
+++ b/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
@@ -20,10 +20,7 @@ use Sulu\Component\Util\SuluVersionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @final
- */
-class SuluWebsiteBundle extends Bundle
+final class SuluWebsiteBundle extends Bundle
 {
     use PersistenceBundleTrait;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Marking all Extension classes as `final` and their methods as `@internal`.

#### Why?
They should not be extended and only used by Symfony. We also don't want to mark them as `@internal` because the user still needs to reference them in the `bundles.php` file.

An example on how to properly done can be found in the ArticleBundle: https://github.com/sulu/sulu/blob/3.0/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php#L56