### PR TITLE
Add additonal tests for multi locale and multi site in route update changer

### DIFF
--- a/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
@@ -21,7 +21,7 @@ use Sulu\Route\Infrastructure\Doctrine\EventListener\RouteChangedUpdater;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
- * @phpstan-type RouteData array{resourceId: string, slug: string, parentSlug?: string|null}
+ * @phpstan-type RouteData array{resourceId: string, locale?: string, slug: string, site?: string|null, parentSlug?: string|null}
  */
 #[CoversClass(RouteChangedUpdater::class)]
 class RouteChangedUpdaterTest extends KernelTestCase
@@ -94,8 +94,8 @@ class RouteChangedUpdaterTest extends KernelTestCase
             $route = $repository->findOneBy([
                 'resourceKey' => 'page',
                 'resourceId' => $expectedRoute['resourceId'],
-                'locale' => 'en',
-                'site' => 'website',
+                'locale' => $expectedRoute['locale'] ?? 'en',
+                'site' =>  $expectedRoute['site'] ?? null,
             ]);
             $this->assertNotNull($route);
 
@@ -116,6 +116,8 @@ class RouteChangedUpdaterTest extends KernelTestCase
             foreach ($routes as $route) {
                 if ($expectedRoute['resourceId'] === $route['resourceId']
                     && $expectedRoute['slug'] !== $route['slug']
+                    && ($expectedRoute['locale'] ?? 'en') !== ($route['locale'] ?? 'en')
+                    && ($expectedRoute['site'] ?? null) !== ($route['site'] ?? null)
                 ) {
                     $expectedHistoryRoutes[] = $route;
                 }
@@ -125,8 +127,8 @@ class RouteChangedUpdaterTest extends KernelTestCase
         if (\count($expectedHistoryRoutes)) {
             foreach ($expectedHistoryRoutes as $expectedHistoryRoute) {
                 $route = $repository->findOneBy([
-                    'locale' => 'en',
-                    'site' => 'website',
+                    'locale' => $expectedHistoryRoute['locale'] ?? 'en',
+                    'site' => $expectedHistoryRoute['site'] ?? null,
                     'slug' => $expectedHistoryRoute['slug'],
                 ]);
 
@@ -259,6 +261,120 @@ class RouteChangedUpdaterTest extends KernelTestCase
             ],
         ];
 
+        yield 'nested_childs_update_multiple_locales' => [
+            'routes' => [
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test/child-a',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test/child-b',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '4',
+                    'slug' => '/test/child-b/grand-child-a',
+                    'parentSlug' => '/test/child-b',
+                ],
+                [
+                    'resourceId' => '5',
+                    'slug' => '/test/child-b/grand-child-b',
+                    'parentSlug' => '/test/child-b',
+                ],
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test',
+                    'locale' => 'de',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test/child-a',
+                    'locale' => 'de',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test/child-b',
+                    'locale' => 'de',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '4',
+                    'slug' => '/test/child-b/grand-child-a',
+                    'locale' => 'de',
+                    'parentSlug' => '/test/child-b',
+                ],
+                [
+                    'resourceId' => '5',
+                    'slug' => '/test/child-b/grand-child-b',
+                    'locale' => 'de',
+                    'parentSlug' => '/test/child-b',
+                ],
+            ],
+            'changeRoute' => '/test-article',
+            'expectedRoutes' => [
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test-article',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test-article/child-a',
+                    'parentSlug' => '/test-article',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test-article/child-b',
+                    'parentSlug' => '/test-article',
+                ],
+                [
+                    'resourceId' => '4',
+                    'slug' => '/test-article/child-b/grand-child-a',
+                    'parentSlug' => '/test-article/child-b',
+                ],
+                [
+                    'resourceId' => '5',
+                    'slug' => '/test-article/child-b/grand-child-b',
+                    'parentSlug' => '/test-article/child-b',
+                ],
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test',
+                    'locale' => 'de',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test/child-a',
+                    'locale' => 'de',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test/child-b',
+                    'locale' => 'de',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '4',
+                    'slug' => '/test/child-b/grand-child-a',
+                    'locale' => 'de',
+                    'parentSlug' => '/test/child-b',
+                ],
+                [
+                    'resourceId' => '5',
+                    'slug' => '/test/child-b/grand-child-b',
+                    'locale' => 'de',
+                    'parentSlug' => '/test/child-b',
+                ],
+            ],
+        ];
+
         // yield 'heavy_load' => static::generateNestedRoutes('/rezepte', '/rezepte-neu', 10, 100_000);
     }
 
@@ -346,9 +462,9 @@ class RouteChangedUpdaterTest extends KernelTestCase
         return new Route(
             'page',
             $route['resourceId'],
-            'en',
+            $route['locale'] ?? 'en',
             $route['slug'],
-            'website',
+            $route['site'] ?? null,
         );
     }
 }

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
@@ -95,9 +95,15 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 'resourceKey' => 'page',
                 'resourceId' => $expectedRoute['resourceId'],
                 'locale' => $expectedRoute['locale'] ?? 'en',
-                'site' =>  $expectedRoute['site'] ?? null,
+                'site' => $expectedRoute['site'] ?? null,
             ]);
-            $this->assertNotNull($route);
+
+            $this->assertNotNull($route, \sprintf(
+                'Expected route with resourceId "%s", locale "%s" and site "%s" not found.',
+                $expectedRoute['resourceId'],
+                $expectedRoute['locale'] ?? 'en',
+                $expectedRoute['site'] ?? 'NULL',
+            ));
 
             $this->assertSame($expectedRoute['slug'], $route->getSlug());
             $this->assertSame($expectedRoute['parentSlug'] ?? null, $route->getParentRoute()?->getSlug());
@@ -370,6 +376,130 @@ class RouteChangedUpdaterTest extends KernelTestCase
                     'resourceId' => '5',
                     'slug' => '/test/child-b/grand-child-b',
                     'locale' => 'de',
+                    'parentSlug' => '/test/child-b',
+                ],
+            ],
+        ];
+
+        yield 'nested_childs_update_multiple_sites' => [
+            'routes' => [
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test',
+                    'site' => 'website',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test/child-a',
+                    'site' => 'website',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test/child-b',
+                    'site' => 'website',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '4',
+                    'slug' => '/test/child-b/grand-child-a',
+                    'site' => 'website',
+                    'parentSlug' => '/test/child-b',
+                ],
+                [
+                    'resourceId' => '5',
+                    'slug' => '/test/child-b/grand-child-b',
+                    'site' => 'website',
+                    'parentSlug' => '/test/child-b',
+                ],
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test',
+                    'site' => 'intranet',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test/child-a',
+                    'site' => 'intranet',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test/child-b',
+                    'site' => 'intranet',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '4',
+                    'slug' => '/test/child-b/grand-child-a',
+                    'site' => 'intranet',
+                    'parentSlug' => '/test/child-b',
+                ],
+                [
+                    'resourceId' => '5',
+                    'slug' => '/test/child-b/grand-child-b',
+                    'site' => 'intranet',
+                    'parentSlug' => '/test/child-b',
+                ],
+            ],
+            'changeRoute' => '/test-article',
+            'expectedRoutes' => [
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test-article',
+                    'site' => 'website',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test-article/child-a',
+                    'site' => 'website',
+                    'parentSlug' => '/test-article',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test-article/child-b',
+                    'site' => 'website',
+                    'parentSlug' => '/test-article',
+                ],
+                [
+                    'resourceId' => '4',
+                    'slug' => '/test-article/child-b/grand-child-a',
+                    'site' => 'website',
+                    'parentSlug' => '/test-article/child-b',
+                ],
+                [
+                    'resourceId' => '5',
+                    'slug' => '/test-article/child-b/grand-child-b',
+                    'site' => 'website',
+                    'parentSlug' => '/test-article/child-b',
+                ],
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test',
+                    'site' => 'intranet',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test/child-a',
+                    'site' => 'intranet',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test/child-b',
+                    'site' => 'intranet',
+                    'parentSlug' => '/test',
+                ],
+                [
+                    'resourceId' => '4',
+                    'slug' => '/test/child-b/grand-child-a',
+                    'site' => 'intranet',
+                    'parentSlug' => '/test/child-b',
+                ],
+                [
+                    'resourceId' => '5',
+                    'slug' => '/test/child-b/grand-child-b',
+                    'site' => 'intranet',
                     'parentSlug' => '/test/child-b',
                 ],
             ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | part of #7726, requires: https://github.com/sulu/sulu/pull/7830
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add additonal tests for multi locale and multi site in route update changer.

#### Why?

The new route implementation should work with multi site and multi locale. To make sure this PR add more additional tests to existing implementation in https://github.com/sulu/sulu/pull/7726 and https://github.com/sulu/sulu/pull/7830