### PR TITLE
Fix unused variables in tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -15546,11 +15546,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\CollectionControllerTest\\:\\:\\$roleRepository is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\CollectionControllerTest\\:\\:\\$systemCollectionCache \\(Sulu\\\\Component\\\\Cache\\\\CacheInterface\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -15567,11 +15562,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\FormatControllerTest\\:\\:\\$formatOptions is unused\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
 
@@ -16166,16 +16156,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\MediaWebsiteControllerTest\\:\\:\\$category is unused\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\MediaWebsiteControllerTest\\:\\:\\$category2 is unused\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Tests\\\\Functional\\\\Controller\\\\MediaWebsiteControllerTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
@@ -16526,11 +16506,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
 
 		-
-			message: "#^Property Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:\\$collections is unused\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
-
-		-
 			message: "#^Property Functional\\\\Entity\\\\MediaRepositoryTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\ORM\\\\EntityManagerInterface\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -16862,16 +16837,6 @@ parameters:
 
 		-
 			message: "#^If condition is always true\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\TypeManager\\\\TypeManagerTest\\:\\:\\$em is unused\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\TypeManager\\\\TypeManagerTest\\:\\:\\$em with generic class Prophecy\\\\Prophecy\\\\ObjectProphecy does not specify its types\\: T$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
 
@@ -21021,11 +20986,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Command\\\\ValidateWebspacesCommandTest\\:\\:\\$documentManager is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:getChildren\\(\\)\\.$#"
 			count: 3
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
@@ -21666,16 +21626,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Controller\\\\PageResourcelocatorControllerTest\\:\\:\\$session \\(PHPCR\\\\SessionInterface\\) does not accept object\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Controller\\\\PageResourcelocatorControllerTest\\:\\:\\$session is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
-
-		-
 			message: "#^Cannot access offset 'id' on mixed\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/ResourcelocatorControllerTest.php
@@ -21762,11 +21712,6 @@ parameters:
 
 		-
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Controller\\\\SmartContentItemControllerTest\\:\\:\\$session \\(PHPCR\\\\SessionInterface\\) does not accept object\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Controller\\\\SmartContentItemControllerTest\\:\\:\\$structureManager is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
 
@@ -22212,11 +22157,6 @@ parameters:
 
 		-
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Export\\\\WebspaceExportTest\\:\\:\\$creator is never written, only read\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Export/WebspaceExportTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Export\\\\WebspaceExportTest\\:\\:\\$extensionManager is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Export/WebspaceExportTest.php
 
@@ -22696,11 +22636,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Mapper\\\\ContentMapperTest\\:\\:\\$contentTypeManager is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Mapper\\\\ContentMapperTest\\:\\:\\$session \\(Jackalope\\\\Session\\) does not accept Sulu\\\\Bundle\\\\DocumentManagerBundle\\\\Session\\\\Session\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
@@ -23121,16 +23056,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Repository\\\\NodeRepositoryTest\\:\\:\\$extensions is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Repository\\\\NodeRepositoryTest\\:\\:\\$sessionManager is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Content\\\\Document\\\\Behavior\\\\ResourceSegmentBehavior\\:\\:getUuid\\(\\)\\.$#"
 			count: 5
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -23196,11 +23121,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\ResourceLocator\\\\Mapper\\\\PhpcrMapperTest\\:\\:\\$mapper is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
-
-		-
 			message: "#^Class Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator constructor invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
@@ -23212,21 +23132,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#3 \\$webspaceKey of method Sulu\\\\Component\\\\Content\\\\SimpleContentType\\:\\:read\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\ResourceLocator\\\\ResourceLocatorTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManager\\) does not accept Doctrine\\\\Persistence\\\\ObjectManager\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\ResourceLocator\\\\ResourceLocatorTest\\:\\:\\$em is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\ResourceLocator\\\\ResourceLocatorTest\\:\\:\\$resourceLocatorMapper is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
 
@@ -23308,11 +23213,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$userId of method Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator\\\\Strategy\\\\ResourceLocatorStrategyInterface\\:\\:save\\(\\) expects int, null given\\.$#"
 			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Strategy/TreeFullEditStrategyTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\ResourceLocator\\\\Strategy\\\\TreeFullEditStrategyTest\\:\\:\\$documentInspector is never read, only written\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Strategy/TreeFullEditStrategyTest.php
 
 		-
@@ -23398,11 +23298,6 @@ parameters:
 		-
 			message: "#^Parameter \\#2 \\$userId of method Sulu\\\\Component\\\\Content\\\\Types\\\\ResourceLocator\\\\Strategy\\\\ResourceLocatorStrategyInterface\\:\\:save\\(\\) expects int, null given\\.$#"
 			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Strategy/TreeLeafEditStrategyTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\ResourceLocator\\\\Strategy\\\\TreeLeafEditStrategyTest\\:\\:\\$documentInspector is never read, only written\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Strategy/TreeLeafEditStrategyTest.php
 
 		-
@@ -25227,16 +25122,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$route of method Sulu\\\\Bundle\\\\RouteBundle\\\\Entity\\\\RouteRepositoryInterface\\:\\:remove\\(\\) expects Sulu\\\\Bundle\\\\RouteBundle\\\\Model\\\\RouteInterface, Sulu\\\\Bundle\\\\RouteBundle\\\\Entity\\\\Route\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/Tests/Functional/Entity/RouteRepositoryTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\RouteBundle\\\\Tests\\\\Functional\\\\Controller\\\\RouteRepositoryTest\\:\\:\\$route \\(Sulu\\\\Bundle\\\\RouteBundle\\\\Entity\\\\Route\\) does not accept Sulu\\\\Bundle\\\\RouteBundle\\\\Model\\\\RouteInterface\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/Tests/Functional/Entity/RouteRepositoryTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\RouteBundle\\\\Tests\\\\Functional\\\\Controller\\\\RouteRepositoryTest\\:\\:\\$route is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/RouteBundle/Tests/Functional/Entity/RouteRepositoryTest.php
 
@@ -27201,11 +27086,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Functional\\\\Controller\\\\RoleControllerTest\\:\\:\\$role3 is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Functional\\\\Controller\\\\RoleSettingControllerTest\\:\\:testPut\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleSettingControllerTest.php
@@ -27323,11 +27203,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$object_or_class of function property_exists expects object\\|string, mixed given\\.$#"
 			count: 4
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\SecurityBundle\\\\Tests\\\\Functional\\\\Controller\\\\UserControllerTest\\:\\:\\$contact3 is never read, only written\\.$#"
-			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
 
 		-
@@ -29141,16 +29016,6 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
 
 		-
-			message: "#^Property Sulu\\\\Bundle\\\\SnippetBundle\\\\Tests\\\\Functional\\\\Controller\\\\SnippetControllerTest\\:\\:\\$phpcrSession \\(PHPCR\\\\SessionInterface\\) does not accept object\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\SnippetBundle\\\\Tests\\\\Functional\\\\Controller\\\\SnippetControllerTest\\:\\:\\$phpcrSession is never read, only written\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Component\\\\Snippet\\\\Export\\\\SnippetExportInterface\\:\\:getExportData\\(\\)\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
@@ -29162,16 +29027,6 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Export\\\\SnippetTest\\:\\:prepareData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Export\\\\SnippetTest\\:\\:\\$creator is unused\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
-
-		-
-			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Tests\\\\Functional\\\\Export\\\\SnippetTest\\:\\:\\$extensionManager is unused\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -20,7 +20,6 @@ use Sulu\Bundle\MediaBundle\Entity\CollectionType;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
-use Sulu\Bundle\SecurityBundle\Entity\RoleRepository;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
@@ -72,11 +71,6 @@ class CollectionControllerTest extends SuluTestCase
     private $client;
 
     /**
-     * @var RoleRepository
-     */
-    private $roleRepository;
-
-    /**
      * @var AccessControlManager
      */
     private $accessControlManager;
@@ -91,7 +85,6 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->systemCollectionCache = $this->getContainer()->get('sulu_media_test.system_collections.cache');
         $this->systemCollectionConfig = $this->getContainer()->getParameter('sulu_media.system_collections');
-        $this->roleRepository = $this->getContainer()->get('sulu.repository.role');
         $this->accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
 
         // to be sure that the system collections will rebuild after purge database

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
@@ -12,16 +12,10 @@
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
 
 use Imagine\Image\ImageInterface;
-use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class FormatControllerTest extends SuluTestCase
 {
-    /**
-     * @var FormatOptions[]
-     */
-    private $formatOptions;
-
     public function testCGet(): void
     {
         $client = $this->createAuthenticatedClient();

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaWebsiteControllerTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManager;
-use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
 use Sulu\Bundle\MediaBundle\Entity\CollectionType;
@@ -50,16 +49,6 @@ class MediaWebsiteControllerTest extends WebsiteTestCase
      * @var MediaType
      */
     private $imageType;
-
-    /**
-     * @var CategoryInterface
-     */
-    private $category;
-
-    /**
-     * @var CategoryInterface
-     */
-    private $category2;
 
     /**
      * @var string

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -40,11 +40,6 @@ class MediaRepositoryTest extends SuluTestCase
     private $em;
 
     /**
-     * @var Collection[]
-     */
-    private $collections;
-
-    /**
      * @var MediaType[]
      */
     private $mediaTypes = [];

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\MediaBundle\Media\TypeManager;
 
 use Doctrine\Persistence\ObjectManager;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
@@ -22,11 +21,6 @@ class TypeManagerTest extends SuluTestCase
      * @var TypeManager
      */
     private $typeManager;
-
-    /**
-     * @var ObjectProphecy
-     */
-    private $em;
 
     private $mediaTypes = [
         [

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/ValidateWebspacesCommandTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\PageBundle\Tests\Functional\Command;
 
 use Sulu\Bundle\PageBundle\Command\ValidateWebspacesCommand;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Sulu\Component\DocumentManager\DocumentManager;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -24,15 +23,9 @@ class ValidateWebspacesCommandTest extends SuluTestCase
      */
     private $tester;
 
-    /**
-     * @var DocumentManager
-     */
-    private $documentManager;
-
     public function setUp(): void
     {
         $application = new Application();
-        $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $controllerNameParser = null;
         if ($this->getContainer()->has('sulu_page.controller_name_converter')) {
             /** @var \Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser $controllerNameParser */

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageResourcelocatorControllerTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Controller;
 
-use PHPCR\SessionInterface;
 use Sulu\Bundle\ActivityBundle\Domain\Model\Activity;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -21,11 +20,6 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class PageResourcelocatorControllerTest extends SuluTestCase
 {
-    /**
-     * @var SessionInterface
-     */
-    private $session;
-
     /**
      * @var KernelBrowser
      */
@@ -51,7 +45,6 @@ class PageResourcelocatorControllerTest extends SuluTestCase
         $this->client = $this->createAuthenticatedClient();
         $this->purgeDatabase();
         $this->initPhpcr();
-        $this->session = $this->getContainer()->get('doctrine')->getConnection();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->data = $this->prepareRepositoryContent();
         $this->activityRepository = $this->getContainer()->get('sulu.repository.activity');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/SmartContentItemControllerTest.php
@@ -20,7 +20,6 @@ use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\DocumentManager\DocumentInspector;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -74,11 +73,6 @@ class SmartContentItemControllerTest extends SuluTestCase
     private $tag1;
 
     /**
-     * @var StructureManagerInterface
-     */
-    private $structureManager;
-
-    /**
      * @var DocumentInspector
      */
     private $inspector;
@@ -95,7 +89,6 @@ class SmartContentItemControllerTest extends SuluTestCase
         $this->session = $this->getContainer()->get('doctrine_phpcr')->getConnection();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->formFactory = $this->getContainer()->get('form.factory');
-        $this->structureManager = $this->getContainer()->get('sulu.content.structure_manager');
         $this->inspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
 
         $this->initOrm();

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Export/WebspaceExportTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Export/WebspaceExportTest.php
@@ -21,7 +21,6 @@ use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Export\WebspaceExportInterface;
-use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
@@ -43,11 +42,6 @@ class WebspaceExportTest extends SuluTestCase
     private $documentManager;
 
     /**
-     * @var ExtensionManagerInterface
-     */
-    private $extensionManager;
-
-    /**
      * @var int
      */
     private $creator;
@@ -56,7 +50,6 @@ class WebspaceExportTest extends SuluTestCase
     {
         parent::initPhpcr();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->extensionManager = $this->getContainer()->get('sulu_page.extension.manager');
         $this->webspaceExporter = $this->getContainer()->get('sulu_page.export.webspace');
     }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\BreadcrumbItemInterface;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Content\ContentTypeManager;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
 use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
@@ -82,11 +81,6 @@ class ContentMapperTest extends SuluTestCase
      */
     private $tokenStorage = null;
 
-    /**
-     * @var ContentTypeManager
-     */
-    private $contentTypeManager;
-
     public function setUp(): void
     {
         $this->initPhpcr();
@@ -96,7 +90,6 @@ class ContentMapperTest extends SuluTestCase
         $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->extensionManager = $this->getContainer()->get('sulu_page.extension.manager');
-        $this->contentTypeManager = $this->getContainer()->get('sulu.content.type_manager');
 
         /** @var bool $hasTokenStorage */
         $hasTokenStorage = $this->getContainer()->has('security.token_storage');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
@@ -25,12 +25,10 @@ use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Extension\AbstractExtension;
-use Sulu\Component\Content\Extension\ExtensionInterface;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
-use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class NodeRepositoryTest extends SuluTestCase
@@ -44,16 +42,6 @@ class NodeRepositoryTest extends SuluTestCase
      * @var ExtensionManagerInterface
      */
     private $extensionManager;
-
-    /**
-     * @var ExtensionInterface[]
-     */
-    private $extensions;
-
-    /**
-     * @var SessionManagerInterface
-     */
-    private $sessionManager;
 
     /**
      * @var ContentMapperInterface
@@ -74,12 +62,10 @@ class NodeRepositoryTest extends SuluTestCase
     {
         $this->purgeDatabase();
         $this->initPhpcr();
-        $this->extensions = [new TestExtension('test1', 'test1')];
         $this->mapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->nodeRepository = $this->getContainer()->get('sulu_page.node_repository');
         $this->extensionManager = $this->getContainer()->get('sulu_page.extension.manager');
-        $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->extensionManager->addExtension(new TestExtension('test1', 'test1'));
         $this->em = $this->getEntityManager();
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Mapper/PhpcrMapperTest.php
@@ -20,7 +20,6 @@ use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
 use Sulu\Component\Content\Exception\ResourceLocatorMovedException;
 use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
-use Sulu\Component\Content\Mapper\ContentMapperInterface;
 use Sulu\Component\Content\Types\ResourceLocator\Mapper\PhpcrMapper;
 use Sulu\Component\Content\Types\ResourceLocator\Mapper\ResourceLocatorMapperInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
@@ -42,11 +41,6 @@ class PhpcrMapperTest extends SuluTestCase
      * @var ResourceLocatorMapperInterface
      */
     private $phpcrMapper;
-
-    /**
-     * @var ContentMapperInterface
-     */
-    private $mapper;
 
     /**
      * @var DocumentManagerInterface
@@ -81,7 +75,6 @@ class PhpcrMapperTest extends SuluTestCase
     public function setUp(): void
     {
         $this->initPhpcr();
-        $this->mapper = $this->getContainer()->get('sulu.content.mapper');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->documentInspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
         $this->defaultSession = $this->getContainer()->get('sulu_document_manager.default_session');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/ResourceLocatorTest.php
@@ -11,22 +11,14 @@
 
 namespace Sulu\Bundle\PageBundle\Tests\Functional\ResourceLocator;
 
-use Doctrine\ORM\EntityManager;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Types\ResourceLocator;
-use Sulu\Component\Content\Types\ResourceLocator\Mapper\PhpcrMapper;
-use Sulu\Component\Content\Types\ResourceLocator\Mapper\ResourceLocatorMapperInterface;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
 
 class ResourceLocatorTest extends SuluTestCase
 {
-    /**
-     * @var EntityManager
-     */
-    private $em;
-
     /**
      * @var SessionManagerInterface
      */
@@ -36,11 +28,6 @@ class ResourceLocatorTest extends SuluTestCase
      * @var SessionInterface
      */
     private $session;
-
-    /**
-     * @var ResourceLocatorMapperInterface
-     */
-    private $resourceLocatorMapper;
 
     /**
      * @var ResourceLocator
@@ -55,18 +42,12 @@ class ResourceLocatorTest extends SuluTestCase
 
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->session = $this->sessionManager->getSession();
-        $this->resourceLocatorMapper = new PhpcrMapper(
-            $this->getContainer()->get('sulu.phpcr.session'),
-            $this->getContainer()->get('sulu_document_manager.document_manager'),
-            $this->getContainer()->get('sulu_document_manager.document_inspector')
-        );
 
         $this->resourceLocator = new ResourceLocator('not-in-use');
     }
 
     protected function initOrm()
     {
-        $this->em = $this->getContainer()->get('doctrine')->getManager();
     }
 
     public function testWrite(): void

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Strategy/TreeFullEditStrategyTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Strategy/TreeFullEditStrategyTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\PageBundle\Tests\Functional\ResourceLocator\Strategy;
 
 use PHPCR\SessionInterface;
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Exception\ResourceLocatorMovedException;
 use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
@@ -32,11 +31,6 @@ class TreeFullEditStrategyTest extends SuluTestCase
     private $documentManager;
 
     /**
-     * @var DocumentInspector
-     */
-    private $documentInspector;
-
-    /**
      * @var SessionInterface
      */
     private $session;
@@ -45,7 +39,6 @@ class TreeFullEditStrategyTest extends SuluTestCase
     {
         $this->resourceLocatorStrategy = $this->getContainer()->get('sulu_page_test.resource_locator.strategy.tree_full_edit');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->documentInspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
         $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
 
         $this->initPhpcr();

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Strategy/TreeLeafEditStrategyTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/ResourceLocator/Strategy/TreeLeafEditStrategyTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\PageBundle\Tests\Functional\ResourceLocator\Strategy;
 
 use PHPCR\SessionInterface;
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Exception\ResourceLocatorMovedException;
 use Sulu\Component\Content\Exception\ResourceLocatorNotFoundException;
@@ -32,11 +31,6 @@ class TreeLeafEditStrategyTest extends SuluTestCase
     private $documentManager;
 
     /**
-     * @var DocumentInspector
-     */
-    private $documentInspector;
-
-    /**
      * @var SessionInterface
      */
     private $session;
@@ -45,7 +39,6 @@ class TreeLeafEditStrategyTest extends SuluTestCase
     {
         $this->resourceLocatorStrategy = $this->getContainer()->get('sulu_page_test.resource_locator.strategy.tree_leaf_edit');
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
-        $this->documentInspector = $this->getContainer()->get('sulu_document_manager.document_inspector');
         $this->session = $this->getContainer()->get('sulu_document_manager.default_session');
 
         $this->initPhpcr();

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Entity/RouteRepositoryTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Entity/RouteRepositoryTest.php
@@ -18,11 +18,6 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 class RouteRepositoryTest extends SuluTestCase
 {
     /**
-     * @var Route
-     */
-    private $route;
-
-    /**
      * @var int
      */
     private $routeId;
@@ -46,8 +41,6 @@ class RouteRepositoryTest extends SuluTestCase
         $entityManager->persist($route);
         $entityManager->flush();
         $entityManager->clear();
-
-        $this->route = $route;
         $this->routeId = $route->getId();
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/RoleControllerTest.php
@@ -39,11 +39,6 @@ class RoleControllerTest extends SuluTestCase
     private $role2;
 
     /**
-     * @var Role
-     */
-    private $role3;
-
-    /**
      * @var SecurityType
      */
     protected $securityType1;
@@ -107,7 +102,6 @@ class RoleControllerTest extends SuluTestCase
         $role3->setSystem('Website');
         $role3->setAnonymous(true);
         $this->em->persist($role3);
-        $this->role3 = $role3;
 
         $permission1 = new Permission();
         $permission1->setRole($role1);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
@@ -43,11 +43,6 @@ class UserControllerTest extends SuluTestCase
     private $contact2;
 
     /**
-     * @var Contact
-     */
-    private $contact3;
-
-    /**
      * @var Role
      */
     private $role1;
@@ -133,14 +128,12 @@ class UserControllerTest extends SuluTestCase
         $contact3->setLastName('User');
         $contact3->addEmail($email);
         $this->em->persist($contact3);
-        $this->contact3 = $contact3;
 
         $contact4 = new Contact();
         $contact4->setFirstName('Locked');
         $contact4->setLastName('User');
         $contact4->addEmail($email);
         $this->em->persist($contact4);
-        $this->contact3 = $contact4;
 
         $this->em->flush();
 

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Controller/SnippetControllerTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\SnippetBundle\Tests\Functional\Controller;
 
 use Doctrine\Persistence\ObjectRepository;
-use PHPCR\SessionInterface;
 use Sulu\Bundle\ActivityBundle\Domain\Model\ActivityInterface;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\SnippetBundle\Snippet\DefaultSnippetManagerInterface;
@@ -47,11 +46,6 @@ class SnippetControllerTest extends SuluTestCase
     protected $documentManager;
 
     /**
-     * @var SessionInterface
-     */
-    private $phpcrSession;
-
-    /**
      * @var DefaultSnippetManagerInterface
      */
     private $defaultSnippetManager;
@@ -71,7 +65,6 @@ class SnippetControllerTest extends SuluTestCase
         $this->client = $this->createAuthenticatedClient();
         $this->purgeDatabase();
         $this->initPhpcr();
-        $this->phpcrSession = $this->getContainer()->get('doctrine_phpcr')->getConnection();
         $this->documentManager = $this->getContainer()->get('sulu_document_manager.document_manager');
         $this->defaultSnippetManager = $this->getContainer()->get('sulu_snippet.default_snippet.manager');
         $this->activityRepository = $this->getEntityManager()->getRepository(ActivityInterface::class);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\PageBundle\Tests\Functional\Export;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Document\WorkflowStage;
-use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Snippet\Export\SnippetExportInterface;
 
@@ -42,16 +41,6 @@ class SnippetTest extends SuluTestCase
      * @var SnippetDocument
      */
     private $snippet2;
-
-    /**
-     * @var ExtensionManagerInterface
-     */
-    private $extensionManager;
-
-    /**
-     * @var int
-     */
-    private $creator;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix unused variables in tests.

#### Why?

Remove never used private variables in tests. We can not do it generally via a rule as sometimes private variables are used for API entity serialization process.
