### PR TITLE
Fix mandatory condition for page tree route

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
+++ b/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
@@ -15,11 +15,18 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPCR\ItemNotFoundException;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AnyOfsMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NullMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ObjectMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperInterface;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
 use Sulu\Bundle\RouteBundle\Entity\Route;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
 use Sulu\Bundle\RouteBundle\Generator\ChainRouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\SimpleContentType;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\DocumentRegistry;
@@ -27,7 +34,7 @@ use Sulu\Component\DocumentManager\DocumentRegistry;
 /**
  * Provides page_tree_route content-type.
  */
-class PageTreeRouteContentType extends SimpleContentType
+class PageTreeRouteContentType extends SimpleContentType implements PropertyMetadataMapperInterface
 {
     public const NAME = 'page_tree_route';
 
@@ -214,5 +221,37 @@ class PageTreeRouteContentType extends SimpleContentType
     private function getRouteRepository(): RouteRepositoryInterface
     {
         return $this->entityManager->getRepository(Route::class);
+    }
+
+    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    {
+        $mandatory = $propertyMetadata->isRequired();
+
+        $pageMetadata = new ObjectMetadata([
+            new PropertyMetadata('uuid', $mandatory, new StringMetadata()),
+            new PropertyMetadata('path', $mandatory, new StringMetadata()),
+        ]);
+
+        if (!$mandatory) {
+            $pageMetadata = new AnyOfsMetadata([
+                new NullMetadata(),
+                $pageMetadata,
+            ]);
+        }
+
+        $pageTreeRouteMetadata = new ObjectMetadata([
+            new PropertyMetadata('page', $mandatory, $pageMetadata),
+            new PropertyMetadata('path', $mandatory, new StringMetadata()),
+            new PropertyMetadata('suffix', false, new StringMetadata()),
+        ]);
+
+        if (!$mandatory) {
+            $pageTreeRouteMetadata = new AnyOfsMetadata([
+                new NullMetadata(),
+                $pageTreeRouteMetadata,
+            ]);
+        }
+
+        return new PropertyMetadata((string) $propertyMetadata->getName(), $mandatory, $pageTreeRouteMetadata);
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/services.xml
@@ -18,6 +18,7 @@
 
             <tag name="sulu.content.type" alias="page_tree_route"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
+            <tag name="sulu_admin.property_metadata_mapper" type="page_tree_route"/>
         </service>
 
         <service id="sulu_route.subscriber.routable"

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
@@ -26,6 +26,7 @@ use Sulu\Bundle\RouteBundle\Generator\ChainRouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
+use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\Route\Document\Behavior\RoutableBehavior;
@@ -422,5 +423,66 @@ class PageTreeRouteContentTypeTest extends TestCase
         $this->property->getValue()->willReturn($value);
 
         $this->assertEquals($value, $this->contentType->getViewData($this->property->reveal()));
+    }
+
+    public function testMapPropertyMetadata(): void
+    {
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+
+        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+
+        $this->assertEquals([
+            'anyOf' => [
+                [
+                    'type' => 'null',
+                ],
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'page' => [
+                            'anyOf' => [
+                                ['type' => 'null'],
+                                [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'uuid' => ['type' => 'string'],
+                                        'path' => ['type' => 'string'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'path' => ['type' => 'string'],
+                        'suffix' => ['type' => 'string'],
+                    ],
+                ],
+            ],
+        ], $jsonSchema);
+    }
+
+    public function testMapPropertyMetadataRequired(): void
+    {
+        $propertyMetadata = new PropertyMetadata();
+        $propertyMetadata->setName('property-name');
+        $propertyMetadata->setRequired(true);
+
+        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+
+        $this->assertEquals([
+            'type' => 'object',
+            'properties' => [
+                'page' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'uuid' => ['type' => 'string'],
+                        'path' => ['type' => 'string'],
+                    ],
+                    'required' => ['uuid', 'path'],
+                ],
+                'path' => ['type' => 'string'],
+                'suffix' => ['type' => 'string'],
+            ],
+            'required' => ['page', 'path'],
+        ], $jsonSchema);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds property metadata to the PageTreeRouteContentType.

#### Why?

The mandatory condition of the `page_tree_route` content type did not work properly.