### PR TITLE
Mark all Sulu Configuration Classes as `final` and `@internal`

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ActivityBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -16,7 +16,10 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal this method is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -15,11 +15,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function __construct(private bool $debug)
     {

--- a/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/DependencyInjection/Configuration.php
@@ -25,9 +25,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration definition of sulu_audience_targeting.
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CategoryBundle/DependencyInjection/Configuration.php
@@ -24,11 +24,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
@@ -40,12 +38,7 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    /**
-     * Adds `objects` section.
-     *
-     * @return void
-     */
-    private function addObjectsSection(ArrayNodeDefinition $node)
+    private function addObjectsSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
@@ -20,9 +20,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -16,11 +16,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/DependencyInjection/Configuration.php
@@ -14,7 +14,10 @@ namespace Sulu\Bundle\DocumentManagerBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/Configuration.php
@@ -14,19 +14,13 @@ namespace Sulu\Bundle\HttpCacheBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
-    /**
-     * @var bool
-     */
-    private $debug;
-
-    /**
-     * @param bool $debug Whether to use the debug mode
-     */
-    public function __construct($debug)
+    public function __construct(private bool $debug)
     {
-        $this->debug = $debug;
     }
 
     public function getConfigTreeBuilder(): TreeBuilder

--- a/src/Sulu/Bundle/LocationBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/LocationBundle/DependencyInjection/Configuration.php
@@ -14,7 +14,10 @@ namespace Sulu\Bundle\LocationBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/MarkupBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MarkupBundle/DependencyInjection/Configuration.php
@@ -14,7 +14,10 @@ namespace Sulu\Bundle\MarkupBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -17,7 +17,10 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public const STORAGE_GOOGLE_CLOUD = 'google_cloud';
 

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/Configuration.php
@@ -14,7 +14,10 @@ namespace Sulu\Bundle\PageBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PersistenceBundle/DependencyInjection/Configuration.php
@@ -15,9 +15,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -17,7 +17,10 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/ReferenceBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -19,9 +19,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * @internal this class should not be used or instanced by project code
+ * @internal this method is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/RouteBundle/DependencyInjection/Configuration.php
@@ -18,9 +18,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Configuration definition of sulu_route.
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -14,7 +14,10 @@ namespace Sulu\Bundle\SearchBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -24,9 +24,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/SnippetBundle/DependencyInjection/Configuration.php
@@ -14,7 +14,10 @@ namespace Sulu\Bundle\SnippetBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/Configuration.php
@@ -17,9 +17,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * Build tree for tag-bundle.
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/Sulu/Bundle/TestBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TestBundle/DependencyInjection/Configuration.php
@@ -15,23 +15,18 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * @internal this method is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_test');
-        $rootNode = $treeBuilder->getRootNode();
-        $rootNode->children()
-            ->booleanNode('enable_test_user_provider')->defaultFalse()->end()
-        ->end();
+        $rootNode = $treeBuilder->getRootNode()
+            ->children()
+                ->booleanNode('enable_test_user_provider')->defaultFalse()->end()
+            ->end();
 
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
         return $treeBuilder;
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/TrashBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -18,14 +18,15 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-class Configuration implements ConfigurationInterface
+/**
+ * @internal this is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sulu_trash');
         $rootNode = $treeBuilder->getRootNode();
-        $rootNode->children()
-        ->end();
 
         $this->addObjectsSection($rootNode);
 

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -18,11 +18,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files.
- *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * @internal is not part of the public API and should only be called by the Symfony framework classes
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Marking all Configuration Classes as `final` and `@internal`

#### Why?
They are not supposed to be reused or extended or modified in any way. So let the code reflect that.