### PR TITLE
Refactor "create_draft" transition to "edit" transition

### DIFF
--- a/packages/content/config/data-mapper.xml
+++ b/packages/content/config/data-mapper.xml
@@ -23,6 +23,8 @@
         </service>
 
         <service id="sulu_content.workflow_data_mapper" class="Sulu\Content\Application\ContentDataMapper\DataMapper\WorkflowDataMapper">
+            <argument type="service" id="sulu_content.content_workflow"/>
+
             <tag name="sulu_content.data_mapper" priority="24"/>
         </service>
 

--- a/packages/content/src/Application/ContentWorkflow/ContentWorkflow.php
+++ b/packages/content/src/Application/ContentWorkflow/ContentWorkflow.php
@@ -135,9 +135,11 @@ class ContentWorkflow implements ContentWorkflowInterface
         // | New |--------->| Unpublished |                      | Review |---------->| Published  |                | draft |                             | Review draft  |
         // |     |          |             |<---------------------|        |           |            |--------------->|       |<----------------------------|               |
         // +-----+          +-------------+       reject         +--------+           +------------+      edit      +-------+        reject draft         +---------------+
-        //                     A   |                                                    A   |    A                                                                |
-        //                     +---+                                                    +---+    |                          publish                               |
-        //                     edit                                                    publish   +----------------------------------------------------------------+
+        //                     A   |                                                    A   |    A                    A    |                                      |
+        //                     +---+                                                    +---+    |                    +----+                                      |
+        //                     edit                                                    publish   |                     edit                                       |
+        //                                                                                       |                          publish                               |
+        //                                                                                       +----------------------------------------------------------------+
 
         // Configures places
         $definition = $definitionBuilder
@@ -210,6 +212,11 @@ class ContentWorkflow implements ContentWorkflowInterface
             ->addTransition(new Transition(
                 WorkflowInterface::WORKFLOW_TRANSITION_EDIT,
                 WorkflowInterface::WORKFLOW_PLACE_PUBLISHED,
+                WorkflowInterface::WORKFLOW_PLACE_DRAFT
+            ))
+            ->addTransition(new Transition(
+                WorkflowInterface::WORKFLOW_TRANSITION_EDIT,
+                WorkflowInterface::WORKFLOW_PLACE_DRAFT,
                 WorkflowInterface::WORKFLOW_PLACE_DRAFT
             ))
             // Remove a draft

--- a/packages/content/src/Application/ContentWorkflow/ContentWorkflow.php
+++ b/packages/content/src/Application/ContentWorkflow/ContentWorkflow.php
@@ -134,10 +134,10 @@ class ContentWorkflow implements ContentWorkflowInterface
         // |     |  create  |             |--------------------->|        |  publish  |            |<---------------|       |---------------------------->|               |
         // | New |--------->| Unpublished |                      | Review |---------->| Published  |                | draft |                             | Review draft  |
         // |     |          |             |<---------------------|        |           |            |--------------->|       |<----------------------------|               |
-        // +-----+          +-------------+       reject         +--------+           +------------+  create draft  +-------+        reject draft         +---------------+
-        //                                                                              A   |    A                                                                |
-        //                                                                              +---+    |                          publish                               |
-        //                                                                             publish   +----------------------------------------------------------------+
+        // +-----+          +-------------+       reject         +--------+           +------------+      edit      +-------+        reject draft         +---------------+
+        //                     A   |                                                    A   |    A                                                                |
+        //                     +---+                                                    +---+    |                          publish                               |
+        //                     edit                                                    publish   +----------------------------------------------------------------+
 
         // Configures places
         $definition = $definitionBuilder
@@ -151,6 +151,11 @@ class ContentWorkflow implements ContentWorkflowInterface
             ->setInitialPlaces([
                 WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED,
             ])
+            ->addTransition(new Transition(
+                WorkflowInterface::WORKFLOW_TRANSITION_EDIT,
+                WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED,
+                WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED
+            ))
             // Transfer a unpublished to review
             ->addTransition(new Transition(
                 WorkflowInterface::WORKFLOW_TRANSITION_REQUEST_FOR_REVIEW,
@@ -203,7 +208,7 @@ class ContentWorkflow implements ContentWorkflowInterface
             ))
             // Create a draft out of a published
             ->addTransition(new Transition(
-                WorkflowInterface::WORKFLOW_TRANSITION_CREATE_DRAFT,
+                WorkflowInterface::WORKFLOW_TRANSITION_EDIT,
                 WorkflowInterface::WORKFLOW_PLACE_PUBLISHED,
                 WorkflowInterface::WORKFLOW_PLACE_DRAFT
             ))

--- a/packages/content/src/Domain/Model/WorkflowInterface.php
+++ b/packages/content/src/Domain/Model/WorkflowInterface.php
@@ -37,6 +37,8 @@ interface WorkflowInterface
 
     public const WORKFLOW_TRANSITION_CREATE_DRAFT = 'create_draft';
 
+    public const WORKFLOW_TRANSITION_EDIT = 'edit';
+
     public const WORKFLOW_TRANSITION_REMOVE_DRAFT = 'remove_draft';
 
     public const WORKFLOW_TRANSITION_REQUEST_FOR_REVIEW_DRAFT = 'request_for_review_draft';
@@ -46,6 +48,10 @@ interface WorkflowInterface
     public const WORKFLOW_DEFAULT_NAME = 'content_workflow';
 
     public static function getWorkflowName(): string;
+
+    public static function getWorkflowInitialPlace(): string;
+
+    public static function getWorkflowTransitionEdit(): string;
 
     public function getWorkflowPlace(): ?string;
 

--- a/packages/content/src/Domain/Model/WorkflowTrait.php
+++ b/packages/content/src/Domain/Model/WorkflowTrait.php
@@ -30,6 +30,16 @@ trait WorkflowTrait
         return WorkflowInterface::WORKFLOW_DEFAULT_NAME;
     }
 
+    public static function getWorkflowInitialPlace(): string
+    {
+        return WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED;
+    }
+
+    public static function getWorkflowTransitionEdit(): string
+    {
+        return WorkflowInterface::WORKFLOW_TRANSITION_EDIT;
+    }
+
     public function getWorkflowPlace(): ?string
     {
         return $this->workflowPlace;

--- a/packages/content/tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
@@ -308,7 +308,7 @@ class ContentWorkflowTest extends TestCase
                 'reject' => false,
                 'publish' => true,
                 'unpublish' => true,
-                'edit' => false,
+                'edit' => true,
                 'remove_draft' => true,
                 'request_for_review_draft' => true,
                 'reject_draft' => false,

--- a/packages/content/tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Content\Tests\Unit\Content\Application\ContentWorkflow;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Content\Application\ContentMerger\ContentMergerInterface;
 use Sulu\Content\Application\ContentWorkflow\ContentWorkflow;
@@ -35,7 +36,7 @@ use Sulu\Content\Tests\Unit\Mocks\WorkflowMockWrapperTrait;
 
 class ContentWorkflowTest extends TestCase
 {
-    use \Prophecy\PhpUnit\ProphecyTrait;
+    use ProphecyTrait;
 
     protected function createContentWorkflowInstance(
         DimensionContentRepositoryInterface $dimensionContentRepository,
@@ -277,7 +278,7 @@ class ContentWorkflowTest extends TestCase
                 'reject' => false,
                 'publish' => true,
                 'unpublish' => false,
-                'create_draft' => false,
+                'edit' => true,
                 'remove_draft' => false,
                 'request_for_review_draft' => false,
                 'reject_draft' => false,
@@ -287,7 +288,7 @@ class ContentWorkflowTest extends TestCase
                 'reject' => true,
                 'publish' => true,
                 'unpublish' => false,
-                'create_draft' => false,
+                'edit' => false,
                 'remove_draft' => false,
                 'request_for_review_draft' => false,
                 'reject_draft' => false,
@@ -297,7 +298,7 @@ class ContentWorkflowTest extends TestCase
                 'reject' => false,
                 'publish' => true,
                 'unpublish' => true,
-                'create_draft' => true,
+                'edit' => true,
                 'remove_draft' => false,
                 'request_for_review_draft' => false,
                 'reject_draft' => false,
@@ -307,7 +308,7 @@ class ContentWorkflowTest extends TestCase
                 'reject' => false,
                 'publish' => true,
                 'unpublish' => true,
-                'create_draft' => false,
+                'edit' => false,
                 'remove_draft' => true,
                 'request_for_review_draft' => true,
                 'reject_draft' => false,
@@ -317,7 +318,7 @@ class ContentWorkflowTest extends TestCase
                 'reject' => false,
                 'publish' => true,
                 'unpublish' => false,
-                'create_draft' => false,
+                'edit' => false,
                 'remove_draft' => false,
                 'request_for_review_draft' => false,
                 'reject_draft' => true,

--- a/packages/content/tests/Unit/Mocks/WorkflowMockWrapperTrait.php
+++ b/packages/content/tests/Unit/Mocks/WorkflowMockWrapperTrait.php
@@ -48,4 +48,14 @@ trait WorkflowMockWrapperTrait
     {
         $this->instance->setWorkflowPublished($workflowPublished);
     }
+
+    public static function getWorkflowInitialPlace(): string
+    {
+        return WorkflowInterface::WORKFLOW_PLACE_UNPUBLISHED;
+    }
+
+    public static function getWorkflowTransitionEdit(): string
+    {
+        return WorkflowInterface::WORKFLOW_TRANSITION_EDIT;
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

* Refactored the `create_draft` transition to the `edit` transition.
* Added the `edit` transition from `unpublished` -> `unpublished`

#### Why?

The `workflowPlace` state was not correctly rendered in the admin ui, due to the fact that the `workflowPlace` was never set back to `draft` when a new `draft` dimension is created.
