### PR TITLE
Refactor content resolver to resolve recursively

### DIFF
--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -12,6 +12,7 @@
                 index-by="type"
             />
             <argument type="service" id="sulu_content.resource_loader_provider"/>
+            <argument type="service" id="sulu_content.content_aggregator"/>
         </service>
         <service id="Sulu\Content\Application\ContentResolver\ContentResolverInterface" alias="sulu_content.content_resolver"/>
 

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -28,6 +28,7 @@ use Webmozart\Assert\Assert;
  */
 class ContentResolver implements ContentResolverInterface
 {
+    // TODO add configurable parameter for max depth
     private const MAX_DEPTH = 3;
 
     /**
@@ -388,7 +389,6 @@ class ContentResolver implements ContentResolverInterface
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
      *     extension: array<string, array<string, mixed>>,
-     *     settings: SettingsData,
      * }
      */
     private function normalizeContentData(array $content, array $view, ContentRichEntityInterface $resource): array
@@ -402,18 +402,20 @@ class ContentResolver implements ContentResolverInterface
         unset($view['template']);
 
         /** @var SettingsData $settingsData */
-        $settingsData = $content['settings'];
+        $settingsData = $content['settings'] ?? [];
         unset($content['settings'], $view['settings']);
 
         /** @var array<string, array<string, mixed>> $extensionData */
         $extensionData = $content;
 
-        return [
-            'resource' => $resource,
-            'content' => $templateData,
-            'view' => $templateView,
-            'extension' => $extensionData,
-            'settings' => $settingsData,
-        ];
+        return \array_merge(
+            [
+                'resource' => $resource,
+                'content' => $templateData,
+                'view' => $templateView,
+                'extension' => $extensionData,
+            ],
+            $settingsData
+        );
     }
 }

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -13,60 +13,170 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Application\ContentResolver;
 
+use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
 use Sulu\Content\Application\ContentResolver\Resolver\SettingsResolver;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
+use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @phpstan-import-type SettingsData from SettingsResolver
  */
 class ContentResolver implements ContentResolverInterface
 {
+    private const MAX_DEPTH = 3;
+
     /**
      * @param iterable<ResolverInterface> $contentResolvers
      */
     public function __construct(
         private iterable $contentResolvers,
-        private ResourceLoaderProvider $resourceLoaderProvider
+        private ResourceLoaderProvider $resourceLoaderProvider,
+        private ContentAggregatorInterface $contentAggregator,
     ) {
     }
 
     public function resolve(DimensionContentInterface $dimensionContent): array
     {
+        $locale = $dimensionContent->getLocale();
+        Assert::string($locale, 'Locale must be a string');
+        $stage = $dimensionContent->getStage();
+
+        // Initial resolution to gather ResolvableResources
+        /** @var array<int, array<string, array<int, array<int|string, ResolvableResource>>>> $priorityQueue */
+        $priorityQueue = [];
+        $resolvedResources = [];
+
+        $resolvedContent = $this->resolveInternal($dimensionContent, 0, $priorityQueue);
+        // Process the priority queue until it's empty
+        while (!empty($priorityQueue)) {
+            // Get the highest priority resources (first key due to krsort in mergeResolvableResources)
+            $highestPriorityKey = \array_key_first($priorityQueue);
+            $resourcesAtPriority = $priorityQueue[$highestPriorityKey];
+            unset($priorityQueue[$highestPriorityKey]);
+
+            $loaderIdDepths = [];
+            $resourcesToLoad = [];
+            // filter resources with depth too high
+            foreach ($resourcesAtPriority as $loaderKey => $resourcePerDepth) {
+                foreach ($resourcePerDepth as $depth => $resources) {
+                    if ($depth > self::MAX_DEPTH) {
+                        continue;
+                    }
+                    foreach ($resources as $id => $resource) {
+                        $resourcesToLoad[$loaderKey][$id] = $resource;
+                        $loaderIdDepths[$loaderKey][$id] = $depth;
+                    }
+                }
+            }
+
+            // Load resources at this priority level
+            /** @var array<string, array<string, ResolvableResource>> $resourcesToLoad */
+            $loadedResources = $this->loadResources($resourcesToLoad, $locale);
+
+            // Process loaded resources
+            foreach ($loadedResources as $loaderKey => $resources) {
+                foreach ($resources as $id => $resource) {
+                    if ($resource instanceof ContentRichEntityInterface) {
+                        // Get the dimension content for this entity
+                        $resourceDimension = $this->contentAggregator->aggregate($resource, [
+                            'locale' => $locale,
+                            'stage' => $stage,
+                        ]);
+
+                        // Resolve this entity
+                        $depth = $loaderIdDepths[$loaderKey][$id];
+                        $result = $this->resolveInternal($resourceDimension, $depth, $priorityQueue);
+                        $resolvedValue = $this->normalizeContentData(
+                            $result['content'],
+                            $result['view'],
+                            $resource
+                        );
+                    } else {
+                        // For non-entity resources, just store the resource directly
+                        $resolvedValue = $resource;
+                    }
+
+                    $resolvedResources[$loaderKey][$id] = $resolvedValue;
+                }
+            }
+        }
+
+        // Replace all ResolvableResource references with their actual resolved values
+        $finalContent = $this->replaceResolvableResourcesWithResolvedValues(
+            $resolvedContent['content'],
+            $resolvedResources,
+            1 // Start at depth 1 since the initial resolution was at depth 0
+        );
+
+        return $this->normalizeContentData(
+            $finalContent,
+            $resolvedContent['view'],
+            $dimensionContent->getResource()
+        );
+    }
+
+    /**
+     * Internal method that resolves the DimensionContent and populates the priority queue.
+     *
+     * @template T of ContentRichEntityInterface
+     *
+     * @param DimensionContentInterface<T> $dimensionContent
+     * @param int $depth Current depth
+     * @param array<int, array<string, array<int, array<int|string, ResolvableResource>>>> $priorityQueue Reference to the priority queue
+     *
+     * @return array{
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     resolvableResources: array<int, array<string, array<int, array<string|int, ResolvableResource>>>>,
+     * }
+     */
+    private function resolveInternal(
+        DimensionContentInterface $dimensionContent,
+        int $depth,
+        array &$priorityQueue
+    ): array {
+        $contentViews = $this->getContentViews($dimensionContent);
+        $resolvedContent = $this->resolveContentViews($contentViews, $depth);
+
+        // Add resolvable resources to priority queue
+        $priorityQueue = $this->mergeResolvableResources(
+            $resolvedContent['resolvableResources'],
+            $priorityQueue
+        );
+
+        return $resolvedContent;
+    }
+
+    /**
+     * @template T of ContentRichEntityInterface
+     *
+     * @param DimensionContentInterface<T> $dimensionContent
+     *
+     * @return array<string|int, ContentView>
+     */
+    private function getContentViews(DimensionContentInterface $dimensionContent): array
+    {
         $contentViews = [];
+
+        /**
+         * @var string $resolverKey
+         * @var ResolverInterface $contentResolver
+         */
         foreach ($this->contentResolvers as $resolverKey => $contentResolver) {
+            if (!$contentResolver->supports($dimensionContent)) {
+                continue;
+            }
+
             $contentView = $contentResolver->resolve($dimensionContent);
             $contentViews[$resolverKey] = $contentView;
         }
-        $resolvedContent = $this->resolveContentViews($contentViews);
-        $resolvedResources = $this->loadAndResolveResources($resolvedContent['resolvableResources'], $dimensionContent->getLocale());
-        $content = $this->replaceResolvableResourcesWithResolvedValues($resolvedContent['content'], $resolvedResources);
 
-        /** @var array<string, mixed> $templateData */
-        $templateData = $content['template'];
-        unset($content['template']);
-
-        /** @var array<string, mixed> $templateView */
-        $templateView = $resolvedContent['view']['template'];
-        unset($resolvedContent['view']['template']);
-
-        /** @var SettingsData $settingsData */
-        $settingsData = $content['settings'] ?? [];
-        unset($content['settings']);
-        unset($resolvedContent['view']['settings']);
-
-        /** @var array<string, array<string, mixed>> $extensionData */
-        $extensionData = $content;
-
-        return \array_merge([
-            'resource' => $dimensionContent->getResource(),
-            'content' => $templateData,
-            'extension' => $extensionData,
-            'view' => $templateView,
-        ], $settingsData);
+        return $contentViews;
     }
 
     /**
@@ -75,27 +185,27 @@ class ContentResolver implements ContentResolverInterface
      * @return array{
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
-     *     resolvableResources: array<string, array<ResolvableResource>>,
+     *     resolvableResources: array<int, array<string, array<int, array<string|int, ResolvableResource>>>>,
      * }
      */
-    private function resolveContentViews(array $contentViews): array
+    private function resolveContentViews(array $contentViews, int $depth): array
     {
         $content = [];
         $view = [];
-        /** @var array<string, array<ResolvableResource>> $resolvableResources */
-        $resolvableResources = [];
 
+        $resolvableResources = [];
         foreach ($contentViews as $name => $contentView) {
-            $result = $this->resolveContentView($contentView, (string) $name);
+            $result = $this->resolveContentView($contentView, (string) $name, $depth);
             $content = \array_merge($content, $result['content']);
             $view = \array_merge($view, $result['view']);
-            $resolvableResources = \array_merge_recursive($resolvableResources, $result['resolvableResources']);
+            $resolvableResources = $this->mergeResolvableResources($resolvableResources, $result['resolvableResources']);
         }
 
         return [
             'content' => $content,
             'view' => $view,
             'resolvableResources' => $resolvableResources,
+            'depth' => $depth,
         ];
     }
 
@@ -103,10 +213,10 @@ class ContentResolver implements ContentResolverInterface
      * @return array{
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
-     *     resolvableResources: array<string, array<ResolvableResource>>
+     *     resolvableResources: array<int, array<string, array<int, array<string|int, ResolvableResource>>>>
      * }
      */
-    private function resolveContentView(ContentView $contentView, string $name): array
+    private function resolveContentView(ContentView $contentView, string $name, int $depth): array
     {
         $content = $contentView->getContent();
         $view = $contentView->getView();
@@ -115,14 +225,16 @@ class ContentResolver implements ContentResolverInterface
             'content' => [],
             'view' => [],
             'resolvableResources' => [],
+            'depth' => $depth,
         ];
         if (\is_array($content)) {
             if (\count(\array_filter($content, fn ($entry) => $entry instanceof ContentView)) === \count($content)) {
+                /** @var ContentView[] $content */
                 // resolve array of content views
-                $resolvedContentViews = $this->resolveContentViews($content);
+                $resolvedContentViews = $this->resolveContentViews($content, $depth + 1);
                 $result['content'][$name] = $resolvedContentViews['content'];
                 $result['view'][$name] = $resolvedContentViews['view'];
-                $result['resolvableResources'] = \array_merge_recursive($result['resolvableResources'], $resolvedContentViews['resolvableResources']);
+                $result['resolvableResources'] = $this->mergeResolvableResources($result['resolvableResources'], $resolvedContentViews['resolvableResources']);
 
                 return $result;
             }
@@ -131,16 +243,16 @@ class ContentResolver implements ContentResolverInterface
             foreach ($content as $key => $entry) {
                 // resolve array of mixed content
                 if ($entry instanceof ContentView) {
-                    $resolvedContentView = $this->resolveContentView($entry, $key);
+                    $resolvedContentView = $this->resolveContentView($entry, $key, $depth + 1);
                     $result['content'][$name] = \array_merge($result['content'][$name] ?? [], $resolvedContentView['content']);
                     $result['view'][$name] = \array_merge($result['view'][$name] ?? [], $resolvedContentView['view']);
-                    $resolvableResources = \array_merge_recursive($resolvableResources, $resolvedContentView['resolvableResources']);
+                    $resolvableResources = $this->mergeResolvableResources($resolvableResources, $resolvedContentView['resolvableResources']);
 
                     continue;
                 }
 
                 if ($entry instanceof ResolvableResource) {
-                    $resolvableResources[$entry->getResourceLoaderKey()][] = $entry;
+                    $resolvableResources[$entry->getPriority()][$entry->getResourceLoaderKey()][$depth][$entry->getId()] = $entry;
                 }
 
                 $result['content'][$name][$key] = $entry;
@@ -153,7 +265,8 @@ class ContentResolver implements ContentResolverInterface
         }
 
         if ($content instanceof ResolvableResource) {
-            $result['resolvableResources'][$content->getResourceLoaderKey()][] = $content;
+            // @phpstan-ignore-next-line
+            $result['resolvableResources'][$content->getPriority()][$content->getResourceLoaderKey()][$depth][$content->getId()] = $content;
         }
 
         $result['content'][$name] = $content;
@@ -165,14 +278,13 @@ class ContentResolver implements ContentResolverInterface
     /**
      * Loads and resolves resources from various resource loaders.
      *
-     * @param array<string, array<ResolvableResource>> $resourcesPerLoader Resource loaders and their associated resources to load
+     * @param array<string, array<string, ResolvableResource>> $resourcesPerLoader Resource loaders and their associated resources to load
      *
      * @return array<string, mixed[]> Resolved resources organized by resource loader key
      */
-    private function loadAndResolveResources(array $resourcesPerLoader, ?string $locale): array
+    private function loadResources(array $resourcesPerLoader, ?string $locale): array
     {
-        $resolvedResources = [];
-
+        $loadedResources = [];
         foreach ($resourcesPerLoader as $loaderKey => $resourcesToLoad) {
             if (!$loaderKey) {
                 throw new \RuntimeException(\sprintf('ResourceLoader key "%s" is invalid', $loaderKey));
@@ -184,33 +296,124 @@ class ContentResolver implements ContentResolverInterface
             }
 
             $resourceIds = \array_map(fn (ResolvableResource $resource) => $resource->getId(), $resourcesToLoad);
-            $resolvedResources[$loaderKey] = $resourceLoader->load(
+            $loadedResources[$loaderKey] = $resourceLoader->load(
                 $resourceIds,
                 $locale
             );
         }
 
-        return $resolvedResources;
+        return $loadedResources;
     }
 
     /**
-     * Replaces all instances of ResolvableResource in the given content with their resolved values.
+     * @param array<string, mixed> $content
+     * @param array<string, mixed[]> $resolvedResources
      *
-     * @param mixed[] $content The content to replace ResolvableResource instances
-     * @param array<string, mixed[]> $resolvedResources The resolved resources, indexed by resource loader key and objectHash
-     *
-     * @return mixed[] The content with all ResolvableResource instances replaced with their resolved values
+     * @return array<string, mixed>
      */
-    private function replaceResolvableResourcesWithResolvedValues(array $content, array $resolvedResources): array
+    private function replaceResolvableResourcesWithResolvedValues(array $content, array $resolvedResources, int $depth): array
     {
-        \array_walk_recursive($content, function(&$value) use ($resolvedResources) {
-            if ($value instanceof ResolvableResource) {
+        if ($depth > self::MAX_DEPTH) {
+            // replace non resolved resources with null
+            \array_walk_recursive($content, function(&$value) {
+                if ($value instanceof ResolvableResource) {
+                    // TODO add callback with exception in dev mode
+                    $value = null;
+                }
+            });
+
+            return $content;
+        }
+
+        if (0 === \count($resolvedResources)) {
+            return $content;
+        }
+
+        $hasReplaced = false;
+        \array_walk_recursive($content, function(&$value) use ($resolvedResources, &$hasReplaced) {
+            if ($value instanceof ResolvableResource && isset($resolvedResources[$value->getResourceLoaderKey()][$value->getId()])) {
                 $value = $value->executeResourceCallback(
                     $resolvedResources[$value->getResourceLoaderKey()][$value->getId()]
                 );
+                $hasReplaced = true;
             }
         });
 
+        // Recursively replace ResolvableResource instances in nested arrays
+        // if a replacement was made in the previous step.
+        // This is necessary to resolve nested ResolvableResource instances
+        // which might have been added during the first replacement,
+        // e.g., when a ResolvableResource is replaced with an array containing another ResolvableResource.
+        if ($hasReplaced) {
+            $content = $this->replaceResolvableResourcesWithResolvedValues($content, $resolvedResources, $depth + 1);
+        }
+
         return $content;
+    }
+
+    /**
+     * Merges the given resolvable resources with the existing resolvable resources.
+     * The resolvable resources are ordered by priority and indexed by priority, loader key and object id.
+     *
+     * @param array<int, array<string, array<int, array<string|int, ResolvableResource>>>> $resolvableResources
+     * @param array<int, array<string, array<int, array<string|int, ResolvableResource>>>> $existingResolvableResources
+     *
+     * @return array<int, array<string, array<int, array<string|int, ResolvableResource>>>>
+     */
+    private function mergeResolvableResources(array $resolvableResources, array $existingResolvableResources): array
+    {
+        foreach ($resolvableResources as $priority => $loaderResolvableResources) {
+            foreach ($loaderResolvableResources as $loaderKey => $resolvableResourcesPerLoader) {
+                foreach ($resolvableResourcesPerLoader as $depth => $resolvableResourcePerDepth) {
+                    foreach ($resolvableResourcePerDepth as $resolvableResource) {
+                        $existingResolvableResources[$priority][$loaderKey][$depth][$resolvableResource->getId()] = $resolvableResource;
+                    }
+                }
+            }
+        }
+        \krsort($existingResolvableResources);
+
+        return $existingResolvableResources;
+    }
+
+    /**
+     * @template T of DimensionContentInterface
+     *
+     * @param array<string, mixed> $content
+     * @param array<string, mixed> $view
+     * @param ContentRichEntityInterface<T> $resource
+     *
+     * @return array{
+     *     resource: ContentRichEntityInterface<T>,
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     extension: array<string, array<string, mixed>>,
+     *     settings: SettingsData,
+     * }
+     */
+    private function normalizeContentData(array $content, array $view, ContentRichEntityInterface $resource): array
+    {
+        /** @var array<string, mixed> $templateData */
+        $templateData = $content['template'] ?? [];
+        unset($content['template']);
+
+        /** @var array<string, mixed> $templateView */
+        $templateView = $view['template'] ?? [];
+        unset($view['template']);
+
+        /** @var SettingsData $settingsData */
+        $settingsData = $content['settings'];
+        unset($content['settings'], $view['settings']);
+
+        /** @var array<string, array<string, mixed>> $extensionData */
+        $extensionData = $content;
+
+        return [
+            'resource' => $resource,
+            'content' => $templateData,
+            'view' => $templateView,
+            'extension' => $extensionData,
+            'settings' => $settingsData,
+        ];
     }
 }

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -169,11 +169,12 @@ class ContentResolver implements ContentResolverInterface
          * @var ResolverInterface $contentResolver
          */
         foreach ($this->contentResolvers as $resolverKey => $contentResolver) {
-            if (!$contentResolver->supports($dimensionContent)) {
+            $contentView = $contentResolver->resolve($dimensionContent);
+
+            if (!$contentView instanceof ContentView) {
                 continue;
             }
 
-            $contentView = $contentResolver->resolve($dimensionContent);
             $contentViews[$resolverKey] = $contentView;
         }
 

--- a/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
@@ -25,9 +25,10 @@ interface ContentResolverInterface
      *
      * @return array{
      *     resource: object,
-     *     content: mixed,
-     *     view: mixed[],
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
      *     extension: array<string, array<string, mixed>>,
+     *     settings: array<string, mixed>,
      * }
      */
     public function resolve(DimensionContentInterface $dimensionContent): array;

--- a/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
@@ -28,7 +28,6 @@ interface ContentResolverInterface
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
      *     extension: array<string, array<string, mixed>>,
-     *     settings: array<string, mixed>,
      * }
      */
     public function resolve(DimensionContentInterface $dimensionContent): array;

--- a/packages/content/src/Application/ContentResolver/Resolver/ExcerptResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ExcerptResolver.php
@@ -30,10 +30,10 @@ readonly class ExcerptResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): ContentView
+    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView
     {
         if (!$dimensionContent instanceof ExcerptInterface) {
-            throw new \RuntimeException('DimensionContent needs to extend the ' . ExcerptInterface::class);
+            return null;
         }
 
         /** @var string $locale */
@@ -94,10 +94,5 @@ readonly class ExcerptResolver implements ResolverInterface
             'excerptIcon' => $dimensionContent->getExcerptIcon(),
             'excerptImage' => $dimensionContent->getExcerptImage(),
         ];
-    }
-
-    public function supports(DimensionContentInterface $dimensionContent): bool
-    {
-        return $dimensionContent instanceof ExcerptInterface;
     }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/ExcerptResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ExcerptResolver.php
@@ -95,4 +95,9 @@ readonly class ExcerptResolver implements ResolverInterface
             'excerptImage' => $dimensionContent->getExcerptImage(),
         ];
     }
+
+    public function supports(DimensionContentInterface $dimensionContent): bool
+    {
+        return $dimensionContent instanceof ExcerptInterface;
+    }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/ResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ResolverInterface.php
@@ -24,12 +24,5 @@ interface ResolverInterface
      *
      * @param DimensionContentInterface<T> $dimensionContent
      */
-    public function resolve(DimensionContentInterface $dimensionContent): ContentView;
-
-    /**
-     * @template T of ContentRichEntityInterface
-     *
-     * @param DimensionContentInterface<T> $dimensionContent
-     */
-    public function supports(DimensionContentInterface $dimensionContent): bool;
+    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView;
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/ResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ResolverInterface.php
@@ -25,4 +25,11 @@ interface ResolverInterface
      * @param DimensionContentInterface<T> $dimensionContent
      */
     public function resolve(DimensionContentInterface $dimensionContent): ContentView;
+
+    /**
+     * @template T of ContentRichEntityInterface
+     *
+     * @param DimensionContentInterface<T> $dimensionContent
+     */
+    public function supports(DimensionContentInterface $dimensionContent): bool;
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
@@ -28,10 +28,10 @@ readonly class SeoResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): ContentView
+    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView
     {
         if (!$dimensionContent instanceof SeoInterface) {
-            throw new \RuntimeException('DimensionContent needs to extend the ' . SeoInterface::class);
+            return null;
         }
 
         /** @var string $locale */
@@ -99,10 +99,5 @@ readonly class SeoResolver implements ResolverInterface
             'seoNoFollow' => $dimensionContent->getSeoNoFollow(),
             'seoHideInSitemap' => $dimensionContent->getSeoHideInSitemap(),
         ];
-    }
-
-    public function supports(DimensionContentInterface $dimensionContent): bool
-    {
-        return $dimensionContent instanceof SeoInterface;
     }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
@@ -100,4 +100,9 @@ readonly class SeoResolver implements ResolverInterface
             'seoHideInSitemap' => $dimensionContent->getSeoHideInSitemap(),
         ];
     }
+
+    public function supports(DimensionContentInterface $dimensionContent): bool
+    {
+        return $dimensionContent instanceof SeoInterface;
+    }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
@@ -51,7 +51,7 @@ readonly class SettingsResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): ContentView
+    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView
     {
         /** @var SettingsData $result */
         $result = [
@@ -193,10 +193,5 @@ readonly class SettingsResolver implements ResolverInterface
         return [
             'shadowBaseLocale' => $dimensionContent->getShadowLocale(),
         ];
-    }
-
-    public function supports(DimensionContentInterface $dimensionContent): bool
-    {
-        return true;
     }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
@@ -194,4 +194,9 @@ readonly class SettingsResolver implements ResolverInterface
             'shadowBaseLocale' => $dimensionContent->getShadowLocale(),
         ];
     }
+
+    public function supports(DimensionContentInterface $dimensionContent): bool
+    {
+        return true;
+    }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/TemplateResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/TemplateResolver.php
@@ -55,4 +55,9 @@ readonly class TemplateResolver implements ResolverInterface
             []
         );
     }
+
+    public function supports(DimensionContentInterface $dimensionContent): bool
+    {
+        return $dimensionContent instanceof TemplateInterface;
+    }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/TemplateResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/TemplateResolver.php
@@ -28,10 +28,10 @@ readonly class TemplateResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): ContentView
+    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView
     {
         if (!$dimensionContent instanceof TemplateInterface) {
-            throw new \RuntimeException('DimensionContent needs to extend the ' . TemplateInterface::class);
+            return null;
         }
 
         /** @var string $locale */
@@ -54,10 +54,5 @@ readonly class TemplateResolver implements ResolverInterface
             $this->metadataResolver->resolveItems($formMetadata->getItems(), $dimensionContent->getTemplateData(), $locale),
             []
         );
-    }
-
-    public function supports(DimensionContentInterface $dimensionContent): bool
-    {
-        return $dimensionContent instanceof TemplateInterface;
     }
 }

--- a/packages/content/src/Application/ContentResolver/Value/ContentView.php
+++ b/packages/content/src/Application/ContentResolver/Value/ContentView.php
@@ -38,21 +38,37 @@ class ContentView
     /**
      * @param mixed[] $view
      */
-    public static function createResolvable(string|int $id, string $resourceLoaderKey, array $view, ?\Closure $closure = null): self
+    public static function createResolvable(string|int $id, string $resourceLoaderKey, array $view, int $priority = 0, ?\Closure $closure = null): self
     {
-        return new self(new ResolvableResource($id, $resourceLoaderKey, $closure), $view);
+        return new self(
+            new ResolvableResource(
+                id: $id,
+                resourceLoaderKey: $resourceLoaderKey,
+                priority: $priority,
+                resourceCallback: $closure
+            ),
+            $view
+        );
     }
 
     /**
      * @param array<string|int> $ids
      * @param mixed[] $view
      */
-    public static function createResolvables(array $ids, string $resourceLoaderKey, array $view): self
-    {
+    public static function createResolvables(
+        array $ids,
+        string $resourceLoaderKey,
+        array $view,
+        int $priority = 0
+    ): self {
         $resolvableResources = [];
 
         foreach ($ids as $id) {
-            $resolvableResources[] = new ResolvableResource($id, $resourceLoaderKey);
+            $resolvableResources[] = new ResolvableResource(
+                id: $id,
+                resourceLoaderKey: $resourceLoaderKey,
+                priority: $priority,
+            );
         }
 
         return new self($resolvableResources, $view);

--- a/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
+++ b/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
@@ -23,7 +23,8 @@ class ResolvableResource
     public function __construct(
         private string|int $id,
         private string $resourceLoaderKey,
-        ?\Closure $resourceCallback = null
+        private int $priority,
+        ?\Closure $resourceCallback = null,
     ) {
         $this->callback = $resourceCallback ?? (static fn (mixed $resource) => $resource);
     }
@@ -41,5 +42,10 @@ class ResolvableResource
     public function executeResourceCallback(mixed $resource): mixed
     {
         return ($this->callback)($resource);
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
     }
 }

--- a/packages/content/src/Application/PropertyResolver/Resolver/LinkPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/LinkPropertyResolver.php
@@ -35,14 +35,15 @@ class LinkPropertyResolver implements PropertyResolverInterface
         $resourceLoaderKey = $params['resourceLoader'] ?? LinkResourceLoader::getKey();
 
         return ContentView::createResolvable(
-            $data['provider'] . '::' . $data['href'],
-            $resourceLoaderKey,
-            [
+            id: $data['provider'] . '::' . $data['href'],
+            resourceLoaderKey: $resourceLoaderKey,
+            view: [
                 ...$data,
                 ...$params,
             ],
+            priority: -50,
             // external links are not passed as a LinkItem
-            static function(string|LinkItem $linkItem) use ($data) {
+            closure: static function(string|LinkItem $linkItem) use ($data) {
                 if (\is_string($linkItem)) {
                     return $linkItem;
                 }

--- a/packages/content/src/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolver.php
@@ -52,13 +52,14 @@ class TeaserSelectionPropertyResolver implements PropertyResolverInterface
             $id = $item['id'];
 
             $contentViews[] = ContentView::createResolvable(
-                $type . '::' . $id,
-                $resourceLoaderKey,
-                [
+                id: $type . '::' . $id,
+                resourceLoaderKey: $resourceLoaderKey,
+                view: [
                     'id' => $id,
                     'type' => $type,
                 ],
-                static function(Teaser $resource) use ($item) {
+                priority: -50,
+                closure: static function(Teaser $resource) use ($item) {
                     return $resource->merge($item);
                 }
             );

--- a/packages/content/src/Application/ResourceLoader/Loader/CachedResourceLoader.php
+++ b/packages/content/src/Application/ResourceLoader/Loader/CachedResourceLoader.php
@@ -32,10 +32,10 @@ class CachedResourceLoader implements ResourceLoaderInterface, ResetInterface
         $result = [];
         $uncachedIds = [];
 
-        foreach ($ids as $id) {
+        foreach ($ids as $index => $id) {
             $cacheKey = $this->generateCacheKey($id, $locale, $params);
             if (!isset($this->cache[$cacheKey])) {
-                $uncachedIds[] = $id;
+                $uncachedIds[$index] = $id;
                 continue;
             }
 

--- a/packages/content/src/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTrait.php
+++ b/packages/content/src/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTrait.php
@@ -46,7 +46,7 @@ trait ResolveContentDimensionUrlTrait
         }
 
         foreach ($metadata->getProperties() as $property) {
-            if ('route' === $property->getType()) {
+            if ('route' === $property->getType() || 'resource_locator' === $property->getType()) {
                 /** @var string|null */
                 return $dimensionContent->getTemplateData()[$property->getName()] ?? null;
             }

--- a/packages/content/tests/Application/config/templates/pages/default_with_page_selection.xml
+++ b/packages/content/tests/Application/config/templates/pages/default_with_page_selection.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default_with_page_selection</key>
+
+    <view>pages/default</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Default</title>
+        <title lang="de">Standard</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="article" type="text_editor">
+            <meta>
+                <title lang="en">Article</title>
+                <title lang="de">Artikel</title>
+            </meta>
+        </property>
+
+        <property name="pages" type="page_selection">
+            <meta>
+                <title lang="en">Pages</title>
+                <title lang="de">Seiten</title>
+            </meta>
+        </property>
+    </properties>
+</template>

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Application\ContentResolver\ContentResolver;
+use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
+use Sulu\Content\Application\ContentResolver\Resolver\TemplateResolver;
+use Sulu\Content\Application\MetadataResolver\MetadataResolver;
+use Sulu\Content\Application\PropertyResolver\PropertyResolverProvider;
+use Sulu\Content\Application\PropertyResolver\Resolver\DefaultPropertyResolver;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionPropertyResolver;
+
+class ContentResolverTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    private PropertyResolverProvider $propertyResolverProvider;
+
+    private ResourceLoaderProvider $resourceLoaderProvider;
+
+    private MetadataResolver $metadataResolver;
+
+    private ContentResolver $contentResolver;
+
+    /**
+     * @var ObjectProphecy<MetadataProviderInterface>
+     */
+    private $metadataProvider;
+
+    /**
+     * @var ObjectProphecy<ContentAggregatorInterface>
+     */
+    private $contentAggregator;
+
+    /**
+     * @var ResolverInterface[]
+     */
+    private array $resolvers = [];
+
+    /**
+     * @var ObjectProphecy<ResourceLoaderInterface>[]
+     */
+    private array $resourceLoaders = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->propertyResolverProvider = new PropertyResolverProvider(
+            new \ArrayIterator([
+                'default' => new DefaultPropertyResolver(),
+                'page_selection' => new PageSelectionPropertyResolver(),
+            ])
+        );
+        $this->metadataResolver = new MetadataResolver($this->propertyResolverProvider);
+        $this->metadataProvider = $this->prophesize(MetadataProviderInterface::class);
+
+        // ResourceLoaders
+        $pageResourceLoader = $this->prophesize(ResourceLoaderInterface::class);
+        $this->resourceLoaders['page'] = $pageResourceLoader;
+
+        // Resolvers
+        $templateResolver = new TemplateResolver(
+            $this->metadataProvider->reveal(),
+            $this->metadataResolver
+        );
+        $this->resolvers = ['template' => $templateResolver];
+
+        $this->resourceLoaderProvider = new ResourceLoaderProvider(\array_map(fn (ObjectProphecy $resourceLoader) => $resourceLoader->reveal(), $this->resourceLoaders));
+        $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
+        $this->contentResolver = new ContentResolver(
+            $this->resolvers,
+            $this->resourceLoaderProvider,
+            $this->contentAggregator->reveal()
+        );
+    }
+
+    public function testResolveSubPage(): void
+    {
+        $contentRichEntity = new Page();
+        $this->setPrivateProperty($contentRichEntity, 'uuid', '111-111-111');
+        /** @var PageDimensionContentInterface $dimensionContent */
+        $dimensionContent = $contentRichEntity->createDimensionContent();
+        $dimensionContent->setStage('live');
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default_with_page_selection');
+        $dimensionContent->setTemplateData([
+            'title' => 'Sulu',
+            'url' => '/page',
+            'pages' => [
+                '111-111-222', //$page2 uuid
+            ],
+        ]);
+
+        $page2 = new Page();
+        $this->setPrivateProperty($page2, 'uuid', '111-111-222');
+        /** @var PageDimensionContentInterface $dimensionContent2 */
+        $dimensionContent2 = $page2->createDimensionContent();
+        $dimensionContent2->setStage('live');
+        $dimensionContent2->setLocale('en');
+        $dimensionContent2->setTemplateKey('default');
+        $dimensionContent2->setTemplateData([
+            'title' => 'Page 2',
+            'url' => '/page-2',
+            'article' => '<p>Page 2 article</p>',
+        ]);
+
+        $this->resourceLoaders['page']->load(['111-111-222' => '111-111-222'], 'en')
+            ->shouldBeCalledOnce()
+            ->willReturn(['111-111-222' => $page2]);
+
+        $this->contentAggregator->aggregate($page2, ['stage' => 'live', 'locale' => 'en'])
+            ->shouldBeCalledOnce()
+            ->willReturn($dimensionContent2);
+
+        $this->metadataProvider->getMetadata('page', 'en', [])
+            ->shouldBeCalled()
+            ->willReturn($this->getTemplateFormMetadata('page'));
+
+        /**
+         * @var array{
+         *   resource: Page,
+         *   content: array{
+         *     title: string,
+         *     url: string,
+         *     article: string|null,
+         *     pages: array{
+         *       array{
+         *         resource: Page,
+         *         content: array{
+         *           title: string,
+         *           url: string,
+         *           article: string|null
+         *         },
+         *         view: array{
+         *           title: mixed[],
+         *           url: mixed[],
+         *           article: mixed[]
+         *         }
+         *       }
+         *     }
+         *   },
+         *   view: array{
+         *     title: mixed[],
+         *     url: mixed[],
+         *     article: mixed[],
+         *     pages: array{0: array{ids: array<string>}}
+         *   }
+         * } $result
+         */
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertSame($contentRichEntity, $result['resource']);
+
+        $content = $result['content'];
+        self::assertSame('Sulu', $content['title']);
+        self::assertSame('/page', $content['url']);
+        self::assertNull($content['article']);
+
+        $view = $result['view'];
+        self::assertSame([], $view['title']);
+        self::assertSame([], $view['url']);
+        self::assertSame([], $view['article']);
+        self::assertSame(['111-111-222'], $view['pages'][0]['ids']);
+
+        // SubEntity
+        self::assertSame($content['pages'][0]['resource'], $page2);
+        $innerContent = $content['pages'][0]['content'];
+        self::assertSame('Page 2', $innerContent['title']);
+        self::assertSame('/page-2', $innerContent['url']);
+        self::assertSame('<p>Page 2 article</p>', $innerContent['article']);
+
+        $innerView = $content['pages'][0]['view'];
+        self::assertSame([], $innerView['title']);
+        self::assertSame([], $innerView['url']);
+        self::assertSame([], $innerView['article']);
+    }
+
+    public function testResolveCircularLoopPages(): void
+    {
+        $page1 = new Page();
+        $this->setPrivateProperty($page1, 'uuid', '111-111-111');
+        /** @var PageDimensionContentInterface $dimensionContent1 */
+        $dimensionContent1 = $page1->createDimensionContent();
+        $dimensionContent1->setStage('live');
+        $dimensionContent1->setLocale('en');
+        $dimensionContent1->setTemplateKey('default_with_page_selection');
+        $dimensionContent1->setTemplateData([
+            'title' => 'Sulu',
+            'url' => '/page',
+            'pages' => [
+                '111-111-222', //$page2 uuid
+            ],
+        ]);
+
+        $page2 = new Page();
+        $this->setPrivateProperty($page2, 'uuid', '111-111-222');
+        /** @var PageDimensionContentInterface $dimensionContent2 */
+        $dimensionContent2 = $page2->createDimensionContent();
+        $dimensionContent2->setStage('live');
+        $dimensionContent2->setLocale('en');
+        $dimensionContent2->setTemplateKey('default_with_page_selection');
+        $dimensionContent2->setTemplateData([
+            'title' => 'Page 2',
+            'url' => '/page-2',
+            'article' => '<p>Page 2 article</p>',
+            'pages' => [
+                '111-111-111', //$page1 uuid
+            ],
+        ]);
+
+        $this->resourceLoaders['page']->load(['111-111-222' => '111-111-222'], 'en')
+            ->shouldBeCalled()
+            ->willReturn(['111-111-222' => $page2]);
+
+        $this->resourceLoaders['page']->load(['111-111-111' => '111-111-111'], 'en')
+            ->shouldBeCalled()
+            ->willReturn(['111-111-111' => $page1]);
+
+        $this->contentAggregator->aggregate($page1, ['stage' => 'live', 'locale' => 'en'])
+            ->shouldBeCalled()
+            ->willReturn($dimensionContent1);
+
+        $this->contentAggregator->aggregate($page2, ['stage' => 'live', 'locale' => 'en'])
+            ->shouldBeCalled()
+            ->willReturn($dimensionContent2);
+
+        $this->metadataProvider->getMetadata('page', 'en', [])
+            ->shouldBeCalled()
+            ->willReturn($this->getTemplateFormMetadata('page'));
+
+        /**
+         * @var array{
+         *     resource: Page,
+         *     content: array{
+         *         title: string,
+         *         url: string,
+         *         article: string|null,
+         *         pages: array{
+         *             array{
+         *                 resource: Page,
+         *                 content: array{
+         *                     title: string,
+         *                     url: string,
+         *                     article: string|null,
+         *                     pages: array{
+         *                         array{
+         *                             resource: Page,
+         *                             content: array{
+         *                                 title: string,
+         *                                 url: string,
+         *                                 article: string|null,
+         *                                 pages: array{
+         *                                     array{
+         *                                         resource: Page,
+         *                                         content: array{
+         *                                             title: string,
+         *                                             url: string,
+         *                                             article: string|null,
+         *                                             pages: array{0: mixed},
+         *                                         },
+         *                                         view: array{
+         *                                             title: mixed[],
+         *                                             url: mixed[],
+         *                                             article: mixed[],
+         *                                             pages: array{0: array{ids: array<string>}}
+         *                                         }
+         *                                     }
+         *                                 }
+         *                             },
+         *                             view: array{
+         *                                 title: mixed[],
+         *                                 url: mixed[],
+         *                                 article: mixed[],
+         *                                 pages: array{0: array{ids: array<string>}}
+         *                             }
+         *                         }
+         *                     }
+         *                 },
+         *                 view: array{
+         *                     title: mixed[],
+         *                     url: mixed[],
+         *                     article: mixed[],
+         *                     pages: array{0: array{ids: array<string>}}
+         *                 }
+         *             }
+         *         }
+         *     },
+         *     view: array{
+         *         title: mixed[],
+         *         url: mixed[],
+         *         article: mixed[],
+         *         pages: array{0: array{ids: array<string>}}
+         *     }
+         * } $result
+         */
+        $result = $this->contentResolver->resolve($dimensionContent1);
+
+        self::assertSame($page1, $result['resource']);
+
+        $content = $result['content'];
+        // level 0
+        self::assertSame('Sulu', $content['title']);
+        self::assertSame('/page', $content['url']);
+        self::assertNull($content['article']);
+
+        $view = $result['view'];
+        self::assertSame([], $view['title']);
+        self::assertSame([], $view['url']);
+        self::assertSame([], $view['article']);
+        self::assertSame(['111-111-222'], $view['pages'][0]['ids']);
+
+        // level 1
+        self::assertSame($content['pages'][0]['resource'], $page2);
+        $innerContent = $content['pages'][0]['content'];
+        self::assertSame('Page 2', $innerContent['title']);
+        self::assertSame('/page-2', $innerContent['url']);
+        self::assertSame('<p>Page 2 article</p>', $innerContent['article']);
+
+        $innerView = $content['pages'][0]['view'];
+        self::assertSame([], $innerView['title']);
+        self::assertSame([], $innerView['url']);
+        self::assertSame([], $innerView['article']);
+        self::assertSame(['111-111-111'], $innerView['pages'][0]['ids']);
+
+        // level 2
+        self::assertSame($innerContent['pages'][0]['resource'], $page1);
+        $innerInnerContent = $innerContent['pages'][0]['content'];
+        self::assertSame('Sulu', $innerInnerContent['title']);
+        self::assertSame('/page', $innerInnerContent['url']);
+        self::assertNull($innerInnerContent['article']);
+
+        $innerInnerView = $innerContent['pages'][0]['view'];
+        self::assertSame([], $innerInnerView['title']);
+        self::assertSame([], $innerInnerView['url']);
+        self::assertSame([], $innerInnerView['article']);
+        self::assertSame(['111-111-222'], $innerInnerView['pages'][0]['ids']);
+
+        // level 3
+        self::assertSame($innerInnerContent['pages'][0]['resource'], $page2);
+        $innerInnerInnerContent = $innerInnerContent['pages'][0]['content'];
+        self::assertSame('Page 2', $innerInnerInnerContent['title']);
+        self::assertSame('/page-2', $innerInnerInnerContent['url']);
+        self::assertSame('<p>Page 2 article</p>', $innerInnerInnerContent['article']);
+
+        $innerInnerInnerView = $innerInnerContent['pages'][0]['view'];
+        self::assertSame([], $innerInnerInnerView['title']);
+        self::assertSame([], $innerInnerInnerView['url']);
+        self::assertSame([], $innerInnerInnerView['article']);
+        self::assertSame(['111-111-111'], $innerInnerInnerView['pages'][0]['ids']);
+
+        // level 4 should be null to break the circular loop
+        self::assertNull($innerInnerInnerContent['pages'][0]);
+    }
+
+    private function getTemplateFormMetadata(string $templateType): TypedFormMetadata
+    {
+        return match ($templateType) {
+            'page' => $this->getTypedFormMetadataForPage(),
+            default => throw new \RuntimeException('TemplateType with type "' . $templateType . '" not configured.'),
+        };
+    }
+
+    private function getTypedFormMetadataForPage(): TypedFormMetadata
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        foreach (['default', 'default_with_page_selection'] as $templateKey) {
+            $formMetadata = new FormMetadata();
+
+            $fieldMetadataCallback = match ($templateKey) {
+                'default' => function() {
+                    $titleFieldMetadata = new FieldMetadata('title');
+                    $titleFieldMetadata->setType('text_line');
+                    $urlFieldMetadata = new FieldMetadata('url');
+                    $urlFieldMetadata->setType('resource_locator');
+                    $articleFieldMetadata = new FieldMetadata('article');
+                    $articleFieldMetadata->setType('text_editor');
+
+                    return [$titleFieldMetadata, $urlFieldMetadata, $articleFieldMetadata];
+                },
+                'default_with_page_selection' => function() {
+                    $titleFieldMetadata = new FieldMetadata('title');
+                    $titleFieldMetadata->setType('text_line');
+                    $urlFieldMetadata = new FieldMetadata('url');
+                    $urlFieldMetadata->setType('resource_locator');
+                    $articleFieldMetadata = new FieldMetadata('article');
+                    $articleFieldMetadata->setType('text_editor');
+                    $pagesFieldMetadata = new FieldMetadata('pages');
+                    $pagesFieldMetadata->setType('page_selection');
+
+                    return [$titleFieldMetadata, $urlFieldMetadata, $articleFieldMetadata, $pagesFieldMetadata];
+                },
+            };
+
+            $formMetadata->setItems($fieldMetadataCallback());
+            $typedFormMetadata->addForm($templateKey, $formMetadata);
+        }
+
+        return $typedFormMetadata;
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/ExcerptResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/ExcerptResolverTest.php
@@ -24,7 +24,6 @@ use Sulu\Content\Application\ContentResolver\Resolver\ExcerptResolver;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\MetadataResolver\MetadataResolver;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Content\Domain\Model\ExcerptInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
@@ -40,10 +39,7 @@ class ExcerptResolverTest extends TestCase
             $this->prophesize(MetadataResolver::class)->reveal()
         );
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('DimensionContent needs to extend the ' . ExcerptInterface::class);
-
-        $templateResolver->resolve($this->prophesize(DimensionContentInterface::class)->reveal());
+        self::assertNull($templateResolver->resolve($this->prophesize(DimensionContentInterface::class)->reveal()));
     }
 
     public function testResolve(): void
@@ -96,8 +92,9 @@ class ExcerptResolverTest extends TestCase
 
         $contentView = $excerptResolver->resolve($dimensionContent);
 
+        self::assertInstanceOf(ContentView::class, $contentView);
         $content = $contentView->getContent();
-        $this->assertIsArray($content);
-        $this->assertCount(1, $content);
+        self::assertIsArray($content);
+        self::assertCount(1, $content);
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SeoResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SeoResolverTest.php
@@ -21,7 +21,6 @@ use Sulu\Content\Application\ContentResolver\Resolver\SeoResolver;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\MetadataResolver\MetadataResolver;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Content\Domain\Model\SeoInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
@@ -36,10 +35,7 @@ class SeoResolverTest extends TestCase
             $this->prophesize(MetadataResolver::class)->reveal()
         );
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('DimensionContent needs to extend the ' . SeoInterface::class);
-
-        $templateResolver->resolve($this->prophesize(DimensionContentInterface::class)->reveal());
+        self::assertNull($templateResolver->resolve($this->prophesize(DimensionContentInterface::class)->reveal()));
     }
 
     public function testResolve(): void
@@ -87,8 +83,9 @@ class SeoResolverTest extends TestCase
 
         $contentView = $templateResolver->resolve($dimensionContent);
 
+        self::assertInstanceOf(ContentView::class, $contentView);
         $content = $contentView->getContent();
-        $this->assertIsArray($content);
-        $this->assertCount(1, $content);
+        self::assertIsArray($content);
+        self::assertCount(1, $content);
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SettingsResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SettingsResolverTest.php
@@ -24,6 +24,7 @@ use Sulu\Component\Localization\Localization;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentResolver\Resolver\SettingsResolver;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
@@ -69,6 +70,8 @@ class SettingsResolverTest extends TestCase
         $exampleDimension->addAvailableLocale('en');
 
         $result = $this->resolver->resolve($exampleDimension);
+        self::assertInstanceOf(ContentView::class, $result);
+
         /** @var SettingsData $content */
         $content = $result->getContent();
 
@@ -81,6 +84,8 @@ class SettingsResolverTest extends TestCase
         $exampleDimension = new ExampleDimensionContent($example);
 
         $result = $this->resolver->resolve($exampleDimension);
+        self::assertInstanceOf(ContentView::class, $result);
+
         /** @var SettingsData $content */
         $content = $result->getContent();
 
@@ -93,6 +98,8 @@ class SettingsResolverTest extends TestCase
         $exampleDimension = new ExampleDimensionContent($example);
 
         $result = $this->resolver->resolve($exampleDimension);
+        self::assertInstanceOf(ContentView::class, $result);
+
         /** @var SettingsData $content */
         $content = $result->getContent();
 
@@ -158,6 +165,8 @@ class SettingsResolverTest extends TestCase
         )->shouldNotBeCalled();
 
         $result = $this->resolver->resolve($exampleDimension);
+        self::assertInstanceOf(ContentView::class, $result);
+
         /** @var SettingsData $content */
         $content = $result->getContent();
 
@@ -190,6 +199,8 @@ class SettingsResolverTest extends TestCase
         $exampleDimension->setMainWebspace('sulu_io');
 
         $result = $this->resolver->resolve($exampleDimension);
+        self::assertInstanceOf(ContentView::class, $result);
+
         /** @var SettingsData $content */
         $content = $result->getContent();
 
@@ -204,6 +215,8 @@ class SettingsResolverTest extends TestCase
         $exampleDimension->setTemplateData(['exampleKey' => 'exampleValue']);
 
         $result = $this->resolver->resolve($exampleDimension);
+        self::assertInstanceOf(ContentView::class, $result);
+
         /** @var SettingsData $content */
         $content = $result->getContent();
 
@@ -221,6 +234,8 @@ class SettingsResolverTest extends TestCase
         $exampleDimension->setLastModified(new \DateTimeImmutable('2021-01-01'));
 
         $result = $this->resolver->resolve($exampleDimension);
+        self::assertInstanceOf(ContentView::class, $result);
+
         /** @var SettingsData $content */
         $content = $result->getContent();
 
@@ -236,6 +251,8 @@ class SettingsResolverTest extends TestCase
         $exampleDimension->setShadowLocale('de');
 
         $result = $this->resolver->resolve($exampleDimension);
+        self::assertInstanceOf(ContentView::class, $result);
+
         /** @var SettingsData $content */
         $content = $result->getContent();
 

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/TemplateResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/TemplateResolverTest.php
@@ -25,7 +25,6 @@ use Sulu\Content\Application\MetadataResolver\MetadataResolver;
 use Sulu\Content\Application\PropertyResolver\PropertyResolverProvider;
 use Sulu\Content\Application\PropertyResolver\Resolver\DefaultPropertyResolver;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Content\Domain\Model\TemplateInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
@@ -40,10 +39,7 @@ class TemplateResolverTest extends TestCase
             $this->prophesize(MetadataResolver::class)->reveal()
         );
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('DimensionContent needs to extend the ' . TemplateInterface::class);
-
-        $templateResolver->resolve($this->prophesize(DimensionContentInterface::class)->reveal());
+        self::assertNull($templateResolver->resolve($this->prophesize(DimensionContentInterface::class)->reveal()));
     }
 
     public function testInvalidTemplateKeyResolve(): void
@@ -104,12 +100,13 @@ class TemplateResolverTest extends TestCase
         );
 
         $contentView = $templateResolver->resolve($dimensionContent);
+        self::assertInstanceOf(ContentView::class, $contentView);
 
         $content = $contentView->getContent();
-        $this->assertIsArray($content);
-        $this->assertCount(1, $content);
-        $this->assertInstanceOf(ContentView::class, $content['title']);
-        $this->assertSame('Sulu', $content['title']->getContent());
-        $this->assertSame([], $content['title']->getView());
+        self::assertIsArray($content);
+        self::assertCount(1, $content);
+        self::assertInstanceOf(ContentView::class, $content['title']);
+        self::assertSame('Sulu', $content['title']->getContent());
+        self::assertSame([], $content['title']->getView());
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ResolvableResourceTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ResolvableResourceTest.php
@@ -20,14 +20,14 @@ class ResolvableResourceTest extends TestCase
 {
     public function testGetId(): void
     {
-        $resolvableResource = new ResolvableResource(5, 'resourceLoaderKey');
+        $resolvableResource = new ResolvableResource(5, 'resourceLoaderKey', 0);
 
         $this->assertSame(5, $resolvableResource->getId());
     }
 
     public function testGetResourceLoaderKey(): void
     {
-        $resolvableResource = new ResolvableResource(5, 'resourceLoaderKey');
+        $resolvableResource = new ResolvableResource(5, 'resourceLoaderKey', 0);
 
         $this->assertSame('resourceLoaderKey', $resolvableResource->getResourceLoaderKey());
     }

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -38,12 +38,13 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
         $ids = $data;
 
         return ContentView::createResolvables(
-            $ids,
-            $resourceLoaderKey,
-            [
+            ids: $ids,
+            resourceLoaderKey: $resourceLoaderKey,
+            view: [
                 'ids' => $ids,
                 ...$params,
             ],
+            priority: 150
         );
     }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -32,12 +32,13 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
         $resourceLoaderKey = $params['resourceLoader'] ?? PageResourceLoader::getKey();
 
         return ContentView::createResolvable(
-            $data,
-            $resourceLoaderKey,
-            [
+            id: $data,
+            resourceLoaderKey: $resourceLoaderKey,
+            view: [
                 'id' => $data,
                 ...$params,
             ],
+            priority: 150
         );
     }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
@@ -28,9 +28,12 @@ class PageResourceLoader implements ResourceLoaderInterface
     ) {
     }
 
+    /**
+     * @param string[] $ids
+     */
     public function load(array $ids, ?string $locale, array $params = []): array
     {
-        $result = $this->pageRepository->findBy(['id' => $ids]);
+        $result = $this->pageRepository->findBy(['uuids' => $ids]);
 
         $mappedResult = [];
         foreach ($result as $page) {

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoaderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoaderTest.php
@@ -47,7 +47,7 @@ class PageResourceLoaderTest extends TestCase
         $page1 = $this->createPage('123-123-123');
         $page2 = $this->createPage('321-321-321');
 
-        $this->pageRepository->findBy(['id' => ['123-123-123', '321-321-321']])->willReturn([
+        $this->pageRepository->findBy(['uuids' => ['123-123-123', '321-321-321']])->willReturn([
             $page1,
             $page2,
         ])

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
@@ -32,12 +32,13 @@ class SingleSnippetSelectionPropertyResolver implements PropertyResolverInterfac
         $resourceLoaderKey = $params['resourceLoader'] ?? SnippetResourceLoader::getKey();
 
         return ContentView::createResolvable(
-            $data,
-            $resourceLoaderKey,
-            [
+            id: $data,
+            resourceLoaderKey: $resourceLoaderKey,
+            view: [
                 'id' => $data,
                 ...$params,
             ],
+            priority: 100
         );
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
@@ -44,12 +44,13 @@ class SnippetSelectionPropertyResolver implements PropertyResolverInterface
         $resourceLoaderKey = $params['resourceLoader'] ?? SnippetResourceLoader::getKey();
 
         return ContentView::createResolvables(
-            $identifiers,
-            $resourceLoaderKey,
-            [
+            ids: $identifiers,
+            resourceLoaderKey: $resourceLoaderKey,
+            view: [
                 'ids' => $identifiers,
                 ...$params,
             ],
+            priority: 100
         );
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
@@ -30,9 +30,12 @@ class SnippetResourceLoader implements ResourceLoaderInterface
     ) {
     }
 
+    /**
+     * @param string[] $ids
+     */
     public function load(array $ids, ?string $locale, array $params = []): array
     {
-        $result = $this->snippetRepository->findBy(['id' => $ids]);
+        $result = $this->snippetRepository->findBy(['uuids' => $ids]);
 
         $mappedResult = [];
         foreach ($result as $snippet) {

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoaderTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoaderTest.php
@@ -47,7 +47,7 @@ class SnippetResourceLoaderTest extends TestCase
         $snippet1 = $this->createSnippet('1');
         $snippet2 = $this->createSnippet('3');
 
-        $this->snippetRepository->findBy(['id' => ['1', '3']])->willReturn([
+        $this->snippetRepository->findBy(['uuids' => ['1', '3']])->willReturn([
             $snippet1,
             $snippet2,
         ])

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoaderTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoaderTest.php
@@ -44,28 +44,25 @@ class SnippetResourceLoaderTest extends TestCase
 
     public function testLoad(): void
     {
-        $snippet1 = $this->createSnippet(1);
-        $snippet2 = $this->createSnippet(3);
+        $snippet1 = $this->createSnippet('1');
+        $snippet2 = $this->createSnippet('3');
 
-        $this->snippetRepository->findBy(['id' => [1, 3]])->willReturn([
+        $this->snippetRepository->findBy(['id' => ['1', '3']])->willReturn([
             $snippet1,
             $snippet2,
         ])
             ->shouldBeCalled();
 
-        $result = $this->loader->load([1, 3], 'en');
+        $result = $this->loader->load(['1', '3'], 'en');
 
         $this->assertSame([
-            1 => $snippet1,
-            3 => $snippet2,
+            '1' => $snippet1,
+            '3' => $snippet2,
         ], $result);
     }
 
-    private static function createSnippet(int $id): Snippet
+    private static function createSnippet(string $uuid): Snippet
     {
-        $snippet = new Snippet();
-        self::setprivateProperty($snippet, 'uuid', $id);
-
-        return $snippet;
+        return new Snippet($uuid);
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,36 +55,6 @@ parameters:
 			path: packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
 
 		-
-			message: '#^Cannot access an offset on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: packages/content/src/Application/ContentResolver/ContentResolver.php
-
-		-
-			message: '#^Method Sulu\\Content\\Application\\ContentResolver\\ContentResolver\:\:resolveContentView\(\) should return array\{content\: array\<string, mixed\>, view\: array\<string, mixed\>, resolvableResources\: array\<string, array\<Sulu\\Content\\Application\\ContentResolver\\Value\\ResolvableResource\>\>\} but returns array\{content\: array\{\}, view\: array\{\}, resolvableResources\: array\}\|array\{content\: non\-empty\-array\<string, array\>, view\: non\-empty\-array\<string, array\>, resolvableResources\: array\}\.$#'
-			identifier: return.type
-			count: 1
-			path: packages/content/src/Application/ContentResolver/ContentResolver.php
-
-		-
-			message: '#^Method Sulu\\Content\\Application\\ContentResolver\\ContentResolver\:\:resolveContentView\(\) should return array\{content\: array\<string, mixed\>, view\: array\<string, mixed\>, resolvableResources\: array\<string, array\<Sulu\\Content\\Application\\ContentResolver\\Value\\ResolvableResource\>\>\} but returns array\{content\: non\-empty\-array\<string, array\<string, mixed\>\>, view\: non\-empty\-array\<string, array\<string, mixed\>\>, resolvableResources\: array\}\.$#'
-			identifier: return.type
-			count: 1
-			path: packages/content/src/Application/ContentResolver/ContentResolver.php
-
-		-
-			message: '#^Method Sulu\\Content\\Application\\ContentResolver\\ContentResolver\:\:resolveContentViews\(\) should return array\{content\: array\<string, mixed\>, view\: array\<string, mixed\>, resolvableResources\: array\<string, array\<Sulu\\Content\\Application\\ContentResolver\\Value\\ResolvableResource\>\>\} but returns array\{content\: array\<string, mixed\>, view\: array\<string, mixed\>, resolvableResources\: array\}\.$#'
-			identifier: return.type
-			count: 1
-			path: packages/content/src/Application/ContentResolver/ContentResolver.php
-
-		-
-			message: '#^Parameter \#1 \$contentViews of method Sulu\\Content\\Application\\ContentResolver\\ContentResolver\:\:resolveContentViews\(\) expects array\<Sulu\\Content\\Application\\ContentResolver\\Value\\ContentView\>, array\<mixed, mixed\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: packages/content/src/Application/ContentResolver/ContentResolver.php
-
-		-
 			message: '#^Cannot access offset ''index'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 4

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -16,9 +16,6 @@ parameters:
     parallel:
         processTimeout: 300.0
     ignoreErrors:
-        -
-            message: '#Cannot access offset .+ on mixed.#' # TODO we should match against a whole array not every single item
-            path: packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
         - message: '#^Property Sulu\\(.*)\\Domain\\Model\\(.*)\:\:\$id \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
     excludePaths:
         - %currentWorkingDirectory%/node_modules/*

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Content/PropertyResolver/ContactAccountSelectionPropertyResolver.php
@@ -62,8 +62,8 @@ class ContactAccountSelectionPropertyResolver implements PropertyResolverInterfa
             // but in this case we need to use it to load resources depending on the key correctly
             // the ResolvableResource is kept internal to the content bundle and should not be used by other bundles
             match ($key) {
-                self::PREFIX_CONTACT => $resolvableResources[] = new ResolvableResource($id, $contactResourceLoaderKey),
-                self::PREFIX_ACCOUNT => $resolvableResources[] = new ResolvableResource($id, $accountResourceLoaderKey),
+                self::PREFIX_CONTACT => $resolvableResources[] = new ResolvableResource($id, $contactResourceLoaderKey, 0),
+                self::PREFIX_ACCOUNT => $resolvableResources[] = new ResolvableResource($id, $accountResourceLoaderKey, 0),
                 default => null,
             };
         }

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
@@ -81,7 +81,7 @@ class ImageMapPropertyResolver implements PropertyResolverInterface // TODO we m
 
         return ContentView::create(
             [
-                'image' => new ResolvableResource($imageId, $resourceLoaderKey),
+                'image' => new ResolvableResource($imageId, $resourceLoaderKey, -50),
                 'hotspots' => $hotspots->getContent(),
             ],
             [

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/MediaSelectionPropertyResolver.php
@@ -46,13 +46,14 @@ class MediaSelectionPropertyResolver implements PropertyResolverInterface
         $resourceLoaderKey = $params['resourceLoader'] ?? MediaResourceLoader::getKey();
 
         return ContentView::createResolvables(
-            $ids,
-            $resourceLoaderKey,
-            [
+            ids: $ids,
+            resourceLoaderKey: $resourceLoaderKey,
+            view: [
                 'ids' => $ids,
                 'displayOption' => $displayOption,
                 ...$params,
             ],
+            priority: -50
         );
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/SingleMediaSelectionPropertyResolver.php
@@ -42,13 +42,14 @@ class SingleMediaSelectionPropertyResolver implements PropertyResolverInterface
         $id = (int) $data['id'];
 
         return ContentView::createResolvable(
-            $id,
-            $resourceLoaderKey,
-            [
+            id: $id,
+            resourceLoaderKey: $resourceLoaderKey,
+            view: [
                 'id' => $id,
                 'displayOption' => $displayOption,
                 ...$params,
             ],
+            priority: -50
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7672 
| License | MIT

#### What's in this PR?

Refactors the content resolver to resolve recursively and break circular resources after a specified depth

#### Why?

We have to resolve newly loaded resources (esp. ContentRichEntities) recursively to guarantee that everything is resolved properly.
