### PR TITLE
Add type to translator request

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Translator/Translator.js
@@ -86,6 +86,7 @@ export default class Translator extends React.Component<Props> {
     translateText = debounce(action(() => {
         const {
             url,
+            type,
             messages: {
                 errorTranslatingText: errorTranslatingTextMessage,
             },
@@ -100,6 +101,7 @@ export default class Translator extends React.Component<Props> {
                 text: this.sourceText,
                 sourceLanguage: this.sourceLanguage,
                 targetLanguage: this.targetLanguage,
+                type,
             }
         ).then(action((data: {
             response: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Translator/tests/Translator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Translator/tests/Translator.test.js
@@ -11,6 +11,10 @@ jest.mock('../../../utils/Translator', () => ({
     translate: (key) => key,
 }));
 
+jest.mock('../../../containers', () => ({
+    TextEditor: jest.fn(() => <div data-testid="text-editor" />),
+}));
+
 const mockProps = {
     locale: 'en',
     value: 'Hallo',
@@ -55,10 +59,28 @@ describe('Translator', () => {
                 text: 'Hallo',
                 sourceLanguage: undefined,
                 targetLanguage: 'en',
+                type: 'text_line',
             });
         });
 
         expect(screen.getByDisplayValue('Hello')).toBeInTheDocument();
+    });
+
+    test('renders correctly with initial props and text_editor', async() => {
+        Requester.post.mockResolvedValue({
+            response: {text: '<h1>Hello</h1>', sourceLanguage: undefined, targetLanguage: 'en'},
+        });
+
+        render(<Translator {...mockProps} type="text_editor" value="<h1>Hallo</h1>" />);
+
+        await waitFor(() => {
+            expect(Requester.post).toHaveBeenCalledWith('/api/translate', {
+                text: '<h1>Hallo</h1>',
+                sourceLanguage: undefined,
+                targetLanguage: 'en',
+                type: 'text_editor',
+            });
+        });
     });
 
     test('translates text when source text changes', async() => {
@@ -81,6 +103,7 @@ describe('Translator', () => {
                 text: 'Auf wiedersehen',
                 sourceLanguage: undefined,
                 targetLanguage: 'en',
+                type: 'text_line',
             });
         });
 
@@ -113,6 +136,7 @@ describe('Translator', () => {
                 text: 'Hallo',
                 sourceLanguage: 'de',
                 targetLanguage: 'en',
+                type: 'text_line',
             });
         });
     });
@@ -143,6 +167,7 @@ describe('Translator', () => {
                 text: 'Hallo',
                 sourceLanguage: undefined,
                 targetLanguage: 'fr',
+                type: 'text_line',
             });
         });
 
@@ -201,6 +226,7 @@ describe('Translator', () => {
                 text: 'Bonjour',
                 sourceLanguage: 'EN',
                 targetLanguage: 'FR',
+                type: 'text_line',
             },
         });
 
@@ -218,6 +244,7 @@ describe('Translator', () => {
                     text: 'Bonjour',
                     sourceLanguage: 'EN',
                     targetLanguage: 'FR',
+                    type: 'text_line',
                 },
             },
         }, {});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

Add type of field to the request.

#### Why?

This can be used in the controller to detect if content is HTML.

