### PR TITLE
Add error output to the phpcr cleanup command

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -183,6 +183,11 @@ class PHPCRCleanupCommand extends Command
                 if (0 !== $status) {
                     ++$stats['erroredNodes'];
                     $erroredUuids[$uuid] = $process->getErrorOutput();
+                    $this->logger->writeln(\sprintf(
+                        "# Error processing node '%s'\n\n%s\n",
+                        $uuid,
+                        $process->getErrorOutput(),
+                    ));
 
                     continue;
                 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -67,18 +68,7 @@ class PHPCRCleanupCommand extends Command
         if (!$dryRun) {
             $io->warning('This command will remove properties from the PHPCR repository. Make sure to have a backup before running this command.');
             if (!$input->getOption('force')) {
-                $answer = $io->ask('Do you want to continue [y/n]', null, function(?string $value) {
-                    if (null === $value) {
-                        return false;
-                    }
-
-                    $value = \strtolower($value);
-                    if (!\in_array($value, ['y', 'n'], true)) {
-                        throw new \RuntimeException('You need to enter "y" to continue or "n" to abort.');
-                    }
-
-                    return 'y' === $value;
-                });
+                $answer = $io->askQuestion(new ConfirmationQuestion('Do you want to continue?'));
 
                 if (!$answer) {
                     $io->warning('You have aborted the command');
@@ -192,20 +182,20 @@ class PHPCRCleanupCommand extends Command
                 }
                 if (0 !== $status) {
                     ++$stats['erroredNodes'];
-                    $erroredUuids[] = $uuid;
+                    $erroredUuids[$uuid] = $process->getErrorOutput();
 
                     continue;
                 }
 
-                $output = $process->getOutput();
-                \preg_match('/Documents: (\d+)/', $output, $matches);
+                $subCommandOutput = $process->getOutput();
+                \preg_match('/Documents: (\d+)/', $subCommandOutput, $matches);
                 $stats['documents'] += (int) ($matches[1] ?? 0);
-                \preg_match('/Removed properties: (\d+)/', $output, $matches);
+                \preg_match('/Removed properties: (\d+)/', $subCommandOutput, $matches);
                 $stats['removedProperties'] += (int) ($matches[1] ?? 0);
-                \preg_match('/Total properties: (\d+)/', $output, $matches);
+                \preg_match('/Total properties: (\d+)/', $subCommandOutput, $matches);
                 $stats['properties'] += (int) ($matches[1] ?? 0);
 
-                $this->logger->writeln($output);
+                $this->logger->writeln($subCommandOutput);
 
                 $progressBar->setMessage((string) $stats['nodes'], 'nodes');
                 $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
@@ -222,10 +212,7 @@ class PHPCRCleanupCommand extends Command
         $progressBar->finish();
         $io->success('Cleanup process finished');
 
-        if (0 < \count($erroredUuids)) {
-            $io->section('Following nodes are errored');
-            $io->listing($erroredUuids);
-        }
+        $this->printErroredNodes($erroredUuids, $io, $output->isVerbose());
 
         if (0 < \count($ignoredUuids)) {
             $io->section('Following nodes are ignored');
@@ -252,5 +239,26 @@ class PHPCRCleanupCommand extends Command
         $process->setTimeout(120);
 
         return $process;
+    }
+
+    /**
+     * @param array<string, string> $errors
+     */
+    private function printErroredNodes(array $errors, SymfonyStyle $io, bool $verbose): void
+    {
+        if ([] === $errors) {
+            return;
+        }
+
+        $io->section('Following nodes are errored');
+        if ($verbose) {
+            foreach ($errors as $uuid => $errorMessage) {
+                $io->error($uuid);
+                $io->writeln($errorMessage);
+            }
+        } else {
+            $io->listing(\array_keys($errors));
+            $io->note('To get more info about the errors rerun the command with the -v flag');
+        }
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -155,6 +155,8 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
                 $this->documentManager->clear();
             } catch (\Exception $e) {
+                \fwrite(\STDERR, (string) $e);
+
                 return self::INVALID;
             }
 
@@ -243,7 +245,11 @@ class PHPCRCleanupSingleNodeCommand extends Command
             yield true;
         }
 
-        $this->logger->writeln(\sprintf("Removed:\n* %s\n", \implode("\n* ", $removedProperties)));
+        if ([] !== $removedProperties) {
+            $this->logger->writeln(\sprintf("Removed properties:\n* %s\n", \implode("\n* ", $removedProperties)));
+        } else {
+            $this->logger->writeln("No properties to remove.\n");
+        }
     }
 
     private function getOptionsResolver(string $eventName): OptionsResolver


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
* Adding error output to the `sulu:document:phpcr-cleanup -v` command so that the user can see what went wrong.
* Replacing the Confirmation question with a Symfony Confirmation question.
![image](https://github.com/user-attachments/assets/da67dbf8-7c33-4fdf-a41e-cb364cd1c587)
* Writing an error output of the single node clean command (right now it's just being caught and ignored)


#### Why?
* Depending on the kind of error maybe re-running the command might help. Or further investigations need to be done.
* Changing the default of the "do you want to do this" to yes:
    * makes it usable in scripts
    * you can now use the `-n` flag to skip the prompt
    * if you answer no, why did you call the command in the first place?

#### Example Usage

````
bin/console sulu:document:phpcr-cleanup
```
Same output as before. Just a list of ids.


````
bin/console sulu:document:phpcr-cleanup -v
```
Returns a list of ids and their error output. Maybe this should be redirected to a file then.