### PR TITLE
Remove optional argument in `AccountMediaController`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -738,6 +738,10 @@ The corresponding traits `TimestampableTrait` and `UserBlameTrait` have been upd
  - `src/Sulu/Component/Content/Metadata/Loader/schema/template-1.0.xsd` -> `src/Sulu/Bundle/AdminBundle/Resources/config/schema/template-1.0.xsd`
  - `src/Sulu/Component/Content/Metadata/Loader/schema/xml.xsd` -> `src/Sulu/Bundle/AdminBundle/Resources/config/schema/xml.xsd`
 
+### Changed methods for 3.0
+
+- `Sulu\Bundle\ContactBundle\Controller\AbstractMediaController::__construct`
+
 ### Piwik replaced with Matomo script
 
 The script provided by Sulu for the piwik implementation has been updated to use mataomo path so the script is now pointing to matomo.php instead of the piwik.php file.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15835,38 +15835,8 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Content/Types/SingleContactSelection.php
 
 		-
-			message: '#^Binary operation "\." between mixed and ''\.fileVersions'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 6
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
 			message: '#^Binary operation "\." between mixed and ''\.id \= '' results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Binary operation "\." between mixed and ''\.meta'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 2
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Binary operation "\." between mixed and ''\.version \= '' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 6
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Binary operation "\." between non\-falsy\-string and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 7
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Call to an undefined method Sulu\\Component\\Rest\\ListBuilder\\ListBuilderInterface\:\:setIdField\(\)\.$#'
-			identifier: method.notFound
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
@@ -15885,18 +15855,6 @@ parameters:
 		-
 			message: '#^Call to an undefined method object\:\:removeMedia\(\)\.$#'
 			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Cannot access offset ''thumbnails'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Cannot access offset ''url'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
@@ -15925,48 +15883,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:addThumbnails\(\) has parameter \$entities with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:addThumbnails\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:addUrls\(\) has parameter \$entities with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:addUrls\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:getFieldDescriptors\(\) has parameter \$id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:getFieldDescriptors\(\) should return array\<Sulu\\Component\\Rest\\ListBuilder\\Doctrine\\FieldDescriptor\\DoctrineFieldDescriptor\> but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:getListRepresentation\(\) has parameter \$contactId with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:getMultipleView\(\) has parameter \$contactId with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -15979,49 +15895,19 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:initFieldDescriptors\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:initFieldDescriptors\(\) has parameter \$id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
 			message: '#^Parameter \#1 \$className of method Doctrine\\ORM\\EntityManagerInterface\:\:getRepository\(\) expects class\-string\<object\>, string given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
 		-
-			message: '#^Parameter \#1 \$entities of method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:addThumbnails\(\) expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
 			message: '#^Parameter \#1 \$entityName of class Sulu\\Component\\Rest\\ListBuilder\\Doctrine\\FieldDescriptor\\DoctrineJoinDescriptor constructor expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 15
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
 		-
 			message: '#^Parameter \#1 \$id of method Sulu\\Bundle\\ContactBundle\\Contact\\ContactManagerInterface\<mixed,mixed,mixed\>\:\:getById\(\) expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
@@ -16045,31 +15931,13 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
 		-
-			message: '#^Parameter \#2 \$rel of class Sulu\\Component\\Rest\\ListBuilder\\PaginatedRepresentation constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
 			message: '#^Parameter \#2 \$value of method Sulu\\Component\\Rest\\ListBuilder\\AbstractListBuilder\:\:where\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
 		-
-			message: '#^Parameter \#3 \$entityName of class Sulu\\Component\\Rest\\ListBuilder\\Doctrine\\FieldDescriptor\\DoctrineFieldDescriptor constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 6
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
 			message: '#^Parameter \#3 \$rel of method Sulu\\Bundle\\MediaBundle\\Media\\ListRepresentationFactory\\MediaListRepresentationFactory\:\:getListRepresentation\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
-
-		-
-			message: '#^Parameter \#5 \$locale of method Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:getListRepresentation\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
@@ -16105,8 +15973,26 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 
 		-
+			message: '#^Property Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:\$listBuilderFactory is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
+
+		-
 			message: '#^Property Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:\$mediaEntityKey has no type specified\.$#'
 			identifier: missingType.property
+			count: 1
+			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
+
+		-
+			message: '#^Property Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:\$mediaManager is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
+
+		-
+			message: '#^Property Sulu\\Bundle\\ContactBundle\\Controller\\AbstractMediaController\:\:\$restHelper is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AbstractMediaController.php
@@ -28,7 +28,6 @@ use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescri
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescriptor;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
-use Sulu\Component\Rest\ListBuilder\PaginatedRepresentation;
 use Sulu\Component\Rest\RestHelperInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -61,19 +60,11 @@ abstract class AbstractMediaController extends AbstractRestController
         private MediaRepositoryInterface $mediaRepository,
         private MediaManagerInterface $mediaManager,
         private string $mediaClass,
-        private ?MediaListBuilderFactory $mediaListBuilderFactory = null,
-        private ?MediaListRepresentationFactory $mediaListRepresentationFactory = null,
-        private ?FieldDescriptorFactoryInterface $fieldDescriptorFactory = null
+        private MediaListBuilderFactory $mediaListBuilderFactory,
+        private MediaListRepresentationFactory $mediaListRepresentationFactory,
+        private FieldDescriptorFactoryInterface $fieldDescriptorFactory
     ) {
         parent::__construct($viewHandler, $tokenStorage);
-
-        if (null === $this->mediaListBuilderFactory || null === $this->mediaListRepresentationFactory || null === $this->fieldDescriptorFactory) {
-            @trigger_deprecation(
-                'sulu/sulu',
-                '2.3',
-                'Instantiating AbstractMediaController without the $mediaListBuilderFactory, $mediaListRepresentationFactory or $fieldDescriptorFactory argument is deprecated.'
-            );
-        }
     }
 
     /**
@@ -202,60 +193,48 @@ abstract class AbstractMediaController extends AbstractRestController
             $locale = $this->getUser()->getLocale();
 
             if ('true' === $request->get('flat')) {
-                if (null === $this->mediaListBuilderFactory
-                    || null === $this->mediaListRepresentationFactory
-                    || null === $this->fieldDescriptorFactory) {
-                    $listRepresentation = $this->getListRepresentation(
-                        $entityName,
-                        $routeName,
-                        $contactId,
-                        $request,
-                        $locale
-                    );
-                } else {
-                    $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('media');
+                $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('media');
 
-                    $fieldDescriptors['contactId'] = new DoctrineFieldDescriptor(
-                        'id',
-                        'contactId',
-                        $entityName,
-                        null,
-                        [
-                            $entityName => new DoctrineJoinDescriptor(
-                                $entityName,
-                                $entityName,
-                                $entityName . '.id = :contactId'
-                            ),
-                            static::$mediaEntityKey => new DoctrineJoinDescriptor(
-                                static::$mediaEntityKey,
-                                $entityName . '.medias',
-                                static::$mediaEntityKey . '.id = ' . $this->mediaClass . '.id',
-                                DoctrineJoinDescriptor::JOIN_METHOD_INNER
-                            ),
-                        ],
-                        FieldDescriptorInterface::VISIBILITY_NEVER,
-                        FieldDescriptorInterface::SEARCHABILITY_NEVER
-                    );
+                $fieldDescriptors['contactId'] = new DoctrineFieldDescriptor(
+                    'id',
+                    'contactId',
+                    $entityName,
+                    null,
+                    [
+                        $entityName => new DoctrineJoinDescriptor(
+                            $entityName,
+                            $entityName,
+                            $entityName . '.id = :contactId'
+                        ),
+                        static::$mediaEntityKey => new DoctrineJoinDescriptor(
+                            static::$mediaEntityKey,
+                            $entityName . '.medias',
+                            static::$mediaEntityKey . '.id = ' . $this->mediaClass . '.id',
+                            DoctrineJoinDescriptor::JOIN_METHOD_INNER
+                        ),
+                    ],
+                    FieldDescriptorInterface::VISIBILITY_NEVER,
+                    FieldDescriptorInterface::SEARCHABILITY_NEVER
+                );
 
-                    $listBuilder = $this->mediaListBuilderFactory->getListBuilder(
-                        $fieldDescriptors,
-                        $user,
-                        [],
-                        !$request->get('sortBy'),
-                        null
-                    );
+                $listBuilder = $this->mediaListBuilderFactory->getListBuilder(
+                    $fieldDescriptors,
+                    $user,
+                    [],
+                    !$request->get('sortBy'),
+                    null
+                );
 
-                    $listBuilder->setParameter('contactId', $contactId);
-                    $listBuilder->where($fieldDescriptors['contactId'], $contactId);
+                $listBuilder->setParameter('contactId', $contactId);
+                $listBuilder->where($fieldDescriptors['contactId'], $contactId);
 
-                    $listRepresentation = $this->mediaListRepresentationFactory->getListRepresentation(
-                        $listBuilder,
-                        $locale,
-                        static::$mediaEntityKey,
-                        $routeName,
-                        \array_merge(['contactId' => $contactId], $request->query->all())
-                    );
-                }
+                $listRepresentation = $this->mediaListRepresentationFactory->getListRepresentation(
+                    $listBuilder,
+                    $locale,
+                    static::$mediaEntityKey,
+                    $routeName,
+                    \array_merge(['contactId' => $contactId], $request->query->all())
+                );
             } else {
                 $media = $contactManager->getById($contactId, $locale)->getMedias();
                 $listRepresentation = new CollectionRepresentation($media, static::$mediaEntityKey);
@@ -267,297 +246,5 @@ abstract class AbstractMediaController extends AbstractRestController
         }
 
         return $this->handleView($view);
-    }
-
-    /**
-     * Returns a list representation containing all media of an entity.
-     *
-     * @deprecated
-     *
-     * @param string $entityName
-     * @param string $routeName
-     * @param Request $request
-     * @param string $locale
-     *
-     * @return PaginatedRepresentation
-     */
-    private function getListRepresentation($entityName, $routeName, $contactId, $request, $locale)
-    {
-        $listBuilder = $this->listBuilderFactory->create($entityName);
-        $fieldDescriptors = $this->getFieldDescriptors($entityName, $contactId);
-        $listBuilder->setIdField($fieldDescriptors['id']);
-        $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
-
-        $listResponse = $listBuilder->execute();
-        $listResponse = $this->addThumbnails($listResponse, $locale);
-        $listResponse = $this->addUrls($listResponse, $locale);
-
-        return new PaginatedRepresentation(
-            $listResponse,
-            static::$mediaEntityKey,
-            (int) $listBuilder->getCurrentPage(),
-            (int) $listBuilder->getLimit(),
-            (int) $listBuilder->count()
-        );
-    }
-
-    /**
-     * Returns the field-descriptors. Ensures that the descriptors get only instantiated once.
-     *
-     * @deprecated
-     *
-     * @param string $entityName
-     *
-     * @return DoctrineFieldDescriptor[]
-     */
-    private function getFieldDescriptors($entityName, $id)
-    {
-        if (null === $this->fieldDescriptors) {
-            $this->initFieldDescriptors($entityName, $id);
-        }
-
-        return $this->fieldDescriptors;
-    }
-
-    /**
-     * Creates the array of field-descriptors.
-     *
-     * @deprecated
-     *
-     * @param string $entityName
-     */
-    private function initFieldDescriptors($entityName, $id)
-    {
-        $mediaEntityName = $this->mediaClass;
-
-        $entityJoin = new DoctrineJoinDescriptor(
-            $mediaEntityName,
-            $entityName . '.medias',
-            $entityName . '.id = ' . $id,
-            DoctrineJoinDescriptor::JOIN_METHOD_INNER
-        );
-
-        $this->fieldDescriptors = [];
-
-        $this->fieldDescriptors['entity'] = new DoctrineFieldDescriptor(
-            'id',
-            'entity',
-            $entityName,
-            null,
-            [],
-            FieldDescriptorInterface::VISIBILITY_NO,
-            FieldDescriptorInterface::SEARCHABILITY_NO
-        );
-
-        $this->fieldDescriptors['id'] = new DoctrineFieldDescriptor(
-            'id',
-            'id',
-            $mediaEntityName,
-            'public.id',
-            [
-                $mediaEntityName => $entityJoin,
-            ],
-            FieldDescriptorInterface::VISIBILITY_NO,
-            FieldDescriptorInterface::SEARCHABILITY_NO
-        );
-
-        $this->fieldDescriptors['thumbnails'] = new DoctrineFieldDescriptor(
-            'id',
-            'thumbnails',
-            $mediaEntityName,
-            'media.media.thumbnails',
-            [
-                $mediaEntityName => $entityJoin,
-            ],
-            FieldDescriptorInterface::VISIBILITY_YES,
-            FieldDescriptorInterface::SEARCHABILITY_NEVER,
-            'thumbnails',
-            false
-        );
-
-        $this->fieldDescriptors['name'] = new DoctrineFieldDescriptor(
-            'name',
-            'name',
-            self::$fileVersionEntityName,
-            'public.name',
-            [
-                $mediaEntityName => $entityJoin,
-                self::$fileEntityName => new DoctrineJoinDescriptor(
-                    self::$fileEntityName,
-                    $mediaEntityName . '.files'
-                ),
-                self::$fileVersionEntityName => new DoctrineJoinDescriptor(
-                    self::$fileVersionEntityName,
-                    self::$fileEntityName . '.fileVersions',
-                    self::$fileVersionEntityName . '.version = ' . self::$fileEntityName . '.version'
-                ),
-            ]
-        );
-        $this->fieldDescriptors['size'] = new DoctrineFieldDescriptor(
-            'size',
-            'size',
-            self::$fileVersionEntityName,
-            'media.media.size',
-            [
-                $mediaEntityName => $entityJoin,
-                self::$fileEntityName => new DoctrineJoinDescriptor(
-                    self::$fileEntityName,
-                    $mediaEntityName . '.files'
-                ),
-                self::$fileVersionEntityName => new DoctrineJoinDescriptor(
-                    self::$fileVersionEntityName,
-                    self::$fileEntityName . '.fileVersions',
-                    self::$fileVersionEntityName . '.version = ' . self::$fileEntityName . '.version'
-                ),
-            ],
-            FieldDescriptorInterface::VISIBILITY_NO,
-            FieldDescriptorInterface::SEARCHABILITY_NEVER,
-            'bytes'
-        );
-
-        $this->fieldDescriptors['changed'] = new DoctrineFieldDescriptor(
-            'changed',
-            'changed',
-            self::$fileVersionEntityName,
-            'public.changed',
-            [
-                $mediaEntityName => $entityJoin,
-                self::$fileEntityName => new DoctrineJoinDescriptor(
-                    self::$fileEntityName,
-                    $mediaEntityName . '.files'
-                ),
-                self::$fileVersionEntityName => new DoctrineJoinDescriptor(
-                    self::$fileVersionEntityName,
-                    self::$fileEntityName . '.fileVersions',
-                    self::$fileVersionEntityName . '.version = ' . self::$fileEntityName . '.version'
-                ),
-            ],
-            FieldDescriptorInterface::VISIBILITY_NO,
-            FieldDescriptorInterface::SEARCHABILITY_NEVER,
-            'date'
-        );
-
-        $this->fieldDescriptors['created'] = new DoctrineFieldDescriptor(
-            'created',
-            'created',
-            self::$fileVersionEntityName,
-            'public.created',
-            [
-                $mediaEntityName => $entityJoin,
-                self::$fileEntityName => new DoctrineJoinDescriptor(
-                    self::$fileEntityName,
-                    $mediaEntityName . '.files'
-                ),
-                self::$fileVersionEntityName => new DoctrineJoinDescriptor(
-                    self::$fileVersionEntityName,
-                    self::$fileEntityName . '.fileVersions',
-                    self::$fileVersionEntityName . '.version = ' . self::$fileEntityName . '.version'
-                ),
-            ],
-            FieldDescriptorInterface::VISIBILITY_NO,
-            FieldDescriptorInterface::SEARCHABILITY_NEVER,
-            'date'
-        );
-
-        $this->fieldDescriptors['title'] = new DoctrineFieldDescriptor(
-            'title',
-            'title',
-            self::$fileVersionMetaEntityName,
-            'public.title',
-            [
-                $mediaEntityName => $entityJoin,
-                self::$fileEntityName => new DoctrineJoinDescriptor(
-                    self::$fileEntityName,
-                    $mediaEntityName . '.files'
-                ),
-                self::$fileVersionEntityName => new DoctrineJoinDescriptor(
-                    self::$fileVersionEntityName,
-                    self::$fileEntityName . '.fileVersions',
-                    self::$fileVersionEntityName . '.version = ' . self::$fileEntityName . '.version'
-                ),
-                self::$fileVersionMetaEntityName => new DoctrineJoinDescriptor(
-                    self::$fileVersionMetaEntityName,
-                    self::$fileVersionEntityName . '.meta'
-                ),
-            ],
-            FieldDescriptorInterface::VISIBILITY_NO,
-            FieldDescriptorInterface::SEARCHABILITY_YES,
-            'title'
-        );
-
-        $this->fieldDescriptors['description'] = new DoctrineFieldDescriptor(
-            'description',
-            'description',
-            self::$fileVersionMetaEntityName,
-            'media.media.description',
-            [
-                $mediaEntityName => $entityJoin,
-                self::$fileEntityName => new DoctrineJoinDescriptor(
-                    self::$fileEntityName,
-                    $mediaEntityName . '.files'
-                ),
-                self::$fileVersionEntityName => new DoctrineJoinDescriptor(
-                    self::$fileVersionEntityName,
-                    self::$fileEntityName . '.fileVersions',
-                    self::$fileVersionEntityName . '.version = ' . self::$fileEntityName . '.version'
-                ),
-                self::$fileVersionMetaEntityName => new DoctrineJoinDescriptor(
-                    self::$fileVersionMetaEntityName,
-                    self::$fileVersionEntityName . '.meta'
-                ),
-            ],
-            FieldDescriptorInterface::VISIBILITY_YES,
-            FieldDescriptorInterface::SEARCHABILITY_YES
-        );
-    }
-
-    /**
-     * Takes an array of entities and resets the thumbnails-property containing the media id with
-     * the actual urls to the thumbnails.
-     *
-     * @deprecated
-     *
-     * @param array $entities
-     * @param string $locale
-     *
-     * @return array
-     */
-    private function addThumbnails($entities, $locale)
-    {
-        $ids = \array_filter(\array_column($entities, 'thumbnails'));
-        $thumbnails = $this->mediaManager->getFormatUrls($ids, $locale);
-        foreach ($entities as $key => $entity) {
-            if (\array_key_exists('thumbnails', $entity)
-                && $entity['thumbnails']
-                && \array_key_exists($entity['thumbnails'], $thumbnails)
-            ) {
-                $entities[$key]['thumbnails'] = $thumbnails[$entity['thumbnails']];
-            }
-        }
-
-        return $entities;
-    }
-
-    /**
-     * Takes an array of entities and resets the url-property with the actual urls to the original file.
-     *
-     * @deprecated
-     *
-     * @param array $entities
-     * @param string $locale
-     *
-     * @return array
-     */
-    private function addUrls($entities, $locale)
-    {
-        $ids = \array_filter(\array_column($entities, 'id'));
-        $apiEntities = $this->mediaManager->getByIds($ids, $locale);
-        $i = 0;
-        foreach ($entities as $key => $entity) {
-            $entities[$key]['url'] = $apiEntities[$i]->getUrl();
-            ++$i;
-        }
-
-        return $entities;
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountMediaController.php
@@ -48,9 +48,9 @@ class AccountMediaController extends AbstractMediaController
         private DomainEventCollectorInterface $domainEventCollector,
         private string $accountClass,
         string $mediaClass,
-        ?MediaListBuilderFactory $mediaListBuilderFactory = null,
-        ?MediaListRepresentationFactory $mediaListRepresentationFactory = null,
-        ?FieldDescriptorFactoryInterface $fieldDescriptorFactory = null
+        MediaListBuilderFactory $mediaListBuilderFactory,
+        MediaListRepresentationFactory $mediaListRepresentationFactory,
+        FieldDescriptorFactoryInterface $fieldDescriptorFactory
     ) {
         parent::__construct(
             $viewHandler,

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactMediaController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactMediaController.php
@@ -48,9 +48,9 @@ class ContactMediaController extends AbstractMediaController
         private DomainEventCollectorInterface $domainEventCollector,
         private string $contactClass,
         string $mediaClass,
-        ?MediaListBuilderFactory $mediaListBuilderFactory = null,
-        ?MediaListRepresentationFactory $mediaListRepresentationFactory = null,
-        ?FieldDescriptorFactoryInterface $fieldDescriptorFactory = null
+        MediaListBuilderFactory $mediaListBuilderFactory,
+        MediaListRepresentationFactory $mediaListRepresentationFactory,
+        FieldDescriptorFactoryInterface $fieldDescriptorFactory
     ) {
         parent::__construct(
             $viewHandler,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7547 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing all code relating to the optional constructor arguments of the `AccountMediaController`

#### Why?
Less code is better.