### PR TITLE
Fix output in test run

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -609,4 +609,10 @@ class FormatManagerTest extends TestCase
 
         $this->formatManager->purge(1, 'test.JPG', 'image/jpeg', null);
     }
+
+    protected function tearDown(): void
+    {
+        $this->logger->cleanLogs();
+        parent::tearDown();
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/sulu/sulu/pull/7825#issuecomment-2701430472
| License | MIT
| Documentation PR | -

#### What's in this PR?

Fixes log message that ended up in the test output by accident.

Before

![image](https://github.com/user-attachments/assets/288cf124-8320-40d1-87d4-32cfd37186bc)


After 

![image](https://github.com/user-attachments/assets/ad6fddd3-5e6c-4d0e-b5d4-72ed3540a870)

