### PR TITLE
Refactor bundle tests to be independent of the SnippetBundle

### DIFF
--- a/packages/article/tests/Application/Kernel.php
+++ b/packages/article/tests/Application/Kernel.php
@@ -13,11 +13,13 @@ namespace Sulu\Article\Tests\Application;
 
 use Sulu\Article\Infrastructure\Symfony\HttpKernel\SuluArticleBundle;
 use Sulu\Bundle\AutomationBundle\SuluAutomationBundle;
+use Sulu\Bundle\SnippetBundle\SuluSnippetBundle as DeprecatedSuluSnippetBundle;
 use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ExampleTestBundle;
 use Sulu\Page\Infrastructure\Symfony\HttpKernel\SuluPageBundle;
+use Sulu\Snippet\Infrastructure\Symfony\HttpKernel\SuluSnippetBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Task\TaskBundle\TaskBundle;
 
@@ -50,6 +52,17 @@ class Kernel extends SuluTestKernel
         $bundles[] = new ExampleTestBundle(); // TODO currently required for test content bundle, everybody should setup database by its own
         $bundles[] = new SuluAutomationBundle(); // TODO currently required for test content bundle, everybody should setup database by its own
         $bundles[] = new TaskBundle(); // TODO currently required for test content bundle, everybody should setup database by its own
+        $bundles[] = new SuluSnippetBundle();
+
+        foreach ($bundles as $key => $bundle) {
+            // Audience Targeting is not configured and so should not be here
+            // remove deprecated SuluSnippetBundle to avoid conflicts
+            if (
+                $bundle instanceof DeprecatedSuluSnippetBundle
+            ) {
+                unset($bundles[$key]);
+            }
+        }
 
         return $bundles;
     }

--- a/packages/content/tests/Application/Kernel.php
+++ b/packages/content/tests/Application/Kernel.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ExampleTestBundle;
 use Sulu\Page\Infrastructure\Symfony\HttpKernel\SuluPageBundle;
+use Sulu\Snippet\Infrastructure\Symfony\HttpKernel\SuluSnippetBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Task\TaskBundle\TaskBundle;
 
@@ -32,6 +33,7 @@ class Kernel extends SuluTestKernel
         $bundles[] = new SuluAutomationBundle();
         $bundles[] = new SuluPageBundle();
         $bundles[] = new ExampleTestBundle();
+        $bundles[] = new SuluSnippetBundle();
 
         foreach ($bundles as $key => $bundle) {
             // Audience Targeting is not configured and so should not be here

--- a/packages/content/tests/Application/Kernel.php
+++ b/packages/content/tests/Application/Kernel.php
@@ -40,8 +40,8 @@ class Kernel extends SuluTestKernel
             // Audience Targeting is not configured and so should not be here
             // remove deprecated SuluSnippetBundle to avoid conflicts
             if (
-                $bundle instanceof SuluAudienceTargetingBundle ||
-                $bundle instanceof DeprecatedSuluSnippetBundle
+                $bundle instanceof SuluAudienceTargetingBundle
+                || $bundle instanceof DeprecatedSuluSnippetBundle
             ) {
                 unset($bundles[$key]);
             }

--- a/packages/content/tests/Application/Kernel.php
+++ b/packages/content/tests/Application/Kernel.php
@@ -15,6 +15,7 @@ namespace Sulu\Content\Tests\Application;
 
 use Sulu\Bundle\AudienceTargetingBundle\SuluAudienceTargetingBundle;
 use Sulu\Bundle\AutomationBundle\SuluAutomationBundle;
+use Sulu\Bundle\SnippetBundle\SuluSnippetBundle as DeprecatedSuluSnippetBundle;
 use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ExampleTestBundle;
@@ -37,10 +38,12 @@ class Kernel extends SuluTestKernel
 
         foreach ($bundles as $key => $bundle) {
             // Audience Targeting is not configured and so should not be here
-            if ($bundle instanceof SuluAudienceTargetingBundle) {
+            // remove deprecated SuluSnippetBundle to avoid conflicts
+            if (
+                $bundle instanceof SuluAudienceTargetingBundle ||
+                $bundle instanceof DeprecatedSuluSnippetBundle
+            ) {
                 unset($bundles[$key]);
-
-                break;
             }
         }
 

--- a/packages/content/tests/Application/config/routing_admin.yml
+++ b/packages/content/tests/Application/config/routing_admin.yml
@@ -55,8 +55,7 @@ sulu_category_api:
     prefix: /admin/api
 
 sulu_snippet_api:
-    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluSnippetBundle/config/routing_admin_api.yaml"
     prefix: /admin/api
 
 sulu_location:

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -37,7 +37,6 @@ class ContentResolverTest extends SuluTestCase
     protected function setUp(): void
     {
         self::purgeDatabase();
-        self::initPhpcr();
 
         $this->contentResolver = self::getContainer()->get('sulu_content.content_resolver');
         $this->contentAggregator = self::getContainer()->get('sulu_content.content_aggregator');

--- a/packages/content/tests/Functional/Integration/ExampleControllerAvailableAndShadowLocalesTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerAvailableAndShadowLocalesTest.php
@@ -43,7 +43,6 @@ class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
     public function testPostCreateEnDraft(): int
     {
         self::purgeDatabase();
-        self::initPhpcr();
 
         $this->client->request('POST', '/admin/api/examples?locale=en', [], [], [], \json_encode([
             'template' => 'example-2',

--- a/packages/content/tests/Functional/Integration/ExampleControllerTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerTest.php
@@ -41,7 +41,6 @@ class ExampleControllerTest extends SuluTestCase
     public function testPostPublish(): int
     {
         self::purgeDatabase();
-        self::initPhpcr();
 
         $this->client->request('POST', '/admin/api/examples?locale=en&action=publish', [], [], [], \json_encode([
             'template' => 'example-2',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3135,19 +3135,19 @@ parameters:
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\FormMetadata\\\\FormMetadata'' and Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
-			count: 6
+			count: 5
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
 
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\SchemaMetadata\\\\SchemaMetadata'' and Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
-			count: 6
+			count: 5
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
 
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
-			count: 6
+			count: 5
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
 
 		-
@@ -18295,13 +18295,13 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: '#^Parameter \#2 \$array of method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) expects array\<mixed\>\|ArrayAccess\<\(int\|string\), mixed\>, mixed given\.$#'
+			message: '#^Parameter \#2 \$array of method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) expects array\<mixed\>\|ArrayAccess\<\(int\|string\), mixed\>, array\|ArrayAccess given\.$#'
 			identifier: argument.type
 			count: 3
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: '#^Parameter \#2 \$array of method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) expects array\<mixed\>\|ArrayAccess\<\(int\|string\), mixed\>, non\-empty\-array\|ArrayAccess given\.$#'
+			message: '#^Parameter \#2 \$array of method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) expects array\<mixed\>\|ArrayAccess\<\(int\|string\), mixed\>, mixed given\.$#'
 			identifier: argument.type
 			count: 3
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -46551,6 +46551,12 @@ parameters:
 		-
 			message: '#^Call to an undefined method Symfony\\Component\\Security\\Core\\User\\UserInterface\:\:getId\(\)\.$#'
 			identifier: method.notFound
+			count: 1
+			path: src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
+
+		-
+			message: '#^Class Sulu\\Bundle\\SecurityBundle\\User\\UserProvider implements generic interface Symfony\\Component\\Security\\Core\\User\\PasswordUpgraderInterface but does not specify its types\: TUser$#'
+			identifier: missingType.generics
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/User/UserProvider.php
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -54,11 +54,6 @@ sulu_category_api:
     resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
     prefix: /admin/api
 
-sulu_snippet_api:
-    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
-    type: rest
-    prefix: /admin/api
-
 sulu_location:
     resource: "@SuluLocationBundle/Resources/config/routing.yml"
     prefix: /admin/location

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
@@ -54,17 +54,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -32,7 +32,6 @@ class AdminControllerTest extends SuluTestCase
 
     public function testGetConfig(): void
     {
-        $this->initPhpcr();
         $collectionType = new LoadCollectionTypes();
         $collectionType->load($this->getEntityManager());
 
@@ -60,8 +59,6 @@ class AdminControllerTest extends SuluTestCase
 
     public function testGetConfigWithFallbackNonExistUserLocale(): void
     {
-        $this->initPhpcr();
-
         $this->getTestUser()->setLocale('not-exist');
 
         $collectionType = new LoadCollectionTypes();
@@ -91,7 +88,6 @@ class AdminControllerTest extends SuluTestCase
 
     public function testTemplateConfig(): void
     {
-        $this->initPhpcr();
         $collectionType = new LoadCollectionTypes();
         $collectionType->load($this->getEntityManager());
 
@@ -148,7 +144,6 @@ class AdminControllerTest extends SuluTestCase
 
     public function testGetMetaDataKeysOnly(): void
     {
-        $this->initPhpcr();
         $collectionType = new LoadCollectionTypes();
         $collectionType->load($this->getEntityManager());
 
@@ -170,7 +165,6 @@ class AdminControllerTest extends SuluTestCase
 
     public function testGetMetaData(): void
     {
-        $this->initPhpcr();
         $collectionType = new LoadCollectionTypes();
         $collectionType->load($this->getEntityManager());
 
@@ -196,7 +190,6 @@ class AdminControllerTest extends SuluTestCase
 
     public function testGetMetaDataGhostLocale(): void
     {
-        $this->initPhpcr();
         $collectionType = new LoadCollectionTypes();
         $collectionType->load($this->getEntityManager());
 
@@ -244,7 +237,6 @@ class AdminControllerTest extends SuluTestCase
 
     public function testGetMetaDataCopyLocale(): void
     {
-        $this->initPhpcr();
         $collectionType = new LoadCollectionTypes();
         $collectionType->load($this->getEntityManager());
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/FOSJSRoutingControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/FOSJSRoutingControllerTest.php
@@ -113,6 +113,5 @@ class FOSJSRoutingControllerTest extends SuluTestCase
             'sulu_website.cget_webspace_analytics',
             'sulu_website.get_webspace_analytics',
         ], $routes);
-
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/FOSJSRoutingControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/FOSJSRoutingControllerTest.php
@@ -106,11 +106,6 @@ class FOSJSRoutingControllerTest extends SuluTestCase
             'sulu_security.get_security-contexts',
             'sulu_security.get_user',
             'sulu_security.get_users',
-            'sulu_snippet.get_languages',
-            'sulu_snippet.get_snippet',
-            'sulu_snippet.get_snippet-areas',
-            'sulu_snippet.get_snippets',
-            'sulu_snippet.put_snippet-area',
             'sulu_tag.get_tag',
             'sulu_tag.get_tags',
             'sulu_trash.get_trash-item',
@@ -118,5 +113,6 @@ class FOSJSRoutingControllerTest extends SuluTestCase
             'sulu_website.cget_webspace_analytics',
             'sulu_website.get_webspace_analytics',
         ], $routes);
+
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -352,41 +352,6 @@
                         "type": "string",
                         "minLength": 1
                     },
-                    "animals": {
-                        "anyOf": [
-                            {
-                                "type": "null"
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "type": [
-                                        "number",
-                                        "string",
-                                        "boolean",
-                                        "object",
-                                        "array",
-                                        "null"
-                                    ]
-                                },
-                                "maxItems": 0
-                            },
-                            {
-                                "type": "array",
-                                "items": {
-                                    "anyOf": [
-                                        {
-                                            "type": "string"
-                                        },
-                                        {
-                                            "type": "number"
-                                        }
-                                    ]
-                                },
-                                "uniqueItems": true
-                            }
-                        ]
-                    },
                     "blog": {
                         "anyOf": [
                             {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -48,32 +48,6 @@
                 }
             ]
         },
-        "animals": {
-            "label": "Animals",
-            "disabledCondition": null,
-            "visibleCondition": null,
-            "description": "",
-            "type": "snippet_selection",
-            "colSpan": 12,
-            "options": {
-                "snippetType": {
-                    "name": "snippetType",
-                    "type": "string",
-                    "value": "animal",
-                    "title": null,
-                    "placeholder": null,
-                    "infoText": null
-                }
-            },
-            "types": [],
-            "defaultType": null,
-            "required": false,
-            "spaceAfter": null,
-            "minOccurs": null,
-            "maxOccurs": null,
-            "onInvalid": null,
-            "tags": []
-        },
         "blog": {
             "label": null,
             "disabledCondition": null,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -139,22 +139,4 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
 
         $this->assertEquals('default', $typedForm->getDefaultType());
     }
-
-    public function testGetMetadataForSnippets(): void
-    {
-        $typedForm = $this->structureFormMetadataLoader->getMetadata('snippet', 'de');
-        $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
-        $this->assertCount(1, $typedForm->getForms());
-
-        $defaultForm = $typedForm->getForms()['default'];
-        $this->assertInstanceOf(FormMetadata::class, $defaultForm);
-        $this->assertEquals('default', $defaultForm->getName());
-        $this->assertEquals('Standard', $defaultForm->getTitle());
-        $this->assertCount(2, $defaultForm->getItems());
-        $this->assertCount(0, $defaultForm->getTags());
-        $this->assertNotNull($defaultForm->getSchema());
-        $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
-
-        $this->assertEquals('default', $typedForm->getDefaultType());
-    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -60,7 +60,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Animals', $defaultForm->getTitle());
-        $this->assertCount(6, $defaultForm->getItems());
+        $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
@@ -91,7 +91,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Tiers', $defaultForm->getTitle());
-        $this->assertCount(6, $defaultForm->getItems());
+        $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());
@@ -132,7 +132,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
         $this->assertEquals('default', $defaultForm->getName());
         $this->assertEquals('Tiers', $defaultForm->getTitle());
-        $this->assertCount(6, $defaultForm->getItems());
+        $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
         $this->assertInstanceOf(SchemaMetadata::class, $defaultForm->getSchema());

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/CoreBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,16 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
 
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
@@ -223,7 +223,7 @@ class SearchControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $response);
         $result = \json_decode($response->getContent(), true);
 
-        $this->assertEquals('snippet', $result['_embedded']['search_indexes'][0]['indexName']);
+        $this->assertEquals('category', $result['_embedded']['search_indexes'][0]['indexName']);
         $this->assertEquals([], $result['_embedded']['search_indexes'][0]['contexts']);
     }
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/SearchControllerTest.php
@@ -223,7 +223,7 @@ class SearchControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $response);
         $result = \json_decode($response->getContent(), true);
 
-        $this->assertEquals('category', $result['_embedded']['search_indexes'][0]['indexName']);
+        $this->assertEquals('snippet', $result['_embedded']['search_indexes'][0]['indexName']);
         $this->assertEquals([], $result['_embedded']['search_indexes'][0]['contexts']);
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/default.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/simple.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/simple.xml
@@ -35,17 +35,6 @@
             <tag name="sulu.rlp"/>
         </property>
 
-        <property name="animals" type="snippet_selection">
-            <params>
-                <param name="snippetType" value="animal" />
-            </params>
-
-            <meta>
-                <title lang="de">Tiers</title>
-                <title lang="en">Animals</title>
-            </meta>
-        </property>
-
         <property name="blog" type="text_area" multilingual="false" mandatory="false"/>
 
         <property name="localized_blog" type="text_area" mandatory="false" />

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -300,20 +300,10 @@ class StructureXmlLoaderTest extends TestCase
 
         $properties = $result->getProperties();
 
-        $this->assertCount(2, $properties);
+        //invalid property will also be loaded
+        $this->assertCount(3, $properties);
         $this->assertEquals('title', $properties['title']->getName());
         $this->assertEquals('url', $properties['url']->getName());
-    }
-
-    public function testLoadInvalidWithoutIgnore(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-
-        $this->contentTypeManager->has('text_line')->willReturn(true);
-        $this->contentTypeManager->has('resource_locator')->willReturn(true);
-        $this->contentTypeManager->has('test')->willReturn(false);
-        $this->contentTypeManager->getAll()->willReturn(['text_line', 'resource_locator']);
-        $this->load('template_without_invalid_ignore.xml');
     }
 
     public function testLoadRequiredProperty(): void

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -301,7 +301,7 @@ class StructureXmlLoaderTest extends TestCase
         $properties = $result->getProperties();
 
         //invalid property will also be loaded
-        $this->assertCount(3, $properties);
+        $this->assertCount(2, $properties);
         $this->assertEquals('title', $properties['title']->getName());
         $this->assertEquals('url', $properties['url']->getName());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/7888
| License | MIT

#### What's in this PR?

Cleanup of some bundle tests that are not required anymore or need to be reimplemented (see #7672 Test section)
