### PR TITLE
Fix deprecated null argument on ReflectionClass instantiation

### DIFF
--- a/src/Sulu/Component/Security/Authorization/AccessControl/PhpcrAccessControlProvider.php
+++ b/src/Sulu/Component/Security/Authorization/AccessControl/PhpcrAccessControlProvider.php
@@ -73,6 +73,10 @@ class PhpcrAccessControlProvider implements AccessControlProviderInterface
 
     public function supports($type)
     {
+        if (null === $type) {
+            return false;
+        }
+
         try {
             $class = new \ReflectionClass($type);
         } catch (\ReflectionException $e) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no 
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR adds a check to the `PhpcrAccessControlProvider::supports` method which prevents from a deprecated call.

#### Why?

When Sulu's AccessControlManager tries to get the permissions for a SecurityCondition which does not have an objectType, it calls the PhpcrAccessControlProvider::supports method with a null value. This is in turn passed as argument to the ReflectionClass contructor resulting in a deprecation.
