### PR TITLE
Add test about same starting url for route update changer

### DIFF
--- a/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
@@ -176,6 +176,51 @@ class RouteChangedUpdaterTest extends KernelTestCase
             'expectedChangedRoutes' => 1,
         ];
 
+        yield 'not_effect_same_level_with_same_starting' => [
+            'routes' => [
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test',
+                    'locale' => 'en',
+                    'site' => 'website',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test-2',
+                    'locale' => 'en',
+                    'site' => 'website',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test-2/child-a',
+                    'locale' => 'en',
+                    'site' => 'website',
+                ],
+            ],
+            'changeRoute' => '/test-article',
+            'expectedRoutes' => [
+                [
+                    'resourceId' => '1',
+                    'slug' => '/test-article',
+                    'locale' => 'en',
+                    'site' => 'website',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/test-2',
+                    'locale' => 'en',
+                    'site' => 'website',
+                ],
+                [
+                    'resourceId' => '3',
+                    'slug' => '/test-2/child-a',
+                    'locale' => 'en',
+                    'site' => 'website',
+                ],
+            ],
+            'expectedChangedRoutes' => 1,
+        ];
+
         yield 'direct_childs_update' => [
             'routes' => [
                 [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | part of https://github.com/sulu/sulu/pull/7726
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add missing test for that updating /test has no effects on urls which also starts with /test but arent child of /test/.

#### Why?

Avoid accidently side effects.