### PR TITLE
Add test about naming methods of ContentController which extends AbstractController

### DIFF
--- a/packages/content/tests/Unit/Content/UserInterface/Controller/Website/ContentControllerTest.php
+++ b/packages/content/tests/Unit/Content/UserInterface/Controller/Website/ContentControllerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\UserInterface\Controller\Website;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\UserInterface\Controller\Website\ContentController;
+
+class ContentControllerTest extends TestCase
+{
+    public function testMethodShouldContainWordSuluToAvoidFutureConflicts(): void
+    {
+        $reflection = new \ReflectionClass(ContentController::class);
+        $methods = $reflection->getMethods();
+
+        $skippedMethods = [
+            'indexAction',
+            'getSubscribedServices',
+        ];
+
+        foreach ($methods as $method) {
+            $methodName = $method->getName();
+
+            if (ContentController::class !== $method->class) {
+                continue;
+            }
+
+            if (\in_array($methodName, $skippedMethods)) {
+                continue;
+            }
+
+            $this->assertStringContainsString('Sulu', $methodName, \sprintf(
+                'Method "%s"" should contain "Sulu" to avoid future conflicts like we had with renderBlock in the past.',
+                $methodName,
+            ));
+        }
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7148
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add test about naming methods of [ContentController](https://github.com/sulu/sulu/blob/3.0/packages/content/src/UserInterface/Controller/Website/ContentController.php) which extends AbstractController.

#### Why?

Methods extending a Class which is not in our control should contain "Sulu" to avoid future conflicts like we had with renderBlock in the past.

We named our methods `resolveSuluParameters` and `renderSuluView` to avoid this. If we add new methods here we should keep that Pattern.

See https://github.com/sulu/sulu/pull/7148
