### PR TITLE
Fix deprecated usage of execute method in doctrine query builder and statement

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Infrastructure/Doctrine/Repository/ActivityRepository.php
+++ b/src/Sulu/Bundle/ActivityBundle/Infrastructure/Doctrine/Repository/ActivityRepository.php
@@ -114,6 +114,14 @@ class ActivityRepository implements ActivityRepositoryInterface
         // use query-builder to insert only given entity instead of flushing all managed entities via the entity-manager
         // this prevents flushing unrelated changes and allows to call this method in a postFlush event-listener
         $queryBuilder = $this->getInsertQueryBuilder($activity);
+
+        // DBAL 3 to 4 BC Layer
+        if (\method_exists($queryBuilder, 'executeStatement')) {
+            $queryBuilder->executeStatement();
+
+            return;
+        }
+
         $queryBuilder->execute();
     }
 }

--- a/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
+++ b/src/Sulu/Bundle/CategoryBundle/Command/RecoverCommand.php
@@ -168,6 +168,12 @@ class RecoverCommand extends Command
                 WHERE ( c2.depth - 1 ) <> c1.depth';
 
         $statement = $this->entityManager->getConnection()->prepare($sql);
+
+        // DBAL 3 to 4 BC Layer
+        if (\method_exists($statement, 'executeStatement')) {
+            return $statement->executeStatement();
+        }
+
         $result = $statement->execute();
 
         if ($result) {

--- a/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
+++ b/src/Sulu/Bundle/ContactBundle/Command/AccountRecoverCommand.php
@@ -167,6 +167,12 @@ class AccountRecoverCommand extends Command
                 WHERE ( c2.depth - 1 ) <> c1.depth';
 
         $statement = $this->entityManager->getConnection()->prepare($sql);
+
+        // DBAL 3 to 4 BC Layer
+        if (\method_exists($statement, 'executeStatement')) {
+            return $statement->executeStatement();
+        }
+
         $result = $statement->execute();
 
         if ($result) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

I have changed the call of `execute()` on Doctrine DBAL's QueryBuilder and Statement in favor of `executeStatement()` in all places that I could find. BC for DBAL v2 is kept.

#### Why?

The usage of the `execute` method in Doctrine DBAL's  [`QueryBuilder`](https://github.com/doctrine/dbal/blob/8b1e40a5027bda21296297a31d0f20bbde849513/src/Query/QueryBuilder.php#L375) and [`Statement`](https://github.com/doctrine/dbal/blob/8b1e40a5027bda21296297a31d0f20bbde849513/src/Statement.php#L170) classes was deprecated in v3.
