### PR TITLE
Feature: add requestParameters to SelectionFieldFilterType

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectionFieldFilterType.js
@@ -34,7 +34,9 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
         this.selectionStore = new MultiSelectionStore(
             this.resourceKey,
             [],
-            observable.box(userStore.contentLocale)
+            observable.box(userStore.contentLocale),
+            'ids',
+            this.resourceParameters
         );
 
         this.selectionStoreDisposer = autorun(() => {
@@ -80,6 +82,27 @@ class SelectionFieldFilterType extends AbstractFieldFilterType<?Array<string | n
         }
 
         return resourceKey;
+    }
+
+    @computed get resourceParameters() {
+        const {parameters} = this;
+
+        if (!parameters) {
+            throw new Error('The "SelectionFieldFilterType" needs some parameters to work!');
+        }
+
+        const {requestParameters} = parameters;
+
+        if (typeof requestParameters !== 'object') {
+            return {};
+        }
+
+        const resourceParameters = {};
+        for (const parameter in requestParameters) {
+            resourceParameters[parameter] = requestParameters[parameter];
+        }
+
+        return resourceParameters;
     }
 
     @computed get displayProperty() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js
@@ -32,11 +32,11 @@ test('Pass correct props to MultiAutoComplete', () => {
 
     const selectionFieldFilterType = new SelectionFieldFilterType(
         jest.fn(),
-        {displayProperty: 'name', resourceKey: 'accounts'},
+        {displayProperty: 'name', resourceKey: 'accounts', requestParameters: {rootKey: 'rootKey'}},
         undefined
     );
 
-    expect(MultiSelectionStore).toBeCalledWith('accounts', [], expect.anything());
+    expect(MultiSelectionStore).toBeCalledWith('accounts', [], expect.anything(), 'ids', {rootKey: 'rootKey'});
     // $FlowFixMe
     expect(MultiSelectionStore.mock.calls[0][2].get()).toEqual('ru');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/MultiAutoComplete.js
@@ -41,7 +41,7 @@ class MultiAutoComplete extends React.Component<Props> {
         this.searchStore = new SearchStore(
             selectionStore.resourceKey,
             searchProperties,
-            options,
+            {...options, ...selectionStore.requestParameters},
             selectionStore.locale
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

adds handling of `requestParameters` in `SelectionFieldFilterType`. 

#### Why?

This enables the `rootKey` to be passed to the `CategoryController` for example, so only subcategories of the provided category key are shown in the selection

#### Example Usage

```xml
<!-- contacts.xml -->
<property
    name="categoryId"
    visibility="never"
    translation="sulu_category.categories"
>
    <field-name>id</field-name>
    <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>

    <joins>
        <join>
            <entity-name>Sulu\Bundle\CategoryBundle\Entity\Category</entity-name>
            <field-name>%sulu.model.contact.class%.categories</field-name>
        </join>
    </joins>

    <filter type="selection">
        <params>
            <param name="displayProperty" value="name" />
            <param name="resourceKey" value="categories" />
            <!-- add the requestParameters and the rootKey here -->
            <param name="requestParameters" type="collection">
                <param name="rootKey" value="{the key of the category}" />
            </param>
        </params>
    </filter>
</property>

```