### PR TITLE
Ignore non existing sort columns

### DIFF
--- a/src/Sulu/Component/Rest/RestHelper.php
+++ b/src/Sulu/Component/Rest/RestHelper.php
@@ -76,7 +76,7 @@ class RestHelper implements RestHelperInterface
         }
 
         $sortBy = $this->listRestHelper->getSortColumn();
-        if (null != $sortBy) {
+        if (null != $sortBy && \array_key_exists($sortBy, $fieldDescriptors)) {
             $listBuilder->sort($fieldDescriptors[$sortBy], $this->listRestHelper->getSortOrder());
         }
     }

--- a/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RestHelperTest.php
@@ -204,6 +204,18 @@ class RestHelperTest extends TestCase
         $this->restHelper->initializeListBuilder($this->listBuilder->reveal(), ['name' => $field->reveal()]);
     }
 
+    public function testInitializeListBuilderSortWithNonExistingColumn(): void
+    {
+        $field = $this->prophesize(FieldDescriptor::class);
+
+        $this->listRestHelper->getSortColumn()->willReturn('non-existing');
+        $this->listRestHelper->getSortOrder()->willReturn('ASC');
+
+        $this->listBuilder->sort(Argument::any())->shouldNotBeCalled();
+
+        $this->restHelper->initializeListBuilder($this->listBuilder->reveal(), ['name' => $field->reveal()]);
+    }
+
     public function testprocessSubEntitiesEmpty(): void
     {
         $mock = $this->getMockBuilder('Mock')->setMethods(['delete', 'update', 'add', 'get'])->getMock();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7207
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
The code changes proposed in the issue. :laughing:

Thanks @MrSrsen

#### Why?
Ignoring the sort query parameter when there is no column in the database with that names reduces the amount of errors.

This also helps with view switching as the filter settings when switching between views remain (even though the new view might not have those columns).