### PR TITLE
Deprecate `Permissions::$modules`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,6 +62,11 @@ See also the Symfony Password Upgrade Documentation [here](https://symfony.com/d
 
 </details>
 
+
+### Deprecations
+
+- `Sulu\Bundle\SecurityBundle\Entity\Permission::module` and its setters and getters (define in your own project)
+
 ## 2.6.4
 
 ### Stricter Image Format Url Handling

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Permission.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Permission.php
@@ -46,6 +46,8 @@ class Permission
 
     /**
      * @var string|null
+     *
+     * @deprecated since version 2.6
      */
     #[Expose]
     private $module;
@@ -135,6 +137,8 @@ class Permission
      *
      * @param string $module
      *
+     * @deprecated since version 2.6
+     *
      * @return Permission
      */
     public function setModule($module)
@@ -146,6 +150,8 @@ class Permission
 
     /**
      * Get module.
+     *
+     * @deprecated since version 2.6
      *
      * @return string|null
      */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #5451
| Related issues/PRs | #7547 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Marking the property as deprecated so we can remove it in 3.0

#### Why?
Nobody is using this property.