### PR TITLE
Remove getId method from preview provider

### DIFF
--- a/packages/content/src/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/packages/content/src/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -98,16 +98,6 @@ class ContentObjectProvider implements PreviewObjectProviderInterface
 
     /**
      * @param B $object
-     *
-     * @return string|int
-     */
-    public function getId($object)
-    {
-        return $object->getResource()->getId();
-    }
-
-    /**
-     * @param B $object
      * @param string $locale
      * @param array<string, mixed> $data
      */

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -222,18 +222,6 @@ class ContentObjectProviderTest extends TestCase
         $this->assertNull($result);
     }
 
-    public function testGetId(int $id = 1): void
-    {
-        $contentRichEntity = new Example();
-        static::setPrivateProperty($contentRichEntity, 'id', $id);
-
-        $dimensionContent = new ExampleDimensionContent($contentRichEntity);
-
-        $actualId = (string) $this->contentObjectProvider->getId($dimensionContent);
-
-        $this->assertSame((string) $id, $actualId);
-    }
-
     /**
      * @param array<string, mixed> $data
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41173,12 +41173,6 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderInterface.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:getId\(\) has parameter \$object with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderInterface.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:getObject\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/src/Sulu/Bundle/PageBundle/Preview/PageObjectProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Preview/PageObjectProvider.php
@@ -42,14 +42,6 @@ class PageObjectProvider implements PreviewObjectProviderInterface
     /**
      * @param BasePageDocument $object
      */
-    public function getId($object)
-    {
-        return $object->getUuid();
-    }
-
-    /**
-     * @param BasePageDocument $object
-     */
     public function setValues($object, $locale, array $data)
     {
         $propertyAccess = PropertyAccess::createPropertyAccessorBuilder()

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderInterface.php
@@ -25,13 +25,6 @@ interface PreviewObjectProviderInterface
     public function getObject($id, $locale);
 
     /**
-     * Returns id for given object.
-     *
-     * @return string
-     */
-    public function getId($object);
-
-    /**
      * Set given data to the object.
      *
      * @param string $locale


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove getId method from preview provider.

#### Why?

Currenty working on bringing the new route bundle to the preview so I step by step remove what we eventually not longer require.