### PR TITLE
Grouping test output by Bundle in Github Actions

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -8,6 +8,9 @@ on:
             - '[0-9]+.[0-9]+'
     workflow_dispatch:
 
+env:
+    CI_GROUP_OUTPUT: true
+
 # automatically cancel previously started workflows when pushing a new commit to a branch
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/bin/runtests
+++ b/bin/runtests
@@ -352,11 +352,15 @@ if ($target = $input->getOption('target')) {
 }
 
 write_header('Bundle tests');
-
+$enableGrouping = getenv('CI_GROUP_OUTPUT') === 'true';
 foreach ($bundles as $bundle) {
-    echo "::group::". basename($bundle->getPath()). PHP_EOL;
+    if ($enableGrouping) {
+        echo "::group::". basename($bundle->getPath()). PHP_EOL;
+    }
     run_bundle_tests($bundle);
-    echo "::endgroup::\n";
+    if ($enableGrouping) {
+        echo "::endgroup::\n";
+    }
 }
 echo "\n";
 

--- a/bin/runtests
+++ b/bin/runtests
@@ -351,9 +351,14 @@ if ($target = $input->getOption('target')) {
     $bundles = get_bundles($target);
 }
 
+write_header('Bundle tests');
+
 foreach ($bundles as $bundle) {
+    echo "::group::". basename($bundle->getPath()). PHP_EOL;
     run_bundle_tests($bundle);
+    echo "::endgroup::\n";
 }
+echo "\n";
 
 if (false === $input->getOption('no-component-tests') || $input->getOption('all')) {
     write_header('Components');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

![image](https://github.com/user-attachments/assets/e461580b-c949-4daf-ab5f-66490429f8b5)


#### Why?
With the amount of output the tests produce you have to scroll a lot when the first components fail. And the search isn't helping 'cause it only sometimes works.

This way you can just expand the section(s) that are broken.