### PR TITLE
Add a hint that article bundle removal may remove the template files

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -37,6 +37,13 @@ return [
 -    ONGR\ElasticsearchBundle\ONGRElasticsearchBundle::class => ['all' => true],
 ```
 
+It can happen that flex removes the `config/templates/articles/*` files. If you need the article bundle, make sure 
+to not lose them by checking out the files again:
+
+```bash
+git checkout config/templates/articles/
+```
+
 ### Upgrade to Sulu 3.0 and register new bundles
 
 Now upgrade the dependencies to Sulu 3.0:

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -37,8 +37,8 @@ return [
 -    ONGR\ElasticsearchBundle\ONGRElasticsearchBundle::class => ['all' => true],
 ```
 
-It can happen that flex removes the `config/templates/articles/*` files. If you need the article bundle, make sure 
-to not lose them by checking out the files again:
+It can happen that flex removes the `config/templates/articles/*` files. If you need the article bundle, ensure you 
+don’t lose these files by checking them out again from version control:
 
 ```bash
 git checkout config/templates/articles/


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add a hint that article bundle removal may remove the template files.

#### Why?

A hint by our partners @icapps that the files where removed by flex. I added `--no-scripts` which may not longer make this bug appear but to be sure add a hint that such files should be restored.