### PR TITLE
Remove reference handling of tags in properties parser

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -492,7 +492,9 @@ Removed classes / services:
 - `Sulu\Bundle\MediaBundle\DependencyInjection\S3ClientCompilerPass` (internal)
 - `Sulu\Bundle\AdminBundle\Command\DownloadBuildCommand`
 - `Sulu\Component\Rest\ListBuilder\ListRepresentation`
-- `src\Sulu\Component\Content\Metadata\XmlParserTrait`
+- `src\Sulu\Component\Content\Metadata\XmlParserTrait`  (internal)
+- `Sulu\Component\Content\Metadata\Parser\PropertiesXmlParser` (moved and internal)
+- `Sulu\Component\Content\Metadata\Parser\SchemaXmlParser` (moved and internal)
 
 Removed deprecated functions and properties:
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2167,7 +2167,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
 
 		-
-			message: '#^Parameter \#3 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -2527,12 +2527,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2546,12 +2540,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadBlock\(\) has parameter \$formKey with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadBlock\(\) has parameter \$tags with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -2593,12 +2581,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2617,12 +2599,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperty\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2630,12 +2606,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has parameter \$formKey with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has parameter \$tags with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -2653,12 +2623,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTags\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2671,12 +2635,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2684,12 +2642,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has parameter \$formKey with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has parameter \$tags with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -2923,6 +2875,12 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects DOMNode, DOMNode\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
 			message: '#^Parameter \#2 \$defaultType of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -2947,13 +2905,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#3 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects DOMNode, DOMNode\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Parameter \#4 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#3 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -60543,7 +60495,7 @@ parameters:
 		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 3
+			count: 2
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
@@ -60579,7 +60531,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''key'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 3
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
@@ -60853,12 +60805,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
 			message: '#^Parameter \#1 \$metaValues of method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:loadMetaValues\(\) expects array\<string, string\>, mixed given\.$#'
 			identifier: argument.type
 			count: 2
@@ -60907,12 +60853,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#1 \$template of class Sulu\\Component\\Content\\Metadata\\Loader\\Exception\\RequiredTagNotFoundException constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
 			message: '#^Parameter \#1 \$template of class Sulu\\Component\\Content\\Metadata\\Loader\\Exception\\ReservedPropertyNameException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -60937,9 +60877,9 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
@@ -60950,12 +60890,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$reservedPropertyName of method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:isReservedProperty\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
-			message: '#^Parameter \#2 \$tagName of class Sulu\\Component\\Content\\Metadata\\Loader\\Exception\\RequiredTagNotFoundException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -60973,7 +60907,7 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#3 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
+			message: '#^Parameter \#3 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -60991,8 +60925,8 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#4 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
+			message: '#^Property Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:\$requiredTagNames is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -50,9 +50,6 @@ class FormXmlLoader extends AbstractLoader
 
     protected function parse($resource, \DOMXPath $xpath, $type): LocalizedFormMetadataCollection
     {
-        // init running vars
-        $tags = [];
-
         if (0 === $xpath->query('/x:form')->count()) {
             throw new InvalidRootTagException($resource, 'form');
         }
@@ -64,7 +61,6 @@ class FormXmlLoader extends AbstractLoader
 
         $propertiesNode = $xpath->query('/x:form/x:properties')->item(0);
         $properties = $this->propertiesXmlParser->load(
-            $tags,
             $xpath,
             $propertiesNode,
             $form->getKey()

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -20,7 +20,7 @@ use Sulu\Component\Content\Metadata\SectionMetadata;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * Parse properties structure from an XML file.
+ * @internal this class is not part of the public API and may be changed or removed without further notice
  */
 class PropertiesXmlParser
 {
@@ -173,7 +173,7 @@ class PropertiesXmlParser
         /** @var \DOMElement $node */
         foreach ($xpath->query('x:tag', $context) as $node) {
             $tag = $this->loadTag($xpath, $node);
-            $this->validateTag($tag, $tags);
+            $this->validateTag($tags, $tag);
 
             $result[] = $tag;
         }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -37,30 +37,29 @@ class PropertiesXmlParser
     }
 
     public function load(
-        &$tags,
         \DOMXPath $xpath,
         \DOMNode $context,
         ?string $formKey = null
     ): array {
-        $propertyData = $this->loadProperties($tags, $xpath, $context, $formKey);
+        $propertyData = $this->loadProperties($xpath, $context, $formKey);
 
         return $this->mapProperties($propertyData);
     }
 
-    private function loadProperties(&$tags, \DOMXPath $xpath, \DOMNode $context, ?string $formKey): array
+    private function loadProperties(\DOMXPath $xpath, \DOMNode $context, ?string $formKey): array
     {
         $result = [];
 
         /** @var \DOMElement $node */
         foreach ($xpath->query('x:*', $context) as $node) {
             if ('property' === $node->tagName) {
-                $value = $this->loadProperty($xpath, $node, $tags, $formKey);
+                $value = $this->loadProperty($xpath, $node, $formKey);
                 $result[$value['name']] = $value;
             } elseif ('block' === $node->tagName) {
-                $value = $this->loadBlock($xpath, $node, $tags, $formKey);
+                $value = $this->loadBlock($xpath, $node, $formKey);
                 $result[$value['name']] = $value;
             } elseif ('section' === $node->tagName) {
-                $value = $this->loadSection($xpath, $node, $tags, $formKey);
+                $value = $this->loadSection($xpath, $node, $formKey);
                 $result[$value['name']] = $value;
             }
         }
@@ -68,7 +67,7 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadProperty(\DOMXPath $xpath, \DOMNode $node, &$tags, $formKey)
+    private function loadProperty(\DOMXPath $xpath, \DOMNode $node, $formKey)
     {
         $result = $this->loadValues(
             $xpath,
@@ -90,10 +89,10 @@ class PropertiesXmlParser
         $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
         $result['multilingual'] = $this->getValueFromXPath('@multilingual', $xpath, $node, true);
         $result['onInvalid'] = $this->getValueFromXPath('@onInvalid', $xpath, $node);
-        $result['tags'] = $this->loadTags($tags, $xpath, $node);
+        $result['tags'] = $this->loadTags($xpath, $node);
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
         $result['meta'] = $this->loadMeta($xpath, $node);
-        $result['types'] = $this->loadTypes($tags, $xpath, $node, $formKey);
+        $result['types'] = $this->loadTypes($xpath, $node, $formKey);
 
         $typeNames = \array_map(function($type) {
             return $type['name'];
@@ -112,7 +111,7 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function validateTag($tag, &$tags)
+    private function validateTag(&$tags, $tag)
     {
         if (!isset($tags[$tag['name']])) {
             $tags[$tag['name']] = [];
@@ -140,15 +139,15 @@ class PropertiesXmlParser
         return $tag;
     }
 
-    private function loadBlock(\DOMXPath $xpath, \DOMNode $node, &$tags, $formKey)
+    private function loadBlock(\DOMXPath $xpath, \DOMNode $node, $formKey)
     {
-        $result = $this->loadProperty($xpath, $node, $tags, $formKey);
+        $result = $this->loadProperty($xpath, $node, $formKey);
         $result['type'] = 'block';
 
         return $result;
     }
 
-    private function loadSection(\DOMXPath $xpath, \DOMNode $node, &$tags, $formKey)
+    private function loadSection(\DOMXPath $xpath, \DOMNode $node, $formKey)
     {
         $result = $this->loadValues(
             $xpath,
@@ -161,13 +160,14 @@ class PropertiesXmlParser
         $result['meta'] = $this->loadMeta($xpath, $node);
 
         $propertiesNode = $xpath->query('x:properties', $node)->item(0);
-        $result['properties'] = $this->loadProperties($tags, $xpath, $propertiesNode, $formKey);
+        $result['properties'] = $this->loadProperties($xpath, $propertiesNode, $formKey);
 
         return $result;
     }
 
-    private function loadTags(&$tags, \DOMXPath $xpath, ?\DOMNode $context = null)
+    private function loadTags(\DOMXPath $xpath, ?\DOMNode $context = null)
     {
+        $tags = [];
         $result = [];
 
         /** @var \DOMElement $node */
@@ -181,20 +181,20 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadTypes(&$tags, \DOMXPath $xpath, ?\DOMNode $context, $formKey)
+    private function loadTypes(\DOMXPath $xpath, ?\DOMNode $context, $formKey)
     {
         $result = [];
 
         /** @var \DOMElement $node */
         foreach ($xpath->query('x:types/x:type', $context) as $node) {
-            $value = $this->loadType($xpath, $node, $tags, $formKey);
+            $value = $this->loadType($xpath, $node, $formKey);
             $result[$value['name']] = $value;
         }
 
         return $result;
     }
 
-    private function loadType(\DOMXPath $xpath, \DOMNode $node, &$tags, $formKey)
+    private function loadType(\DOMXPath $xpath, \DOMNode $node, $formKey)
     {
         $result = $this->loadValues($xpath, $node, ['name', 'ref']);
         if ($result['ref'] && $result['name']) {
@@ -220,7 +220,7 @@ class PropertiesXmlParser
 
         $propertiesNode = $xpath->query('x:properties', $node)->item(0);
         if ($propertiesNode) {
-            $result['properties'] = $this->loadProperties($tags, $xpath, $propertiesNode, $formKey);
+            $result['properties'] = $this->loadProperties($xpath, $propertiesNode, $formKey);
         }
 
         return $result;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
@@ -16,6 +16,9 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
 
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
 class SchemaXmlParser
 {
     use XmlParserTrait;

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Metadata\Loader\Exception\InvalidXmlException;
 use Sulu\Component\Content\Metadata\Loader\Exception\RequiredPropertyNameNotFoundException;
-use Sulu\Component\Content\Metadata\Loader\Exception\RequiredTagNotFoundException;
 use Sulu\Component\Content\Metadata\Loader\Exception\ReservedPropertyNameException;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\SectionMetadata;
@@ -130,16 +129,12 @@ class StructureXmlLoader extends AbstractLoader
 
     protected function parse($resource, \DOMXPath $xpath, $type)
     {
-        // init running vars
-        $tags = [];
-
         // init result
         $result = $this->loadTemplateAttributes($resource, $xpath, $type);
 
         // load properties
         $propertiesNode = $xpath->query('/x:template/x:properties')->item(0);
         $result['properties'] = $this->propertiesXmlParser->load(
-            $tags,
             $xpath,
             $propertiesNode,
             $type
@@ -186,18 +181,6 @@ class StructureXmlLoader extends AbstractLoader
             ));
             */
         });
-
-        // FIXME until excerpt-template is no page template anymore
-        // - https://github.com/sulu-io/sulu/issues/1220#issuecomment-110704259
-        if (!\array_key_exists('internal', $result) || !$result['internal']) {
-            if (isset($this->requiredTagNames[$type])) {
-                foreach ($this->requiredTagNames[$type] as $requiredTagName) {
-                    if (!\array_key_exists($requiredTagName, $tags)) {
-                        throw new RequiredTagNotFoundException($result['key'], $requiredTagName);
-                    }
-                }
-            }
-        }
 
         return $result;
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -21,7 +21,6 @@ use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Exception\InvalidDefaultTypeException;
 use Sulu\Component\Content\Metadata\Loader\Exception\RequiredPropertyNameNotFoundException;
-use Sulu\Component\Content\Metadata\Loader\Exception\RequiredTagNotFoundException;
 use Sulu\Component\Content\Metadata\Loader\StructureXmlLoader;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -313,16 +312,6 @@ class StructureXmlLoaderTest extends TestCase
         $this->contentTypeManager->has('resource_locator')->willReturn(true);
         $this->contentTypeManager->getAll()->willReturn(['text_line', 'resource_locator']);
         $this->load('template_without_title.xml');
-    }
-
-    public function testLoadRequiredTag(): void
-    {
-        $this->expectException(RequiredTagNotFoundException::class);
-
-        $this->contentTypeManager->has('text_line')->willReturn(true);
-        $this->contentTypeManager->has('resource_locator')->willReturn(true);
-        $this->contentTypeManager->getAll()->willReturn(['text_line', 'resource_locator']);
-        $this->load('template_without_sulu_rlp.xml');
     }
 
     public function testLoadRequiredPropertyOtherType(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove reference handling of tags in properties parser. And make the services internal.

#### Why?

The tags reference handling is really changed and valdiation and loading should be seperated, to be open for future changes we should also mark such service as internal as its loading should be in our full control.