### PR TITLE
Add service layers to support old and new routing bundle

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -46,6 +46,7 @@ return [
     Sulu\Bundle\ReferenceBundle\SuluReferenceBundle::class => ['all' => true],
     Sulu\Bundle\CustomUrlBundle\SuluCustomUrlBundle::class => ['all' => true],
     Sulu\Bundle\RouteBundle\SuluRouteBundle::class => ['all' => true],
+    Sulu\Route\Infrastructure\Symfony\HttpKernel\SuluRouteBundle::class => ['all' => true],
     Sulu\Bundle\MarkupBundle\SuluMarkupBundle::class => ['all' => true],
     Sulu\Bundle\AudienceTargetingBundle\SuluAudienceTargetingBundle::class => ['all' => true],
     PHPCR\PhpcrMigrationsBundle\PhpcrMigrationsBundle::class => ['all' => true],

--- a/packages/article/tests/Application/Kernel.php
+++ b/packages/article/tests/Application/Kernel.php
@@ -18,7 +18,6 @@ use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ExampleTestBundle;
 use Sulu\Page\Infrastructure\Symfony\HttpKernel\SuluPageBundle;
-use Sulu\Route\Infrastructure\Symfony\HttpKernel\SuluRouteBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Task\TaskBundle\TaskBundle;
 
@@ -48,7 +47,6 @@ class Kernel extends SuluTestKernel
         $bundles[] = new SuluPageBundle();
         $bundles[] = new SuluContentBundle();
         $bundles[] = new SuluArticleBundle();
-        $bundles[] = new SuluRouteBundle();
         $bundles[] = new ExampleTestBundle(); // TODO currently required for test content bundle, everybody should setup database by its own
         $bundles[] = new SuluAutomationBundle(); // TODO currently required for test content bundle, everybody should setup database by its own
         $bundles[] = new TaskBundle(); // TODO currently required for test content bundle, everybody should setup database by its own

--- a/packages/route/config/deprecated_service_bridge.xml
+++ b/packages/route/config/deprecated_service_bridge.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sulu_next_route.routing.uri_filter_regexp"></parameter>
+    </parameters>
+
+    <services>
+        <!-- router -->
+        <service id="sulu_next_route.routing.generator" class="Symfony\Cmf\Component\Routing\ProviderBasedGenerator">
+            <argument type="service" id="sulu_route.symfony_cmf_route_provider"/>
+        </service>
+
+        <service id="sulu_next_route.routing.final_matcher" class="Symfony\Cmf\Component\Routing\NestedMatcher\UrlMatcher">
+            <argument type="service" id="cmf_routing.matcher.dummy_collection"/>
+            <argument type="service" id="cmf_routing.matcher.dummy_context"/>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_next_route.routing.nested_matcher" class="Symfony\Cmf\Component\Routing\NestedMatcher\NestedMatcher">
+            <argument type="service" id="sulu_route.symfony_cmf_route_provider"/>
+            <argument type="service" id="sulu_next_route.routing.final_matcher"/>
+
+            <tag name="sulu.context" context="website"/>
+        </service>
+
+        <service id="sulu_next_route.routing.router" class="Symfony\Cmf\Bundle\RoutingBundle\Routing\DynamicRouter">
+            <argument type="service" id="router.request_context"/>
+            <argument type="service" id="sulu_next_route.routing.nested_matcher"/>
+            <argument type="service" id="sulu_next_route.routing.generator"/>
+            <argument>%sulu_next_route.routing.uri_filter_regexp%</argument>
+            <argument type="service" id="event_dispatcher" on-invalid="ignore"/>
+            <argument type="service" id="sulu_route.symfony_cmf_route_provider"/>
+
+            <tag name="sulu.context" context="website"/>
+            <tag name="router" priority="30"/>
+        </service>
+    </services>
+</container>

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
@@ -56,7 +56,7 @@ class RouteRepositoryTest extends KernelTestCase
 
     protected function setUp(): void
     {
-        $this->routeRepository = self::getContainer()->get('sulu_route.route_repository'); // @phpstan-ignore-line
+        $this->routeRepository = self::getContainer()->get('sulu_route.route_repository');
     }
 
     public function testFindOneBySiteSlugLocale(): void

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -15,8 +15,6 @@ parameters:
     level: max
     parallel:
         processTimeout: 300.0
-    ignoreErrors:
-        - message: '#^Property Sulu\\(.*)\\Domain\\Model\\(.*)\:\:\$id \(int\|null\) is never assigned int so it can be removed from the property type\.$#'
     excludePaths:
         - %currentWorkingDirectory%/node_modules/*
         - %currentWorkingDirectory%/var/*

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -71,7 +71,8 @@ class SuluTestKernel extends SuluKernel
             new \Sulu\Bundle\HashBundle\SuluHashBundle(),
             new \Sulu\Bundle\ActivityBundle\SuluActivityBundle(),
             new \Sulu\Bundle\CustomUrlBundle\SuluCustomUrlBundle(),
-            new \Sulu\Bundle\RouteBundle\SuluRouteBundle(),
+            new \Sulu\Bundle\RouteBundle\SuluRouteBundle(), // TODO replace with new routing bundle
+            new \Sulu\Route\Infrastructure\Symfony\HttpKernel\SuluRouteBundle(),
             new \Sulu\Bundle\MarkupBundle\SuluMarkupBundle(),
             new \Sulu\Bundle\PreviewBundle\SuluPreviewBundle(),
             new \Sulu\Bundle\AudienceTargetingBundle\SuluAudienceTargetingBundle(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7749
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add a service layers to support old and new routing bundle.

#### Why?

We need to keep the old routing bundle active as dives into several parts now. With this PR we add a new dynamic router bridge to our new router. Needed to get https://github.com/sulu/sulu/pull/7749 working.