### PR TITLE
Fix return empty array if teaser selection property resolver data not matching

### DIFF
--- a/packages/content/src/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolver.php
@@ -32,7 +32,7 @@ class TeaserSelectionPropertyResolver implements PropertyResolverInterface
             || !\array_key_exists('items', $data)
             || !\is_array($data['items'])
         ) {
-            return ContentView::create($data, $returnedParams);
+            return ContentView::create([], $returnedParams);
         }
 
         $resourceLoaderKey = isset($params['resourceLoader']) && \is_string($params['resourceLoader']) ? $params['resourceLoader'] : TeaserResourceLoader::getKey();

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolverTest.php
@@ -36,6 +36,14 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $this->assertSame(['presentsAs' => null], $contentView->getView());
     }
 
+    public function testResolveWrongData(): void
+    {
+        $contentView = $this->resolver->resolve(['source' => 1], 'en');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['presentsAs' => null], $contentView->getView());
+    }
+
     public function testResolveParams(): void
     {
         $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7928
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Return always empty array for teaser selection if unexpected data was given the the property resolver.

#### Why?

If I switch a block type or change property xmls without a migration a teaser selection should return a empty array instead of the eventually false raw data of another type.

Currently this code snippet can error:

```twig
{% for teaser in content.teasers %}
```

as it might return null, string or something else.