### PR TITLE
Add homepage initialization builder command

### DIFF
--- a/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -165,9 +165,10 @@ class RoutableDataMapper implements DataMapperInterface
             );
         }
 
-        if ('/' === $routePath) {
-            throw new \RuntimeException('Not allowed url "/" given or generated.');
-        }
+        //        TODO: we need this for the homepage
+        //        if ('/' === $routePath) {
+        //            throw new \RuntimeException('Not allowed url "/" given or generated.');
+        //        }
 
         if (DimensionContentInterface::STAGE_LIVE === $localizedDimensionContent->getStage()) {
             if (!$localizedDimensionContent->getResourceId()) {

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -165,11 +165,6 @@ class RoutableDataMapper implements DataMapperInterface
             );
         }
 
-        //        TODO: we need this for the homepage
-        //        if ('/' === $routePath) {
-        //            throw new \RuntimeException('Not allowed url "/" given or generated.');
-        //        }
-
         if (DimensionContentInterface::STAGE_LIVE === $localizedDimensionContent->getStage()) {
             if (!$localizedDimensionContent->getResourceId()) {
                 // TODO route bundle should work to update the entity later with a resourceId over UPDATE SQL statement

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
@@ -568,42 +568,6 @@ class RoutableDataMapperTest extends TestCase
         ], $localizedDimensionContent->getTemplateData());
     }
 
-    public function testMapOnlySlash(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Not allowed url "/" given or generated.');
-
-        $data = [
-            'url' => null,
-        ];
-
-        $route = new Route();
-        $route->setPath('/custom/testEntity-123');
-
-        $example = new Example();
-        static::setPrivateProperty($example, 'id', 123);
-        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
-        $localizedDimensionContent = new ExampleDimensionContent($example);
-        $localizedDimensionContent->setTemplateKey('default');
-        $localizedDimensionContent->setLocale('en');
-        $localizedDimensionContent->setTemplateData(['title' => 'Test', 'url' => null]);
-
-        $this->structureMetadataFactory->getStructureMetadata('example', 'default')
-            ->shouldBeCalled()
-            ->willReturn($this->createRouteStructureMetadata());
-        $this->routeGenerator->generate(Argument::cetera())->willReturn('/');
-
-        $this->conflictResolver->resolve(Argument::cetera())->shouldNotBeCalled();
-
-        $mapper = $this->createRouteDataMapperInstance();
-        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
-
-        $this->assertSame([
-            'url' => '/custom/testEntity-123',
-            'title' => 'Test',
-        ], $localizedDimensionContent->getTemplateData());
-    }
-
     private function createRouteStructureMetadata(string $propertyName = 'url'): StructureMetadata
     {
         $property = $this->prophesize(PropertyMetadata::class);

--- a/packages/page/src/Application/MessageHandler/CreatePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/CreatePageMessageHandler.php
@@ -24,25 +24,15 @@ use Sulu\Page\Domain\Repository\PageRepositoryInterface;
  */
 final class CreatePageMessageHandler
 {
-    /**
-     * @var PageRepositoryInterface
-     */
-    private $pageRepository;
-
-    /**
-     * @var iterable<PageMapperInterface>
-     */
-    private $pageMappers;
+    public const HOMEPAGE_PARENT_ID = 'homepage';
 
     /**
      * @param iterable<PageMapperInterface> $pageMappers
      */
     public function __construct(
-        PageRepositoryInterface $pageRepository,
-        iterable $pageMappers
+        private PageRepositoryInterface $pageRepository,
+        private iterable $pageMappers
     ) {
-        $this->pageRepository = $pageRepository;
-        $this->pageMappers = $pageMappers;
     }
 
     public function __invoke(CreatePageMessage $message): PageInterface
@@ -50,15 +40,24 @@ final class CreatePageMessageHandler
         $data = $message->getData();
         $page = $this->pageRepository->createNew($message->getUuid());
         $page->setWebspaceKey($message->getWebspaceKey());
-
-        $parent = $this->pageRepository->getOneBy(['uuid' => $message->getParentId()]);
-        $page->setParent($parent);
+        $page = $this->setParent($message->getParentId(), $page);
 
         foreach ($this->pageMappers as $pageMapper) {
             $pageMapper->mapPageData($page, $data);
         }
 
         $this->pageRepository->add($page);
+
+        return $page;
+    }
+
+    public function setParent(string $parentId, PageInterface $page): PageInterface
+    {
+        // only the homepage is allowed to not have a parent
+        if (self::HOMEPAGE_PARENT_ID !== $parentId) {
+            $parent = $this->pageRepository->getOneBy(['uuid' => $parentId]);
+            $page->setParent($parent);
+        }
 
         return $page;
     }

--- a/packages/page/src/Application/MessageHandler/CreatePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/CreatePageMessageHandler.php
@@ -51,7 +51,7 @@ final class CreatePageMessageHandler
         return $page;
     }
 
-    public function setParent(string $parentId, PageInterface $page): PageInterface
+    private function setParent(string $parentId, PageInterface $page): PageInterface
     {
         // only the homepage is allowed to not have a parent
         if (self::HOMEPAGE_PARENT_ID !== $parentId) {

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -224,6 +224,8 @@ class PageRepository implements PageRepositoryInterface
      *     tagOperator?: 'AND'|'OR',
      *     templateKeys?: string[],
      *     loadGhost?: bool,
+     *     parentId?: string,
+     *     webspace?: string,
      *     page?: int,
      *     limit?: int,
      * } $filters
@@ -264,6 +266,20 @@ class PageRepository implements PageRepositoryInterface
             Assert::isArray($uuids); // @phpstan-ignore staticMethod.alreadyNarrowedType
             $queryBuilder->andWhere('page.uuid IN(:uuids)')
                 ->setParameter('uuids', $uuids);
+        }
+
+        $webspace = $filters['webspace'] ?? null;
+        if (null !== $webspace) {
+            Assert::string($webspace); // @phpstan-ignore staticMethod.alreadyNarrowedType
+            $queryBuilder->andWhere('page.webspace = :webspace')
+                ->setParameter('webspace', $webspace);
+        }
+
+        $parentId = $filters['parentId'] ?? null;
+        if (null !== $parentId) {
+            Assert::string($parentId); // @phpstan-ignore staticMethod.alreadyNarrowedType
+            $queryBuilder->andWhere('page.parentId = :parentId')
+                ->setParameter('parentId', $parentId);
         }
 
         $limit = $filters['limit'] ?? null;

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -224,8 +224,8 @@ class PageRepository implements PageRepositoryInterface
      *     tagOperator?: 'AND'|'OR',
      *     templateKeys?: string[],
      *     loadGhost?: bool,
-     *     parentId?: string,
-     *     webspace?: string,
+     *     parentId?: string|null,
+     *     webspaceKey?: string,
      *     page?: int,
      *     limit?: int,
      * } $filters
@@ -268,18 +268,22 @@ class PageRepository implements PageRepositoryInterface
                 ->setParameter('uuids', $uuids);
         }
 
-        $webspace = $filters['webspace'] ?? null;
+        $webspace = $filters['webspaceKey'] ?? null;
         if (null !== $webspace) {
             Assert::string($webspace); // @phpstan-ignore staticMethod.alreadyNarrowedType
-            $queryBuilder->andWhere('page.webspace = :webspace')
-                ->setParameter('webspace', $webspace);
+            $queryBuilder->andWhere('page.webspaceKey = :webspaceKey')
+                ->setParameter('webspaceKey', $webspace);
         }
 
         $parentId = $filters['parentId'] ?? null;
-        if (null !== $parentId) {
-            Assert::string($parentId); // @phpstan-ignore staticMethod.alreadyNarrowedType
-            $queryBuilder->andWhere('page.parentId = :parentId')
-                ->setParameter('parentId', $parentId);
+        // null is a valid value for parentId
+        if (\array_key_exists('parentId', $filters)) {
+            Assert::nullOrString($parentId); // @phpstan-ignore staticMethod.alreadyNarrowedType
+            match ($parentId) {
+                null => $queryBuilder->andWhere('page.parent IS NULL'),
+                default => $queryBuilder->andWhere('page.parent = :parentId')
+                    ->setParameter('parentId', $parentId),
+            };
         }
 
         $limit = $filters['limit'] ?? null;

--- a/packages/page/src/Infrastructure/Sulu/Build/HomepageBuilder.php
+++ b/packages/page/src/Infrastructure/Sulu/Build/HomepageBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Build;
+
+use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
+
+class HomepageBuilder extends SuluBuilder
+{
+    public function getName(): string
+    {
+        return 'homepage';
+    }
+
+    public function getDependencies(): array
+    {
+        return ['database'];
+    }
+
+    public function build()
+    {
+        $this->execCommand('Create homepage per webspace', 'sulu:page:initialize');
+    }
+}

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -34,12 +34,14 @@ use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Infrastructure\Doctrine\Repository\PageRepository;
 use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
+use Sulu\Page\Infrastructure\Sulu\Build\HomepageBuilder;
 use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Sulu\Page\Infrastructure\Sulu\Content\PageSitemapProvider;
 use Sulu\Page\Infrastructure\Sulu\Content\PageTeaserProvider;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionPropertyResolver;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\SinglePageSelectionPropertyResolver;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
+use Sulu\Page\UserInterface\Command\InitializeHomepageCommand;
 use Sulu\Page\UserInterface\Controller\Admin\PageController;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -185,6 +187,11 @@ final class SuluPageBundle extends AbstractBundle
             ])
             ->tag('sulu_content.resource_loader', ['type' => PageResourceLoader::RESOURCE_LOADER_KEY]);
 
+        // Sulu Builder service
+        $services->set('sulu_page.homepage_builder')
+            ->class(HomepageBuilder::class)
+            ->tag('massive_build.builder');
+
         // Sulu Integration service
         $services->set('sulu_page.page_admin')
             ->class(PageAdmin::class)
@@ -207,6 +214,16 @@ final class SuluPageBundle extends AbstractBundle
             ]);
 
         $services->alias(PageRepositoryInterface::class, 'sulu_page.page_repository');
+
+        // Commands services
+        $services->set('sulu_page.command.initialize_homepage')
+            ->class(InitializeHomepageCommand::class)
+            ->args([
+                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_page.page_repository'),
+                new Reference('sulu_message_bus'),
+            ])
+            ->tag('console.command');
 
         // Controllers services
         $services->set('sulu_page.admin_page_controller')

--- a/packages/page/src/UserInterface/Command/InitializeHomepageCommand.php
+++ b/packages/page/src/UserInterface/Command/InitializeHomepageCommand.php
@@ -13,6 +13,7 @@ namespace Sulu\Page\UserInterface\Command;
 
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\WorkflowInterface;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
 use Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage;
@@ -30,9 +31,9 @@ use Symfony\Component\Messenger\HandleTrait;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * @internal Your code should not create direct dependencies on this implementation
+ * @internal your code should not create direct dependencies on this implementation
  *           projects can utilize the `sulu:page:initialize` command to
- *           initialize new webspaces with the homepage.
+ *           initialize new webspaces with the homepage
  *
  * @final
  */
@@ -56,12 +57,10 @@ class InitializeHomepageCommand extends Command
 
         $webspaces = $this->webspaceManager->getWebspaceCollection();
         foreach ($webspaces as $webspace) {
-            $ui->section('Initialize homepage for webspace ' . $webspace->getKey());
-
             $localizations = $webspace->getLocalizations();
             foreach ($localizations as $localization) {
                 if ($this->homepageExists($webspace, $localization->getLocale())) {
-                    $ui->text(
+                    $ui->info(
                         \sprintf(
                             'Homepage for locale "%s" in webspace "%s" already exists',
                             $localization->getLocale(),
@@ -81,14 +80,14 @@ class InitializeHomepageCommand extends Command
 
     private function homepageExists(Webspace $webspace, string $locale): bool
     {
-        // TODO more optimized query
-        $homepage = $this->pageRepository->findOneBy([
+        $result = $this->pageRepository->countBy([
             'webspaceKey' => $webspace->getKey(),
             'locale' => $locale,
-            'url' => '/',
+            'parentId' => null,
+            'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
-        return null !== $homepage;
+        return $result > 0;
     }
 
     private function createHomepage(Webspace $webspace, string $locale): PageInterface

--- a/packages/page/src/UserInterface/Command/InitializeHomepageCommand.php
+++ b/packages/page/src/UserInterface/Command/InitializeHomepageCommand.php
@@ -31,12 +31,12 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * @internal Your code should not create direct dependencies on this implementation
- *  projects can utilize the `sulu:page:initialize` command to
- *  initialize new webspaces with the homepage
+ *           projects can utilize the `sulu:page:initialize` command to
+ *           initialize new webspaces with the homepage.
  *
  * @final
  */
-#[AsCommand(name: 'sulu:page:initialize', description: 'Initializes the homepage per webspace')]
+#[AsCommand(name: 'sulu:page:initialize', description: 'Initializes the homepage per webspace locale')]
 class InitializeHomepageCommand extends Command
 {
     use HandleTrait;

--- a/packages/page/src/UserInterface/Command/InitializeHomepageCommand.php
+++ b/packages/page/src/UserInterface/Command/InitializeHomepageCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\UserInterface\Command;
+
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Content\Domain\Model\WorkflowInterface;
+use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
+use Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage;
+use Sulu\Page\Application\Message\CreatePageMessage;
+use Sulu\Page\Application\MessageHandler\CreatePageMessageHandler;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\HandleTrait;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @internal Your code should not create direct dependencies on this implementation
+ *  projects can utilize the `sulu:page:initialize` command to
+ *  initialize new webspaces with the homepage
+ *
+ * @final
+ */
+#[AsCommand(name: 'sulu:page:initialize', description: 'Initializes the homepage per webspace')]
+class InitializeHomepageCommand extends Command
+{
+    use HandleTrait;
+
+    public function __construct(
+        private WebspaceManagerInterface $webspaceManager,
+        private PageRepositoryInterface $pageRepository,
+        MessageBusInterface $messageBus
+    ) {
+        parent::__construct();
+        $this->messageBus = $messageBus;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $ui = new SymfonyStyle($input, $output);
+
+        $webspaces = $this->webspaceManager->getWebspaceCollection();
+        foreach ($webspaces as $webspace) {
+            $ui->section('Initialize homepage for webspace ' . $webspace->getKey());
+
+            $localizations = $webspace->getLocalizations();
+            foreach ($localizations as $localization) {
+                if ($this->homepageExists($webspace, $localization->getLocale())) {
+                    $ui->text(
+                        \sprintf(
+                            'Homepage for locale "%s" in webspace "%s" already exists',
+                            $localization->getLocale(),
+                            $webspace->getKey()
+                        )
+                    );
+                    continue;
+                }
+                $homepage = $this->createHomepage($webspace, $localization->getLocale());
+                $this->publishHomepage($homepage->getUuid(), $localization->getLocale());
+            }
+        }
+        $ui->success('Homepage initialization completed');
+
+        return Command::SUCCESS;
+    }
+
+    private function homepageExists(Webspace $webspace, string $locale): bool
+    {
+        // TODO more optimized query
+        $homepage = $this->pageRepository->findOneBy([
+            'webspaceKey' => $webspace->getKey(),
+            'locale' => $locale,
+            'url' => '/',
+        ]);
+
+        return null !== $homepage;
+    }
+
+    private function createHomepage(Webspace $webspace, string $locale): PageInterface
+    {
+        $webspaceKey = $webspace->getKey();
+        $message = new CreatePageMessage(
+            $webspaceKey,
+            CreatePageMessageHandler::HOMEPAGE_PARENT_ID,
+            [
+                'title' => $webspace->getName(),
+                'template' => $webspace->getDefaultTemplate('home'),
+                'locale' => $locale,
+                'url' => '/',
+            ]
+        );
+
+        /** @see CreatePageMessageHandler */
+        /** @var PageInterface $page */
+        $page = $this->handle(new Envelope($message, [new EnableFlushStamp()]));
+
+        return $page;
+    }
+
+    private function publishHomepage(string $uuid, string $locale): void
+    {
+        $message = new ApplyWorkflowTransitionPageMessage(
+            identifier: ['uuid' => $uuid],
+            locale: $locale,
+            transitionName: WorkflowInterface::WORKFLOW_TRANSITION_PUBLISH
+        );
+
+        /** @see ApplyWorkflowTransitionPageMessageHandler */
+        $this->handle(new Envelope($message, [new EnableFlushStamp()]));
+    }
+}

--- a/packages/page/tests/Functional/Command/InitializeHomepageCommandTest.php
+++ b/packages/page/tests/Functional/Command/InitializeHomepageCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Command;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class InitializeHomepageCommandTest extends SuluTestCase
+{
+    private PageRepositoryInterface $pageRepository;
+
+    protected function setUp(): void
+    {
+        $pageRepository = $this->getContainer()->get('sulu_page.page_repository');
+        self::assertInstanceOf(PageRepositoryInterface::class, $pageRepository);
+        $this->pageRepository = $pageRepository;
+    }
+
+    public function testExecuteWithNoExistingHomepage(): void
+    {
+        self::purgeDatabase();
+        self::assertInstanceOf(KernelInterface::class, self::$kernel);
+        $application = new Application(self::$kernel);
+
+        self::assertSame(0, $this->pageRepository->countBy([
+            'parentId' => null,
+            'webspaceKey' => 'sulu-io',
+            'locale' => 'en',
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+        ]));
+
+        $command = $application->find('sulu:page:initialize');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        self::assertSame(1, $this->pageRepository->countBy([
+            'parentId' => null,
+            'webspaceKey' => 'sulu-io',
+            'locale' => 'en',
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+        ]));
+    }
+
+    /**
+     * @depends testExecuteWithNoExistingHomepage
+     */
+    public function testExecuteWithExistingHomepage(): void
+    {
+        self::assertInstanceOf(KernelInterface::class, self::$kernel);
+        $application = new Application(self::$kernel);
+
+        self::assertSame(1, $this->pageRepository->countBy([
+            'parentId' => null,
+            'webspaceKey' => 'sulu-io',
+            'locale' => 'en',
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+        ]));
+
+        $command = $application->find('sulu:page:initialize');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $commandTester->assertCommandIsSuccessful();
+
+        self::assertSame(1, $this->pageRepository->countBy([
+            'parentId' => null,
+            'webspaceKey' => 'sulu-io',
+            'locale' => 'en',
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+        ]));
+    }
+}

--- a/packages/page/tests/Functional/UserInterface/Command/InitializeHomepageCommandTest.php
+++ b/packages/page/tests/Functional/UserInterface/Command/InitializeHomepageCommandTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Page\Tests\Functional\Command;
+namespace Sulu\Page\Tests\Functional\UserInterface\Command;
 
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Domain\Model\DimensionContentInterface;

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -206,41 +206,58 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
         }
 
         if ($container->hasExtension('massive_build')) {
-            $container->prependExtensionConfig(
-                'massive_build',
-                [
-                    'targets' => [
-                        'prod' => [
-                            'dependencies' => [
-                                'database' => [],
-                                'phpcr' => [],
-                                'fixtures' => [],
-                                'phpcr_migrations' => [],
-                                'system_collections' => [],
-                                'security' => [],
-                            ],
-                        ],
-                        'dev' => [
-                            'dependencies' => [
-                                'database' => [],
-                                'fixtures' => [],
-                                'phpcr' => [],
-                                'user' => [],
-                                'phpcr_migrations' => [],
-                                'system_collections' => [],
-                                'security' => [],
-                                'search_init' => [],
-                            ],
-                        ],
-                        'maintain' => [
-                            'dependencies' => [
-                                'node_order' => [],
-                                'search_index' => [],
-                                'phpcr_migrations' => [],
-                            ],
+            $massiveBuildConfig = [
+                'targets' => [
+                    'prod' => [
+                        'dependencies' => [
+                            'database' => [],
+                            'phpcr' => [],
+                            'fixtures' => [],
+                            'phpcr_migrations' => [],
+                            'system_collections' => [],
+                            'security' => [],
                         ],
                     ],
-                ]
+                    'dev' => [
+                        'dependencies' => [
+                            'database' => [],
+                            'fixtures' => [],
+                            'phpcr' => [],
+                            'user' => [],
+                            'phpcr_migrations' => [],
+                            'system_collections' => [],
+                            'security' => [],
+                            'search_init' => [],
+                        ],
+                    ],
+                    'maintain' => [
+                        'dependencies' => [
+                            'node_order' => [],
+                            'search_index' => [],
+                            'phpcr_migrations' => [],
+                        ],
+                    ],
+                ],
+            ];
+
+            // Check sulu page bundle enabled
+            /** @var array<string, string> $bundles */
+            $bundles = $container->getParameter('kernel.bundles');
+            $contentPageBundle = \array_key_exists('SuluNextPageBundle', $bundles) ? $bundles['SuluNextPageBundle'] : null;
+            if ($contentPageBundle) {
+                $massiveBuildConfig['targets']['prod']['dependencies']['homepage'] = [];
+                $massiveBuildConfig['targets']['dev']['dependencies']['homepage'] = [];
+            }
+
+            $phpcrPageBundle = \array_key_exists('SuluPageBundle', $bundles) ? $bundles['SuluPageBundle'] : null;
+            if ($phpcrPageBundle) {
+                $massiveBuildConfig['targets']['prod']['dependencies']['phpcr'] = [];
+                $massiveBuildConfig['targets']['dev']['dependencies']['phpcr'] = [];
+            }
+
+            $container->prependExtensionConfig(
+                'massive_build',
+                $massiveBuildConfig
             );
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7672
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add homepage initialization builder command.

#### Why?

This new command `sulu:page:initialize` command will replace the `sulu:document:initialize` command which will be removed with 3.0.
