### PR TITLE
Fix ObjectProphecy definitions and Sitemap return types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -33026,32 +33026,7 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtension\\:\\:sitemapFunction\\(\\) has parameter \\$locale with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtension\\:\\:sitemapFunction\\(\\) has parameter \\$webspaceKey with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtension\\:\\:sitemapUrlFunction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtension\\:\\:sitemapUrlFunction\\(\\) has parameter \\$locale with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtension\\:\\:sitemapUrlFunction\\(\\) has parameter \\$url with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtension\\:\\:sitemapUrlFunction\\(\\) has parameter \\$webspaceKey with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
 
@@ -33066,32 +33041,7 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtensionInterface\\:\\:sitemapFunction\\(\\) has parameter \\$locale with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtensionInterface\\:\\:sitemapFunction\\(\\) has parameter \\$webspaceKey with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtensionInterface\\:\\:sitemapUrlFunction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtensionInterface\\:\\:sitemapUrlFunction\\(\\) has parameter \\$locale with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtensionInterface\\:\\:sitemapUrlFunction\\(\\) has parameter \\$url with no type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\WebsiteBundle\\\\Twig\\\\Sitemap\\\\SitemapTwigExtensionInterface\\:\\:sitemapUrlFunction\\(\\) has parameter \\$webspaceKey with no type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
 

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
@@ -54,7 +54,7 @@ class TagsSubscriberTest extends TestCase
     private $requestStack;
 
     /**
-     * @var (ReferenceStoreInterface|ObjectProphecy)[]
+     * @var ObjectProphecy<(ReferenceStoreInterface>)[]
      */
     private $referenceStores;
 

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
@@ -54,9 +54,9 @@ class TagsSubscriberTest extends TestCase
     private $requestStack;
 
     /**
-     * @var ObjectProphecy<(ReferenceStoreInterface>)[]
+     * @var array<ObjectProphecy<ReferenceStoreInterface>>
      */
-    private $referenceStores;
+    private $referenceStores = [];
 
     /**
      * @var ObjectProphecy<StructureInterface>

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/SwiftMailerListenerTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/SwiftMailerListenerTest.php
@@ -77,7 +77,7 @@ class SwiftMailerListenerTest extends TestCase
 
     public function testReplaceMarkup(): void
     {
-        /** @var Request|ObjectProphecy $request */
+        /** @var ObjectProphecy<Request> $request */
         $request = $this->prophesize(Request::class);
         $request->getLocale()->willReturn('de');
         $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
@@ -110,7 +110,7 @@ class SwiftMailerListenerTest extends TestCase
 
     public function testReplaceMarkupWithUnknownContentType(): void
     {
-        /** @var Request|ObjectProphecy $request */
+        /** @var ObjectProphecy<Request> $request */
         $request = $this->prophesize(Request::class);
         $request->getLocale()->willReturn('de');
         $this->requestStack->getCurrentRequest()->willReturn($request->reveal());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -201,7 +201,7 @@ class MediaManagerTest extends TestCase
      */
     public function testGetByIds(array $ids, ?SuluUserInterface $user, ?int $permissions, array $media, array $result): void
     {
-        /** @var TokenInterface|ObjectProphecy $token */
+        /** @var ObjectProphecy<TokenInterface> $token */
         $token = $this->prophesize(TokenInterface::class);
 
         if (!$permissions) {
@@ -349,7 +349,7 @@ class MediaManagerTest extends TestCase
      */
     public function testSpecialCharacterFileName(string $fileName, string $cleanUpArgument, string $cleanUpResult, string $extension): void
     {
-        /** @var UploadedFile|ObjectProphecy $uploadedFile */
+        /** @var ObjectProphecy<UploadedFile> $uploadedFile */
         $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith([__DIR__ . \DIRECTORY_SEPARATOR . 'test.txt', 1, null, null, 1, true]);
         $uploadedFile->getClientOriginalName()->willReturn($fileName);
         $uploadedFile->getPathname()->willReturn('');

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Document/Subscriber/PublishSubscriberTest.php
@@ -249,7 +249,7 @@ class PublishSubscriberTest extends TestCase
         $properties = [];
 
         for ($i = 0; $i < 10; ++$i) {
-            /** @var PropertyInterface|ObjectProphecy $property */
+            /** @var ObjectProphecy<PropertyInterface> $property */
             $property = $this->prophesize(PropertyInterface::class);
             $property->remove()->shouldBeCalled();
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Content/SnippetDataProviderTest.php
@@ -131,14 +131,14 @@ class SnippetDataProviderTest extends TestCase
 
     public function testGetTypesConfiguration(): void
     {
-        /** @var TokenStorageInterface|ObjectProphecy $tokenStorage */
+        /** @var ObjectProphecy<TokenStorageInterface> $tokenStorage */
         $tokenStorage = $this->prophesize(TokenStorageInterface::class);
-        /** @var FormMetadataProvider|ObjectProphecy $formMetadataProvider */
+        /** @var ObjectProphecy<FormMetadataProvider> $formMetadataProvider */
         $formMetadataProvider = $this->prophesize(FormMetadataProvider::class);
 
-        /** @var TokenInterface|ObjectProphecy $token */
+        /** @var ObjectProphecy<TokenInterface> $token */
         $token = $this->prophesize(TokenInterface::class);
-        /** @var UserInterface|ObjectProphecy $user */
+        /** @var ObjectProphecy<UserInterface> $user */
         $user = $this->prophesize(UserInterface::class);
 
         $tokenStorage->getToken()

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -187,7 +187,7 @@ class SnippetResolverTest extends TestCase
         $structure2->setIsShadow(true)->shouldBeCalled();
         $structure2->setShadowBaseLanguage('en')->shouldBeCalled();
 
-        /** @var SnippetDocument|ObjectProphecy $snippetDocument */
+        /** @var ObjectProphecy<SnippetDocument> $snippetDocument */
         $snippetDocument = $this->prophesize(SnippetDocument::class);
         $structure2->getDocument()->willReturn($snippetDocument->reveal());
         $snippetDocument->setLocale('en')->shouldBeCalled();

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtensionInterface.php
@@ -20,11 +20,18 @@ interface SitemapTwigExtensionInterface extends ExtensionInterface
 {
     /**
      * Returns prefixed resourcelocator with the url and locale.
+     *
+     * @param string $url
+     * @param string|null $locale
+     * @param string|null $webspaceKey
      */
     public function sitemapUrlFunction($url, $locale = null, $webspaceKey = null);
 
     /**
      * Returns full sitemap of webspace and language from the content.
+     *
+     * @param string|null $locale
+     * @param string|null $webspaceKey
      */
     public function sitemapFunction($locale = null, $webspaceKey = null);
 }

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/CopyLocaleSubscriberTest.php
@@ -67,7 +67,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
     public function testHandleCopyLocale(): void
     {
-        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        /** @var ObjectProphecy<CopyLocaleEvent> $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
         $event->getDestLocale()->willReturn('de');
@@ -80,11 +80,11 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
             'bar' => 'baz',
         ];
 
-        /** @var StructureInterface|ObjectProphecy $structure */
+        /** @var ObjectProphecy<StructureInterface> $structure */
         $structure = $this->prophesize(StructureInterface::class);
         $structure->toArray()->willReturn($structureData);
 
-        /** @var PageDocument|ObjectProphecy $document */
+        /** @var ObjectProphecy<PageDocument> $document */
         $document = $this->prophesize(PageDocument::class);
         $document->getUuid()->willReturn('page-uuid');
         $document->getWebspaceName()->willReturn('sulu_io');
@@ -95,20 +95,20 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
         $event->getDocument()->willReturn($document->reveal());
 
-        /** @var PageDocument|ObjectProphecy $parentDocument */
+        /** @var ObjectProphecy<PageDocument> $parentDocument */
         $parentDocument = $this->prophesize(PageDocument::class);
         $this->documentInspector->getParent($document->reveal())->willReturn($parentDocument->reveal());
         $this->documentInspector->getUuid($parentDocument->reveal())->willReturn('parent-page-uuid');
 
-        /** @var ResourceLocatorStrategyInterface|ObjectProphecy $resourceLocatorStrategy */
+        /** @var ObjectProphecy<ResourceLocatorStrategyInterface> $resourceLocatorStrategy */
         $resourceLocatorStrategy = $this->prophesize(ResourceLocatorStrategyInterface::class);
         $this->resourceLocatorStrategyPool->getStrategyByWebspaceKey('sulu_io')->willReturn($resourceLocatorStrategy->reveal());
 
-        /** @var PageDocument|ObjectProphecy $destDocument */
+        /** @var ObjectProphecy<PageDocument> $destDocument */
         $destDocument = $this->prophesize(PageDocument::class);
         $this->documentManager->find('page-uuid', 'de')->willReturn($destDocument->reveal());
 
-        /** @var StructureInterface|ObjectProphecy $destStructure */
+        /** @var ObjectProphecy<StructureInterface> $destStructure */
         $destStructure = $this->prophesize(StructureInterface::class);
 
         $destDocument->setLocale('de')->shouldBeCalled();
@@ -136,7 +136,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
     public function testHandleCopyLocalePageTreeRouteNonArrayRoutePath(): void
     {
-        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        /** @var ObjectProphecy<CopyLocaleEvent> $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
         $event->getDestLocale()->willReturn('de');
@@ -146,15 +146,15 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
             'routePath' => 'test',
         ];
 
-        /** @var StructureInterface|ObjectProphecy $structure */
+        /** @var ObjectProphecy<StructureInterface> $structure */
         $structure = $this->prophesize(StructureInterface::class);
         $structure->toArray()->willReturn($structureData);
 
-        /** @var PageDocument|ObjectProphecy $document */
+        /** @var ObjectProphecy<PageDocument> $document */
         $document = $this->prophesize(PageDocument::class);
         $document->getStructure()->willReturn($structure->reveal());
 
-        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        /** @var ObjectProphecy<RoutableBehavior> $destDocument */
         $destDocument = $this->prophesize(RoutableBehavior::class);
 
         $structure = $this->subscriber->checkPageTreeRoute($destDocument->reveal(), $document->reveal(), 'de');
@@ -168,7 +168,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
     public function testHandleCopyLocalePageTreeRoute(): void
     {
-        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        /** @var ObjectProphecy<CopyLocaleEvent> $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
         $event->getDestLocale()->willReturn('de');
@@ -185,15 +185,15 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
             ],
         ];
 
-        /** @var StructureInterface|ObjectProphecy $structure */
+        /** @var ObjectProphecy<StructureInterface> $structure */
         $structure = $this->prophesize(StructureInterface::class);
         $structure->toArray()->willReturn($structureData);
 
-        /** @var PageDocument|ObjectProphecy $document */
+        /** @var ObjectProphecy<PageDocument> $document */
         $document = $this->prophesize(PageDocument::class);
         $document->getStructure()->willReturn($structure->reveal());
 
-        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        /** @var ObjectProphecy<RoutableBehavior> $destDocument */
         $destDocument = $this->prophesize(RoutableBehavior::class);
         $routeInterface = $this->prophesize(RouteInterface::class);
         $destDocument->setRoutePath('/new')->shouldBeCalled();
@@ -217,7 +217,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
     public function testHandleCopyLocalePageTreeRouteParentNotPublished(): void
     {
-        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        /** @var ObjectProphecy<CopyLocaleEvent> $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
         $event->getDestLocale()->willReturn('de');
@@ -234,13 +234,13 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
             ],
         ];
 
-        /** @var StructureInterface|ObjectProphecy $structure */
+        /** @var ObjectProphecy<StructureInterface> $structure */
         $structure = $this->prophesize(StructureInterface::class);
         $structure->toArray()->willReturn($structureData);
         $propertyValue = new PropertyValue('url', '/destParentPageUrl');
         $structure->getProperty('url')->willReturn($propertyValue);
 
-        /** @var PageDocument|ObjectProphecy $document */
+        /** @var ObjectProphecy<PageDocument> $document */
         $document = $this->prophesize(PageDocument::class);
 
         $document->getStructure()->willReturn($structure->reveal());
@@ -249,7 +249,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
         $pageDocument->getStructure()->willReturn($structure->reveal());
         $this->documentManager->find('2ad86c23-04b7-41e0-b2bf-086b7d43d4a2', 'de')->willReturn($pageDocument->reveal());
 
-        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        /** @var ObjectProphecy<RoutableBehavior> $destDocument */
         $destDocument = $this->prophesize(RoutableBehavior::class);
         $routeInterface = $this->prophesize(RouteInterface::class);
         $destDocument->setRoutePath('/destParentPageUrl/new')->shouldBeCalled();
@@ -273,7 +273,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
     public function testHandleCopyLocalePageTreeRouteParent(): void
     {
-        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        /** @var ObjectProphecy<CopyLocaleEvent> $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
         $event->getDestLocale()->willReturn('de');
@@ -290,11 +290,11 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
             ],
         ];
 
-        /** @var StructureInterface|ObjectProphecy $structure */
+        /** @var ObjectProphecy<StructureInterface> $structure */
         $structure = $this->prophesize(StructureInterface::class);
         $structure->toArray()->willReturn($structureData);
 
-        /** @var PageDocument|ObjectProphecy $document */
+        /** @var ObjectProphecy<PageDocument> $document */
         $document = $this->prophesize(PageDocument::class);
 
         $document->getStructure()->willReturn($structure->reveal());
@@ -309,7 +309,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
         $pageDocument->getStructure()->willReturn($structureInterface->reveal());
         $this->documentManager->find('2ad86c23-04b7-41e0-b2bf-086b7d43d4a2', 'de')->willReturn($pageDocument->reveal());
 
-        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        /** @var ObjectProphecy<RoutableBehavior> $destDocument */
         $destDocument = $this->prophesize(RoutableBehavior::class);
         $routeInterface = $this->prophesize(RouteInterface::class);
         $destDocument->setRoutePath('/overview/new')->shouldBeCalled();
@@ -333,7 +333,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
     public function testHandleCopyLocaleOnNotExistingRoute(): void
     {
-        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        /** @var ObjectProphecy<CopyLocaleEvent> $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
         $event->getDestLocale()->willReturn('de');
@@ -350,15 +350,15 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
             ],
         ];
 
-        /** @var StructureInterface|ObjectProphecy $structure */
+        /** @var ObjectProphecy<StructureInterface> $structure */
         $structure = $this->prophesize(StructureInterface::class);
         $structure->toArray()->willReturn($structureData);
 
-        /** @var PageDocument|ObjectProphecy $document */
+        /** @var ObjectProphecy<PageDocument> $document */
         $document = $this->prophesize(PageDocument::class);
         $document->getStructure()->willReturn($structure->reveal());
 
-        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        /** @var ObjectProphecy<RoutableBehavior> $destDocument */
         $destDocument = $this->prophesize(RoutableBehavior::class);
         $destDocument->setRoutePath('/new')->shouldBeCalled();
         $destDocument->getRoute()->willReturn(null);
@@ -381,7 +381,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
     public function testHandleCopyLocaleOnExistingRoute(): void
     {
-        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        /** @var ObjectProphecy<CopyLocaleEvent> $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
         $event->getDestLocale()->willReturn('de');
@@ -398,15 +398,15 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
             ],
         ];
 
-        /** @var StructureInterface|ObjectProphecy $structure */
+        /** @var ObjectProphecy<StructureInterface> $structure */
         $structure = $this->prophesize(StructureInterface::class);
         $structure->toArray()->willReturn($structureData);
 
-        /** @var PageDocument|ObjectProphecy $document */
+        /** @var ObjectProphecy<PageDocument> $document */
         $document = $this->prophesize(PageDocument::class);
         $document->getStructure()->willReturn($structure->reveal());
 
-        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        /** @var ObjectProphecy<RoutableBehavior> $destDocument */
         $destDocument = $this->prophesize(RoutableBehavior::class);
         $destDocument->setRoutePath('/new')->shouldBeCalled();
         $route = new Route();
@@ -434,7 +434,7 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
 
     public function testHandleCopyLocaleOnExistingRouteWrongLocale(): void
     {
-        /** @var CopyLocaleEvent|ObjectProphecy $event */
+        /** @var ObjectProphecy<CopyLocaleEvent> $event */
         $event = $this->prophesize(CopyLocaleEvent::class);
         $event->getLocale()->willReturn('en');
         $event->getDestLocale()->willReturn('de');
@@ -451,15 +451,15 @@ class CopyLocaleSubscriberTest extends SubscriberTestCase
             ],
         ];
 
-        /** @var StructureInterface|ObjectProphecy $structure */
+        /** @var ObjectProphecy<StructureInterface> $structure */
         $structure = $this->prophesize(StructureInterface::class);
         $structure->toArray()->willReturn($structureData);
 
-        /** @var PageDocument|ObjectProphecy $document */
+        /** @var ObjectProphecy<PageDocument> $document */
         $document = $this->prophesize(PageDocument::class);
         $document->getStructure()->willReturn($structure->reveal());
 
-        /** @var RoutableBehavior|ObjectProphecy $destDocument */
+        /** @var ObjectProphecy<RoutableBehavior> $destDocument */
         $destDocument = $this->prophesize(RoutableBehavior::class);
         $destDocument->setRoutePath('/new')->shouldBeCalled();
         $route = new Route();

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Subscriber/ResourceSegmentSubscriberTest.php
@@ -67,7 +67,7 @@ class ResourceSegmentSubscriberTest extends TestCase
     private $resourceLocatorStrategyPool;
 
     /**
-     * @var ResourceSegmentBehavior|ObjectProphecy
+     * @var ObjectProphecy<ResourceSegmentBehavior>
      */
     private $document;
 

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -182,14 +182,14 @@ class PageDataProviderTest extends TestCase
 
     public function testGetTypesConfiguration(): void
     {
-        /** @var TokenStorageInterface|ObjectProphecy $tokenStorage */
+        /** @var ObjectProphecy<TokenStorageInterface> $tokenStorage */
         $tokenStorage = $this->prophesize(TokenStorageInterface::class);
-        /** @var FormMetadataProvider|ObjectProphecy $formMetadataProvider */
+        /** @var ObjectProphecy<FormMetadataProvider> $formMetadataProvider */
         $formMetadataProvider = $this->prophesize(FormMetadataProvider::class);
 
-        /** @var TokenInterface|ObjectProphecy $token */
+        /** @var ObjectProphecy<TokenInterface> $token */
         $token = $this->prophesize(TokenInterface::class);
-        /** @var UserInterface|ObjectProphecy $user */
+        /** @var ObjectProphecy<UserInterface> $user */
         $user = $this->prophesize(UserInterface::class);
 
         $tokenStorage->getToken()

--- a/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
+++ b/src/Sulu/Component/Media/Tests/Unit/SmartContent/MediaDataProviderTest.php
@@ -166,10 +166,10 @@ class MediaDataProviderTest extends TestCase
 
     public function testGetTypesConfiguration(): void
     {
-        /** @var EntityManagerInterface|ObjectProphecy $entityManager */
+        /** @var ObjectProphecy<EntityManagerInterface> $entityManager */
         $entityManager = $this->prophesize(EntityManagerInterface::class);
 
-        /** @var ObjectRepository|ObjectProphecy $mediaTypeRepository */
+        /** @var ObjectProphecy<ObjectRepository> $mediaTypeRepository */
         $mediaTypeRepository = $this->prophesize(ObjectRepository::class);
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
@@ -193,7 +193,7 @@ class MediaDataProviderTest extends TestCase
             ->shouldBeCalled()
             ->willReturn([$mediaType1, $mediaType2]);
 
-        /** @var TranslatorInterface|ObjectProphecy $translator */
+        /** @var ObjectProphecy<TranslatorInterface> $translator */
         $translator = $this->prophesize(TranslatorInterface::class);
         $translator->trans('sulu_media.audio', [], 'admin')
             ->shouldBeCalled()

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/MetadataSubscriberTest.php
@@ -160,7 +160,7 @@ class MetadataSubscriberTest extends TestCase
         $this->configuration->getNamingStrategy()->willReturn(null);
         $this->classMetadataFactory->getReflectionService()->willReturn($this->reflectionService->reveal());
 
-        /** @var MappingDriver|ObjectProphecy $mappingDriver */
+        /** @var ObjectProphecy<MappingDriver> $mappingDriver */
         $mappingDriver = $this->prophesize(MappingDriver::class);
         $this->configuration->getMetadataDriverImpl()->willReturn($mappingDriver->reveal());
         $mappingDriver->getAllClassNames()->willReturn([\get_class($this->parentObject->reveal())]);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix ObjectProphecy definitions and Sitemap return types.

#### Why?

Stumbled over this while work on the preview integration of the new route bundle and cherry picked it to 2.5.
