### PR TITLE
Fix usage of ramsey uuid in TagsSubscriber and replace with symfony uuid method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -23545,7 +23545,7 @@ parameters:
 			path: src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php
 
 		-
-			message: '#^Parameter \#1 \$uuid of static method Ramsey\\Uuid\\Uuid\:\:isValid\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$uuid of static method Symfony\\Component\\Uid\\Uuid\:\:isValid\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php

--- a/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\HttpCacheBundle\EventSubscriber;
 
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
-use Ramsey\Uuid\Uuid;
+use Symfony\Component\Uid\Uuid;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStorePoolInterface;
 use Sulu\Component\Content\Compat\StructureInterface;

--- a/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php
@@ -12,13 +12,13 @@
 namespace Sulu\Bundle\HttpCacheBundle\EventSubscriber;
 
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
-use Symfony\Component\Uid\Uuid;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStorePoolInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Adds tags to the Symfony response tagger from all available reference stores.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix usage of ramsey uuid in TagsSubscriber and replace with symfony uuid method for

https://github.com/sulu/sulu/blob/ca9a60f96312278f0b8950d27ca3cc3d24071e4b/src/Sulu/Bundle/HttpCacheBundle/EventSubscriber/TagsSubscriber.php#L79-L86

#### Why?

For less dependencies we decided to go with symfony ulid packages instead of ramsey uuid. The ramsey uuid is not longer installed since merge of php-task which is also not longer requiring it.