### PR TITLE
Requiring correct http methods on `AdminController`

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
@@ -10,13 +10,13 @@ sulu_admin.config:
 
 sulu_admin.metadata:
     path: /metadata/{type}/{key}
-    methods: 'GET'
+    methods: ['GET', 'OPTIONS']
     defaults:
         _controller: sulu_admin.admin_controller::metadataAction
 
 sulu_admin.translation:
     path: /translations
-    methods: 'GET'
+    methods: ['GET', 'OPTIONS']
     defaults:
         _controller: sulu_admin.admin_controller::translationsAction
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/routing.yml
@@ -10,11 +10,13 @@ sulu_admin.config:
 
 sulu_admin.metadata:
     path: /metadata/{type}/{key}
+    methods: 'GET'
     defaults:
         _controller: sulu_admin.admin_controller::metadataAction
 
 sulu_admin.translation:
     path: /translations
+    methods: 'GET'
     defaults:
         _controller: sulu_admin.admin_controller::translationsAction
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | technically yes
| Deprecations? | -
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
The `metadata` and the `translations` endpoints never accept any data so calling them with anything other than a get would not make sense. Let's also enforce that.

#### Why?
This makes it clear to the caller of the API that this endpoint only returns data.

In the long run those should be moved to their own controller classes.