### PR TITLE
Replace Sulu 3.0 packages PHPUnit Annotations with Attributes

### DIFF
--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -19,9 +19,8 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
  * The integration test should have no impact on the coverage so we set it to coversNothing.
- *
- * @coversNothing
  */
+#[\PHPUnit\Framework\Attributes\CoversNothing]
 class ArticleControllerTest extends SuluTestCase
 {
     use AssertSnapshotTrait;
@@ -94,9 +93,7 @@ class ArticleControllerTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostPublish
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostPublish')]
     public function testPostTriggerUnpublish(string $id): void
     {
         $this->client->request('POST', '/admin/api/articles/' . $id . '?locale=en&action=unpublish');
@@ -156,9 +153,7 @@ class ArticleControllerTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testGet(string $id): void
     {
         $this->client->request('GET', '/admin/api/articles/' . $id . '?locale=en');
@@ -174,9 +169,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $response);
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testGetGhostLocale(string $id): void
     {
         $this->client->request('GET', '/admin/api/articles/' . $id . '?locale=de');
@@ -192,9 +185,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $response);
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testPostTriggerCopyLocale(string $id): void
     {
         $this->client->request('POST', '/admin/api/articles/' . $id . '?locale=de&action=copy-locale&src=en&dest=de');
@@ -204,10 +195,8 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('article_post_trigger_copy_locale.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGet
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGet')]
     public function testPut(string $id): void
     {
         $this->client->request('PUT', '/admin/api/articles/' . $id . '?locale=en', [], [], [], \json_encode([
@@ -241,10 +230,8 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('article_put.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testPut
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testPut')]
     public function testGetList(): void
     {
         $this->client->request('GET', '/admin/api/articles?locale=en');
@@ -253,10 +240,8 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('article_cget.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGetList
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGetList')]
     public function testDelete(string $id): void
     {
         $this->client->request('DELETE', '/admin/api/articles/' . $id . '?locale=en');

--- a/packages/content/tests/Functional/Integration/ExampleControllerAvailableAndShadowLocalesTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerAvailableAndShadowLocalesTest.php
@@ -23,9 +23,8 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
  * publishing processes.
  *
  * The integration test should have no impact on the coverage so we set it to coversNothing.
- *
- * @coversNothing
  */
+#[\PHPUnit\Framework\Attributes\CoversNothing]
 class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
 {
     /**
@@ -86,9 +85,7 @@ class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostCreateEnDraft
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostCreateEnDraft')]
     public function testPostCreateDeDraft(int $id): int
     {
         $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=de', [], [], [], \json_encode([
@@ -145,9 +142,7 @@ class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostCreateDeDraft
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostCreateDeDraft')]
     public function testPostPublishEn(int $id): int
     {
         $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=en&action=publish', [], [], [], \json_encode([
@@ -222,9 +217,7 @@ class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostPublishEn
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostPublishEn')]
     public function testPostPublishDe(int $id): int
     {
         $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=de&action=publish', [], [], [], \json_encode([
@@ -313,9 +306,7 @@ class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostPublishDe
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostPublishDe')]
     public function testPostRepublishEn(int $id): int
     {
         $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=en&action=publish', [], [], [], \json_encode([
@@ -402,9 +393,7 @@ class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostRepublishEn
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostRepublishEn')]
     public function testPostUnpublishDe(int $id): int
     {
         $this->client->request('POST', '/admin/api/examples/' . $id . '?locale=de&action=unpublish', [], [], [], \json_encode([
@@ -481,9 +470,7 @@ class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostRepublishEn
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostRepublishEn')]
     public function testPostRepublishEnAgain(int $id): int
     {
         $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=en&action=publish', [], [], [], \json_encode([

--- a/packages/content/tests/Functional/Integration/ExampleControllerTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerTest.php
@@ -19,9 +19,8 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
  * The integration test should have no impact on the coverage so we set it to coversNothing.
- *
- * @coversNothing
  */
+#[\PHPUnit\Framework\Attributes\CoversNothing]
 class ExampleControllerTest extends SuluTestCase
 {
     use AssertSnapshotTrait;
@@ -93,9 +92,7 @@ class ExampleControllerTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostPublish
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostPublish')]
     public function testPostTriggerUnpublish(int $id): void
     {
         $this->client->request('POST', '/admin/api/examples/' . $id . '?locale=en&action=unpublish');
@@ -155,9 +152,7 @@ class ExampleControllerTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testGet(int $id): void
     {
         $this->client->request('GET', '/admin/api/examples/' . $id . '?locale=en');
@@ -173,9 +168,7 @@ class ExampleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $response);
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testGetGhostLocale(int $id): void
     {
         $this->client->request('GET', '/admin/api/examples/' . $id . '?locale=de');
@@ -191,9 +184,7 @@ class ExampleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $response);
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testPostTriggerCopyLocale(int $id): void
     {
         $this->client->request('POST', '/admin/api/examples/' . $id . '?locale=de&action=copy-locale&src=en&dest=de');
@@ -203,10 +194,8 @@ class ExampleControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('example_post_trigger_copy_locale.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGet
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGet')]
     public function testPut(int $id): void
     {
         $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=en', [], [], [], \json_encode([
@@ -242,10 +231,8 @@ class ExampleControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('example_put.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testPut
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testPut')]
     public function testGetList(): void
     {
         $this->client->request('GET', '/admin/api/examples?locale=en');
@@ -254,10 +241,8 @@ class ExampleControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('example_cget.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGetList
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGetList')]
     public function testDelete(int $id): void
     {
         $this->client->request('DELETE', '/admin/api/examples/' . $id . '?locale=en');

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -23,9 +23,8 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
  * The integration test should have no impact on the coverage so we set it to coversNothing.
- *
- * @coversNothing
  */
+#[\PHPUnit\Framework\Attributes\CoversNothing]
 class PageControllerTest extends SuluTestCase
 {
     use AssertSnapshotTrait;
@@ -146,9 +145,7 @@ class PageControllerTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostPublish
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostPublish')]
     public function testPostTriggerUnpublish(string $id): void
     {
         $this->client->request('POST', '/admin/api/pages/' . $id . '?locale=en&action=unpublish');
@@ -215,9 +212,7 @@ class PageControllerTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testGet(string $id): void
     {
         $this->client->request('GET', '/admin/api/pages/' . $id . '?locale=en');
@@ -233,9 +228,7 @@ class PageControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $response);
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testGetGhostLocale(string $id): void
     {
         $this->client->request('GET', '/admin/api/pages/' . $id . '?locale=de');
@@ -251,9 +244,7 @@ class PageControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(404, $response);
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testPostTriggerCopyLocale(string $id): void
     {
         $this->client->request('POST', '/admin/api/pages/' . $id . '?locale=de&action=copy-locale&src=en&dest=de');
@@ -263,10 +254,8 @@ class PageControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('page_post_trigger_copy_locale.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGet
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGet')]
     public function testPut(string $id): void
     {
         $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=en', [], [], [], \json_encode([
@@ -300,10 +289,8 @@ class PageControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('page_put.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testPut
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testPut')]
     public function testGetList(string $id): void
     {
         $this->client->request('GET', '/admin/api/pages?locale=en&webspace=sulu-io&expandedIds=' . $id);
@@ -312,10 +299,8 @@ class PageControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('page_cget.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGetList
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGetList')]
     public function testOrderPages(string $id): void
     {
         $page1 = $this->createPage($id);
@@ -340,10 +325,8 @@ class PageControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('page_post_before_order_list.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGetList
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGetList')]
     public function testDelete(string $id): void
     {
         $this->client->request('DELETE', '/admin/api/pages/' . $id . '?locale=en');

--- a/packages/page/tests/Functional/UserInterface/Command/InitializeHomepageCommandTest.php
+++ b/packages/page/tests/Functional/UserInterface/Command/InitializeHomepageCommandTest.php
@@ -56,9 +56,7 @@ class InitializeHomepageCommandTest extends SuluTestCase
         ]));
     }
 
-    /**
-     * @depends testExecuteWithNoExistingHomepage
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testExecuteWithNoExistingHomepage')]
     public function testExecuteWithExistingHomepage(): void
     {
         self::assertInstanceOf(KernelInterface::class, self::$kernel);

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -21,9 +21,8 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
  * The integration test should have no impact on the coverage so we set it to coversNothing.
- *
- * @coversNothing
  */
+#[\PHPUnit\Framework\Attributes\CoversNothing]
 class SnippetControllerTest extends SuluTestCase
 {
     use AssertSnapshotTrait;
@@ -80,9 +79,7 @@ class SnippetControllerTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPostPublish
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPostPublish')]
     public function testPostTriggerUnpublish(string $id): void
     {
         $this->client->request('POST', '/admin/api/snippets/' . $id . '?locale=en&action=unpublish');
@@ -119,9 +116,7 @@ class SnippetControllerTest extends SuluTestCase
         return $id;
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testGet(string $id): void
     {
         $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=en');
@@ -129,9 +124,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('snippet_get.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testGetGhostLocale(string $id): void
     {
         $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=de');
@@ -139,9 +132,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('snippet_get_ghost_locale.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
     public function testPostTriggerCopyLocale(string $id): void
     {
         $this->client->request('POST', '/admin/api/snippets/' . $id . '?locale=de&action=copy-locale&src=en&dest=de');
@@ -151,10 +142,8 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('snippet_post_trigger_copy_locale.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGet
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGet')]
     public function testPut(string $id): void
     {
         $this->client->request('PUT', '/admin/api/snippets/' . $id . '?locale=en', [], [], [], \json_encode([
@@ -175,10 +164,8 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('snippet_put.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testPut
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testPut')]
     public function testGetList(): void
     {
         $this->client->request('GET', '/admin/api/snippets?locale=en');
@@ -187,10 +174,8 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('snippet_cget.json', $response, 200);
     }
 
-    /**
-     * @depends testPost
-     * @depends testGetList
-     */
+    #[\PHPUnit\Framework\Attributes\Depends('testPost')]
+    #[\PHPUnit\Framework\Attributes\Depends('testGetList')]
     public function testDelete(string $id): void
     {
         $this->client->request('DELETE', '/admin/api/snippets/' . $id . '?locale=en');

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Doctrine\Set\DoctrineSetList;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
 use Rector\Set\ValueObject\LevelSetList;
@@ -29,6 +30,7 @@ return RectorConfig::configure()
         __DIR__ . '/public',
         __DIR__ . '/src',
         __DIR__ . '/tests',
+        __DIR__ . '/packages',
     ])
     ->withSkipPath('*/var/cache')
     ->withSkipPath('*/tests/Resources/cache')
@@ -44,6 +46,7 @@ return RectorConfig::configure()
         // SymfonySetList::SYMFONY_CODE_QUALITY,
         // DoctrineSetList::DOCTRINE_CODE_QUALITY,
         // LevelSetList::UP_TO_PHP_80,
+        PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
     ])
     ->withRules([
         StaticDataProviderClassMethodRector::class,

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/SvgFileInspectorTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/FileInspector/SvgFileInspectorTest.php
@@ -59,9 +59,7 @@ class SvgFileInspectorTest extends TestCase
         yield 'svg with phishing link' => ['<svg><a href="http://phishing-site.com" target="_blank"><text x="10" y="50">Click here for a prize!</text></a></svg>', false];
     }
 
-    /**
-     * @dataProvider provideSvgs
-     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSvgs')]
     public function testIsSafe(string $svg, bool $expectedSafe): void
     {
         if (!$expectedSafe) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #6988 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding a rector rule that enforces the use of Attributes over Annotations.
Also adding the "packages" directory to the rector files.

#### Why?
Since the introduction of PhpUnit 10 we can use Attributes for everything. They're better supported by PHP than annotations.

#### Example Usage
See changes.