### PR TITLE
Make the property resolver provider final and internal provide an interface for extendability

### DIFF
--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -69,6 +69,8 @@
             />
         </service>
 
+        <service id="Sulu\Content\Application\PropertyResolver\PropertyResolverProviderInterface" alias="sulu_content.property_resolver_provider"/>
+
         <service id="sulu_content.default_property_resolver"
                  class="Sulu\Content\Application\PropertyResolver\Resolver\DefaultPropertyResolver">
 

--- a/packages/content/src/Application/MetadataResolver/MetadataResolver.php
+++ b/packages/content/src/Application/MetadataResolver/MetadataResolver.php
@@ -16,7 +16,7 @@ namespace Sulu\Content\Application\MetadataResolver;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Content\Application\PropertyResolver\PropertyResolverProvider;
+use Sulu\Content\Application\PropertyResolver\PropertyResolverProviderInterface;
 
 /**
  * @internal This class is intended for internal use only within the library. Modifying or depending on this class may result in unexpected behavior and is not supported.
@@ -24,7 +24,7 @@ use Sulu\Content\Application\PropertyResolver\PropertyResolverProvider;
 class MetadataResolver
 {
     public function __construct(
-        private PropertyResolverProvider $propertyResolverProvider
+        private PropertyResolverProviderInterface $propertyResolverProvider
     ) {
     }
 

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
@@ -16,7 +16,7 @@ namespace Sulu\Content\Application\PropertyResolver;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
- * @internal The constructor of this class maybe change in future releases to add new features or improve performance.
+ * @internal The constructor of this class may change in future releases to add new features or improve performance.
  *           Use this service via the dependency injection container via the PropertyResolverProviderInterface only.
  *           It is still fine to use this class to create a new instance for mock-less unit tests,
  *           but no backwards compatibility promise can be given for the constructor.

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
@@ -16,6 +16,11 @@ namespace Sulu\Content\Application\PropertyResolver;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 /**
+ * @internal The constructor of this class maybe change in future releases to add new features or improve performance.
+ *           Use this service via the dependency injection container via the PropertyResolverProviderInterface only.
+ *           It is still fine to use this class to create a new instance for mock-less unit tests,
+ *           but no backwards compatibility promise can be given for the constructor.
+ *
  * If you need to override this service use service decoration via the provided interface: https://symfony.com/doc/6.4/service_container/service_decoration.html.
  */
 final class PropertyResolverProvider implements PropertyResolverProviderInterface
@@ -26,8 +31,6 @@ final class PropertyResolverProvider implements PropertyResolverProviderInterfac
     private array $propertyResolvers;
 
     /**
-     * @internal The constructor of this class maybe change in future releases. Use this service via the dependency injection container only.
-     *
      * @param iterable<PropertyResolverInterface> $propertyResolvers
      */
     public function __construct(iterable $propertyResolvers)

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
@@ -15,6 +15,9 @@ namespace Sulu\Content\Application\PropertyResolver;
 
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
+/**
+ * If you need to override this service use service decoration via the provided interface: https://symfony.com/doc/6.4/service_container/service_decoration.html.
+ */
 final class PropertyResolverProvider implements PropertyResolverProviderInterface
 {
     /**

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
@@ -15,7 +15,7 @@ namespace Sulu\Content\Application\PropertyResolver;
 
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
-class PropertyResolverProvider
+final class PropertyResolverProvider implements PropertyResolverProviderInterface
 {
     /**
      * @var PropertyResolverInterface[]
@@ -23,6 +23,8 @@ class PropertyResolverProvider
     private array $propertyResolvers;
 
     /**
+     * @internal The constructor of this class maybe change in future releases. Use this service via the dependency injection container only.
+     *
      * @param iterable<PropertyResolverInterface> $propertyResolvers
      */
     public function __construct(iterable $propertyResolvers)

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProviderInterface.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProviderInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\PropertyResolver;
+
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+
+interface PropertyResolverProviderInterface
+{
+    public function getPropertyResolver(string $type): PropertyResolverInterface;
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Make the property resolver provider final, add a interface for extendability.

#### Why?

This service should not be extended only decorated, also we are free to change how the constructor is created as making it internal as so we are free to choose if tagged_iterator or tagged_locator is the best choice for us.

Overriding and changing the behaviour can still be done via decorating the service: https://symfony.com/doc/6.4/service_container/service_decoration.html

The new interface for decorating can also now be used then for creating `mocks`.