### PR TITLE
Fix return type for getBlock on BlockPropertyWrapper method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -33756,11 +33756,6 @@ parameters:
 			path: src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
 
 		-
-			message: "#^Method Sulu\\\\Component\\\\Content\\\\Compat\\\\Block\\\\BlockPropertyWrapper\\:\\:getBlock\\(\\) should return Sulu\\\\Component\\\\Content\\\\Compat\\\\Block\\\\BlockPropertyInterface but returns Sulu\\\\Component\\\\Content\\\\Compat\\\\PropertyInterface\\.$#"
-			count: 1
-			path: src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
-
-		-
 			message: "#^Method Sulu\\\\Component\\\\Content\\\\Compat\\\\Block\\\\BlockPropertyWrapper\\:\\:getParams\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php

--- a/src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockPropertyWrapper.php
@@ -115,7 +115,7 @@ class BlockPropertyWrapper implements PropertyInterface
     }
 
     /**
-     * @param BlockPropertyInterface $block
+     * @param PropertyInterface $block
      */
     public function setBlock($block)
     {
@@ -123,7 +123,7 @@ class BlockPropertyWrapper implements PropertyInterface
     }
 
     /**
-     * @return BlockPropertyInterface
+     * @return PropertyInterface
      */
     public function getBlock()
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix return type for getBlock on BlockPropertyWrapper method.

#### Why?

PHPStan says in the `ImageMapContentTypeTest` that `$blockProperty->getBlock() === $property` is always false but that is a false positive. 

`getBlock` is marked as return a `BlockPropertyInterface` but that seems not be true as constructor says it can be a PropertyInterface.