### PR TITLE
Remove call of initPhpcr from new bundles

### DIFF
--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -41,7 +41,6 @@ class ArticleControllerTest extends SuluTestCase
     public function testPostPublish(): string
     {
         self::purgeDatabase();
-        self::initPhpcr();
 
         $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
             'template' => 'article',

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -84,7 +84,6 @@ class PageControllerTest extends SuluTestCase
     public function testPostPublish(): string
     {
         self::purgeDatabase();
-        self::initPhpcr();
 
         $homepage = $this->createHomepage();
         $this->client->request(

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -49,7 +49,6 @@ class SnippetControllerTest extends SuluTestCase
     public function testPostPublish(): string
     {
         self::purgeDatabase();
-        self::initPhpcr();
 
         $this->client->request('POST', '/admin/api/snippets?locale=en&action=publish', [], [], [], \json_encode([
             'template' => 'snippet',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove call of initPhpcr from new bundles.

#### Why?

Make bundles independent from phpcr.
