### PR TITLE
Add support using Route Entity for  Entities with AutoIncrement Id

### DIFF
--- a/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
+++ b/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
@@ -48,7 +48,8 @@ final class SuluRouteBundle extends AbstractBundle
         $services->set('sulu_route.doctrine_route_changed_updater')
             ->class(RouteChangedUpdater::class)
             ->tag('doctrine.event_listener', ['event' => 'preUpdate', 'entity' => Route::class, 'method' => 'preUpdate'])
-            ->tag('doctrine.event_listener', ['event' => 'postFlush', 'method' => 'postFlush'])
+            ->tag('doctrine.event_listener', ['event' => 'prePersist', 'entity' => Route::class, 'method' => 'prePersist'])
+            ->tag('doctrine.event_listener', ['event' => 'postFlush', 'method' => 'postFlush', 'priority' => 1000])
             ->tag('doctrine.event_listener', ['event' => 'onClear', 'method' => 'onClear'])
             ->tag('kernel.reset', ['method' => 'reset']);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? |  yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7726
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

We have some kind of a `Chicken & Egg` problem when try to use the `Route` entity with a Entity which using auto increment ids. As the Route entity requires the `resourceId` but the Entity itself does not yet have a `getId()`.

In this pull request we are adding a new way to create a instance of `Route` without knowing the related resourceId at that time.

```diff
-       $route = new Route(
+       $route = Route::createRouteWithTempId(
            $localizedDimensionContent::getResourceKey(),
-           (string) $localizedDimensionContent->getResourceId(),
+           fn (): string => (string) $localizedDimensionContent->getResourceId(),
            $locale,
            $routeSlug,
        );
```

This new method will generate the route with a resourceId `temp::<ulid::base58>` which later will be replaced in a `postFlush` listener with the correct id of the entity. As discussed with @Prokyonn we decided to use `ulid::base58` to avoid confusen with uuid, so if something went wrong and they see in the database temp::ulid they not confuse it with a uuid which may exist as page or article. 

#### Why?

As the `Route` entity can be used also for entities which has a autoincremented ids which only exists after `flush`.

#### Example Usage

If you have a entity with autoincrement id use the `createRouteWithTempId` to create your route and the bundle will automatically on postFlush call your callback method to get the correct id and set it to the route entity correctly:

```php
       $route = Route::createRouteWithTempId(
           'example',
           fn (): string => (string) $entity->getId(),
           'en',
           '/new-slug',
       );

       $entity->setRoute($route);
```

#### To Do

- [x] Create test for this
- [ ] Create a documentation PR