### PR TITLE
Replace old metadata loader in block and image map property resolvers

### DIFF
--- a/config/templates/pages/example.xml
+++ b/config/templates/pages/example.xml
@@ -6,7 +6,7 @@
     <key>example</key>
 
     <view>pages/example</view>
-    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
     <cacheLifetime>604800</cacheLifetime>
 
     <meta>

--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -6,7 +6,7 @@
     <key>homepage</key>
 
     <view>pages/homepage</view>
-    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
     <cacheLifetime>86400</cacheLifetime>
 
     <meta>

--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -80,7 +80,7 @@
         <service id="sulu_content.block_property_resolver"
                  class="Sulu\Content\Application\PropertyResolver\Resolver\BlockPropertyResolver">
             <argument type="service" id="logger"/>
-            <argument type="service" id="sulu_admin.structure_form_metadata_loader"/>
+            <argument type="service" id="sulu_admin.metadata_provider_registry"/>
             <argument>%kernel.debug%</argument>
 
             <call method="setMetadataResolver">

--- a/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
@@ -16,8 +16,8 @@ namespace Sulu\Content\Application\PropertyResolver\Resolver;
 use Psr\Log\LoggerInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataLoaderInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\MetadataResolver\MetadataResolver;
 
@@ -27,7 +27,7 @@ class BlockPropertyResolver implements PropertyResolverInterface
 
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly FormMetadataLoaderInterface $formMetadataLoader,
+        private readonly MetadataProviderRegistry $metadataProviderRegistry,
         private readonly bool $debug = false,
     ) {
     }
@@ -56,8 +56,11 @@ class BlockPropertyResolver implements PropertyResolverInterface
         \assert($metadata instanceof FieldMetadata, 'Metadata must be set to resolve blocks.');
         $metadataTypes = $metadata->getTypes();
 
-        /** @var TypedFormMetadata $typedFormMetadata */
-        $typedFormMetadata = $this->formMetadataLoader->getMetadata('block', $locale, []);
+        $typedFormMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')
+            ->getMetadata('block', $locale, []);
+
+        \assert($typedFormMetadata instanceof TypedFormMetadata, 'Block form metadata not found for block resolving.');
+
         $globalBlocksMetadata = $typedFormMetadata->getForms();
 
         $contentViews = [];

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/PropertyResolverProviderTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/PropertyResolverProviderTest.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Content\Tests\Unit\Content\Application\PropertyResolver;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataLoaderInterface;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Content\Application\PropertyResolver\PropertyResolverProvider;
 use Sulu\Content\Application\PropertyResolver\Resolver\BlockPropertyResolver;
 use Sulu\Content\Application\PropertyResolver\Resolver\DefaultPropertyResolver;
@@ -24,19 +22,15 @@ use Symfony\Component\ErrorHandler\BufferingLogger;
 
 class PropertyResolverProviderTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function testGetPropertyResolver(): void
     {
-        $formMetadataLoader = $this->prophesize(FormMetadataLoaderInterface::class);
-        $formMetadataLoader->getMetadata('block', 'en', [])
-            ->willReturn(new TypedFormMetadata());
+        $metadataProviderRegistry = new MetadataProviderRegistry();
 
         $propertyResolverProvider = new PropertyResolverProvider(
             new \ArrayIterator([
                 'block' => new BlockPropertyResolver(
                     new BufferingLogger(),
-                    $formMetadataLoader->reveal(),
+                    $metadataProviderRegistry,
                     false
                 ),
                 'default' => new DefaultPropertyResolver(),

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2239,12 +2239,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadataProvider\:\:getMetadata\(\) has parameter \$metadataOptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
-
-		-
 			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:\$description \(string\) does not accept string\|null\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -2567,18 +2561,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/FieldMetadata.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\ListMetadata\\ListMetadataProvider\:\:getMetadata\(\) has parameter \$metadataOptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ListMetadataProvider.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\MetadataProviderInterface\:\:getMetadata\(\) has parameter \$metadataOptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
 
 		-
 			message: '#^Cannot access offset string on mixed\.$#'

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
@@ -13,5 +13,8 @@ namespace Sulu\Bundle\AdminBundle\Metadata;
 
 interface MetadataProviderInterface
 {
+    /**
+     * @param array<string, mixed> $metadataOptions
+     */
     public function getMetadata(string $key, string $locale, array $metadataOptions): MetadataInterface;
 }

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
@@ -16,8 +16,8 @@ namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver;
 use Psr\Log\LoggerInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataLoaderInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
@@ -35,7 +35,7 @@ class ImageMapPropertyResolver implements PropertyResolverInterface // TODO we m
 
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly FormMetadataLoaderInterface $formMetadataLoader,
+        private readonly MetadataProviderRegistry $metadataProviderRegistry,
         private readonly bool $debug = false,
     ) {
     }
@@ -104,8 +104,11 @@ class ImageMapPropertyResolver implements PropertyResolverInterface // TODO we m
         $content = [];
         $view = [];
 
-        /** @var TypedFormMetadata $typedFormMetadata */
-        $typedFormMetadata = $this->formMetadataLoader->getMetadata('block', $locale, []);
+        $typedFormMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')
+            ->getMetadata('block', $locale, []);
+
+        \assert($typedFormMetadata instanceof TypedFormMetadata, 'Block form metadata not found for image map resolving.');
+
         $globalBlocksMetadata = $typedFormMetadata->getForms();
         foreach ($hotspots as $key => $block) {
             if (!\is_array($block) || !isset($block['type']) || !\is_string($block['type'])) {

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services_content.xml
@@ -17,7 +17,7 @@
         <service id="sulu_media.image_map_property_resolver"
                  class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\PropertyResolver\ImageMapPropertyResolver">
             <argument type="service" id="logger"/>
-            <argument type="service" id="sulu_admin.structure_form_metadata_loader"/>
+            <argument type="service" id="sulu_admin.metadata_provider_registry"/>
             <argument>%kernel.debug%</argument>
 
             <call method="setMetadataResolver">

--- a/templates/pages/example.html.twig
+++ b/templates/pages/example.html.twig
@@ -5,10 +5,14 @@
     <p>{{ content.url }}</p>
     {{ content.text_editor|raw }}
 
-
     {% for block in content.blocks %}
         {% if block.type == 'editor' %}
             {{ block.text_editor|raw }}
+        {% elseif block.type == 'text_block' %}
+            <h2>
+                {{ block.title }}
+            </h2>
+            {{ block.description|raw }}
         {% elseif block.type == 'media' %}
             {% for media in block.media_selection %}
                 <img src="{{ media.thumbnails['sulu-260x'] }}" />
@@ -56,7 +60,7 @@
 
     <p>{{ content.page_selection|map(page => page.title)|join(', ') }}</p>
     <p>{{ content.teaser_selection|map(teaser => teaser.title)|join(', ') }}</p>
-    <p>{{ content.smart_content|map(page => page.title)|join(', ') }}</p>
+    <p>{{ content.smart_content|default([])|map(page => page.title)|join(', ') }}</p>
     <p>{{ content.single_snippet_selection ? content.single_snippet_selection.title : '' }}</p>
     <p>{{ content.snippet_selection|map(snippet => snippet.title)|join(', ') }}</p>
     <p>{{ content.category_selection|map(category => category.name)|join(', ') }}</p>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7928
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Replace old metadata loader in block and image map property resolvers.

#### Why?

The old loader may be removed we should use the service which we use already in the admin controller.
