### PR TITLE
Prepare Preview for new Route Bundle implemention

### DIFF
--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistry;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistryInterface;
+use Sulu\Bundle\PreviewBundle\Preview\Provider\PreviewDefaultsProviderInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
@@ -74,7 +75,7 @@ class ContentViewBuilderFactoryTest extends TestCase
     }
 
     /**
-     * @param array<string, PreviewObjectProviderInterface> $providers
+     * @param array<string, PreviewObjectProviderInterface|PreviewDefaultsProviderInterface> $providers
      */
     protected function createPreviewObjectProviderRegistry(array $providers): PreviewObjectProviderRegistryInterface
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -40939,98 +40939,8 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderInterface.php
 
 		-
-			message: '#^Cannot access offset ''html'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Cannot access offset ''id'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Cannot access offset ''object'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Cannot access offset ''objectClass'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Cannot access offset ''providerKey'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Cannot access offset ''userId'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Preview\:\:render\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Preview\:\:renderPartial\(\) has parameter \$options with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Preview\:\:start\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Preview\:\:start\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Preview\:\:update\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Preview\:\:update\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#1 \$html of method Sulu\\Bundle\\PreviewBundle\\Preview\\PreviewCacheItem\:\:setHtml\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#1 \$id of class Sulu\\Bundle\\PreviewBundle\\Preview\\PreviewCacheItem constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#1 \$object of function get_class expects object, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#1 \$providerKey of method Sulu\\Bundle\\PreviewBundle\\Preview\\Preview\:\:getProvider\(\) expects string, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
 
@@ -41041,61 +40951,7 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
 
 		-
-			message: '#^Parameter \#2 \$locale of method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:getObject\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#2 \$locale of method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:setContext\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#2 \$locale of method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:setValues\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 3
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#2 \$objectClass of method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:deserialize\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#2 \$userId of class Sulu\\Bundle\\PreviewBundle\\Preview\\PreviewCacheItem constructor expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
 			message: '#^Parameter \#2 \$value of method Sulu\\Bundle\\PreviewBundle\\Preview\\PreviewCache\:\:save\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#3 \$context of method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:setContext\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#3 \$data of method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:setValues\(\) expects array\<string, mixed\>, array given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#3 \$data of method Sulu\\Bundle\\PreviewBundle\\Preview\\Object\\PreviewObjectProviderInterface\:\:setValues\(\) expects array\<string, mixed\>, array\<mixed\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
-
-		-
-			message: '#^Parameter \#3 \$providerKey of class Sulu\\Bundle\\PreviewBundle\\Preview\\PreviewCacheItem constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Preview.php
@@ -41203,12 +41059,6 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRenderer\:\:render\(\) has parameter \$object with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRenderer\:\:render\(\) has parameter \$options with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -41233,43 +41083,13 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#1 \$entityClass of method Sulu\\Bundle\\RouteBundle\\Routing\\Defaults\\RouteDefaultsProviderInterface\:\:getByEntity\(\) expects string, class\-string\|false given\.$#'
+			message: '#^Parameter \#1 \$locale of method Symfony\\Component\\HttpFoundation\\Request\:\:setLocale\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#1 \$entityClass of method Sulu\\Bundle\\RouteBundle\\Routing\\Defaults\\RouteDefaultsProviderInterface\:\:supports\(\) expects string, class\-string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
-			message: '#^Parameter \#1 \$locale of method Symfony\\Component\\HttpFoundation\\Request\:\:setLocale\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
-			message: '#^Parameter \#1 \$localization of method Sulu\\Component\\Webspace\\Webspace\:\:getLocalization\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
-			message: '#^Parameter \#1 \$object of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\RouteDefaultsProviderNotFoundException constructor expects object, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
-			message: '#^Parameter \#1 \$object of function get_class expects object, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
-			message: '#^Parameter \#1 \$object of method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRenderer\:\:createPortalInformation\(\) expects object, mixed given\.$#'
+			message: '#^Parameter \#1 \$localization of method Sulu\\Component\\Webspace\\Webspace\:\:getLocalization\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -41281,7 +41101,7 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#1 \$webspaceKey of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findPortalInformationsByWebspaceKeyAndLocale\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$webspaceKey of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findPortalInformationsByWebspaceKeyAndLocale\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -41293,7 +41113,7 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#2 \$locale of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findPortalInformationsByWebspaceKeyAndLocale\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#2 \$locale of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findPortalInformationsByWebspaceKeyAndLocale\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -41305,37 +41125,31 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#3 \$locale of method Sulu\\Bundle\\RouteBundle\\Routing\\Defaults\\RouteDefaultsProviderInterface\:\:getByEntity\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#3 \$locale of method Sulu\\Bundle\\RouteBundle\\Routing\\Defaults\\RouteDefaultsProviderInterface\:\:getByEntity\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#3 \$webspaceKey of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\RouteDefaultsProviderNotFoundException constructor expects string, mixed given\.$#'
+			message: '#^Parameter \#3 \$webspaceKey of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\RouteDefaultsProviderNotFoundException constructor expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#3 \$webspaceKey of method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRenderer\:\:createPortalInformation\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#3 \$webspaceKey of method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRenderer\:\:createPortalInformation\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#4 \$locale of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\RouteDefaultsProviderNotFoundException constructor expects string, mixed given\.$#'
+			message: '#^Parameter \#4 \$locale of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\RouteDefaultsProviderNotFoundException constructor expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#4 \$locale of method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRenderer\:\:createPortalInformation\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
-			message: '#^Parameter \#4 \$object of method Sulu\\Bundle\\RouteBundle\\Routing\\Defaults\\RouteDefaultsProviderInterface\:\:getByEntity\(\) expects object\|null, mixed given\.$#'
+			message: '#^Parameter \#4 \$locale of method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRenderer\:\:createPortalInformation\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -41359,26 +41173,20 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#5 \$locale of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\TemplateNotFoundException constructor expects string, mixed given\.$#'
+			message: '#^Parameter \#5 \$locale of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\TemplateNotFoundException constructor expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#5 \$locale of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\TwigException constructor expects string, mixed given\.$#'
+			message: '#^Parameter \#5 \$locale of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\TwigException constructor expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
 		-
-			message: '#^Parameter \#5 \$locale of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\UnexpectedException constructor expects string, mixed given\.$#'
+			message: '#^Parameter \#5 \$locale of class Sulu\\Bundle\\PreviewBundle\\Preview\\Exception\\UnexpectedException constructor expects string, string\|null given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRenderer\:\:\$defaultHost is unused\.$#'
-			identifier: property.unused
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
 
@@ -41387,12 +41195,6 @@ parameters:
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRendererInterface\:\:render\(\) has parameter \$object with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRendererInterface.php
 
 		-
 			message: '#^Method Sulu\\Bundle\\PreviewBundle\\Preview\\Renderer\\PreviewRendererInterface\:\:render\(\) has parameter \$options with no type specified\.$#'

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderInterface.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\PreviewBundle\Preview\Object;
 
 /**
  * Interface for preview-object-provider.
+ *
+ * @deprecated use PreviewDefaultsProviderInterface instead
  */
 interface PreviewObjectProviderInterface
 {

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderRegistry.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderRegistry.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\PreviewBundle\Preview\Object;
 
 use Sulu\Bundle\PreviewBundle\Preview\Exception\ProviderNotFoundException;
+use Sulu\Bundle\PreviewBundle\Preview\Provider\PreviewDefaultsProviderInterface;
 
 /**
  * @internal No BC promises are given for this class. It may be changed or removed at any time.
@@ -19,7 +20,7 @@ use Sulu\Bundle\PreviewBundle\Preview\Exception\ProviderNotFoundException;
 class PreviewObjectProviderRegistry implements PreviewObjectProviderRegistryInterface
 {
     /**
-     * @param PreviewObjectProviderInterface[] $previewObjectProviders
+     * @param array<string, PreviewObjectProviderInterface|PreviewDefaultsProviderInterface> $previewObjectProviders
      */
     public function __construct(private array $previewObjectProviders)
     {
@@ -30,7 +31,7 @@ class PreviewObjectProviderRegistry implements PreviewObjectProviderRegistryInte
         return $this->previewObjectProviders;
     }
 
-    public function getPreviewObjectProvider(string $providerKey): PreviewObjectProviderInterface
+    public function getPreviewObjectProvider(string $providerKey): PreviewObjectProviderInterface|PreviewDefaultsProviderInterface
     {
         if (!$this->hasPreviewObjectProvider($providerKey)) {
             throw new ProviderNotFoundException($providerKey);

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderRegistryInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderRegistryInterface.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\PreviewBundle\Preview\Object;
 
+use Sulu\Bundle\PreviewBundle\Preview\Provider\PreviewDefaultsProviderInterface;
+
 /**
  * @internal No BC promises are given for this class. It may be changed or removed at any time.
  */
@@ -19,14 +21,14 @@ interface PreviewObjectProviderRegistryInterface
     /**
      * Returns all PreviewObjectProviders.
      *
-     * @return PreviewObjectProviderInterface[]
+     * @return array<PreviewObjectProviderInterface|PreviewDefaultsProviderInterface>
      */
     public function getPreviewObjectProviders(): array;
 
     /**
      * Returns the PreviewObjectProvider for given $providerKey.
      */
-    public function getPreviewObjectProvider(string $providerKey): PreviewObjectProviderInterface;
+    public function getPreviewObjectProvider(string $providerKey): PreviewObjectProviderInterface|PreviewDefaultsProviderInterface;
 
     /**
      * Returns true if a PreviewObjectProvider for given $providerKey exists.

--- a/src/Sulu/Bundle/PreviewBundle/Preview/PreviewCacheItem.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/PreviewCacheItem.php
@@ -26,6 +26,7 @@ class PreviewCacheItem
      */
     public function __construct(
         private string $id,
+        private ?string $locale,
         private int $userId,
         private string $providerKey,
         private $object,
@@ -35,6 +36,11 @@ class PreviewCacheItem
     public function getId(): string
     {
         return $this->id;
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
     }
 
     public function getUserId(): int

--- a/src/Sulu/Bundle/PreviewBundle/Preview/PreviewContext.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/PreviewContext.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Preview;
+
+final class PreviewContext
+{
+    public function __construct(
+        private int|string|null $id = null,
+        private ?string $locale = null
+    ) {
+    }
+
+    public function getId(): int|string|null
+    {
+        return $this->id;
+    }
+
+    public function getLocale(): ?string
+    {
+        return $this->locale;
+    }
+}

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Provider/PreviewDefaultsProviderInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Provider/PreviewDefaultsProviderInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Preview\Provider;
+
+use Sulu\Bundle\PreviewBundle\Preview\PreviewContext;
+
+interface PreviewDefaultsProviderInterface
+{
+    /**
+     * Returns the Route Defaults to render the preview. Should at least return the '_controller' key.
+     *
+     * @example
+     *
+     * ```php
+     *     return [
+     *          'object' => $object,
+     *           '_controller' => MyController::class . '::myAction',
+     *           'view' => 'my-view',
+     *     ];
+     * ```
+     *
+     * @return array<string, mixed>
+     */
+    public function getDefaults(PreviewContext $previewContext): array;
+
+    /**
+     * Called before rendering the preview — can be used to update the values of the defaults.
+     *
+     * @param array<string, mixed> $defaults
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    public function updateValues(PreviewContext $previewContext, array $defaults, array $data): array;
+
+    /**
+     * Called before rendering the preview — called example when template is switched.
+     * Can be used to update the values of the defaults.
+     *
+     * @param array<string, mixed> $defaults
+     * @param array<string, mixed> $context
+     *
+     * @return array<string, mixed>
+     */
+    public function updateContext(PreviewContext $previewContext, array $defaults, array $context): array;
+
+    public function getSecurityContext(PreviewContext $previewContext): ?string;
+}

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRendererInterface.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRendererInterface.php
@@ -19,6 +19,7 @@ interface PreviewRendererInterface
     /**
      * Renders object in given webspace and locale.
      *
+     * @param mixed $object
      * @param string $id
      * @param bool $partial
      *

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.xml
@@ -31,7 +31,7 @@
         </service>
 
         <service id="sulu_preview.preview.renderer" class="Sulu\Bundle\PreviewBundle\Preview\Renderer\PreviewRenderer">
-            <argument type="service" id="sulu_route.routing.defaults_provider"/>
+            <argument type="service" id="sulu_route.routing.defaults_provider" on-invalid="null"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="sulu_preview.preview.kernel_factory"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Preview/PreviewTest.php
@@ -101,9 +101,10 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => null,
+            'locale' => $this->locale,
         ];
 
         $this->cache->save(
@@ -135,9 +136,10 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => null,
+            'locale' => $this->locale,
         ];
 
         $this->cache->save(
@@ -202,17 +204,19 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => \json_encode(['title' => 'test']),
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
         $expectedData = [
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
 
         $this->cache->contains($token)->willReturn(true);
@@ -263,9 +267,10 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
 
         $this->cache->contains($token)->willReturn(true);
@@ -322,7 +327,7 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
         ];
@@ -377,9 +382,10 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
 
         $newObject = $this->prophesize(\stdClass::class);
@@ -387,9 +393,10 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => \json_encode(\array_merge($data, $context)),
-            'objectClass' => \get_class($newObject->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
 
         $this->cache->contains($token)->willReturn(true);
@@ -402,7 +409,7 @@ class PreviewTest extends TestCase
 
         $this->renderer->render(
             $newObject->reveal(),
-            1,
+            '1',
             false,
             ['webspaceKey' => $this->webspaceKey, 'locale' => $this->locale]
         )->willReturn(
@@ -456,7 +463,7 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"></div></body></html>',
         ];
@@ -497,7 +504,7 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
         ];
@@ -546,9 +553,10 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
 
         $newObject = $this->prophesize(\stdClass::class);
@@ -556,9 +564,10 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => \json_encode(\array_merge($data, $context)),
-            'objectClass' => \get_class($newObject->reveal()),
+            'objectClass' => \get_debug_type($newObject->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
 
         $this->cache->contains($token)->willReturn(true);
@@ -620,17 +629,19 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => null,
+            'locale' => $this->locale,
         ];
         $expectedData = [
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
 
         $this->cache->contains($token)->willReturn(true);
@@ -684,17 +695,19 @@ class PreviewTest extends TestCase
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => null,
+            'locale' => $this->locale,
         ];
         $expectedData = [
             'id' => '1',
             'providerKey' => $this->providerKey,
             'object' => $dataJson,
-            'objectClass' => \get_class($this->object->reveal()),
+            'objectClass' => \get_debug_type($this->object->reveal()),
             'userId' => 1,
             'html' => '<html><body><div id="content"><!-- CONTENT-REPLACER --></div></body></html>',
+            'locale' => $this->locale,
         ];
 
         $this->cache->contains($token)->willReturn(true);

--- a/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewController.php
@@ -72,6 +72,7 @@ class PreviewController
         $provider = $this->getRequestParameter($request, 'provider', true);
         $id = $this->getRequestParameter($request, 'id', true);
         $token = $this->getRequestParameter($request, 'token', true);
+        /** @var array<string, mixed> $data */
         $data = (array) $this->getRequestParameter($request, 'data', true);
 
         $options = $this->getOptionsFromRequest($request);
@@ -94,8 +95,9 @@ class PreviewController
         $id = $this->getRequestParameter($request, 'id', true);
         $provider = $this->getRequestParameter($request, 'provider', true);
         $token = $this->getRequestParameter($request, 'token', true);
+        /** @var array<string, mixed> $context */
         $context = (array) $this->getRequestParameter($request, 'context', true);
-        /** @var mixed[] $data */
+        /** @var array<string, mixed> $data */
         $data = $this->getRequestParameter($request, 'data', true);
 
         $options = $this->getOptionsFromRequest($request);
@@ -146,7 +148,7 @@ class PreviewController
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, mixed>
      */
     private function getOptionsFromRequest(Request $request): array
     {

--- a/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PublicPreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PublicPreviewController.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\PreviewBundle\UserInterface\Controller;
 
 use Sulu\Bundle\PreviewBundle\Domain\Repository\PreviewLinkRepositoryInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistryInterface;
+use Sulu\Bundle\PreviewBundle\Preview\PreviewContext;
+use Sulu\Bundle\PreviewBundle\Preview\Provider\PreviewDefaultsProviderInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Renderer\PreviewRendererInterface;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Symfony\Component\HttpFoundation\Response;
@@ -62,7 +64,12 @@ class PublicPreviewController
         $options['locale'] = $locale;
 
         $provider = $this->previewObjectProviderRegistry->getPreviewObjectProvider($resourceKey);
-        $object = $provider->getObject($resourceId, $locale);
+        if ($provider instanceof PreviewDefaultsProviderInterface) {
+            $previewContext = new PreviewContext($resourceId, $locale);
+            $object = $provider->getDefaults($previewContext);
+        } else {
+            $object = $provider->getObject($resourceId, $locale);
+        }
 
         $content = $this->previewRenderer->render($object, $resourceId, false, $options);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? |  yes
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add a new `PreviewDefaultsProviderInterface` to decouple the `Preview` Bundle from the `RouteBundle`. Instead of `getObject` a new `getDefaults` is implemented. This should also in future make it easier to create a preview for any none routable entities.

```php

namespace Sulu\Bundle\PreviewBundle\Preview\Provider;

use Sulu\Bundle\PreviewBundle\Preview\PreviewContext;

interface PreviewDefaultsProviderInterface
{
    /**
     * Returns the Route Defaults to render the preview. Should at least return the '_controller' key.
     *
     * @example
     *
     * ```php
     *     return [
     *          'object' => $object,
     *           '_controller' => MyController::class . '::myAction',
     *           'view' => 'my-view',
     *     ];
     * ```
     *
     * @return array<string, mixed>
     */
    public function getDefaults(PreviewContext $previewContext): array;

    /**
     * Called before rendering the preview — can be used to update the values of the defaults.
     *
     * @param array<string, mixed> $defaults
     * @param array<string, mixed> $data
     *
     * @return array<string, mixed>
     */
    public function updateValues(PreviewContext $previewContext, array $defaults, array $data): array;

    /**
     * Called before rendering the preview — called example when template is switched.
     * Can be used to update the values of the defaults.
     *
     * @param array<string, mixed> $defaults
     * @param array<string, mixed> $context
     *
     * @return array<string, mixed>
     */
    public function updateContext(PreviewContext $previewContext, array $defaults, array $context): array;

    public function getSecurityContext(PreviewContext $previewContext): ?string;
}
```

Syntaxed changed and serialize and deserialized is removed. Currently the Content Bundle does always load the whole entity from Database in serialize method thats why this methods are unnecessary. Still we later could introduced a `CachablePreviewDefaultsProviderInterface` with `serialize` and `deserialize` to improve performance if we want. But most performance improvements where done by not rendering the header and footer always, which is still done as the navigation queries did make most things slow. With future navigation cache maybe also that bottleneck goes away. 

#### Why?

Currently the RouteBundle is deeply integrated into the PreviewRenderer which make usage without RouteBundle hard. This also make it hard to have old and new RouteBundle side by side. So we will move step by step the preview to be independent from Route Bundle.