### PR TITLE
Improve snapshot tests assertion messages

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/AssertSnapshotTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/AssertSnapshotTrait.php
@@ -32,7 +32,7 @@ trait AssertSnapshotTrait
         $this->assertInstanceOf(Response::class, $actualResponse);
         $responseContent = $actualResponse->getContent();
         $this->assertHttpStatusCode($statusCode, $actualResponse);
-        $this->assertIsString($responseContent);
+        $this->assertIsString($responseContent, 'The response content is not a string');
 
         $this->assertSnapshot($snapshotPatternFilename, $responseContent, $message);
     }
@@ -46,7 +46,7 @@ trait AssertSnapshotTrait
         string $message = ''
     ): void {
         $arrayContent = \json_encode($array);
-        $this->assertIsString($arrayContent);
+        $this->assertIsString($arrayContent, 'Unable to encode the data into a string');
 
         $this->assertSnapshot($snapshotPatternFilename, $arrayContent, $message);
     }
@@ -56,9 +56,14 @@ trait AssertSnapshotTrait
         string $content,
         string $message = ''
     ): void {
-        $snapshotFolder = $this->getCalledClassFolder() . \DIRECTORY_SEPARATOR . $this->getSnapshotFolder();
-        $snapshotPattern = \file_get_contents($snapshotFolder . \DIRECTORY_SEPARATOR . $snapshotPatternFilename);
-        $this->assertIsString($snapshotPattern);
+        $snapshotFilePath = \implode(
+            \DIRECTORY_SEPARATOR,
+            [$this->getCalledClassFolder(), $this->getSnapshotFolder(), $snapshotPatternFilename],
+        );
+
+        $this->assertFileExists($snapshotFilePath, 'Unable to find snapshot file');
+        $snapshotPattern = \file_get_contents($snapshotFilePath);
+        $this->assertIsString($snapshotPattern, 'Unable to open snapshot file: ' . $snapshotFilePath);
 
         $this->assertMatchesPattern(\trim($snapshotPattern), \trim($content), $message);
     }


### PR DESCRIPTION
## The problem
When I create a test and assert that the output matches a given snapshot I write this:
```php
$this->assertSnapshot('some-random-path.txt', $response->getContent(), 'Response content does not match');
```
If the file I specified does not exist however the error message was very cryptic and took some debugging to figure out what the real problem was.

## The change
Before I just got a 
```
Failed asserting that false is of type string.
```
Now it says:
```
Failed asserting that file "/some-random-path.txt" exists.
```