### PR TITLE
Fix false unexception error logs in image proxy functionality

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13546,16 +13546,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
 
 		-
-			message: "#^Parameter \\#1 \\$storageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:getPath\\(\\) expects array\\<string, string\\|null\\>, array given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
-
-		-
-			message: "#^Parameter \\#1 \\$storageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:getType\\(\\) expects array\\<string, string\\|null\\>, array given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
-
-		-
 			message: "#^Parameter \\#2 \\$values of method Symfony\\\\Component\\\\HttpFoundation\\\\ResponseHeaderBag\\:\\:set\\(\\) expects array\\<string\\>\\|string\\|null, int given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -13851,11 +13841,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\FileVersion\\:\\:getStorageOptions\\(\\) should return array but returns mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\FileVersion\\:\\:removeCategories\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -13902,16 +13887,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\FileVersion\\:\\:setProperties\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\FileVersion\\:\\:setStorageOptions\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\FileVersion\\:\\:setStorageOptions\\(\\) has parameter \\$storageOptions with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
 
@@ -14606,11 +14581,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatManager\\\\FormatManager\\:\\:\\$supportedImageFormats is unused\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\FormatManager\\\\FormatManagerInterface\\:\\:getFormats\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -14762,11 +14732,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\ImageConverter\\\\MediaImageExtractorInterface\\:\\:extract\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
-
-		-
-			message: "#^Parameter \\#1 \\$storageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:load\\(\\) expects array\\<string, string\\|null\\>, array given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
 
@@ -15016,18 +14981,8 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
 
 		-
-			message: "#^Parameter \\#1 \\$storageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:remove\\(\\) expects array\\<string, string\\|null\\>, array given\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
-
-		-
 			message: "#^Parameter \\#1 \\$userId of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Manager\\\\MediaManager\\:\\:getUser\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
-
-		-
-			message: "#^Parameter \\#3 \\$storageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:save\\(\\) expects array\\<string, string\\|null\\>, array given\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
 
 		-
@@ -17266,11 +17221,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$sourceStorageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:move\\(\\) expects array\\<string, string\\|null\\>, array given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
-
-		-
 			message: "#^Parameter \\#1 \\$sourceStorageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:move\\(\\) expects array\\<string, string\\|null\\>, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
@@ -17292,11 +17242,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$version of method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\FileVersion\\:\\:setVersion\\(\\) expects int, mixed given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
-
-		-
-			message: "#^Parameter \\#2 \\$targetStorageOptions of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\Storage\\\\StorageInterface\\:\\:move\\(\\) expects array\\<string, string\\|null\\>, array given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,6 +23,8 @@ parameters:
         - %currentWorkingDirectory%/tests/Resources/cache/*
         - %currentWorkingDirectory%/*/node_modules/*
         - %currentWorkingDirectory%/*/Tests/Application/var/*
+        - %currentWorkingDirectory%/packages/*/tests/Application/var/*
+        - %currentWorkingDirectory%/packages/content/tests/Unit/Mocks/*
         - %currentWorkingDirectory%/*/Tests/app/cache/*
         - %currentWorkingDirectory%/*/Tests/app/var/*
         # RestController extends FOSRestController which was removed in friendsofsymfony/rest-bundle:3.0

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -13,13 +13,13 @@ namespace Sulu\Bundle\MediaBundle\Controller;
 
 use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
-use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Media\DispositionType\DispositionTypeResolver;
 use Sulu\Bundle\MediaBundle\Media\Exception\FileVersionNotFoundException;
-use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyException;
+use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyInvalidUrl;
+use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyUrlNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
@@ -67,16 +67,16 @@ class MediaStreamController
             $version = (int) (\explode('-', $version)[0] ?? '1');
 
             $mediaProperties = $this->formatCache->analyzedMediaUrl($url);
-
-            return $this->formatManager->returnImage(
-                $mediaProperties['id'],
-                $mediaProperties['format'],
-                $mediaProperties['fileName'],
-                $version,
-            );
-        } catch (ImageProxyException $e) {
+        } catch (ImageProxyUrlNotFoundException|ImageProxyInvalidUrl $e) {
             throw new NotFoundHttpException('Image create error. Code: ' . $e->getCode(), $e);
         }
+
+        return $this->formatManager->returnImage(
+            $mediaProperties['id'],
+            $mediaProperties['format'],
+            $mediaProperties['fileName'],
+            $version,
+        );
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -281,11 +281,16 @@ class FileVersion implements AuditableInterface
         return null;
     }
 
+    /**
+     * @param array<string, string|null> $storageOptions
+     *
+     * @return FileVersion
+     */
     public function setStorageOptions(array $storageOptions)
     {
         $serializedText = \json_encode($storageOptions);
         if (false === $serializedText) {
-            return;
+            return $this;
         }
 
         $this->storageOptions = $serializedText;
@@ -294,10 +299,11 @@ class FileVersion implements AuditableInterface
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, string|null>
      */
     public function getStorageOptions(): array
     {
+        /** @var array<string, string|null>|false $storageOptions */
         $storageOptions = \json_decode($this->storageOptions ?? '', true);
         if (!$storageOptions) {
             return [];

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/ImageProxyException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/ImageProxyException.php
@@ -20,8 +20,8 @@ class ImageProxyException extends MediaException
      * @param string $message
      * @param int $code
      */
-    public function __construct($message, $code)
+    public function __construct($message, $code, ?\Throwable $previous = null)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/Exception/InvalidMimeTypeForPreviewException.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Exception/InvalidMimeTypeForPreviewException.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\Exception;
 
-class InvalidMimeTypeForPreviewException extends MediaException
+class InvalidMimeTypeForPreviewException extends ImageProxyException
 {
     /**
      * @param string $mimeType

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheInterface.php
@@ -11,6 +11,9 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\FormatCache;
 
+use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyInvalidUrl;
+use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyUrlNotFoundException;
+
 /**
  * Defines the operations of the FormatCache
  * The FormatCache is a interface to cache different Image Formats.
@@ -59,6 +62,9 @@ interface FormatCacheInterface
      * @param string $url
      *
      * @return array ($id, $format)
+     *
+     * @throws ImageProxyUrlNotFoundException
+     * @throws ImageProxyInvalidUrl
      */
     public function analyzedMediaUrl($url);
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -18,15 +18,14 @@ use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException;
+use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyException;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyInvalidImageFormat;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyInvalidUrl;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\InvalidMimeTypeForPreviewException;
-use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\ImageConverterInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -49,11 +48,6 @@ class FormatManager implements FormatManagerInterface
      * @var LoggerInterface
      */
     private $logger;
-
-    /**
-     * @var ParameterBag|null
-     */
-    private $supportedImageFormats;
 
     /**
      * @param string $saveImage
@@ -161,8 +155,8 @@ class FormatManager implements FormatManagerInterface
                     $formatKey
                 );
             }
-        } catch (MediaException $e) {
-            $this->logger->error($e->getMessage(), ['exception' => $e]);
+        } catch (ImageProxyException $e) {
+            $this->logger->debug($e->getMessage(), ['exception' => $e]);
             $responseContent = null;
             $status = 404;
             $mimeType = null;

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/FlysystemStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/FlysystemStorage.php
@@ -16,7 +16,7 @@ use League\Flysystem\FileExistsException;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
 use Sulu\Bundle\MediaBundle\Media\Exception\FilenameAlreadyExistsException;
-use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 abstract class FlysystemStorage implements StorageInterface
 {
@@ -57,7 +57,7 @@ abstract class FlysystemStorage implements StorageInterface
         try {
             return $this->filesystem->readStream($filePath);
         } catch (FileNotFoundException $exception) {
-            throw new ImageProxyMediaNotFoundException(\sprintf('Original media at path "%s" not found', $filePath));
+            throw new IOException(\sprintf('Failed to open file with path "%s"', $filePath), path: $filePath);
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -63,7 +63,7 @@ class LocalStorage implements StorageInterface
         $fp = @\fopen($pathName, 'r');
 
         if (false === $fp) {
-            throw new IOException(\sprintf('Failed to open file "%s"', $pathName), path: $pathName);
+            throw new IOException(\sprintf('Failed to open file with path "%s"', $pathName), path: $pathName);
         }
 
         return $fp;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
@@ -236,7 +236,7 @@ class MediaRedirectControllerTest extends SuluTestCase
         $fileVersion->addCategory($this->category2);
         $fileVersion->setChanged(new \DateTime('1937-04-20'));
         $fileVersion->setCreated(new \DateTime('1937-04-20'));
-        $fileVersion->setStorageOptions(['segment' => 1, 'fileName' => $name . '.jpeg']);
+        $fileVersion->setStorageOptions(['segment' => '1', 'fileName' => $name . '.jpeg']);
         if (!\file_exists(__DIR__ . '/../../uploads/media/1')) {
             \mkdir(__DIR__ . '/../../uploads/media/1', 0777, true);
         }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -175,7 +175,7 @@ class MediaRepositoryTest extends SuluTestCase
         $fileVersion->setDownloadCounter(2);
         $fileVersion->setChanged(new \DateTime('1937-04-20'));
         $fileVersion->setCreated(new \DateTime('1937-04-20'));
-        $fileVersion->setStorageOptions(['segment' => 1, 'fileName' => $name . '.jpeg']);
+        $fileVersion->setStorageOptions(['segment' => '1', 'fileName' => $name . '.jpeg']);
         if (!\file_exists(__DIR__ . '/../../uploads/media/1')) {
             \mkdir(__DIR__ . '/../../uploads/media/1', 0777, true);
         }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/AzureBlobStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/AzureBlobStorageTest.php
@@ -19,7 +19,7 @@ use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 class AzureBlobStorageTest extends TestCase
 {
@@ -140,7 +140,7 @@ class AzureBlobStorageTest extends TestCase
 
     public function testLoadNotFound(): void
     {
-        $this->expectException(ImageProxyMediaNotFoundException::class);
+        $this->expectException(IOException::class);
 
         $adapter = $this->prophesize(AzureBlobStorageAdapter::class);
         $flysystem = $this->prophesize(Filesystem::class);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/GoogleCloudStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/GoogleCloudStorageTest.php
@@ -17,8 +17,8 @@ use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
 use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 class GoogleCloudStorageTest extends TestCase
 {
@@ -131,7 +131,7 @@ class GoogleCloudStorageTest extends TestCase
 
     public function testLoadNotFound(): void
     {
-        $this->expectException(ImageProxyMediaNotFoundException::class);
+        $this->expectException(IOException::class);
 
         $adapter = $this->prophesize(GoogleStorageAdapter::class);
         $flysystem = $this->prophesize(Filesystem::class);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
@@ -19,7 +19,7 @@ use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 class S3StorageTest extends TestCase
 {
@@ -157,7 +157,7 @@ class S3StorageTest extends TestCase
 
     public function testLoadNotFound(): void
     {
-        $this->expectException(ImageProxyMediaNotFoundException::class);
+        $this->expectException(IOException::class);
 
         $adapter = $this->prophesize(AwsS3Adapter::class);
         $flysystem = $this->prophesize(Filesystem::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

I propose to not log errors for ImageProxyExceptions which ends in a 404.

#### Why?

There are a few exception thrown but nothing really validates from my point of view as an error:

1. ImageProxyMediaNotFoundException (not found media) -> 404
2. ImageProxyMediaNotFoundException (not found file version) -> 404
3. ImageProxyMediaNotFoundException (slug not match) -> 404 ⚠️ introduced as security fix in but think still validates as not an error even some in the past did misused none matching URLs. Can eventually still make harder to debug for projects upgrade from previous versions now. /cc @chirimoya 
4. ImageProxyMediaNotFoundException (image format not found) -> 404
5. InvalidMimeTypeForPreviewException MimeType not supported -> 404
6. ImageProxyInvalidImageFormat MimeType not supported -> 404
7. ImageProxyInvalidImageFormat MimeType not supported -> 404

The only exception which should end in error is if the media entity exists but the original file not longer exists. The LocalStorage currently throws a `IOException` in that case, the flysystem sadly a ImageProxyMediaNotFoundException which is incorrect.

So this PR normalize that the adapters behave the same here, a `500 error` is fine as in that case as it really something wrong on the "Server" if original file is removed but entity still exists.

