### PR TITLE
Add findBy to RouteRepository for Localization switcher

### DIFF
--- a/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
+++ b/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
@@ -17,6 +17,7 @@ use Sulu\Route\Domain\Model\Route;
  * @phpstan-type RouteFilter array{
  *     site?: string|null,
  *     locale?: string,
+ *     locales?: string[],
  *     slug?: string,
  *     resourceKey?: string,
  *     resourceId?: string,
@@ -30,4 +31,11 @@ interface RouteRepositoryInterface
      * @param RouteFilter $filters
      */
     public function findOneBy(array $filters): ?Route;
+
+    /**
+     * @param RouteFilter $filters
+     *
+     * @return iterable<Route>
+     */
+    public function findBy(array $filters): iterable;
 }

--- a/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
+++ b/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
@@ -49,6 +49,17 @@ class RouteRepository implements RouteRepositoryInterface
         return $queryBuilder->getQuery()->getOneOrNullResult(Query::HYDRATE_OBJECT);
     }
 
+    public function findBy(array $filters): iterable
+    {
+        $queryBuilder = $this->createQueryBuilder($filters);
+        $queryBuilder->select('route');
+
+        // Hydrate Object is default, but we need to specify it here to make PHPStan happy:
+        //     see: https://github.com/phpstan/phpstan-doctrine?tab=readme-ov-file#supported-methods
+        /** @var iterable<Route> */
+        return $queryBuilder->getQuery()->getResult(Query::HYDRATE_OBJECT);
+    }
+
     /**
      * @param RouteFilter $filters
      */
@@ -71,6 +82,12 @@ class RouteRepository implements RouteRepositoryInterface
         if (null !== $locale) {
             $queryBuilder->andWhere('route.locale = :locale')
                 ->setParameter('locale', $locale);
+        }
+
+        $locales = $filters['locales'] ?? null;
+        if (null !== $locales) {
+            $queryBuilder->andWhere('route.locale IN (:locales)')
+                ->setParameter('locales', $locales);
         }
 
         $slug = $filters['slug'] ?? null;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7749
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add findBy to RouteRepository for Localization switcher.

#### Why?

For the SettingsResolver in https://github.com/sulu/sulu/pull/7749 we need findBy method for receive all currently Routes for a specific resource by all published locales.

Typcial usage will be:

```php
$this->routeRepository->findBy([
    'resourceKey' => 'example',
    'resourceId' => '1',
    'locales' => ['en', 'de', 'fr'],
])
```

To create a local switcher.

@Prokyonn FYI