### PR TITLE
Add more details to exception messages in FormatManager

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16771,11 +16771,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
 
 		-
-			message: "#^Parameter \\#4 \\$saveImage of class Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatManager\\\\FormatManager constructor expects string, true given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatManager\\\\FormatManagerTest\\:\\:\\$formats type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -89,7 +89,7 @@ class FormatManager implements FormatManagerInterface
             $info = \pathinfo($fileName);
 
             if (!isset($info['extension'])) {
-                throw new ImageProxyInvalidUrl('No `extension` was found in the url');
+                throw new ImageProxyInvalidUrl(\sprintf('No `extension` was found in the url "%s".', $fileName));
             }
 
             $imageFormat = $info['extension'];
@@ -97,7 +97,7 @@ class FormatManager implements FormatManagerInterface
             $media = $this->mediaRepository->findMediaByIdForRendering($id, $formatKey, $version);
 
             if (!$media) {
-                throw new ImageProxyMediaNotFoundException('Media was not found');
+                throw new ImageProxyMediaNotFoundException(\sprintf('Media with id "%s" was not found.', $id));
             }
 
             $fileVersion = $this->getLatestFileVersion($media);
@@ -108,13 +108,13 @@ class FormatManager implements FormatManagerInterface
             $requestedFileVersion = $file?->getFileVersion($version);
 
             if (!$requestedFileVersion) {
-                throw new ImageProxyMediaNotFoundException('Requested FileVersion for media was not found');
+                throw new ImageProxyMediaNotFoundException(\sprintf('Requested FileVersion "%s" for media with id "%s" was not found.', $version, $id));
             }
 
             $requestedFileVersionImageFormatName = $this->replaceExtension($requestedFileVersion->getName(), $imageFormat);
 
             if ($requestedFileVersionImageFormatName !== $fileName) {
-                throw new ImageProxyMediaNotFoundException('File version was not found');
+                throw new ImageProxyMediaNotFoundException(\sprintf('FileVersion "%s" for media with id "%s" was not found.', $requestedFileVersion->getVersion(), $id));
             }
 
             if ($fileVersion->getVersion() !== $requestedFileVersion->getVersion()) {
@@ -122,7 +122,7 @@ class FormatManager implements FormatManagerInterface
 
                 $formatUrl = $formats[$formatKey . '.' . $imageFormat] ?? null;
                 if (null === $formatUrl) {
-                    throw new ImageProxyMediaNotFoundException('Image format "' . $formatKey . '.' . $imageFormat . '" was not found');
+                    throw new ImageProxyMediaNotFoundException(\sprintf('Image format "%s.%s" was not found for media with id "%s".', $formatKey, $imageFormat, $id));
                 }
 
                 return new RedirectResponse($formatUrl, 301);
@@ -136,7 +136,7 @@ class FormatManager implements FormatManagerInterface
             if (!\in_array($imageFormat, $supportedImageFormats)) {
                 throw new ImageProxyInvalidImageFormat(
                     \sprintf(
-                        'Image format "%s" not supported. Supported image formats are: %s',
+                        'Image format "%s" is not supported. Supported image formats are: "%s"',
                         $imageFormat,
                         \implode(', ', $supportedImageFormats)
                     ));

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\ImageConverterInterface;
+use Symfony\Component\ErrorHandler\BufferingLogger;
 
 class FormatManagerTest extends TestCase
 {
@@ -51,11 +52,15 @@ class FormatManagerTest extends TestCase
      */
     private $formatManager;
 
+    private BufferingLogger $logger;
+
     protected function setUp(): void
     {
         $this->mediaRepository = $this->prophesize(MediaRepositoryInterface::class);
         $this->formatCache = $this->prophesize(FormatCacheInterface::class);
         $this->imageConverter = $this->prophesize(ImageConverterInterface::class);
+        $this->logger = new BufferingLogger();
+
         $this->formats = [
             '640x480' => [
                 'internal' => false,
@@ -97,12 +102,13 @@ class FormatManagerTest extends TestCase
         ];
 
         $this->formatManager = new FormatManager(
-            $this->mediaRepository->reveal(),
-            $this->formatCache->reveal(),
-            $this->imageConverter->reveal(),
-            true,
-            [],
-            $this->formats
+            mediaRepository: $this->mediaRepository->reveal(),
+            formatCache: $this->formatCache->reveal(),
+            converter: $this->imageConverter->reveal(),
+            saveImage: 'true',
+            responseHeaders: [],
+            formats: $this->formats,
+            logger: $this->logger
         );
     }
 
@@ -421,6 +427,169 @@ class FormatManagerTest extends TestCase
             ],
             $formats['50x50']
         );
+    }
+
+    public function testMissingExtension(): void
+    {
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy', 1);
+
+        $this->assertSame(404, $result->getStatusCode());
+        $logs = $this->logger->cleanLogs();
+        $this->assertIsArray($logs[0]);
+        $this->assertCount(1, $logs);
+        $this->assertArrayHasKey(1, $logs[0]);
+        $this->assertSame('No `extension` was found in the url "dummy".', $logs[0][1]);
+    }
+
+    public function testMediaNotFound(): void
+    {
+        $result = $this->formatManager->returnImage(666, '640x480', 'dummy.jpg', 1);
+
+        $this->assertSame(404, $result->getStatusCode());
+        $logs = $this->logger->cleanLogs();
+        $this->assertCount(1, $logs);
+        $this->assertIsArray($logs[0]);
+        $this->assertArrayHasKey(1, $logs[0]);
+        $this->assertSame('Media with id "666" was not found.', $logs[0][1]);
+    }
+
+    public function testFileVersionNotFound(): void
+    {
+        $media = new Media();
+        $reflection = new \ReflectionClass(\get_class($media));
+        $property = $reflection->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($media, 1);
+
+        $file = new File();
+        $file->setVersion(1);
+        $fileVersion = new FileVersion();
+        $fileVersion->setVersion(1);
+        $fileVersion->setName('dummy.gif');
+        $fileVersion->setMimeType('image/gif');
+        $fileVersion->setStorageOptions(['a' => 'b']);
+        $file->addFileVersion($fileVersion);
+        $media->addFile($file);
+
+        $this->mediaRepository->findMediaByIdForRendering(1, '640x480', 17)
+            ->willReturn($media)
+            ->shouldBeCalled();
+
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy.gif', 17);
+
+        $this->assertSame(404, $result->getStatusCode());
+        $logs = $this->logger->cleanLogs();
+        $this->assertCount(1, $logs);
+        $this->assertIsArray($logs[0]);
+        $this->assertArrayHasKey(1, $logs[0]);
+        $this->assertSame('Requested FileVersion "17" for media with id "1" was not found.', $logs[0][1]);
+    }
+
+    public function testFileVersionNameNotFound(): void
+    {
+        $media = new Media();
+        $reflection = new \ReflectionClass(\get_class($media));
+        $property = $reflection->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($media, 1);
+
+        $file = new File();
+        $file->setVersion(1);
+        $fileVersion = new FileVersion();
+        $fileVersion->setVersion(1);
+        $fileVersion->setName('foo.gif');
+        $fileVersion->setMimeType('image/gif');
+        $fileVersion->setStorageOptions(['a' => 'b']);
+        $file->addFileVersion($fileVersion);
+        $media->addFile($file);
+
+        $this->mediaRepository->findMediaByIdForRendering(1, '640x480', 1)
+            ->willReturn($media)
+            ->shouldBeCalled();
+
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy.gif', 1);
+
+        $this->assertSame(404, $result->getStatusCode());
+        $logs = $this->logger->cleanLogs();
+        $this->assertCount(1, $logs);
+        $this->assertIsArray($logs[0]);
+        $this->assertArrayHasKey(1, $logs[0]);
+        $this->assertSame('FileVersion "1" for media with id "1" was not found.', $logs[0][1]);
+    }
+
+    public function testImageFormatNotFound(): void
+    {
+        $media = new Media();
+        $reflection = new \ReflectionClass(\get_class($media));
+        $property = $reflection->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($media, 1);
+
+        $file = new File();
+        $file->setVersion(1);
+        $fileVersion = new FileVersion();
+        $fileVersion->setVersion(1);
+        $fileVersion->setName('dummy.gif');
+        $fileVersion->setMimeType('image/gif');
+        $fileVersion->setStorageOptions(['a' => 'b']);
+        $file->addFileVersion($fileVersion);
+        $media->addFile($file);
+
+        $fileVersion2 = new FileVersion();
+        $fileVersion2->setVersion(17);
+        $fileVersion2->setName('dummy.gif');
+        $fileVersion2->setMimeType('image/gif');
+        $fileVersion2->setStorageOptions(['a' => 'b']);
+        $file->addFileVersion($fileVersion2);
+
+        $this->mediaRepository->findMediaByIdForRendering(1, '640x480', 17)
+            ->willReturn($media)
+            ->shouldBeCalled();
+
+        $this->imageConverter->getSupportedOutputImageFormats(Argument::any())->willReturn(['jpg', 'png', 'gif'])->shouldBeCalled();
+
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy.gif', 17);
+
+        $this->assertSame(404, $result->getStatusCode());
+        $logs = $this->logger->cleanLogs();
+        $this->assertCount(1, $logs);
+        $this->assertIsArray($logs[0]);
+        $this->assertArrayHasKey(1, $logs[0]);
+        $this->assertSame('Image format "640x480.gif" was not found for media with id "1".', $logs[0][1]);
+    }
+
+    public function testImageFormatNotSupported(): void
+    {
+        $media = new Media();
+        $reflection = new \ReflectionClass(\get_class($media));
+        $property = $reflection->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($media, 1);
+
+        $file = new File();
+        $file->setVersion(1);
+        $fileVersion = new FileVersion();
+        $fileVersion->setVersion(1);
+        $fileVersion->setName('dummy.gif');
+        $fileVersion->setMimeType('image/gif');
+        $fileVersion->setStorageOptions(['a' => 'b']);
+        $file->addFileVersion($fileVersion);
+        $media->addFile($file);
+
+        $this->mediaRepository->findMediaByIdForRendering(1, '640x480', 1)
+            ->willReturn($media)
+            ->shouldBeCalled();
+
+        $this->imageConverter->getSupportedOutputImageFormats(Argument::any())->willReturn(['jpg', 'png', 'gif'])->shouldBeCalled();
+
+        $result = $this->formatManager->returnImage(1, '640x480', 'dummy.heic', 1);
+
+        $this->assertSame(404, $result->getStatusCode());
+        $logs = $this->logger->cleanLogs();
+        $this->assertCount(1, $logs);
+        $this->assertIsArray($logs[0]);
+        $this->assertArrayHasKey(1, $logs[0]);
+        $this->assertSame('Image format "heic" is not supported. Supported image formats are: "jpg, png, gif"', $logs[0][1]);
     }
 
     public function testPurge(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Improves the exception messages.

#### Why?

Generic exception messages are not helpful when debugging bugs. Examples before and after:

`Media was not found`  => `Media with id "%s" was not found.`
`Requested FileVersion for media was not found` =>  `Requested FileVersion "%s" for media with id "%s" was not found.`

