### PR TITLE
Add handling for tree_full_edit to disconnect route from parent

### DIFF
--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -98,6 +98,7 @@ class RouteChangedUpdater implements ResetInterface
                 ->andWhere(\is_string($site) ? 'parent.site = :site' : 'parent.site IS NULL')
                 ->andWhere('parent.locale = :locale')
                 ->andWhere('(parent.slug = :newSlug OR parent.slug LIKE :oldSlugSlash)') // direct child is using newSlug already updated as we are in PostFlush, grand child use oldSlugWithSlash as not yet updated
+                ->andWhere('(child.slug LIKE :oldSlugSlash)') // ignore disconnected child routes in case of full tree edit
                 ->setParameter('newSlug', $newSlug, ParameterType::STRING)
                 ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
                 ->setParameter('locale', $locale, ParameterType::STRING);
@@ -115,7 +116,7 @@ class RouteChangedUpdater implements ResetInterface
              *     resource_id: string,
              * }> $childAndGrandChildResult
              */
-            $childAndGrandChildResult = $selectQueryBuilder->executeQuery()->fetchAllAssociative();
+            $childAndGrandChildResult = $selectQueryBuilder->executeQuery()->iterateAssociative();
             $parentIds = [];
             $childAndGrandChildHistoryRoutes = [];
             foreach ($childAndGrandChildResult as $childAndGrandChildRow) {
@@ -126,7 +127,7 @@ class RouteChangedUpdater implements ResetInterface
                     $locale,
                     $childAndGrandChildRow['slug'],
                     $childAndGrandChildRow['site'],
-                    null, // history never has parents ad they never will be updated
+                    null, // history never has parents as they never will be updated
                 );
             }
 
@@ -159,6 +160,8 @@ class RouteChangedUpdater implements ResetInterface
                 ->set('slug', 'CONCAT(:newSlug' . $newSlugCast . ', SUBSTRING(slug, ' . (\strlen($oldSlug) + 1) . '))')
                 ->setParameter('newSlug', $newSlug, ParameterType::STRING)
                 ->where('parent_id IN (:parentIds)')
+                ->andWhere('slug LIKE :oldSlugSlash') // ignore disconnected child routes in case of full tree edit
+                ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
                 ->setParameter('parentIds', $parentIds, ArrayParameterType::INTEGER);
 
             $updateQueryBuilder->executeStatement();

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -145,26 +145,24 @@ class RouteChangedUpdater implements ResetInterface
 
             $this->createHistoryRoute($objectManager, $classMetadata, $historyRoute);
 
-            if (0 === \count($parentIds)) {
-                continue;
+            if (0 !== \count($parentIds)) {
+                $newSlugCast = '';
+                if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+                    $newSlugCast = '::text'; // concat seems not directly supported by dbal and parameter $1 (newSlug) is not cast to text correctly. So manually cast it here: https://github.com/sulu/sulu/pull/7726#discussion_r1930324013
+                }
+
+                // update child and grand routes
+                $updateQueryBuilder = $connection->createQueryBuilder()
+                    ->update($routesTableName, 'r')
+                    ->set('slug', 'CONCAT(:newSlug' . $newSlugCast . ', SUBSTRING(slug, ' . (\strlen($oldSlug) + 1) . '))')
+                    ->setParameter('newSlug', $newSlug, ParameterType::STRING)
+                    ->where('parent_id IN (:parentIds)')
+                    ->andWhere('slug LIKE :oldSlugSlash') // ignore disconnected child routes in case of full tree edit
+                    ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
+                    ->setParameter('parentIds', $parentIds, ArrayParameterType::INTEGER);
+
+                $updateQueryBuilder->executeStatement();
             }
-
-            $newSlugCast = '';
-            if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
-                $newSlugCast = '::text'; // concat seems not directly supported by dbal and parameter $1 (newSlug) is not cast to text correctly. So manually cast it here: https://github.com/sulu/sulu/pull/7726#discussion_r1930324013
-            }
-
-            // update child and grand routes
-            $updateQueryBuilder = $connection->createQueryBuilder()
-                ->update($routesTableName, 'r')
-                ->set('slug', 'CONCAT(:newSlug' . $newSlugCast . ', SUBSTRING(slug, ' . (\strlen($oldSlug) + 1) . '))')
-                ->setParameter('newSlug', $newSlug, ParameterType::STRING)
-                ->where('parent_id IN (:parentIds)')
-                ->andWhere('slug LIKE :oldSlugSlash') // ignore disconnected child routes in case of full tree edit
-                ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
-                ->setParameter('parentIds', $parentIds, ArrayParameterType::INTEGER);
-
-            $updateQueryBuilder->executeStatement();
 
             // create child and grand history routes
             foreach ($childAndGrandChildHistoryRoutes as $childAndGrandChildHistoryRoute) {

--- a/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
+++ b/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
@@ -49,7 +49,8 @@ final class SuluRouteBundle extends AbstractBundle
             ->class(RouteChangedUpdater::class)
             ->tag('doctrine.event_listener', ['event' => 'preUpdate', 'entity' => Route::class, 'method' => 'preUpdate'])
             ->tag('doctrine.event_listener', ['event' => 'postFlush', 'method' => 'postFlush'])
-            ->tag('doctrine.event_listener', ['event' => 'onClear', 'method' => 'onClear']);
+            ->tag('doctrine.event_listener', ['event' => 'onClear', 'method' => 'onClear'])
+            ->tag('kernel.reset', ['method' => 'reset']);
 
         // Repositories services
         $services->set('sulu_route.route_repository')

--- a/packages/route/tests/Unit/Domain/Model/RouteTest.php
+++ b/packages/route/tests/Unit/Domain/Model/RouteTest.php
@@ -42,6 +42,34 @@ class RouteTest extends TestCase
         $this->assertSame('/test2', $route->getSlug());
     }
 
+    public function testGetParentRoute(): void
+    {
+        $parentRoute = $this->createModel(slug: '/test');
+        $route = $this->createModel(slug: '/test/child', parentRoute: $parentRoute);
+
+        $this->assertSame($parentRoute, $route->getParentRoute());
+    }
+
+    public function testSetSlugViaLeafEdit(): void
+    {
+        $parentRoute = $this->createModel(slug: '/test');
+        $route = $this->createModel(slug: '/test/child', parentRoute: $parentRoute);
+
+        $route->setSlug('/test/child-2');
+        $this->assertSame('/test/child-2', $route->getSlug());
+        $this->assertSame($parentRoute, $route->getParentRoute());
+    }
+
+    public function testSetSlugViaFullTreeEdit(): void
+    {
+        $parentRoute = $this->createModel(slug: '/test');
+        $route = $this->createModel(slug: '/test/child', parentRoute: $parentRoute);
+
+        $route->setSlug('/test2');
+        $this->assertSame('/test2', $route->getSlug());
+        $this->assertSame($parentRoute, $route->getParentRoute(), 'We keep connection to parent route for easier opt-in later.');
+    }
+
     public function createModel(
         string $resourceKey = 'resource',
         string $resourceId = '1',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | part of https://github.com/sulu/sulu/pull/7726
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add handling for tree_full_edit to disconnect route from parent.

As discussed with @chirimoya as soon as I edit more as the last part of a URL it is kind of a opt out from parent rout updates and so the route itself not longer has a `parentRoute` and is this so disconnected and lifes by itself.

Example:

```
 - /parent
     - /parent/child-a
```

Will be changed to

```
 - /parent
     - /child-a
```

The connection to the `parent` is removed and so it not longer gets updated.

#### Why?

Sulu supports tree_full_edit strategy to allow that a page can be edit fully and not only its leaf.
