### PR TITLE
Make media and snippet bundle independent from reference and activity bundle

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
+++ b/src/Sulu/Bundle/MediaBundle/Admin/MediaAdmin.php
@@ -48,8 +48,8 @@ class MediaAdmin extends Admin
         private LocalizationManagerInterface $localizationManager,
         private UrlGeneratorInterface $urlGenerator,
         private WebspaceManagerInterface $webspaceManager,
-        private ActivityViewBuilderFactoryInterface $activityViewBuilderFactory,
-        private ReferenceViewBuilderFactoryInterface $referenceViewBuilderFactory
+        private ?ActivityViewBuilderFactoryInterface $activityViewBuilderFactory,
+        private ?ReferenceViewBuilderFactoryInterface $referenceViewBuilderFactory
     ) {
     }
 
@@ -131,7 +131,7 @@ class MediaAdmin extends Admin
                     ->setParent(static::EDIT_FORM_VIEW)
             );
 
-            if ($this->activityViewBuilderFactory->hasActivityListPermission() || $this->referenceViewBuilderFactory->hasReferenceListPermission()) {
+            if ($this->activityViewBuilderFactory?->hasActivityListPermission() || $this->referenceViewBuilderFactory?->hasReferenceListPermission()) {
                 $insightsResourceTabViewName = MediaAdmin::EDIT_FORM_VIEW . '.insights';
 
                 $viewCollection->add(
@@ -144,7 +144,7 @@ class MediaAdmin extends Admin
                         ->setParent(MediaAdmin::EDIT_FORM_VIEW)
                 );
 
-                if ($this->activityViewBuilderFactory->hasActivityListPermission()) {
+                if ($this->activityViewBuilderFactory?->hasActivityListPermission()) {
                     $viewCollection->add(
                         $this->activityViewBuilderFactory
                             ->createActivityListViewBuilder(
@@ -156,7 +156,7 @@ class MediaAdmin extends Admin
                     );
                 }
 
-                if ($this->referenceViewBuilderFactory->hasReferenceListPermission()) {
+                if ($this->referenceViewBuilderFactory?->hasReferenceListPermission()) {
                     $viewCollection->add(
                         $this->referenceViewBuilderFactory
                             ->createReferenceListViewBuilder(

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -163,8 +163,8 @@
             <argument type="service" id="sulu.core.localization_manager"/>
             <argument type="service" id="router"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
-            <argument type="service" id="sulu_activity.activity_list_view_builder_factory" />
-            <argument type="service" id="sulu_reference.reference_list_view_builder_factory" />
+            <argument type="service" id="sulu_activity.activity_list_view_builder_factory" on-invalid="null" />
+            <argument type="service" id="sulu_reference.reference_list_view_builder_factory" on-invalid="null" />
         </service>
         <service id="sulu_media.collection_repository" class="%sulu_media.collection_repository.class%" public="true">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>

--- a/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
+++ b/src/Sulu/Bundle/SnippetBundle/Admin/SnippetAdmin.php
@@ -60,8 +60,8 @@ class SnippetAdmin extends Admin
         private SecurityCheckerInterface $securityChecker,
         private WebspaceManagerInterface $webspaceManager,
         private $defaultEnabled,
-        private ActivityViewBuilderFactoryInterface $activityViewBuilderFactory,
-        private ReferenceViewBuilderFactoryInterface $referenceViewBuilderFactory
+        private ?ActivityViewBuilderFactoryInterface $activityViewBuilderFactory,
+        private ?ReferenceViewBuilderFactoryInterface $referenceViewBuilderFactory,
     ) {
     }
 
@@ -190,7 +190,7 @@ class SnippetAdmin extends Admin
             );
         }
 
-        if (($this->activityViewBuilderFactory->hasActivityListPermission() || $this->referenceViewBuilderFactory->hasReferenceListPermission()) && $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+        if (($this->activityViewBuilderFactory?->hasActivityListPermission() || $this->referenceViewBuilderFactory?->hasReferenceListPermission()) && $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
             $insightsResourceTabViewName = SnippetAdmin::EDIT_FORM_VIEW . '.insights';
 
             $viewCollection->add(
@@ -203,7 +203,7 @@ class SnippetAdmin extends Admin
                     ->setParent(SnippetAdmin::EDIT_FORM_VIEW)
             );
 
-            if ($this->activityViewBuilderFactory->hasActivityListPermission()) {
+            if ($this->activityViewBuilderFactory?->hasActivityListPermission()) {
                 $viewCollection->add(
                     $this->activityViewBuilderFactory
                         ->createActivityListViewBuilder(
@@ -215,7 +215,7 @@ class SnippetAdmin extends Admin
                 );
             }
 
-            if ($this->referenceViewBuilderFactory->hasReferenceListPermission()) {
+            if ($this->referenceViewBuilderFactory?->hasReferenceListPermission()) {
                 $viewCollection->add(
                     $this->referenceViewBuilderFactory
                         ->createReferenceListViewBuilder(

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/admin.xml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/admin.xml
@@ -8,8 +8,8 @@
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument>%sulu_snippet.content-type.default_enabled%</argument>
-            <argument type="service" id="sulu_activity.activity_list_view_builder_factory" />
-            <argument type="service" id="sulu_reference.reference_list_view_builder_factory" />
+            <argument type="service" id="sulu_activity.activity_list_view_builder_factory" on-invalid="null" />
+            <argument type="service" id="sulu_reference.reference_list_view_builder_factory" on-invalid="null" />
 
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Make media and snippet bundle indipendent from reference and activity bundle.

#### Why?

Step by step avoid requirements between bundles. We should think about where the draw lines between the bundles:

https://excalidraw.com/#json=jOoK1pHMK29JLYmYZGSSE,jdCCbrSCEZEUQLJoLWmmWA