### PR TITLE
Remove `module` property of permissions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,16 @@ and the parameters
 - `%sulu_website.twig.meta.class%`
 - `%sulu_website.twig.seo.class%`
 
+### Removing "modules" from Permissions
+The unused column on the permissions table has been removed. This also requires some migration on the table, to recreate
+an index:
+
+```sql
+DROP INDEX UNIQ_5CEC3EEAE25D857EC242628A1FA6DDA ON se_permissions;
+ALTER TABLE se_permissions DROP module;
+CREATE UNIQUE INDEX UNIQ_5CEC3EEAE25D857EA1FA6DDA ON se_permissions (context, idRoles);
+```
+
 ### Changed Media Format HTTP Response Headers
 
 Removed `Pragma` & `Expires` HTTP headers, as the `Cache-Control` header is enough.

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -388,7 +388,6 @@ class RoleController extends AbstractRestController implements ClassResourceInte
                 $roleData['permissions'][] = [
                     'id' => $permission->getId(),
                     'context' => $permission->getContext(),
-                    'module' => $permission->getModule(),
                     'permissions' => $this->maskConverter->convertPermissionsToArray($permission->getPermissions()),
                 ];
             }

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Permission.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Permission.php
@@ -45,14 +45,6 @@ class Permission
     private $role;
 
     /**
-     * @var string|null
-     *
-     * @deprecated since version 2.6
-     */
-    #[Expose]
-    private $module;
-
-    /**
      * Set context.
      *
      * @param string $context
@@ -130,34 +122,6 @@ class Permission
     public function getRole()
     {
         return $this->role;
-    }
-
-    /**
-     * Set module.
-     *
-     * @param string $module
-     *
-     * @deprecated since version 2.6
-     *
-     * @return Permission
-     */
-    public function setModule($module)
-    {
-        $this->module = $module;
-
-        return $this;
-    }
-
-    /**
-     * Get module.
-     *
-     * @deprecated since version 2.6
-     *
-     * @return string|null
-     */
-    public function getModule()
-    {
-        return $this->module;
     }
 
     public function __toString()

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Permission.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/Permission.orm.xml
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity name="Sulu\Bundle\SecurityBundle\Entity\Permission" table="se_permissions">
         <unique-constraints>
-            <unique-constraint columns="context,module,idRoles"/>
+            <unique-constraint columns="context,idRoles"/>
         </unique-constraints>
 
         <id name="id" type="integer" column="id">
@@ -12,7 +12,6 @@
         </id>
 
         <field name="context" type="string" column="context" length="191"/>
-        <field name="module" type="string" column="module" nullable="true" length="60"/>
         <field name="permissions" type="smallint" column="permissions"/>
 
         <many-to-one field="role" target-entity="Sulu\Component\Security\Authentication\RoleInterface" inversed-by="permissions">

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
@@ -293,7 +293,6 @@ class RoleControllerTest extends SuluTestCase
                 [
                     'id' => $this->permission1->getId(),
                     'context' => 'portal1',
-                    'module' => null,
                     'permissions' => [
                         'view' => true,
                         'add' => true,
@@ -307,7 +306,6 @@ class RoleControllerTest extends SuluTestCase
                 [
                     'id' => $this->permission2->getId(),
                     'context' => 'portal2',
-                    'module' => null,
                     'permissions' => [
                         'view' => false,
                         'add' => false,
@@ -320,7 +318,6 @@ class RoleControllerTest extends SuluTestCase
                 ],
                 [
                     'context' => 'portal3',
-                    'module' => null,
                     'permissions' => [
                         'view' => false,
                         'add' => false,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7547 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing unused module field.

#### Why?
Less code = less bugs