### PR TITLE
Bugfix for non-int page value

### DIFF
--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -326,7 +326,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
             return 1;
         }
 
-        $page = $this->requestStack->getCurrentRequest()->get($pageParameter, 1);
+        $page = (int) $this->requestStack->getCurrentRequest()->get($pageParameter, 1);
 
         if ($page <= 1) {
             $page = 1;
@@ -336,7 +336,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
             return \PHP_INT_MAX;
         }
 
-        return (int) $page;
+        return $page;
     }
 
     public function exportData($propertyValue)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/SuluHeadlessBundle/pull/147
| License | MIT

#### What's in this PR?

Cast the smart_content page parameter to int before comparing.

#### Why?

Because otherwise the value is too big for Elasticsearch and an error is thrown...

```
{"error":{"root_cause":[{"type":"input_coercion_exception","reason":"Numeric value (1.1068046444225731e+20) out of range of int (-2147483648 - 2147483647)\n at [Source: (org.elasticsearch.common.io.stream.ByteBufferStreamInput); line: 1, column: 354]"}],"type":"input_coercion_exception","reason":"Numeric value (1.1068046444225731e+20) out of range of int (-2147483648 - 2147483647)\n at [Source: (org.elasticsearch.common.io.stream.ByteBufferStreamInput); line: 1, column: 354]"},"status":500}
```

`?page=zh1m6`
