### PR TITLE
Fix detecting of content-types which are not available

### DIFF
--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -167,18 +167,18 @@ class StructureXmlLoader extends AbstractLoader
 
             $propertyType = $property->getType();
 
-            return true;
-
-            /*
-            // TODO maybe readd validation based on a JSON provided by admin build
             if ($this->contentTypeManager->has($propertyType)) {
-                 return true;
+                return true;
             }
 
             if ('ignore' === $property->getOnInvalid()) {
                 return false;
             }
 
+            return true;
+
+            /*
+            // TODO maybe readd validation based on a JSON provided by admin build
             throw new \InvalidArgumentException(\sprintf(
                 'Content type with alias "%s" has not been registered. Known content types are: "%s"',
                 $propertyType,

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -300,8 +300,7 @@ class StructureXmlLoaderTest extends TestCase
 
         $properties = $result->getProperties();
 
-        //invalid property will also be loaded
-        $this->assertCount(3, $properties);
+        $this->assertCount(2, $properties);
         $this->assertEquals('title', $properties['title']->getName());
         $this->assertEquals('url', $properties['url']->getName());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR |

#### What's in this PR?

This fixes the sulu:build command in the skeleton.

#### Why?

The audience taget group selection breaks the sulu:build if the bundle is not enabled.

