### PR TITLE
Replace `$request->request` with `$request->getPayload()`.

### DIFF
--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -205,7 +205,7 @@ final class ArticleController
     private function getData(Request $request): array
     {
         return \array_replace(
-            $request->request->all(),
+            $request->getPayload()->all(),
             [
                 'locale' => $this->getLocale($request),
             ]

--- a/packages/content/tests/Application/ExampleTestBundle/Controller/ExampleController.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Controller/ExampleController.php
@@ -318,9 +318,7 @@ class ExampleController extends AbstractRestController implements ClassResourceI
      */
     protected function getData(Request $request): array
     {
-        $data = $request->request->all();
-
-        return $data;
+        return $request->getPayload()->all();
     }
 
     /**

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -205,7 +205,7 @@ final class SnippetController
     private function getData(Request $request): array
     {
         return \array_replace(
-            $request->request->all(),
+            $request->getPayload()->all(),
             [
                 'locale' => $this->getLocale($request),
             ]

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -434,7 +434,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
 
             $account = $this->doPost($request);
             $this->entityManager->persist($account);
-            $this->domainEventCollector->collect(new AccountCreatedEvent($account, $request->request->all()));
+            $this->domainEventCollector->collect(new AccountCreatedEvent($account, $request->getPayload()->all()));
             $this->entityManager->flush();
 
             $locale = $this->getUser()->getLocale();
@@ -487,7 +487,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
         $account->setChanger($this->getUser());
 
         // Add urls, phones, emails, tags, bankAccounts, notes, addresses,..
-        $this->accountManager->addNewContactRelations($account, $request->request->all());
+        $this->accountManager->addNewContactRelations($account, $request->getPayload()->all());
 
         return $account;
     }
@@ -511,7 +511,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
             } else {
                 $this->doPut($account, $request, $this->entityManager);
 
-                $this->domainEventCollector->collect(new AccountModifiedEvent($account, $request->request->all()));
+                $this->domainEventCollector->collect(new AccountModifiedEvent($account, $request->getPayload()->all()));
                 $this->entityManager->flush();
 
                 // get api entity
@@ -688,7 +688,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
         $account->setMainContact($mainContact);
 
         if ($accountModified) {
-            $this->domainEventCollector->collect(new AccountModifiedEvent($account, $request->request->all()));
+            $this->domainEventCollector->collect(new AccountModifiedEvent($account, $request->getPayload()->all()));
         }
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -341,7 +341,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
         try {
             $this->checkArguments($request);
             $contact = $this->contactManager->save(
-                $request->request->all()
+                $request->getPayload()->all()
             );
             $apiContact = $this->contactManager->getContact(
                 $contact,
@@ -370,7 +370,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
     public function putAction($id, Request $request)
     {
         try {
-            $contact = $this->contactManager->save($request->request->all(), $id);
+            $contact = $this->contactManager->save($request->getPayload()->all(), $id);
 
             $apiContact = $this->contactManager->getContact($contact, $this->getUser()->getLocale());
             $view = $this->view($apiContact, 200);
@@ -397,7 +397,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
     {
         try {
             $contact = $this->contactManager->save(
-                $request->request->all(),
+                $request->getPayload()->all(),
                 $id,
                 true
             );

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
@@ -103,7 +103,7 @@ class ContactTitleController extends AbstractRestController implements ClassReso
             $this->entityManager->persist($title);
 
             $this->domainEventCollector->collect(
-                new ContactTitleCreatedEvent($title, $request->request->all())
+                new ContactTitleCreatedEvent($title, $request->getPayload()->all())
             );
 
             $this->entityManager->flush();
@@ -142,7 +142,7 @@ class ContactTitleController extends AbstractRestController implements ClassReso
                     $title->setTitle($name);
 
                     $this->domainEventCollector->collect(
-                        new ContactTitleModifiedEvent($title, $request->request->all())
+                        new ContactTitleModifiedEvent($title, $request->getPayload()->all())
                     );
 
                     $this->entityManager->flush();

--- a/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
@@ -110,7 +110,7 @@ class PositionController extends AbstractRestController implements ClassResource
             $this->entityManager->persist($position);
 
             $this->domainEventCollector->collect(
-                new ContactPositionCreatedEvent($position, $request->request->all())
+                new ContactPositionCreatedEvent($position, $request->getPayload()->all())
             );
 
             $this->entityManager->flush();
@@ -149,7 +149,7 @@ class PositionController extends AbstractRestController implements ClassResource
                     $position->setPosition($name);
 
                     $this->domainEventCollector->collect(
-                        new ContactPositionModifiedEvent($position, $request->request->all())
+                        new ContactPositionModifiedEvent($position, $request->getPayload()->all())
                     );
 
                     $this->entityManager->flush();

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -108,7 +108,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                         'serialize_null' => true,
                     ],
                     'body_listener' => [
-                        'enabled' => true,
+                        'enabled' => false,
                     ],
                     'routing_loader' => false,
                     'view' => [

--- a/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
@@ -101,7 +101,7 @@ class CustomUrlController extends AbstractRestController implements SecuredContr
 
         $document = $this->customUrlManager->create(
             $webspace,
-            $request->request->all()
+            $request->getPayload()->all()
         );
         $this->documentManager->flush();
 
@@ -123,7 +123,7 @@ class CustomUrlController extends AbstractRestController implements SecuredContr
     {
         $manager = $this->customUrlManager;
 
-        $document = $manager->save($id, $request->request->all());
+        $document = $manager->save($id, $request->getPayload()->all());
         $this->documentManager->flush();
 
         $context = new Context();

--- a/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
@@ -27,7 +27,7 @@ abstract class AbstractMediaController extends AbstractRestController
      */
     protected function getData(Request $request, $fallback = true)
     {
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
         $data['locale'] = $request->get('locale', $fallback ? $this->getLocale($request) : null);
         $data['collection'] = $request->get('collection');
         $data['contentLanguages'] = $request->get('contentLanguages', []);

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
@@ -60,9 +60,9 @@ class MediaFormatController extends AbstractRestController implements ClassResou
      */
     public function putAction($id, $key, Request $request)
     {
-        $options = $request->request->all();
+        $options = $request->getPayload()->all();
 
-        if (empty($options)) {
+        if ([] === $options) {
             $this->formatOptionsManager->delete($id, $key);
         } else {
             $this->formatOptionsManager->save($id, $key, $options);
@@ -81,8 +81,7 @@ class MediaFormatController extends AbstractRestController implements ClassResou
      */
     public function cpatchAction($id, Request $request)
     {
-        $formatOptions = $request->request->all();
-        foreach ($formatOptions as $formatKey => $formatOption) {
+        foreach ($request->getPayload() as $formatKey => $formatOption) {
             if (empty($formatOption)) {
                 $this->formatOptionsManager->delete($id, $formatKey);
                 continue;

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -505,7 +505,7 @@ class PageController extends AbstractRestController implements ClassResourceInte
 
     private function persistDocument(Request $request, $formType, $document, $locale): void
     {
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
 
         if ($request->query->has('parentId')) {
             $data['parent'] = $request->query->get('parentId');

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -92,7 +92,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $currentRequest = $this->requestStack->getCurrentRequest();
         if (null !== $currentRequest) {
             $query = $currentRequest->query->all();
-            $request = $currentRequest->request->all();
+            $request = $currentRequest->getPayload()->all();
         }
 
         $attributes = $this->routeDefaultsProvider->getByEntity(\get_class($object), $id, $locale, $object);

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
@@ -80,12 +80,13 @@ class ProfileController implements ClassResourceInterface
         $user = $this->tokenStorage->getToken()->getUser();
         $this->userManager->save($this->getData($request), $request->get('locale'), $user->getId(), true);
 
-        $user->setFirstName($request->request->get('firstName'));
-        $user->setLastName($request->request->get('lastName'));
+        $payload = $request->getPayload();
+        $user->setFirstName($payload->get('firstName'));
+        $user->setLastName($payload->get('lastName'));
 
         if ($user instanceof TwoFactorInterface) {
             /** @var array{method?: string|null} $twoFactorData */
-            $twoFactorData = $request->request->all('twoFactor');
+            $twoFactorData = $payload->all('twoFactor');
             $twoFactorMethod = $twoFactorData['method'] ?? null;
 
             if ($twoFactorMethod) {
@@ -124,13 +125,11 @@ class ProfileController implements ClassResourceInterface
      */
     public function patchSettingsAction(Request $request)
     {
-        $settings = $request->request->all();
-
         try {
             /** @var User $user */
             $user = $this->tokenStorage->getToken()->getUser();
 
-            foreach ($settings as $settingKey => $settingValue) {
+            foreach ($request->getPayload() as $settingKey => $settingValue) {
                 // get setting
                 // TODO: move this logic into own service (UserSettingManager?)
                 $setting = $this->userSettingRepository->findOneBy(['user' => $user, 'key' => $settingKey]);
@@ -223,7 +222,7 @@ class ProfileController implements ClassResourceInterface
     {
         $data = [];
 
-        foreach ($request->request->all() as $key => $value) {
+        foreach ($request->getPayload() as $key => $value) {
             if (\in_array($key, ['firstName', 'lastName', 'username', 'email', 'password', 'locale'], true)) {
                 $data[$key] = $value;
             }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -154,9 +154,10 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      */
     public function postAction(Request $request)
     {
-        $name = $request->request->get('name');
-        $key = $request->request->get('key');
-        $system = $request->request->get('system');
+        $payload = $request->getPayload();
+        $name = $payload->get('name');
+        $key = $payload->get('key');
+        $system = $payload->get('system');
 
         try {
             if (null === $name) {
@@ -172,7 +173,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
             $role->setKey($key);
             $role->setSystem($system);
 
-            $permissions = $request->request->all('permissions');
+            $permissions = $payload->all('permissions');
 
             if (!empty($permissions)) {
                 foreach ($permissions as $permissionData) {
@@ -180,14 +181,14 @@ class RoleController extends AbstractRestController implements ClassResourceInte
                 }
             }
 
-            $securityTypeData = $request->request->all('securityType');
+            $securityTypeData = $payload->all('securityType');
             if ($this->checkSecurityTypeData($securityTypeData)) {
                 $this->setSecurityType($role, $securityTypeData);
             }
 
             try {
                 $this->entityManager->persist($role);
-                $this->eventCollector->collect(new RoleCreatedEvent($role, $request->request->all()));
+                $this->eventCollector->collect(new RoleCreatedEvent($role, $payload->all()));
                 $this->entityManager->flush();
 
                 $view = $this->view($this->convertRole($role), 200);
@@ -214,9 +215,10 @@ class RoleController extends AbstractRestController implements ClassResourceInte
     {
         /** @var RoleInterface $role */
         $role = $this->roleRepository->findRoleById($id);
-        $name = $request->request->get('name');
-        $key = $request->request->get('key');
-        $system = $request->request->get('system');
+        $payload = $request->getPayload();
+        $name = $payload->get('name');
+        $key = $payload->get('key');
+        $system = $payload->get('system');
 
         try {
             if (!$role) {
@@ -226,18 +228,18 @@ class RoleController extends AbstractRestController implements ClassResourceInte
                 $role->setKey($key);
                 $role->setSystem($system);
 
-                if (!$this->processPermissions($role, $request->request->all('permissions'))) {
+                if (!$this->processPermissions($role, $payload->all('permissions'))) {
                     throw new RestException('Could not update dependencies!');
                 }
 
-                $securityTypeData = $request->request->all('securityType');
+                $securityTypeData = $payload->all('securityType');
                 if ($this->checkSecurityTypeData($securityTypeData)) {
                     $this->setSecurityType($role, $securityTypeData);
                 } else {
                     $role->setSecurityType(null);
                 }
 
-                $this->eventCollector->collect(new RoleModifiedEvent($role, $request->request->all()));
+                $this->eventCollector->collect(new RoleModifiedEvent($role, $payload->all()));
                 $this->entityManager->flush();
                 $view = $this->view($this->convertRole($role), 200);
             }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -127,7 +127,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
         try {
             $this->checkArguments($request);
             $locale = $this->getRequestParameter($request, 'locale', true);
-            $data = $request->request->all();
+            $data = $request->getPayload()->all();
             $data['contactId'] = $request->query->get('contactId');
             $user = $this->userManager->save($data, $locale);
             $view = $this->view($user, 200);
@@ -182,7 +182,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
         try {
             $this->checkArguments($request);
             $locale = $this->getRequestParameter($request, 'locale', true);
-            $user = $this->userManager->save($request->request->all(), $locale, $id);
+            $user = $this->userManager->save($request->getPayload()->all(), $locale, $id);
             $view = $this->view($user, 200);
         } catch (EntityNotFoundException $exc) {
             $view = $this->view($exc->toArray(), 404);
@@ -206,7 +206,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
     {
         try {
             $locale = $this->getRequestParameter($request, 'locale');
-            $user = $this->userManager->save($request->request->all(), $locale, $id, true);
+            $user = $this->userManager->save($request->getPayload()->all(), $locale, $id, true);
             $view = $this->view($user, 200);
         } catch (EntityNotFoundException $exc) {
             $view = $this->view($exc->toArray(), 404);
@@ -243,16 +243,18 @@ class UserController extends AbstractRestController implements ClassResourceInte
     // https://github.com/sulu-io/sulu/issues/1136
     private function checkArguments(Request $request)
     {
-        if (null == $request->get('username')) {
+        $payload = $request->getPayload();
+
+        if (null == $payload->get('username')) {
             throw new MissingArgumentException($this->userClass, 'username');
         }
-        if ($request->isMethod('POST') && null === $request->get('password')) {
+        if ($request->isMethod(Request::METHOD_POST) && null === $payload->get('password')) {
             throw new MissingArgumentException($this->userClass, 'password');
         }
-        if (null == $request->get('locale')) {
+        if (null == $payload->get('locale')) {
             throw new MissingArgumentException($this->userClass, 'locale');
         }
-        if (null == $request->get('contact') && null == $request->get('contactId')) {
+        if (null == $payload->get('contact') && null == $payload->get('contactId')) {
             throw new MissingArgumentException($this->userClass, 'contact');
         }
     }
@@ -266,7 +268,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
     public function cgetAction(Request $request)
     {
         $view = null;
-        if ('true' == $request->get('flat')) {
+        if ('true' == $request->query->get('flat')) {
             $listBuilder = $this->doctrineListBuilderFactory->create($this->userClass);
 
             $this->restHelper->initializeListBuilder($listBuilder, $this->getFieldDescriptors());

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/SingleSignOnLoginRequestSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/SingleSignOnLoginRequestSubscriber.php
@@ -62,8 +62,10 @@ class SingleSignOnLoginRequestSubscriber implements EventSubscriberInterface
         }
 
         $isResetPassword = 'sulu_security.reset_password.email' === $route;
-        $identifier = $request->request->get('username') ?? $request->request->get('user');
-        $password = $request->request->get('password');
+
+        $payload = $request->getPayload();
+        $identifier = $payload->get('username') ?? $payload->get('user');
+        $password = $payload->get('password');
 
         if (!$identifier || !\is_string($identifier)) {
             return;

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -421,7 +421,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     private function processForm(Request $request, $document)
     {
         $locale = $this->getLocale($request);
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
         $data['workflowStage'] = $request->get('state', WorkflowStage::PUBLISHED);
 
         /** @var class-string<FormTypeInterface> $formType */
@@ -459,7 +459,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     private function checkAreaSnippet(Request $request, SnippetDocument $document)
     {
         $force = $request->headers->get('SuluForcePut', false);
-        $structureType = $request->request->get('template');
+        $structureType = $request->getPayload()->get('template');
 
         return $force
             || $structureType === $document->getStructureType()

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -127,7 +127,7 @@ class TagController extends AbstractRestController implements ClassResourceInter
      */
     public function postAction(Request $request)
     {
-        $name = $request->get('name');
+        $name = $request->getPayload()->get('name');
 
         try {
             if (null == $name) {
@@ -162,7 +162,7 @@ class TagController extends AbstractRestController implements ClassResourceInter
      */
     public function putAction(Request $request, $id)
     {
-        $name = $request->get('name');
+        $name = $request->getPayload()->get('name');
 
         try {
             if (null == $name) {
@@ -218,9 +218,11 @@ class TagController extends AbstractRestController implements ClassResourceInter
      */
     public function postMergeAction(Request $request)
     {
+        $payload = $request->getPayload();
+
         try {
-            $srcTagIds = \explode(',', $request->get('src'));
-            $destTagId = $request->get('dest');
+            $srcTagIds = \explode(',', $payload->getString('src'));
+            $destTagId = $payload->get('dest');
 
             $destTag = $this->tagManager->merge($srcTagIds, $destTagId);
 
@@ -244,11 +246,11 @@ class TagController extends AbstractRestController implements ClassResourceInter
      */
     public function cpatchAction(Request $request)
     {
+        $tags = [];
+        $payload = $request->getPayload();
         try {
-            $tags = [];
-
             $i = 0;
-            while ($item = $request->get($i)) {
+            while ($item = $payload->all((string) $i)) {
                 if (isset($item['id'])) {
                     $tags[] = $this->tagManager->save($item, $item['id']);
                 } else {
@@ -285,6 +287,6 @@ class TagController extends AbstractRestController implements ClassResourceInter
      */
     protected function getData(Request $request)
     {
-        return $request->request->all();
+        return $request->getPayload()->all();
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
+++ b/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
 use Sulu\Bundle\TrashBundle\Infrastructure\Sulu\Admin\TrashAdmin;
 use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
@@ -197,11 +198,15 @@ class TrashItemController extends AbstractRestController implements ClassResourc
 
     public function postTriggerAction(int $id, Request $request): Response
     {
-        $action = $this->getRequestParameter($request, 'action', true);
+        $action = $request->getPayload()->get('action');
 
         try {
+            if (null === $action) {
+                throw new MissingParameterException(self::class, 'name');
+            }
+
             return match ($action) {
-                'restore' => $this->restoreTrashItem($id, $request->request->all()),
+                'restore' => $this->restoreTrashItem($id, $request->getPayload()->all()),
                 default => throw new RestException(\sprintf('Unrecognized action: "%s"', $action)),
             };
         } catch (RestException $ex) {

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -105,7 +105,7 @@ class AnalyticsController extends AbstractRestController implements ClassResourc
      */
     public function postAction(Request $request, $webspace)
     {
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
         $data['content'] = $this->buildContent($data);
 
         $entity = $this->analyticsManager->create($webspace, $data);
@@ -125,7 +125,7 @@ class AnalyticsController extends AbstractRestController implements ClassResourc
      */
     public function putAction(Request $request, $webspace, $id)
     {
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
         $data['content'] = $this->buildContent($data);
 
         $entity = $this->analyticsManager->update($id, $data);

--- a/src/Sulu/Component/Hash/RequestHashChecker.php
+++ b/src/Sulu/Component/Hash/RequestHashChecker.php
@@ -28,9 +28,10 @@ class RequestHashChecker implements RequestHashCheckerInterface
 
     public function checkHash(Request $request, $object, $identifier)
     {
-        if (!$request->request->has($this->hashParameter)
+        $payload = $request->getPayload();
+        if (!$payload->has($this->hashParameter)
             || 'true' === $request->query->get($this->forceParameter, false)
-            || $request->request->get($this->hashParameter) == $this->hasher->hash($object)
+            || $payload->get($this->hashParameter) == $this->hasher->hash($object)
         ) {
             return true;
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | closes #7811 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Using the Symfony `getPayload` for handling of Json parsing of the request body.

#### Why?
We want to use more Symfony and less extensions.

#### Example Usage
Use `$request->getPayload()` instead of `$request->request`.