### PR TITLE
Fix UserProvider PHPStan Generic update for PasswordUpgraderInterface

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+++ b/src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
@@ -32,7 +32,6 @@ use Webmozart\Assert\Assert;
  * configuration from the webspaces into account.
  *
  * @implements UserProviderInterface<UserInterface>
- * @implements PasswordUpgraderInterface<User>
  */
 class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
 {
@@ -127,7 +126,7 @@ class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
 
     public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void
     {
-        if (!$user instanceof User) { // @phpstan-ignore-line we can not be 100% sure about this but generic forces us to check
+        if (!$user instanceof User) {
             return;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove generic definitions for PasswordUpgraderInterface as it was removed from Symfony core.

#### Why?

Not longer generic: https://github.com/symfony/symfony/pull/51283
