### PR TITLE
Fix Sulu 3.0 homepage builder issue

### DIFF
--- a/packages/page/tests/Functional/UserInterface/Command/InitializeHomepageCommandTest.php
+++ b/packages/page/tests/Functional/UserInterface/Command/InitializeHomepageCommandTest.php
@@ -51,8 +51,6 @@ class InitializeHomepageCommandTest extends SuluTestCase
         self::assertSame(1, $this->pageRepository->countBy([
             'parentId' => null,
             'webspaceKey' => 'sulu-io',
-            'locale' => 'en',
-            'stage' => DimensionContentInterface::STAGE_LIVE,
         ]));
     }
 
@@ -65,8 +63,6 @@ class InitializeHomepageCommandTest extends SuluTestCase
         self::assertSame(1, $this->pageRepository->countBy([
             'parentId' => null,
             'webspaceKey' => 'sulu-io',
-            'locale' => 'en',
-            'stage' => DimensionContentInterface::STAGE_LIVE,
         ]));
 
         $command = $application->find('sulu:page:initialize');
@@ -78,8 +74,6 @@ class InitializeHomepageCommandTest extends SuluTestCase
         self::assertSame(1, $this->pageRepository->countBy([
             'parentId' => null,
             'webspaceKey' => 'sulu-io',
-            'locale' => 'en',
-            'stage' => DimensionContentInterface::STAGE_LIVE,
         ]));
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/7818
| License | MIT

#### What's in this PR?

Fix the issue that the initialisation command creates two content rich entities for two locales instead of one content rich entity and multiple dimensions for the other locales.