### PR TITLE
Fixed `CollectionRepositoryInterface` type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27211,12 +27211,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 
 		-
-			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
 			message: '#^Parameter \#2 \$user of method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:addAccessControl\(\) expects Sulu\\Component\\Security\\Authentication\\UserInterface, Sulu\\Component\\Security\\Authentication\\UserInterface\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -46029,7 +46023,7 @@ parameters:
 		-
 			message: '#^Possibly invalid array key type mixed\.$#'
 			identifier: offsetAccess.invalidOffset
-			count: 5
+			count: 4
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Structure/SeoStructureExtensionTest.php
 
 		-
@@ -70009,12 +70003,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/ItemMetadata.php
 
 		-
-			message: '#^Cannot access offset mixed on \$this\(Sulu\\Component\\Content\\Metadata\\ItemMetadata\)\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Component/Content/Metadata/ItemMetadata.php
-
-		-
 			message: '#^Method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:__get\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -72243,7 +72231,7 @@ parameters:
 		-
 			message: '#^Cannot access offset string\|null on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
+			count: 2
 			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php
 
 		-
@@ -72291,24 +72279,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Component\\Content\\Query\\ListToTreeConverter\:\:toArray\(\) has parameter \$tree with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php
-
-		-
-			message: '#^Offset ''children'' does not exist on array\{\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 2
-			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php
-
-		-
-			message: '#^Offset ''children'' on array\{\} in empty\(\) does not exist\.$#'
-			identifier: empty.offset
-			count: 1
-			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php
-
-		-
-			message: '#^Offset ''children'' on array\{\} in isset\(\) does not exist\.$#'
-			identifier: isset.offset
 			count: 1
 			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25117,6 +25117,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
+<<<<<<< HEAD
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManager\:\:setBreadcrumbToCollection\(\) has parameter \$breadcrumbEntities with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -27127,14 +27128,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:countCollections\(\) should return int but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:findCollectionBreadcrumbById\(\) should return array\<Sulu\\Bundle\\MediaBundle\\Entity\\Collection\> but returns mixed\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24973,7 +24973,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-			message: '#^Instanceof between array\<Sulu\\Bundle\\MediaBundle\\Entity\\Collection\> and Doctrine\\ORM\\Tools\\Pagination\\Paginator will always evaluate to false\.$#'
+			message: '#^Instanceof between array\<Sulu\\Bundle\\MediaBundle\\Entity\\CollectionInterface\> and Doctrine\\ORM\\Tools\\Pagination\\Paginator will always evaluate to false\.$#'
 			identifier: instanceof.alwaysFalse
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -25117,7 +25117,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-<<<<<<< HEAD
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManager\:\:setBreadcrumbToCollection\(\) has parameter \$breadcrumbEntities with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -25138,7 +25137,7 @@ parameters:
 		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
@@ -25166,7 +25165,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-			message: '#^Parameter \#1 \$entity of method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManager\:\:getApiEntity\(\) expects Sulu\\Bundle\\MediaBundle\\Entity\\CollectionInterface, Sulu\\Bundle\\MediaBundle\\Entity\\Collection\|null given\.$#'
+			message: '#^Parameter \#1 \$entity of method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManager\:\:getApiEntity\(\) expects Sulu\\Bundle\\MediaBundle\\Entity\\CollectionInterface, Sulu\\Bundle\\MediaBundle\\Entity\\CollectionInterface\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -27104,12 +27103,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 
 		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1
@@ -27124,28 +27117,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:countCollections\(\) has parameter \$filter with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:findCollectionById\(\) should return Sulu\\Bundle\\MediaBundle\\Entity\\Collection\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:findCollectionByKey\(\) should return Sulu\\Bundle\\MediaBundle\\Entity\\Collection but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:findCollectionByKey\(\) should return Sulu\\Bundle\\MediaBundle\\Entity\\Collection but returns mixed\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 
@@ -27170,12 +27141,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:findCollections\(\) has parameter \$sortBy with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionRepository\:\:findCollections\(\) should return array\<Sulu\\Bundle\\MediaBundle\\Entity\\Collection\> but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24973,12 +24973,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-			message: '#^Instanceof between array\<Sulu\\Bundle\\MediaBundle\\Entity\\CollectionInterface\> and Doctrine\\ORM\\Tools\\Pagination\\Paginator will always evaluate to false\.$#'
-			identifier: instanceof.alwaysFalse
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
-
-		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 1
@@ -27178,12 +27172,6 @@ parameters:
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
-
-		-
-			message: '#^PHPDoc tag @var with type array\<Sulu\\Bundle\\MediaBundle\\Entity\\Collection\> is not subtype of native type Doctrine\\ORM\\Tools\\Pagination\\Paginator\<mixed\>\.$#'
-			identifier: varTag.nativeType
-			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
 
 		-

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -123,11 +123,10 @@ class CollectionManager implements CollectionManagerInterface
     public function get($locale, $filter = [], $limit = null, $offset = null, $sortBy = [])
     {
         $collectionEntities = $this->collectionRepository->findCollections($filter, $limit, $offset, $sortBy);
-        $this->count = $collectionEntities instanceof Paginator ?
-            $collectionEntities->count() : \count($collectionEntities);
+        $this->count = $collectionEntities?->count() ?? 0;
 
         $collections = [];
-        foreach ($collectionEntities as $entity) {
+        foreach ($collectionEntities ?? [] as $entity) {
             $collections[] = $this->getApiEntity($entity, $locale);
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -123,10 +123,11 @@ class CollectionManager implements CollectionManagerInterface
     public function get($locale, $filter = [], $limit = null, $offset = null, $sortBy = [])
     {
         $collectionEntities = $this->collectionRepository->findCollections($filter, $limit, $offset, $sortBy);
-        $this->count = $collectionEntities?->count() ?? 0;
+        $this->count = $collectionEntities instanceof Paginator ?
+            $collectionEntities->count() : \count($collectionEntities);
 
         $collections = [];
-        foreach ($collectionEntities ?? [] as $entity) {
+        foreach ($collectionEntities as $entity) {
             $collections[] = $this->getApiEntity($entity, $locale);
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -16,6 +16,7 @@ use FOS\RestBundle\View\ViewHandlerInterface;
 use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
 use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
 use Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Media\Exception\CollectionNotFoundException;
@@ -46,6 +47,7 @@ use Sulu\Component\Security\SecuredControllerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * Makes media available through a REST API.
@@ -291,6 +293,12 @@ class MediaController extends AbstractMediaController implements
         if (!$this->securityChecker->hasPermission('sulu.media.system_collections', PermissionTypes::VIEW)) {
             $systemCollection = $this->collectionRepository
                 ->findCollectionByKey(SystemCollectionManagerInterface::COLLECTION_KEY);
+
+            Assert::isInstanceOf(
+                $systemCollection,
+                CollectionInterface::class,
+                'The system collection fixtures should have been loaded.',
+            );
 
             $lftExpression = $listBuilder->createWhereExpression(
                 $fieldDescriptors['lft'],

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -227,7 +227,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
             /** @var Paginator<CollectionInterface> */
             return new Paginator($qb->getQuery());
         } catch (NoResultException $ex) {
-            return null;
+            return [];
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -256,19 +256,14 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
 
     public function findCollectionByKey($key)
     {
-        $queryBuilder = $this->createQueryBuilder('collection')
+        return $this->createQueryBuilder('collection')
             ->leftJoin('collection.meta', 'collectionMeta')
             ->leftJoin('collection.defaultMeta', 'defaultMeta')
-            ->where('collection.key = :key');
-
-        $query = $queryBuilder->getQuery();
-        $query->setParameter('key', $key);
-
-        try {
-            return $query->getSingleResult();
-        } catch (NoResultException $ex) {
-            return;
-        }
+            ->where('collection.key = :key')
+            ->setParameter('key', $key)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
     }
 
     public function findTree($id, $locale)

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -224,10 +224,10 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
                 $qb->setMaxResults($limit);
             }
 
-            /** @var Collection[] */
+            /** @var Paginator<CollectionInterface> */
             return new Paginator($qb->getQuery());
         } catch (NoResultException $ex) {
-            return [];
+            return null;
         }
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -59,6 +59,8 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
         $query = new Query($this->_em);
         $query->setDQL($dql);
         $query->setParameter('id', $id);
+
+        /** @var CollectionInterface[] */
         $result = $query->getResult();
 
         if (0 === \count($result)) {
@@ -134,7 +136,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
         try {
             return \count($ids);
         } catch (NoResultException $e) {
-            return;
+            return 0;
         }
     }
 
@@ -225,7 +227,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
             /** @var Collection[] */
             return new Paginator($qb->getQuery());
         } catch (NoResultException $ex) {
-            return;
+            return [];
         }
     }
 
@@ -248,6 +250,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
             $query->setDQL($sql);
             $query->setParameter('id', $id);
 
+            /** @var array<Collection> */
             return $query->getResult();
         } catch (NoResultException $ex) {
             return [];
@@ -256,6 +259,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
 
     public function findCollectionByKey($key)
     {
+        /** @var CollectionInterface|null */
         return $this->createQueryBuilder('collection')
             ->leftJoin('collection.meta', 'collectionMeta')
             ->leftJoin('collection.defaultMeta', 'defaultMeta')

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepositoryInterface.php
@@ -84,7 +84,7 @@ interface CollectionRepositoryInterface
      * @param int $offset
      * @param array $sortBy sort by e.g. array('title' => 'ASC')
      *
-     * @return Paginator<CollectionInterface>|null
+     * @return Paginator<CollectionInterface>|array{}
      */
     public function findCollections($filter = [], $limit = null, $offset = null, $sortBy = []);
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepositoryInterface.php
@@ -71,7 +71,7 @@ interface CollectionRepositoryInterface
      *
      * @param int $id
      *
-     * @return Collection|null
+     * @return CollectionInterface|null
      */
     public function findCollectionById($id);
 
@@ -83,7 +83,7 @@ interface CollectionRepositoryInterface
      * @param int $offset
      * @param array $sortBy sort by e.g. array('title' => 'ASC')
      *
-     * @return Collection[]
+     * @return CollectionInterface[]
      */
     public function findCollections($filter = [], $limit = null, $offset = null, $sortBy = []);
 
@@ -92,7 +92,7 @@ interface CollectionRepositoryInterface
      *
      * @param int $id
      *
-     * @return Collection[]
+     * @return CollectionInterface[]
      */
     public function findCollectionBreadcrumbById($id);
 
@@ -101,7 +101,7 @@ interface CollectionRepositoryInterface
      *
      * @param string $key
      *
-     * @return Collection|null
+     * @return CollectionInterface|null
      */
     public function findCollectionByKey($key);
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepositoryInterface.php
@@ -101,7 +101,7 @@ interface CollectionRepositoryInterface
      *
      * @param string $key
      *
-     * @return Collection
+     * @return Collection|null
      */
     public function findCollectionByKey($key);
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepositoryInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Entity;
 
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 /**
@@ -83,7 +84,7 @@ interface CollectionRepositoryInterface
      * @param int $offset
      * @param array $sortBy sort by e.g. array('title' => 'ASC')
      *
-     * @return CollectionInterface[]
+     * @return Paginator<CollectionInterface>|null
      */
     public function findCollections($filter = [], $limit = null, $offset = null, $sortBy = []);
 

--- a/src/Sulu/Bundle/MediaBundle/Media/ListBuilderFactory/MediaListBuilderFactory.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ListBuilderFactory/MediaListBuilderFactory.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\ListBuilderFactory;
 
+use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
 use Sulu\Bundle\MediaBundle\Entity\CollectionRepositoryInterface;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
@@ -21,6 +22,7 @@ use Sulu\Component\Rest\RestHelperInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+use Webmozart\Assert\Assert;
 
 class MediaListBuilderFactory
 {
@@ -82,6 +84,12 @@ class MediaListBuilderFactory
         if (!$this->securityChecker->hasPermission('sulu.media.system_collections', PermissionTypes::VIEW)) {
             $systemCollection = $this->collectionRepository
                 ->findCollectionByKey(SystemCollectionManagerInterface::COLLECTION_KEY);
+
+            Assert::isInstanceOf(
+                $systemCollection,
+                CollectionInterface::class,
+                'The system collection fixtures should have been loaded.',
+            );
 
             $lftExpression = $listBuilder->createWhereExpression(
                 $fieldDescriptors['lft'],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
* Fixing typehints for the CollectionRepository
* Only add where conditions to the collection list when the root collection actually exists.

#### Why?
Better for the IDE and PHPStan also doesn't get confused.