### PR TITLE
Fix passing null to non-nullable argument in UserManager

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27502,7 +27502,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\:\\:getEmail\\(\\)\\.$#"
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27502,7 +27502,7 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Security\\\\Authentication\\\\UserInterface\\:\\:getEmail\\(\\)\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
 
 		-

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/UserManager/UserManagerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/UserManager/UserManagerTest.php
@@ -11,17 +11,24 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Unit\UserManager;
 
+use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Bundle\ContactBundle\Contact\ContactManager;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\SecurityBundle\Entity\GroupRepository;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
+use Sulu\Bundle\SecurityBundle\Security\Exception\EmailNotUniqueException;
 use Sulu\Bundle\SecurityBundle\UserManager\UserManager;
 use Sulu\Component\Security\Authentication\RoleRepositoryInterface;
 use Sulu\Component\Security\Authentication\SaltGenerator;
 use Sulu\Component\Security\Authentication\UserRepositoryInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 class UserManagerTest extends TestCase
 {
@@ -117,5 +124,86 @@ class UserManagerTest extends TestCase
 
         $this->assertTrue($userManager->isValidPassword('testtest'));
         $this->assertFalse($userManager->isValidPassword('test'));
+    }
+
+    public function testSaveCreatesNewUser(): void
+    {
+        $data = [
+            'username' => 'john.doe',
+            'email' => 'john.doe@example.com',
+            'password' => '!1a2B3.HdäG2M+f0o',
+            'contactId' => 1,
+        ];
+
+        $user = new User();
+        $contact = new Contact();
+        $hashedPassword = '-hashed-password-';
+
+        // Wee need to stub UserRepository instead of the interface, because the interface does not
+        // declare 'findUserByEmail'.
+        $userRepository = $this->prophesize(UserRepository::class);
+        $userRepository->createNew()->willReturn($user);
+        $userRepository->findUserByEmail($data['email'])->willThrow(new NoResultException());
+        $userRepository->findUserByUsername($data['username'])->willThrow(new NoResultException());
+
+        $passwordHasher = $this->prophesize(PasswordHasherInterface::class);
+        $passwordHasher->hash($data['password'])->willReturn($hashedPassword);
+
+        $passwordHasherFactory = $this->prophesize(PasswordHasherFactoryInterface::class);
+        $passwordHasherFactory->getPasswordHasher($user)->willReturn($passwordHasher);
+
+        $this->contactManager->findById($data['contactId'])->willReturn($contact);
+
+        $userManager = new UserManager(
+            $this->objectManager->reveal(),
+            $passwordHasherFactory->reveal(),
+            $this->roleRepository->reveal(),
+            $this->groupRepository->reveal(),
+            $this->contactManager->reveal(),
+            $this->saltGenerator->reveal(),
+            $userRepository->reveal(),
+            $this->eventCollector->reveal(),
+            null
+        );
+
+        $result = $userManager->save($data, locale: 'en', id: null);
+
+        $this->assertInstanceOf(User::class, $result);
+        $this->assertSame($data['username'], $result->getUsername());
+        $this->assertSame($data['email'], $result->getEmail());
+        $this->assertSame($hashedPassword, $result->getPassword());
+    }
+
+    public function testSaveValidatesEmailUniquenessForNewUser(): void
+    {
+        $data = [
+            'username' => 'john.doe',
+            'email' => 'john.doe@example.com',
+            'password' => '!1a2B3.HdäG2M+f0o',
+        ];
+
+        $user = new User();
+
+        // Wee need to stub UserRepository instead of the interface, because the interface does not
+        // declare 'findUserByEmail'.
+        $userRepository = $this->prophesize(UserRepository::class);
+        $userRepository->createNew()->willReturn($user);
+        $userRepository->findUserByEmail($data['email'])->willReturn(new User());
+
+        $userManager = new UserManager(
+            $this->objectManager->reveal(),
+            null,
+            $this->roleRepository->reveal(),
+            $this->groupRepository->reveal(),
+            $this->contactManager->reveal(),
+            $this->saltGenerator->reveal(),
+            $userRepository->reveal(),
+            $this->eventCollector->reveal(),
+            null
+        );
+
+        $this->expectException(EmailNotUniqueException::class);
+
+        $result = $userManager->save($data, locale: 'en', id: null);
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -685,7 +685,9 @@ class UserManager implements UserManagerInterface
                 $user->setEmail($email);
             }
         } else {
-            if ($email && 0 !== \strcasecmp($email, $user->getEmail()) && !$this->isEmailUnique($email)) {
+            $emailChanged = $email && (null === $user->getEmail() || 0 !== \strcasecmp($email, $user->getEmail()));
+
+            if ($emailChanged && !$this->isEmailUnique($email)) {
                 throw new EmailNotUniqueException($email);
             }
             $user->setEmail($email);

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -685,9 +685,10 @@ class UserManager implements UserManagerInterface
                 $user->setEmail($email);
             }
         } else {
-            $emailChanged = $email && (null === $user->getEmail() || 0 !== \strcasecmp($email, $user->getEmail()));
+            $currentEmail = $user->getEmail() ?? '';
+            $hasEmailChanged = $email && 0 !== \strcasecmp($email, $currentEmail);
 
-            if ($emailChanged && !$this->isEmailUnique($email)) {
+            if ($hasEmailChanged && !$this->isEmailUnique($email)) {
                 throw new EmailNotUniqueException($email);
             }
             $user->setEmail($email);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| License | MIT

#### What's in this PR?

In the UserManager's `processEmail` method I have added a check for null-ness of the user's email before it is passed to PHP's `strcasecmp` function.

Additionally I added two unit test to test the UserManager's save method.

#### Why?

`strcasecmp` does not accept parameter values of type NULL. Passing NULL to non-nullable parameters of built-in functions was deprecated in PHP 8.1 (see [here](https://www.php.net/manual/en/migration81.deprecated.php)).
