### PR TITLE
Add creating of history routes automatically for new route storage

### DIFF
--- a/packages/article/tests/Application/Kernel.php
+++ b/packages/article/tests/Application/Kernel.php
@@ -18,6 +18,7 @@ use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ExampleTestBundle;
 use Sulu\Page\Infrastructure\Symfony\HttpKernel\SuluPageBundle;
+use Sulu\Route\Infrastructure\Symfony\HttpKernel\SuluRouteBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Task\TaskBundle\TaskBundle;
 
@@ -47,6 +48,7 @@ class Kernel extends SuluTestKernel
         $bundles[] = new SuluPageBundle();
         $bundles[] = new SuluContentBundle();
         $bundles[] = new SuluArticleBundle();
+        $bundles[] = new SuluRouteBundle();
         $bundles[] = new ExampleTestBundle(); // TODO currently required for test content bundle, everybody should setup database by its own
         $bundles[] = new SuluAutomationBundle(); // TODO currently required for test content bundle, everybody should setup database by its own
         $bundles[] = new TaskBundle(); // TODO currently required for test content bundle, everybody should setup database by its own

--- a/packages/route/config/doctrine/Route/Route.orm.xml
+++ b/packages/route/config/doctrine/Route/Route.orm.xml
@@ -4,14 +4,14 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <entity
         name="Sulu\Route\Domain\Model\Route"
-        table="ro_routes"
-    >
+        table="ro_next_routes"
+    ><!-- FIXME change route to `ro_routes` -->
         <unique-constraints>
             <unique-constraint name="ro_routes_unique" fields="site,locale,slug" />
         </unique-constraints>
 
         <indexes>
-            <index name="ro_routes_resource" fields="locale,resourceKey,resourceId"/>
+            <index name="ro_routes_resource_idx" fields="locale,resourceKey,resourceId"/>
         </indexes>
 
         <id name="id" type="integer" column="id">
@@ -27,6 +27,6 @@
         </many-to-one>
 
         <field name="resourceKey" type="string" length="32"/>
-        <field name="resourceId" type="string" length="48"/>
+        <field name="resourceId" type="string" length="70"/> <!-- resourceKey::uuid for history routes is used -->
     </entity>
 </doctrine-mapping>

--- a/packages/route/src/Domain/Model/Route.php
+++ b/packages/route/src/Domain/Model/Route.php
@@ -17,7 +17,7 @@ namespace Sulu\Route\Domain\Model;
 class Route
 {
     /** @internal */
-    public const HISTORY_RESOURCE_KEY = 'history';
+    public const HISTORY_RESOURCE_KEY = 'route_history';
 
     private ?int $id = null;
 

--- a/packages/route/src/Domain/Model/Route.php
+++ b/packages/route/src/Domain/Model/Route.php
@@ -16,6 +16,9 @@ namespace Sulu\Route\Domain\Model;
  */
 class Route
 {
+    /** @internal */
+    public const HISTORY_RESOURCE_KEY = 'history';
+
     private ?int $id = null;
 
     private ?string $site;

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -17,6 +17,8 @@ use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\Event\OnClearEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Sulu\Route\Domain\Model\Route;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -70,9 +72,11 @@ class RouteChangedUpdater implements ResetInterface
             return;
         }
 
-        $connection = $args->getObjectManager()->getConnection();
+        $objectManager = $args->getObjectManager();
+        $connection = $objectManager->getConnection();
 
-        $routesTableName = $args->getObjectManager()->getClassMetadata(Route::class)->getTableName();
+        $classMetadata = $objectManager->getClassMetadata(Route::class);
+        $routesTableName = $classMetadata->getTableName();
 
         foreach ($this->routeChanges as $routeChange) {
             $route = $routeChange['route'];
@@ -113,43 +117,32 @@ class RouteChangedUpdater implements ResetInterface
              */
             $childAndGrandChildResult = $selectQueryBuilder->executeQuery()->fetchAllAssociative();
             $parentIds = [];
-            $childAndGrandChildHistoryUrls = [];
+            $childAndGrandChildHistoryRoutes = [];
             foreach ($childAndGrandChildResult as $childAndGrandChildRow) {
                 $parentIds[] = $childAndGrandChildRow['parent_id'];
-                $childAndGrandChildHistoryUrls[] = [
-                    'site' => $childAndGrandChildRow['site'],
-                    'locale' => $locale,
-                    'slug' => $childAndGrandChildRow['slug'],
-                    // TODO we currently handling history URLs as own
-                    'resourceKey' => Route::HISTORY_RESOURCE_KEY,
-                    'resourceId' => $childAndGrandChildRow['resource_key'] . '::' . $childAndGrandChildRow['resource_id'],
-                ];
+                $childAndGrandChildHistoryRoutes[] = new Route(
+                    Route::HISTORY_RESOURCE_KEY,
+                    $childAndGrandChildRow['resource_key'] . '::' . $childAndGrandChildRow['resource_id'],
+                    $locale,
+                    $childAndGrandChildRow['slug'],
+                    $childAndGrandChildRow['site'],
+                    null, // history never has parents ad they never will be updated
+                );
             }
 
             $parentIds = \array_filter($parentIds);
             $parentIds = \array_unique($parentIds); // DISTINCT and GROUP BY is a lot slower as make it unique in PHP itself
 
-            // create route history for changed route
-            $historyInsertQueryBuilder = $connection->createQueryBuilder()->insert($routesTableName)
-                ->values([
-                    // history never has parents ad they never will be updated
-                    'site' => ':site',
-                    'locale' => ':locale',
-                    'slug' => ':slug',
-                    // TODO we currently handling history URLs as own
-                    'resource_key' => ':resourceKey',
-                    'resource_id' => ':resourceId',
-                ])
-                ->setParameters([
-                    'site' => $oldSite,
-                    'locale' => $locale,
-                    'slug' => $oldSlug,
-                    // TODO we currently handling history URLs as own
-                    'resourceKey' => Route::HISTORY_RESOURCE_KEY,
-                    'resourceId' => $route->getResourceKey() . '::' . $route->getResourceId(),
-                ]);
+            $historyRoute = new Route(
+                Route::HISTORY_RESOURCE_KEY,
+                $route->getResourceKey() . '::' . $route->getResourceId(),
+                $locale,
+                $oldSlug,
+                $oldSite,
+                null, // history never has parents ad they never will be updated
+            );
 
-            $historyInsertQueryBuilder->executeStatement();
+            $this->createHistoryRoute($objectManager, $classMetadata, $historyRoute);
 
             if (0 === \count($parentIds)) {
                 continue;
@@ -171,22 +164,41 @@ class RouteChangedUpdater implements ResetInterface
             $updateQueryBuilder->executeStatement();
 
             // create child and grand history routes
-            foreach ($childAndGrandChildHistoryUrls as $childAndGrandChildHistoryUrl) {
-                $historyInsertQueryBuilder = $connection->createQueryBuilder()->insert($routesTableName)
-                    ->values([
-                        // history never has parents as they never will be updated
-                        'site' => ':site',
-                        'locale' => ':locale',
-                        'slug' => ':slug',
-                        // TODO we currently handling history URLs as own
-                        'resource_key' => ':resourceKey',
-                        'resource_id' => ':resourceId',
-                    ])
-                    ->setParameters($childAndGrandChildHistoryUrl);
-
-                $historyInsertQueryBuilder->executeStatement();
+            foreach ($childAndGrandChildHistoryRoutes as $childAndGrandChildHistoryRoute) {
+                $this->createHistoryRoute($objectManager, $classMetadata, $childAndGrandChildHistoryRoute);
             }
         }
+    }
+
+    private function createHistoryRoute(ObjectManager $objectManager, ClassMetadata $classMetadata, Route $historyRoute): void
+    {
+        $connection = $objectManager->getConnection();
+        $routesTableName = $classMetadata->getTableName();
+
+        $historyInsertQueryBuilder = $connection->createQueryBuilder()->insert($routesTableName)
+            ->values([
+                $classMetadata->getColumnName('resourceKey') => ':resourceKey',
+                $classMetadata->getColumnName('resourceId') => ':resourceId',
+                $classMetadata->getColumnName('locale') => ':locale',
+                $classMetadata->getColumnName('slug') => ':slug',
+                $classMetadata->getColumnName('site') => ':site',
+            ])
+            ->setParameters([
+                'resourceKey' => $historyRoute->getResourceKey(),
+                'resourceId' => $historyRoute->getResourceId(),
+                'locale' => $historyRoute->getLocale(),
+                'slug' => $historyRoute->getSlug(),
+                'site' => $historyRoute->getSite(),
+            ]);
+
+        if (!$classMetadata->idGenerator->isPostInsertGenerator()) {
+            $historyInsertQueryBuilder->setValue(
+                $classMetadata->getColumnName('id'),
+                $classMetadata->idGenerator->generate($objectManager, $historyRoute)
+            );
+        }
+
+        $historyInsertQueryBuilder->executeStatement();
     }
 
     public function onClear(OnClearEventArgs $args): void

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\Service\ResetInterface;
  * @internal No BC promises are given for this class. It may be changed or removed at any time.
  *
  * This is a complex mechanism, and "Test Driven Development" is the recommended way to implement any changes here.
- * When reporting a bug in the following logic, please provide a failing test case. The easiest way in most use cases 
+ * When reporting a bug in the following logic, please provide a failing test case. The easiest way in most use cases
  * is to adopt the existing `RouteChangedUpdaterTest::provideRoutes` test data provider.
  */
 class RouteChangedUpdater implements ResetInterface

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -25,9 +25,9 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * @internal No BC promises are given for this class. It may be changed or removed at any time.
  *
- * This is kind of a complex mechanic here and "Test Driven Development" is recommended way to do any changes here.
- * Reporting a bug inside the following logic please provide a failing test case. Easiest way in most use cases is
- * to adopt the existing `RouteChangedUpdaterTest::provideRoutes` test data provider.
+ * This is a complex mechanism, and "Test Driven Development" is the recommended way to implement any changes here.
+ * When reporting a bug in the following logic, please provide a failing test case. The easiest way in most use cases 
+ * is to adopt the existing `RouteChangedUpdaterTest::provideRoutes` test data provider.
  */
 class RouteChangedUpdater implements ResetInterface
 {

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\Service\ResetInterface;
 class RouteChangedUpdater implements ResetInterface
 {
     /**
-     * @var array<int, array{oldValue: string, newValue: string, locale: string, site: string|null}>
+     * @var array<int, array{oldSlug: string, oldSite: string|null, route: Route}>
      */
     private array $routeChanges = [];
 
@@ -37,20 +37,27 @@ class RouteChangedUpdater implements ResetInterface
             return;
         }
 
-        /** @var string $oldSlug */
-        $oldSlug = $args->getOldValue('slug');
-        /** @var string $newSlug */
-        $newSlug = $args->getNewValue('slug');
 
-        if ($oldSlug === $newSlug) {
+        $oldSlug = $route->getSlug();
+        if ($args->hasChangedField('slug')) {
+            $oldSlug = $args->getOldValue('slug');
+            \assert(\is_string($oldSlug), 'Slug is expected to be always a string.');
+        }
+
+        $oldSite = $route->getSite();
+        if ($args->hasChangedField('site')) {
+            $oldSite = $args->getOldValue('site');
+            \assert(\is_string($oldSite) || \is_null($oldSite), 'Site is expected to be always a string or null.');
+        }
+
+        if ($oldSlug === $route->getSlug()) {
             return;
         }
 
         $this->routeChanges[$route->getId()] = [
-            'oldValue' => $oldSlug,
-            'newValue' => $newSlug,
-            'locale' => $route->getLocale(),
-            'site' => $route->getSite(),
+            'oldSlug' => $oldSlug,
+            'oldSite' => $oldSite,
+            'route' => $route,
         ];
     }
 
@@ -65,15 +72,21 @@ class RouteChangedUpdater implements ResetInterface
         $routesTableName = $args->getObjectManager()->getClassMetadata(Route::class)->getTableName();
 
         foreach ($this->routeChanges as $routeChange) {
-            $oldSlug = $routeChange['oldValue'];
-            $newSlug = $routeChange['newValue'];
-            $locale = $routeChange['locale'];
-            $site = $routeChange['site'];
+            $route = $routeChange['route'];
+            $oldSlug = $routeChange['oldSlug'];
+            $oldSite = $routeChange['oldSite'];
+            $newSlug = $route->getSlug();
+            $locale = $route->getLocale();
+            $site = $route->getSite();
 
             // select all child and grand routes of oldSlug
             $selectQueryBuilder = $connection->createQueryBuilder()
                 ->from($routesTableName, 'parent')
                 ->select('parent.id AS parent_id')
+                ->addSelect('child.site')
+                ->addSelect('child.slug')
+                ->addSelect('child.resource_key')
+                ->addSelect('child.resource_id')
                 ->innerJoin('parent', $routesTableName, 'child', 'child.parent_id = parent.id')
                 ->andWhere(\is_string($site) ? 'parent.site = :site' : 'parent.site IS NULL')
                 ->andWhere('parent.locale = :locale')
@@ -86,16 +99,58 @@ class RouteChangedUpdater implements ResetInterface
                 $selectQueryBuilder->setParameter('site', $site, ParameterType::STRING);
             }
 
-            $parentIds = \array_map(fn ($row) => $row[0], $selectQueryBuilder->executeQuery()->fetchAllNumeric());
+            /**
+             * @var array<int, array{
+             *     parent_id: int,
+             *     site: string|null,
+             *     slug: string,
+             *     resource_key: string,
+             *     resource_id: string,
+             * }> $childAndGrandChildResult
+             */
+            $childAndGrandChildResult = $selectQueryBuilder->executeQuery()->fetchAllAssociative();
+            $parentIds = [];
+            $childAndGrandChildHistoryUrls = [];
+            foreach ($childAndGrandChildResult as $childAndGrandChildRow) {
+                $parentIds[] = $childAndGrandChildRow['parent_id'];
+                $childAndGrandChildHistoryUrls[] = [
+                    'site' => $childAndGrandChildRow['site'],
+                    'locale' => $locale,
+                    'slug' => $childAndGrandChildRow['slug'],
+                    // TODO we currently handling history URLs as own
+                    'resourceKey' => Route::HISTORY_RESOURCE_KEY,
+                    'resourceId' => $childAndGrandChildRow['resource_key'] . '::' . $childAndGrandChildRow['resource_id'],
+                ];
+            }
+
             $parentIds = \array_filter($parentIds);
+            $parentIds = \array_unique($parentIds); // DISTINCT and GROUP BY is a lot slower as make it unique in PHP itself
+
+            // create route history for changed route
+            $historyInsertQueryBuilder = $connection->createQueryBuilder()->insert($routesTableName)
+                ->values([
+                    // history never has parents ad they never will be updated
+                    'site' => ':site',
+                    'locale' => ':locale',
+                    'slug' => ':slug',
+                    // TODO we currently handling history URLs as own
+                    'resource_key' => ':resourceKey',
+                    'resource_id' => ':resourceId',
+                ])
+                ->setParameters([
+                    'site' => $oldSite,
+                    'locale' => $locale,
+                    'slug' => $oldSlug,
+                    // TODO we currently handling history URLs as own
+                    'resourceKey' => Route::HISTORY_RESOURCE_KEY,
+                    'resourceId' => $route->getResourceKey() . '::' . $route->getResourceId(),
+                ]);
+
+            $historyInsertQueryBuilder->executeStatement();
 
             if (0 === \count($parentIds)) {
                 continue;
             }
-
-            $parentIds = \array_unique($parentIds); // DISTINCT and GROUP BY a lot slower as make it unique in PHP itself
-
-            // TODO create history for current ids
 
             $newSlugCast = '';
             if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
@@ -111,6 +166,23 @@ class RouteChangedUpdater implements ResetInterface
                 ->setParameter('parentIds', $parentIds, ArrayParameterType::INTEGER);
 
             $updateQueryBuilder->executeStatement();
+
+            // create child and grand history routes
+            foreach ($childAndGrandChildHistoryUrls as $childAndGrandChildHistoryUrl) {
+                $historyInsertQueryBuilder = $connection->createQueryBuilder()->insert($routesTableName)
+                    ->values([
+                        // history never has parents as they never will be updated
+                        'site' => ':site',
+                        'locale' => ':locale',
+                        'slug' => ':slug',
+                        // TODO we currently handling history URLs as own
+                        'resource_key' => ':resourceKey',
+                        'resource_id' => ':resourceId',
+                    ])
+                    ->setParameters($childAndGrandChildHistoryUrl);
+
+                $historyInsertQueryBuilder->executeStatement();
+            }
         }
     }
 

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -14,11 +14,11 @@ namespace Sulu\Route\Infrastructure\Doctrine\EventListener;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnClearEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\Persistence\ObjectManager;
 use Sulu\Route\Domain\Model\Route;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -170,7 +170,10 @@ class RouteChangedUpdater implements ResetInterface
         }
     }
 
-    private function createHistoryRoute(ObjectManager $objectManager, ClassMetadata $classMetadata, Route $historyRoute): void
+    /**
+     * @param ClassMetadata<Route> $classMetadata
+     */
+    private function createHistoryRoute(EntityManagerInterface $objectManager, ClassMetadata $classMetadata, Route $historyRoute): void
     {
         $connection = $objectManager->getConnection();
         $routesTableName = $classMetadata->getTableName();
@@ -191,10 +194,13 @@ class RouteChangedUpdater implements ResetInterface
                 'site' => $historyRoute->getSite(),
             ]);
 
-        if (!$classMetadata->idGenerator->isPostInsertGenerator()) {
+        if (
+            null !== $classMetadata->idGenerator
+            && !$classMetadata->idGenerator->isPostInsertGenerator()
+        ) {
             $historyInsertQueryBuilder->setValue(
                 $classMetadata->getColumnName('id'),
-                $classMetadata->idGenerator->generate($objectManager, $historyRoute)
+                $classMetadata->idGenerator->generateId($objectManager, $historyRoute), // @phpstan-ignore-line argument.type // not really sure to return a integer id as a string so currently keep the id as int
             );
         }
 

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -22,6 +22,10 @@ use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @internal No BC promises are given for this class. It may be changed or removed at any time.
+ *
+ * This is kind of a complex mechanic here and "Test Driven Development" is recommended way to do any changes here.
+ * Reporting a bug inside the following logic please provide a failing test case. Easiest way in most use cases is
+ * to adopt the existing `RouteChangedUpdaterTest::provideRoutes` test data provider.
  */
 class RouteChangedUpdater implements ResetInterface
 {
@@ -36,7 +40,6 @@ class RouteChangedUpdater implements ResetInterface
         if (!$route instanceof Route) {
             return;
         }
-
 
         $oldSlug = $route->getSlug();
         if ($args->hasChangedField('slug')) {

--- a/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
+++ b/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
@@ -29,6 +29,12 @@ use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
  */
 final class SuluRouteBundle extends AbstractBundle
 {
+    public function __construct()
+    {
+        $this->name = 'SuluNextRouteBundle';
+        $this->extensionAlias = 'sulu_next_route'; // TODO also change route table from `ro_next_routes` to `ro_routes`
+    }
+
     /**
      * @param array<string, mixed> $config
      *

--- a/packages/route/tests/Application/config/config.yml
+++ b/packages/route/tests/Application/config/config.yml
@@ -1,5 +1,3 @@
-sulu_route: {}
-
 framework:
     # symfony recipe default configuration:
     workflows: null

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
@@ -29,7 +29,7 @@ class RouteChangedUpdaterTest extends KernelTestCase
     protected function setUp(): void
     {
         $entityManager = self::getContainer()->get(EntityManagerInterface::class);
-        $entityManager->getConnection()->executeStatement('DELETE FROM ro_routes WHERE 1 = 1');
+        $entityManager->getConnection()->executeStatement('DELETE FROM ro_next_routes WHERE 1 = 1');
 
         $schemaTool = new SchemaTool($entityManager);
         $classes = $entityManager->getMetadataFactory()->getAllMetadata();
@@ -108,6 +108,36 @@ class RouteChangedUpdaterTest extends KernelTestCase
             }
             if (0 === $count % 1000) {
                 \gc_collect_cycles();
+            }
+        }
+
+        $expectedHistoryRoutes = [];
+        foreach ($expectedRoutes as $expectedRoute) {
+            foreach ($routes as $route) {
+                if ($expectedRoute['resourceId'] === $route['resourceId']
+                    && $expectedRoute['slug'] !== $route['slug']
+                ) {
+                    $expectedHistoryRoutes[] = $route;
+                }
+            }
+        }
+
+        if (\count($expectedHistoryRoutes)) {
+            foreach ($expectedHistoryRoutes as $expectedHistoryRoute) {
+                $route = $repository->findOneBy([
+                    'locale' => 'en',
+                    'site' => 'website',
+                    'slug' => $expectedHistoryRoute['slug'],
+                ]);
+
+                $additionalErrorInfoMessage = \sprintf(
+                    'Expected route "%s" be a route history.',
+                    $expectedHistoryRoute['slug'],
+                );
+                $this->assertNotNull($route, $additionalErrorInfoMessage);
+
+                $this->assertSame(Route::HISTORY_RESOURCE_KEY, $route->getResourceKey(), $additionalErrorInfoMessage);
+                $this->assertSame('page::' . $expectedHistoryRoute['resourceId'], $route->getResourceId(), $additionalErrorInfoMessage);
             }
         }
     }

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
@@ -39,7 +39,7 @@ class RouteChangedUpdaterTest extends KernelTestCase
     protected function tearDown(): void
     {
         $entityManager = self::getContainer()->get(EntityManagerInterface::class);
-        $entityManager->getConnection()->executeStatement('DELETE FROM ro_routes WHERE 1 = 1');
+        $entityManager->getConnection()->executeStatement('DELETE FROM ro_next_routes WHERE 1 = 1');
 
         parent::tearDown();
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,18 +241,6 @@ parameters:
 			path: src/Sulu/Bundle/ActivityBundle/Domain/Repository/NullActivityRepository.php
 
 		-
-			message: '#^Cannot call method generate\(\) on Doctrine\\ORM\\Id\\AbstractIdGenerator\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/ActivityBundle/Infrastructure/Doctrine/Repository/ActivityRepository.php
-
-		-
-			message: '#^Cannot call method isPostInsertGenerator\(\) on Doctrine\\ORM\\Id\\AbstractIdGenerator\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/ActivityBundle/Infrastructure/Doctrine/Repository/ActivityRepository.php
-
-		-
 			message: '#^Parameter \#2 \$value of method Doctrine\\DBAL\\Query\\QueryBuilder\:\:setValue\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Sulu/Bundle/ActivityBundle/Infrastructure/Doctrine/Repository/ActivityRepository.php
+++ b/src/Sulu/Bundle/ActivityBundle/Infrastructure/Doctrine/Repository/ActivityRepository.php
@@ -102,8 +102,11 @@ class ActivityRepository implements ActivityRepositoryInterface
         }
 
         // set value of id explicitly if class has a pre-insert identity-generator to be compatible with postgresql
-        if (!$classMetadata->idGenerator->isPostInsertGenerator()) {
-            $queryBuilder->setValue($classMetadata->getColumnName('id'), $classMetadata->idGenerator->generate($this->entityManager, $activity));
+        if (
+            null !== $classMetadata->idGenerator
+            && !$classMetadata->idGenerator->isPostInsertGenerator()
+        ) {
+            $queryBuilder->setValue($classMetadata->getColumnName('id'), $classMetadata->idGenerator->generateId($this->entityManager, $activity));
         }
 
         return $queryBuilder;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | ﻿https://github.com/sulu/sulu/pull/7726 part of https://github.com/sulu/sulu/issues/7672
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add creating of history routes automatically for new route storage.

#### Why?

We should create history routes automatically.
