### PR TITLE
Adopt JS tools stylelint, depcruise, styleguidist to include new packages directory

### DIFF
--- a/dependency-cruiser.json
+++ b/dependency-cruiser.json
@@ -3,67 +3,67 @@
         {
             "name": "components-not-to-containers",
             "severity": "error",
-            "from": {"path": "Resources/js/components"},
+            "from": {"path": "js/components"},
             "to": {"path": "containers"}
         },
         {
             "name": "components-not-to-services",
             "severity": "error",
-            "from": {"path": "Resources/js/components"},
+            "from": {"path": "js/components"},
             "to": {"path": "services"}
         },
         {
             "name": "components-not-to-stores",
             "severity": "error",
-            "from": {"path": "Resources/js/components"},
+            "from": {"path": "js/components"},
             "to": {"path": "stores"}
         },
         {
             "name": "components-not-to-views",
             "severity": "error",
-            "from": {"path": "Resources/js/components"},
+            "from": {"path": "js/components"},
             "to": {"path": "views"}
         },
         {
             "name": "containers-not-to-views",
             "severity": "error",
-            "from": {"path": "Resources/js/containers"},
+            "from": {"path": "js/containers"},
             "to": {"path": "views"}
         },
         {
             "name": "services-not-to-components",
             "severity": "error",
-            "from": {"path": "Resources/js/services"},
+            "from": {"path": "js/services"},
             "to": {"path": "components"}
         },
         {
             "name": "services-not-to-containers",
             "severity": "error",
-            "from": {"path": "Resources/js/services"},
+            "from": {"path": "js/services"},
             "to": {"path": "containers"}
         },
         {
             "name": "services-not-to-views",
             "severity": "error",
-            "from": {"path": "Resources/js/services"},
+            "from": {"path": "js/services"},
             "to": {"path": "views"}
         },
         {
             "name": "stores-not-to-components",
             "severity": "error",
-            "from": {"path": "Resources/js/stores"},
+            "from": {"path": "js/stores"},
             "to": {"path": "components"}
         },
         {
             "name": "stores-not-to-containers",
             "severity": "error",
-            "from": {"path": "Resources/js/stores"},
+            "from": {"path": "js/stores"},
             "to": {"path": "containers"}
         },
         {
             "name": "stores-not-to-views",
             "severity": "error",
-            "from": {"path": "Resources/js/stores"},
+            "from": {"path": "js/stores"},
             "to": {"path": "views"}
         },
         {
@@ -71,6 +71,12 @@
             "severity": "error",
             "from": {"path": "src/Sulu/Bundle/AdminBundle/Resources/js"},
             "to": {"path": "src\\/Sulu\\/Bundle\\/(?!AdminBundle)(.*)Bundle\\/Resources\\/js"}
+        },
+        {
+            "name": "sulu-admin-bundle-not-to-other-sulu-bundles-2",
+            "severity": "error",
+            "from": {"path": "src/Sulu/Bundle/AdminBundle/Resources/js"},
+            "to": {"path": "packages\\/(?!admin)(.*)\\/assets\\/js"}
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "scripts": {
         "preinstall": "node preinstall.js",
         "lint:js": "eslint . --cache",
-        "lint:scss": "stylelint src/Sulu/Bundle/*/Resources/js/**/*.scss",
+        "lint:scss": "stylelint src/Sulu/Bundle/*/Resources/js/**/*.scss packages/*/assets/js/**/*.scss",
         "flow": "flow",
         "test": "jest",
-        "depcruise": "depcruise src/Sulu/Bundle/*/Resources/js -c dependency-cruiser.json",
+        "depcruise": "depcruise src/Sulu/Bundle/*/Resources/js packages/*/assets/js -c dependency-cruiser.json",
         "styleguide": "styleguidist server",
         "styleguide:build": "styleguidist build",
         "build": "webpack --mode production",

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -47,7 +47,7 @@ module.exports = { // eslint-disable-line
         {
             name: 'Views',
             sections: (function() {
-                const folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/views/*');
+                const folders = glob.sync('./{src/Sulu/Bundle/*/Resources,packages/*/assets}/js/views/*');
 
                 return folders
                     .filter((folder) => path.basename(folder) !== 'index.js')
@@ -61,7 +61,7 @@ module.exports = { // eslint-disable-line
         {
             name: 'Services',
             sections: (function() {
-                const folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/services/*');
+                const folders = glob.sync('./{src/Sulu/Bundle/*/Resources,packages/*/assets}/js/services/*');
 
                 return folders
                     .filter((folder) => path.basename(folder) !== 'index.js')
@@ -77,7 +77,7 @@ module.exports = { // eslint-disable-line
         {
             name: 'Containers',
             components() {
-                let folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/containers/*');
+                let folders = glob.sync('./{src/Sulu/Bundle/*/Resources,packages/*/assets}/js/containers/*');
                 // filter out containers
                 folders = folders
                     .filter((folder) => firstLetterIsUppercase(path.basename(folder)))
@@ -94,7 +94,7 @@ module.exports = { // eslint-disable-line
         {
             name: 'Higher-Order components',
             sections: (function() {
-                let folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/components/*');
+                let folders = glob.sync('./{src/Sulu/Bundle/*/Resources,packages/*/assets}/js/components/*');
                 folders = folders.filter((folder) => !firstLetterIsUppercase(path.basename(folder)));
 
                 return folders
@@ -110,7 +110,7 @@ module.exports = { // eslint-disable-line
         {
             name: 'Components',
             components() {
-                let folders = glob.sync('./src/Sulu/Bundle/*/Resources/js/components/*');
+                let folders = glob.sync('./{src/Sulu/Bundle/*/Resources,packages/*/assets}/js/components/*');
                 // filter out higher order components
                 folders = folders
                     .filter((folder) => firstLetterIsUppercase(path.basename(folder)))


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7672
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adopt stylelint, depcruise and styleguidist to include new packages directory.

#### Why?

The `Snippet` package has JS and we require to add validation for that.

#### Todo

 - [x] Tests (work out of box)
 - [x] Flow (work out of box)
 - [x] Depcruise: updated
 - [x] dependency-cruiser.json
 - [x] Stylelint: updated
 - [x] Styleguidist