### PR TITLE
WIP: Refactor properties xml loader to return new metadata

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -525,7 +525,9 @@ Removed classes / services:
 - `Sulu\Bundle\MediaBundle\DependencyInjection\S3ClientCompilerPass` (internal)
 - `Sulu\Bundle\AdminBundle\Command\DownloadBuildCommand`
 - `Sulu\Component\Rest\ListBuilder\ListRepresentation`
-- `src\Sulu\Component\Content\Metadata\XmlParserTrait`
+- `src\Sulu\Component\Content\Metadata\XmlParserTrait`  (internal)
+- `Sulu\Component\Content\Metadata\Parser\PropertiesXmlParser` (moved and internal)
+- `Sulu\Component\Content\Metadata\Parser\SchemaXmlParser` (moved and internal)
 
 Removed deprecated functions and properties:
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2101,7 +2101,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
 
 		-
-			message: '#^Parameter \#3 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -2473,12 +2473,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2492,12 +2486,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadBlock\(\) has parameter \$formKey with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadBlock\(\) has parameter \$tags with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -2539,12 +2527,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -2563,12 +2545,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperty\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2576,12 +2552,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has parameter \$formKey with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has parameter \$tags with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -2599,12 +2569,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTags\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2617,12 +2581,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2630,12 +2588,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has parameter \$formKey with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has parameter \$tags with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -2869,6 +2821,12 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects DOMNode, DOMNode\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
 			message: '#^Parameter \#2 \$defaultType of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -2893,13 +2851,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#3 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects DOMNode, DOMNode\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Parameter \#4 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#3 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -60483,7 +60435,7 @@ parameters:
 		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 3
+			count: 2
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
@@ -60519,7 +60471,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''key'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 3
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
@@ -60793,12 +60745,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
 			message: '#^Parameter \#1 \$metaValues of method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:loadMetaValues\(\) expects array\<string, string\>, mixed given\.$#'
 			identifier: argument.type
 			count: 2
@@ -60847,12 +60793,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#1 \$template of class Sulu\\Component\\Content\\Metadata\\Loader\\Exception\\RequiredTagNotFoundException constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
 			message: '#^Parameter \#1 \$template of class Sulu\\Component\\Content\\Metadata\\Loader\\Exception\\ReservedPropertyNameException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -60877,9 +60817,9 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
@@ -60890,12 +60830,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$reservedPropertyName of method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:isReservedProperty\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
-			message: '#^Parameter \#2 \$tagName of class Sulu\\Component\\Content\\Metadata\\Loader\\Exception\\RequiredTagNotFoundException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -60913,7 +60847,7 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#3 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
+			message: '#^Parameter \#3 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -60931,8 +60865,8 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#4 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
+			message: '#^Property Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:\$requiredTagNames is never read, only written\.$#'
+			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -50,9 +50,6 @@ class FormXmlLoader extends AbstractLoader
 
     protected function parse($resource, \DOMXPath $xpath, $type): LocalizedFormMetadataCollection
     {
-        // init running vars
-        $tags = [];
-
         if (0 === $xpath->query('/x:form')->count()) {
             throw new InvalidRootTagException($resource, 'form');
         }
@@ -64,7 +61,6 @@ class FormXmlLoader extends AbstractLoader
 
         $propertiesNode = $xpath->query('/x:form/x:properties')->item(0);
         $properties = $this->propertiesXmlParser->load(
-            $tags,
             $xpath,
             $propertiesNode,
             $form->getKey()

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -20,7 +20,7 @@ use Sulu\Component\Content\Metadata\SectionMetadata;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * Parse properties structure from an XML file.
+ * @internal this class is not part of the public API and may be changed or removed without further notice
  */
 class PropertiesXmlParser
 {
@@ -173,7 +173,7 @@ class PropertiesXmlParser
         /** @var \DOMElement $node */
         foreach ($xpath->query('x:tag', $context) as $node) {
             $tag = $this->loadTag($xpath, $node);
-            $this->validateTag($tag, $tags);
+            $this->validateTag($tags, $tag);
 
             $result[] = $tag;
         }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -11,12 +11,14 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
 use Sulu\Component\Content\Exception\InvalidDefaultTypeException;
-use Sulu\Component\Content\Metadata\BlockMetadata;
-use Sulu\Component\Content\Metadata\ComponentMetadata;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
-use Sulu\Component\Content\Metadata\SectionMetadata;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -326,21 +328,13 @@ class PropertiesXmlParser
         return $properties;
     }
 
-    /**
-     * @return null|BlockMetadata|PropertyMetadata|SectionMetadata
-     */
-    private function createProperty(string $propertyName, array $propertyData)
+    private function createProperty(string $propertyName, array $propertyData): FieldMetadata|SectionMetadata
     {
-        if ('block' === $propertyData['type']) {
-            return $this->createBlock($propertyName, $propertyData);
-        }
-
         if ('section' === $propertyData['type']) {
             return $this->createSection($propertyName, $propertyData);
         }
 
-        $property = new PropertyMetadata();
-        $property->setName($propertyName);
+        $property = new FieldMetadata($propertyName);
         $this->mapProperty($property, $propertyData);
 
         return $property;
@@ -348,12 +342,12 @@ class PropertiesXmlParser
 
     private function createSection($propertyName, $data): SectionMetadata
     {
-        $section = new SectionMetadata();
-        $section->setName($propertyName);
+        $section = new SectionMetadata($propertyName);
         if (isset($data['colspan'])) {
             $section->setColSpan($data['colspan']);
         }
 
+        /* TODO
         if (isset($data['meta']['title'])) {
             $section->setTitles($data['meta']['title']);
         }
@@ -361,6 +355,7 @@ class PropertiesXmlParser
         if (isset($data['meta']['info_text'])) {
             $section->setDescriptions($data['meta']['info_text']);
         }
+        */
 
         if (isset($data['disabledCondition'])) {
             $section->setDisabledCondition($this->normalizeConditionData($data['disabledCondition']));
@@ -371,87 +366,114 @@ class PropertiesXmlParser
         }
 
         foreach ($data['properties'] as $name => $property) {
-            $section->addChild($this->createProperty($name, $property));
+            $section->addItem($this->createProperty($name, $property));
         }
 
         return $section;
     }
 
-    private function createBlock($propertyName, $data): BlockMetadata
-    {
-        $blockProperty = new BlockMetadata();
-        $blockProperty->setName($propertyName);
-
-        if (isset($data['disabledCondition'])) {
-            $blockProperty->setDisabledCondition($this->normalizeConditionData($data['disabledCondition']));
-        }
-
-        if (isset($data['visibleCondition'])) {
-            $blockProperty->setVisibleCondition($this->normalizeConditionData($data['visibleCondition']));
-        }
-
-        if (isset($data['meta']['title'])) {
-            $blockProperty->setTitles($data['meta']['title']);
-        }
-
-        if (isset($data['meta']['info_text'])) {
-            $blockProperty->setDescriptions($data['meta']['info_text']);
-        }
-
-        $this->mapProperty($blockProperty, $data);
-
-        return $blockProperty;
-    }
-
-    private function mapProperty(PropertyMetadata $property, $data): void
+    private function mapProperty(FieldMetadata $property, $data): void
     {
         $data = $this->normalizePropertyData($data);
 
-        $property->defaultComponentName = $data['default-type'];
+        $property->setDefaultType($data['default-type']);
         $property->setType($data['type']);
-        $property->setLocalized($data['multilingual']);
         $property->setRequired($data['mandatory']);
+        // $property->setMultilingual($data['multilingual']); // TODO https://github.com/sulu/sulu/pull/7929
+        $property->setSpaceAfter($data['spaceAfter']);
         if (isset($data['colspan'])) {
             $property->setColSpan($data['colspan']);
         }
-        $property->setSpaceAfter($data['spaceAfter']);
-        $property->setCssClass($data['cssClass']);
         $property->setTags($data['tags']);
         $property->setMinOccurs(null !== $data['minOccurs'] ? \intval($data['minOccurs']) : null);
         $property->setMaxOccurs(null !== $data['maxOccurs'] ? \intval($data['maxOccurs']) : null);
         $property->setDisabledCondition($this->normalizeConditionData($data['disabledCondition'] ?? null));
         $property->setVisibleCondition($this->normalizeConditionData($data['visibleCondition'] ?? null));
-        $property->setParameters($data['params']);
         $property->setOnInvalid(\array_key_exists('onInvalid', $data) ? $data['onInvalid'] : null);
+
+        foreach ($data['params'] as $parameter) {
+            $option = new OptionMetadata();
+            $option->setName($parameter['name']);
+            $option->setType($parameter['type']);
+
+            if (OptionMetadata::TYPE_COLLECTION === $parameter['type']) {
+                foreach ($parameter['value'] as $parameterName => $parameterValue) {
+                    $valueOption = new OptionMetadata();
+                    $valueOption->setName($parameterValue['name']);
+                    $valueOption->setValue($parameterValue['value']);
+
+                    $this->mapOptionMeta($parameterValue, $valueOption);
+
+                    $option->addValueOption($valueOption);
+                }
+            } elseif (OptionMetadata::TYPE_STRING === $parameter['type'] || OptionMetadata::TYPE_EXPRESSION === $parameter['type']) {
+                $option->setValue($parameter['value']);
+                $this->mapOptionMeta($parameter, $option);
+            } else {
+                throw new \Exception('Unsupported parameter given "' . \get_class($parameter) . '"');
+            }
+
+            $property->addOption($option);
+        }
+
+
         $this->mapMeta($property, $data['meta']);
 
         $types = $data['types'];
-        foreach ($types as $name => $type) {
-            $component = new ComponentMetadata();
-            $component->setName($name);
+        foreach ($types as $name => $typeData) {
+            $type = new FormMetadata();
+            $type->setName($name);
+            $type->setTitles($typeData['meta']['title'] ?? []);
 
-            if (isset($type['meta']['title'])) {
-                $component->setTitles($type['meta']['title']);
+            // TODO title
+            // TODO tags
+            // TODO children
+            /*
+            if (isset($typeData['meta']['title'])) {
+                $component->setTitles($typeData['meta']['title']);
             }
 
             if (isset($data['meta']['info_text'])) {
                 $component->setDescriptions($data['meta']['info_text']);
             }
+            */
 
-            if (!$type['ref']) {
-                foreach ($this->mapProperties($type['properties']) as $childProperty) {
-                    $component->addChild($childProperty);
+            if (!$typeData['ref']) {
+                foreach ($this->mapProperties($typeData['properties']) as $childProperty) {
+                    $type->addItem($childProperty);
                 }
             } else {
-                $component->addTag([
-                    'name' => 'sulu.global_block',
-                    'attributes' => [
-                        'global_block' => $name,
-                    ],
+                $tagMetadata = new TagMetadata();
+                $tagMetadata->setName('sulu.global_block');
+                $tagMetadata->setAttributes([
+                    'global_block' => $name,
                 ]);
+
+                $type->addTag($tagMetadata);
             }
 
-            $property->addComponent($component);
+            $property->addType($type);
+        }
+    }
+
+    private function mapOptionMeta(array $parameterValue, OptionMetadata $option): void
+    {
+        if (!\array_key_exists('meta', $parameterValue)) {
+            return;
+        }
+
+        foreach ($parameterValue['meta'] as $metaKey => $metaValues) {
+            switch ($metaKey) {
+                case 'title':
+                    $option->setTitles($metaValues);
+                    break;
+                case 'info_text':
+                    $option->setInfotexts($metaValues);
+                    break;
+                case 'placeholder':
+                    $option->setPlaceholders($metaValues);
+                    break;
+            }
         }
     }
 
@@ -501,13 +523,9 @@ class PropertiesXmlParser
         return $data;
     }
 
-    private function mapMeta(PropertyMetadata $item, $meta): void
+    private function mapMeta(ItemMetadata $item, $meta): void
     {
-        $item->setTitles($meta['title']);
+        $item->setLabels($meta['title']);
         $item->setDescriptions($meta['info_text']);
-
-        if ($item->getPlaceholders()) {
-            $item->setPlaceholders($meta['info_text']);
-        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -37,30 +37,29 @@ class PropertiesXmlParser
     }
 
     public function load(
-        &$tags,
         \DOMXPath $xpath,
         \DOMNode $context,
         ?string $formKey = null
     ): array {
-        $propertyData = $this->loadProperties($tags, $xpath, $context, $formKey);
+        $propertyData = $this->loadProperties($xpath, $context, $formKey);
 
         return $this->mapProperties($propertyData);
     }
 
-    private function loadProperties(&$tags, \DOMXPath $xpath, \DOMNode $context, ?string $formKey): array
+    private function loadProperties(\DOMXPath $xpath, \DOMNode $context, ?string $formKey): array
     {
         $result = [];
 
         /** @var \DOMElement $node */
         foreach ($xpath->query('x:*', $context) as $node) {
             if ('property' === $node->tagName) {
-                $value = $this->loadProperty($xpath, $node, $tags, $formKey);
+                $value = $this->loadProperty($xpath, $node, $formKey);
                 $result[$value['name']] = $value;
             } elseif ('block' === $node->tagName) {
-                $value = $this->loadBlock($xpath, $node, $tags, $formKey);
+                $value = $this->loadBlock($xpath, $node, $formKey);
                 $result[$value['name']] = $value;
             } elseif ('section' === $node->tagName) {
-                $value = $this->loadSection($xpath, $node, $tags, $formKey);
+                $value = $this->loadSection($xpath, $node, $formKey);
                 $result[$value['name']] = $value;
             }
         }
@@ -68,7 +67,7 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadProperty(\DOMXPath $xpath, \DOMNode $node, &$tags, $formKey)
+    private function loadProperty(\DOMXPath $xpath, \DOMNode $node, $formKey)
     {
         $result = $this->loadValues(
             $xpath,
@@ -90,10 +89,10 @@ class PropertiesXmlParser
         $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
         $result['multilingual'] = $this->getValueFromXPath('@multilingual', $xpath, $node, true);
         $result['onInvalid'] = $this->getValueFromXPath('@onInvalid', $xpath, $node);
-        $result['tags'] = $this->loadTags($tags, $xpath, $node);
+        $result['tags'] = $this->loadTags($xpath, $node);
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
         $result['meta'] = $this->loadMeta($xpath, $node);
-        $result['types'] = $this->loadTypes($tags, $xpath, $node, $formKey);
+        $result['types'] = $this->loadTypes($xpath, $node, $formKey);
 
         $typeNames = \array_map(function($type) {
             return $type['name'];
@@ -112,7 +111,7 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function validateTag($tag, &$tags)
+    private function validateTag(&$tags, $tag)
     {
         if (!isset($tags[$tag['name']])) {
             $tags[$tag['name']] = [];
@@ -140,15 +139,15 @@ class PropertiesXmlParser
         return $tag;
     }
 
-    private function loadBlock(\DOMXPath $xpath, \DOMNode $node, &$tags, $formKey)
+    private function loadBlock(\DOMXPath $xpath, \DOMNode $node, $formKey)
     {
-        $result = $this->loadProperty($xpath, $node, $tags, $formKey);
+        $result = $this->loadProperty($xpath, $node, $formKey);
         $result['type'] = 'block';
 
         return $result;
     }
 
-    private function loadSection(\DOMXPath $xpath, \DOMNode $node, &$tags, $formKey)
+    private function loadSection(\DOMXPath $xpath, \DOMNode $node, $formKey)
     {
         $result = $this->loadValues(
             $xpath,
@@ -161,13 +160,14 @@ class PropertiesXmlParser
         $result['meta'] = $this->loadMeta($xpath, $node);
 
         $propertiesNode = $xpath->query('x:properties', $node)->item(0);
-        $result['properties'] = $this->loadProperties($tags, $xpath, $propertiesNode, $formKey);
+        $result['properties'] = $this->loadProperties($xpath, $propertiesNode, $formKey);
 
         return $result;
     }
 
-    private function loadTags(&$tags, \DOMXPath $xpath, ?\DOMNode $context = null)
+    private function loadTags(\DOMXPath $xpath, ?\DOMNode $context = null)
     {
+        $tags = [];
         $result = [];
 
         /** @var \DOMElement $node */
@@ -181,20 +181,20 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadTypes(&$tags, \DOMXPath $xpath, ?\DOMNode $context, $formKey)
+    private function loadTypes(\DOMXPath $xpath, ?\DOMNode $context, $formKey)
     {
         $result = [];
 
         /** @var \DOMElement $node */
         foreach ($xpath->query('x:types/x:type', $context) as $node) {
-            $value = $this->loadType($xpath, $node, $tags, $formKey);
+            $value = $this->loadType($xpath, $node, $formKey);
             $result[$value['name']] = $value;
         }
 
         return $result;
     }
 
-    private function loadType(\DOMXPath $xpath, \DOMNode $node, &$tags, $formKey)
+    private function loadType(\DOMXPath $xpath, \DOMNode $node, $formKey)
     {
         $result = $this->loadValues($xpath, $node, ['name', 'ref']);
         if ($result['ref'] && $result['name']) {
@@ -220,7 +220,7 @@ class PropertiesXmlParser
 
         $propertiesNode = $xpath->query('x:properties', $node)->item(0);
         if ($propertiesNode) {
-            $result['properties'] = $this->loadProperties($tags, $xpath, $propertiesNode, $formKey);
+            $result['properties'] = $this->loadProperties($xpath, $propertiesNode, $formKey);
         }
 
         return $result;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
@@ -16,6 +16,9 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
 
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
 class SchemaXmlParser
 {
     use XmlParserTrait;

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Metadata\Loader\Exception\InvalidXmlException;
 use Sulu\Component\Content\Metadata\Loader\Exception\RequiredPropertyNameNotFoundException;
-use Sulu\Component\Content\Metadata\Loader\Exception\RequiredTagNotFoundException;
 use Sulu\Component\Content\Metadata\Loader\Exception\ReservedPropertyNameException;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\SectionMetadata;
@@ -130,16 +129,12 @@ class StructureXmlLoader extends AbstractLoader
 
     protected function parse($resource, \DOMXPath $xpath, $type)
     {
-        // init running vars
-        $tags = [];
-
         // init result
         $result = $this->loadTemplateAttributes($resource, $xpath, $type);
 
         // load properties
         $propertiesNode = $xpath->query('/x:template/x:properties')->item(0);
         $result['properties'] = $this->propertiesXmlParser->load(
-            $tags,
             $xpath,
             $propertiesNode,
             $type
@@ -186,18 +181,6 @@ class StructureXmlLoader extends AbstractLoader
             ));
             */
         });
-
-        // FIXME until excerpt-template is no page template anymore
-        // - https://github.com/sulu-io/sulu/issues/1220#issuecomment-110704259
-        if (!\array_key_exists('internal', $result) || !$result['internal']) {
-            if (isset($this->requiredTagNames[$type])) {
-                foreach ($this->requiredTagNames[$type] as $requiredTagName) {
-                    if (!\array_key_exists($requiredTagName, $tags)) {
-                        throw new RequiredTagNotFoundException($result['key'], $requiredTagName);
-                    }
-                }
-            }
-        }
 
         return $result;
     }

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -21,7 +21,6 @@ use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Exception\InvalidDefaultTypeException;
 use Sulu\Component\Content\Metadata\Loader\Exception\RequiredPropertyNameNotFoundException;
-use Sulu\Component\Content\Metadata\Loader\Exception\RequiredTagNotFoundException;
 use Sulu\Component\Content\Metadata\Loader\StructureXmlLoader;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -313,16 +312,6 @@ class StructureXmlLoaderTest extends TestCase
         $this->contentTypeManager->has('resource_locator')->willReturn(true);
         $this->contentTypeManager->getAll()->willReturn(['text_line', 'resource_locator']);
         $this->load('template_without_title.xml');
-    }
-
-    public function testLoadRequiredTag(): void
-    {
-        $this->expectException(RequiredTagNotFoundException::class);
-
-        $this->contentTypeManager->has('text_line')->willReturn(true);
-        $this->contentTypeManager->has('resource_locator')->willReturn(true);
-        $this->contentTypeManager->getAll()->willReturn(['text_line', 'resource_locator']);
-        $this->load('template_without_sulu_rlp.xml');
     }
 
     public function testLoadRequiredPropertyOtherType(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Refactor properties xml loader to return new metadata classes instead of old deprecated.

#### Why?

We want to remove the old metadata classes and services for 3.0 as they are build on top of some old phpcr content services.