### PR TITLE
Update phpstan baseline after release of PHPStan 2.1.5 and PHPStan-Prophecy extension 2.1.0

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29173,27 +29173,9 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/FileVersionPublishLanguage.php
 
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
 			message: '#^Binary operation "\." between ''entity\.'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Binary operation "\." between mixed and ''\.files'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Binary operation "\." between mixed and ''\.type'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
 		-
@@ -29205,108 +29187,6 @@ parameters:
 		-
 			message: '#^Default value of the parameter \#6 \$options \(array\{\}\) of method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:findByFilters\(\) is incompatible with type array\{webspaceKey\?\: string, locale\: string\}\.$#'
 			identifier: parameter.defaultValue
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:append\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:append\(\) has parameter \$alias with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:append\(\) has parameter \$locale with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:append\(\) has parameter \$options with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendCategoriesRelation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendCategoriesRelation\(\) has parameter \$alias with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendDatasource\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendDatasource\(\) has parameter \$alias with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendDatasource\(\) has parameter \$datasource with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendDatasource\(\) has parameter \$includeSubFolders with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendSortByJoins\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendSortByJoins\(\) has parameter \$alias with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendSortByJoins\(\) has parameter \$locale with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendTagsRelation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendTagsRelation\(\) has parameter \$alias with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendTargetGroupRelation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendTargetGroupRelation\(\) has parameter \$alias with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
@@ -29341,15 +29221,15 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
 		-
-			message: '#^Parameter \#1 \$haystack of function strpos expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$datasource of method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendDatasource\(\) expects int\|string, mixed given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
 		-
-			message: '#^Parameter \#1 \$key of method Doctrine\\ORM\\AbstractQuery\<null,mixed\>\:\:setParameter\(\) expects int\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$haystack of function strpos expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
 		-
@@ -29371,21 +29251,9 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
 		-
-			message: '#^Parameter \#1 \.\.\.\$arrays of function array_merge expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
 			message: '#^Parameter \#10 \$permission of method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:parentFindByFilters\(\) expects int\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 2
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
 		-
@@ -29395,21 +29263,9 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
 		-
-			message: '#^Parameter \#2 \$relation of method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendRelation\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 5
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
 			message: '#^Parameter \#2 \$sortMethod of method Sulu\\Bundle\\MediaBundle\\Entity\\MediaDataProviderRepository\:\:appendSortBy\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
-
-		-
-			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -86719,12 +86719,6 @@ parameters:
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
 
 		-
-			message: '#^Call to an undefined method Sulu\\Component\\Persistence\\Tests\\Unit\\EventSubscriber\\ORM\\MetadataSubscriberTest\:\:reveal\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
-
-		-
 			message: '#^Cannot call method shouldNotBeCalled\(\) on Prophecy\\Prophecy\\MethodProphecy\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -86749,12 +86743,6 @@ parameters:
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
 
 		-
-			message: '#^Parameter \#1 \$object of function get_class expects object, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
-
-		-
 			message: '#^Parameter \#2 \$metadata of method Doctrine\\Persistence\\Mapping\\Driver\\MappingDriver\:\:loadMetadataForClass\(\) expects Doctrine\\Persistence\\Mapping\\ClassMetadata\<stdClass\>, Prophecy\\Argument\\Token\\TypeToken given\.$#'
 			identifier: argument.type
 			count: 1
@@ -86763,12 +86751,6 @@ parameters:
 		-
 			message: '#^Property Sulu\\Component\\Persistence\\Tests\\Unit\\EventSubscriber\\ORM\\MetadataSubscriberTest\:\:\$classMetadata with generic class Doctrine\\ORM\\Mapping\\ClassMetadata does not specify its types\: T$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
-
-		-
-			message: '#^Property Sulu\\Component\\Persistence\\Tests\\Unit\\EventSubscriber\\ORM\\MetadataSubscriberTest\:\:\$object \(Prophecy\\Prophecy\\ObjectProphecy\<stdClass\>\) does not accept \$this\(Sulu\\Component\\Persistence\\Tests\\Unit\\EventSubscriber\\ORM\\MetadataSubscriberTest\)\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
@@ -120,6 +120,15 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
             ->setParameter('locale', $locale);
     }
 
+    /**
+     * Append additional condition to query builder for "findByFilters" function.
+     *
+     * @param string $alias
+     * @param string $locale
+     * @param mixed[] $options
+     *
+     * @return array<string, int|string|int[]|string[]> parameters for query
+     */
     protected function append(QueryBuilder $queryBuilder, $alias, $locale, $options = [])
     {
         $parameter = [];
@@ -138,9 +147,17 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
             $parameter['type'] = $options['type'];
         }
 
+        /** @var array<string, string> */
         return $parameter;
     }
 
+    /**
+     * Extension point to append relations to tag relation if it is not direct linked.
+     *
+     * @param string $alias
+     *
+     * @return string field path to tag relation
+     */
     protected function appendTagsRelation(QueryBuilder $queryBuilder, $alias)
     {
         $queryBuilder
@@ -150,16 +167,39 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
         return 'fileVersion.tags';
     }
 
+    /**
+     * Extension point to append relations to category relation if it is not direct linked.
+     *
+     * @param string $alias
+     *
+     * @return string field path to category relation
+     */
     protected function appendCategoriesRelation(QueryBuilder $queryBuilder, $alias)
     {
         return 'fileVersion.categories';
     }
 
+    /**
+     * Extension point to append relations to target group relation if it is not direct linked.
+     *
+     * @param string $alias
+     *
+     * @return string
+     */
     protected function appendTargetGroupRelation(QueryBuilder $queryBuilder, $alias)
     {
         return 'fileVersion.targetGroups';
     }
 
+    /**
+     * Extension point to append datasource.
+     *
+     * @param int|string $datasource
+     * @param bool $includeSubFolders
+     * @param string $alias
+     *
+     * @return array<string, int|string|int[]|string[]> parameters for query
+     */
     protected function appendDatasource($datasource, $includeSubFolders, QueryBuilder $queryBuilder, $alias)
     {
         if (!$includeSubFolders) {
@@ -178,6 +218,14 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
         return ['collectionId' => $datasource];
     }
 
+    /**
+     * Append joins to query builder for "findByFilters" function specially for sort-by.
+     *
+     * @param string $alias
+     * @param string $locale
+     *
+     * @return void
+     */
     protected function appendSortByJoins(QueryBuilder $queryBuilder, $alias, $locale)
     {
         $queryBuilder


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Update phsptan baseline after release of PHPStan 2.1.5 and PHPStan-Prophecy extension 2.1.0

#### Why?

The current verisons 2.1.3 and 2.1.4 of phpstan where broken and returned issues which weren't the release of PHPStan 2.1.5 fixes this issue and helped make the prophecy extension more 