### PR TITLE
Merge lastModified to author methods

### DIFF
--- a/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
@@ -70,7 +70,6 @@ readonly class SettingsResolver implements ResolverInterface
 
         if ($dimensionContent instanceof AuthorInterface) {
             $result = \array_merge($result, $this->getAuthorData($dimensionContent));
-            $result = \array_merge($result, $this->getLastModifiedData($dimensionContent));
         }
 
         if ($dimensionContent instanceof ShadowInterface) {
@@ -171,6 +170,7 @@ readonly class SettingsResolver implements ResolverInterface
         return [
             'author' => $dimensionContent->getAuthor()?->getId(),
             'authored' => $dimensionContent->getAuthored(),
+            'lastModified' => $dimensionContent->getLastModified(),
         ];
     }
 
@@ -183,22 +183,6 @@ readonly class SettingsResolver implements ResolverInterface
     {
         return [
             'shadowBaseLocale' => $dimensionContent->getShadowLocale(),
-        ];
-    }
-
-    /**
-     * @return array{
-     *     lastModified?: \DateTimeImmutable|null
-     * }
-     */
-    protected function getLastModifiedData(AuthorInterface $dimensionContent): array
-    {
-        if (!$dimensionContent->getLastModifiedEnabled()) {
-            return [];
-        }
-
-        return [
-            'lastModified' => $dimensionContent->getLastModified(),
         ];
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SettingsResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SettingsResolverTest.php
@@ -185,6 +185,7 @@ class SettingsResolverTest extends TestCase
         $exampleDimension = new ExampleDimensionContent($example);
         $exampleDimension->setAuthored(new \DateTimeImmutable('2021-01-01'));
         $exampleDimension->setAuthor($author);
+        $exampleDimension->setLastModified(new \DateTimeImmutable('2021-01-01'));
 
         $result = $this->resolver->resolve($exampleDimension);
         /** @var SettingsData $content */
@@ -192,6 +193,7 @@ class SettingsResolverTest extends TestCase
 
         self::assertSame(1, $content['author']);
         self::assertSame('2021-01-01', $content['authored']?->format('Y-m-d'));
+        self::assertSame('2021-01-01', $content['lastModified']?->format('Y-m-d'));
     }
 
     public function testResolveShadowData(): void
@@ -205,18 +207,5 @@ class SettingsResolverTest extends TestCase
         $content = $result->getContent();
 
         self::assertSame('de', $content['shadowBaseLocale']);
-    }
-
-    public function testResolveLastModifiedData(): void
-    {
-        $example = new Example();
-        $exampleDimension = new ExampleDimensionContent($example);
-        $exampleDimension->setLastModified(new \DateTimeImmutable('2021-01-01'));
-
-        $result = $this->resolver->resolve($exampleDimension);
-        /** @var SettingsData $content */
-        $content = $result->getContent();
-
-        self::assertSame('2021-01-01', $content['lastModified']?->format('Y-m-d'));
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Issues | https://github.com/sulu/sulu/issues/7672
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

LastModified belongs to the AuthorInterface, therefore the methods should also consider the lastModified property
