### PR TITLE
Remove mandatory condition from the PageTreeRoute path property

### DIFF
--- a/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
+++ b/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
@@ -241,7 +241,7 @@ class PageTreeRouteContentType extends SimpleContentType implements PropertyMeta
 
         $pageTreeRouteMetadata = new ObjectMetadata([
             new PropertyMetadata('page', $mandatory, $pageMetadata),
-            new PropertyMetadata('path', $mandatory, new StringMetadata()),
+            new PropertyMetadata('path', false, new StringMetadata()),
             new PropertyMetadata('suffix', false, new StringMetadata()),
         ]);
 

--- a/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
+++ b/src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/fields/PageTreeRoute.js
@@ -63,8 +63,8 @@ class PageTreeRoute extends Component<Props> {
     }): void => {
         const {onFinish} = this.props;
 
-        const uuid = (value && value.toString()) || null;
-        const path = (page && page.url) || null;
+        const uuid = (value && value.toString()) || undefined;
+        const path = (page && page.url) || undefined;
 
         this.handleChange({
             ...this.props.value,

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
@@ -482,7 +482,7 @@ class PageTreeRouteContentTypeTest extends TestCase
                 'path' => ['type' => 'string'],
                 'suffix' => ['type' => 'string'],
             ],
-            'required' => ['page', 'path'],
+            'required' => ['page'],
         ], $jsonSchema);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7842 
| License | MIT

#### What's in this PR?

In #7842 we introduced an bug for newly created documents with a PageTreeRoute content type. They could not be created anymore, because in the initial state the `path` property on the root layer is always missing. As this property was mandatory, the validation always threw an error.

Furthermore the PageTreeRoute field type was adjusted, to have `undefined` instead of `null` values, when the selected page is removed. Now the validation works properly and it cannot be saved anymore in this state.

#### Why?

The validation was not working as expected.