### PR TITLE
Make new metadata locale independent to contain all data

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -390,6 +390,32 @@ This will only create the service `sulu_media.storage` as the alias to `sulu_med
 Most of the services in the PreviewBundle are now internal. The new `PreviewDefaultsProviderInterface` is
 now the primary means of interacting with the bundle.
 
+### Metadata now locale independent
+
+The Sulu Metadata classes `ItemMetadata`, `SectionMetadata`, `FieldMetadata`, `OptionMetadata` and `FormMetadata` are
+now independent from the locale and contain all metadata for all locales this means setter and getter changed.
+
+```diff
+// getter
+-$metadata->getLabel();
++$metadata->getLabel($locale);
+-$metadata->getTitle();
++$metadata->getTitle($locale);
+-$metadata->getDescription();
++$metadata->getDescription($locale);
+-$metadata->getPlaceholder();
++$metadata->getPlaceholder($locale);
+// setter
+-$metadata->setLabel($label);
++$metadata->setLabel($label, $locale);
+-$metadata->setTitle($title);
++$metadata->setTitle($title, $locale);
+-$metadata->setDescription($description);
++$metadata->setDescription($description, $locale);
+-$metadata->setPlaceholder($placeholder);
++$metadata->setPlaceholder($placeholder, $locale);
+```
+
 ### Upgrade resourceLocator and route property type
 
 The new content structure used in Sulu 3.0 requires that all the `resource_locators` or `route` properties must be

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1945,12 +1945,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Expression on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.expr
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapChildren\(\) has parameter \$children with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1987,9 +1981,21 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$infoText of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setInfotext\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$descriptions of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setDescriptions\(\) expects array\<string, string\>, array given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+
+		-
+			message: '#^Parameter \#1 \$infoTexts of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setInfoTexts\(\) expects array\<string, string\>, mixed given\.$#'
 			identifier: argument.type
 			count: 1
+			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+
+		-
+			message: '#^Parameter \#1 \$labels of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setLabels\(\) expects array\<string, string\>, array given\.$#'
+			identifier: argument.type
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
@@ -2053,19 +2059,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$placeholder of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setPlaceholder\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$placeholders of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setPlaceholders\(\) expects array\<string, string\>, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
 			message: '#^Parameter \#1 \$priority of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:setPriority\(\) expects int\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
-			message: '#^Parameter \#1 \$string of function ucfirst expects string, float\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -2083,7 +2083,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$title of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setTitle\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$titles of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTitles\(\) expects array\<string, string\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+
+		-
+			message: '#^Parameter \#1 \$titles of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setTitles\(\) expects array\<string, string\>, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -2092,12 +2098,6 @@ parameters:
 			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setValue\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
@@ -2239,19 +2239,25 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
 
 		-
-			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:\$description \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTitles\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setDescription\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setLabel\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
 
 		-
 			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:\$disabledCondition \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:\$label \(string\) does not accept string\|null\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
@@ -2270,6 +2276,12 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:getType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setTitle\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
@@ -3103,12 +3115,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
 
 		-
-			message: '#^Expression on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.expr
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\StructureFormMetadataLoader\:\:__construct\(\) has parameter \$defaultTypes with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -3145,13 +3151,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
 
 		-
-			message: '#^Parameter \#1 \$string of function ucfirst expects string, float\|int\|string given\.$#'
+			message: '#^Parameter \#1 \$tags of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTags\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\>, array given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
 
 		-
-			message: '#^Parameter \#1 \$tags of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTags\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\>, array given\.$#'
+			message: '#^Parameter \#1 \$titles of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTitles\(\) expects array\<string, string\>, array given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -4761,7 +4767,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 8
+			count: 9
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
@@ -4803,7 +4809,7 @@ parameters:
 		-
 			message: '#^Cannot call method getTitle\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 3
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
@@ -4815,7 +4821,7 @@ parameters:
 		-
 			message: '#^Cannot call method getValue\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 8
+			count: 9
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -191,13 +191,15 @@ class AdminController
     public function metadataAction(string $type, string $key, Request $request): Response
     {
         $user = $this->tokenStorage->getToken()->getUser();
+        $locale = $user->getLocale();
 
         $metadataOptions = $request->query->all();
         $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)
-            ->getMetadata($key, $user->getLocale(), $metadataOptions);
+            ->getMetadata($key, $locale, $metadataOptions);
 
         $context = new Context();
         $context->addGroup('Default');
+        $context->setAttribute('locale', $locale);
         if (true === \filter_var($metadataOptions['onlyKeys'] ?? 'false', \FILTER_VALIDATE_BOOLEAN)) {
             $context->addGroup('admin_form_metadata_keys_only');
         }

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormXmlLoader.php
@@ -92,7 +92,7 @@ class FormXmlLoader extends AbstractLoader
     {
         $form = new FormMetadata();
         $form->setTags($this->formMetadataMapper->mapTags($formMetadata->getTags()));
-        $form->setItems($this->formMetadataMapper->mapChildren($formMetadata->getChildren(), $locale));
+        $form->setItems($this->formMetadataMapper->mapChildren($formMetadata->getChildren()));
 
         $schema = $this->formMetadataMapper->mapSchema($formMetadata->getProperties());
         $xmlSchema = $formMetadata->getSchema();

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -25,10 +25,10 @@ class FormMetadata extends AbstractMetadata
     private $name;
 
     /**
-     * @var string
+     * @var array<string, string>
      */
-    #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
-    private $title;
+    #[Exclude]
+    private $titles = [];
 
     /**
      * @var ItemMetadata[]
@@ -80,14 +80,36 @@ class FormMetadata extends AbstractMetadata
         return $this->key;
     }
 
-    public function setTitle(string $title)
+    public function setTitle(string $title, string $locale)
     {
-        $this->title = $title;
+        $this->titles[$locale] = $title;
     }
 
-    public function getTitle(): string
+    /**
+     * @param array<string, string> $titles
+     */
+    public function setTitles(array $titles)
     {
-        return $this->title;
+        $this->titles = $titles;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getTitles(): array
+    {
+        return $this->titles;
+    }
+
+    public function getTitle(string $locale): string
+    {
+        if (isset($this->titles[$locale])) {
+            return $this->titles[$locale];
+        }
+
+        return \count($this->titles)
+            ? $this->titles[\array_key_first($this->titles)]
+            : ($this->name ? \ucfirst($this->name) : '');
     }
 
     /**
@@ -164,8 +186,8 @@ class FormMetadata extends AbstractMetadata
         if ($this->name) {
             $mergedForm->setName($this->name);
         }
-        if ($this->title) {
-            $mergedForm->setTitle($this->title);
+        if ($this->titles) {
+            $mergedForm->setTitles($this->titles);
         }
 
         $mergedForm->setTags(\array_merge($this->getTags(), $otherForm->getTags()));

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
@@ -22,9 +22,16 @@ abstract class ItemMetadata
     protected $name;
 
     /**
-     * @var string
+     * @var array<string, string>
      */
-    protected $label;
+    #[Serializer\Exclude]
+    protected $labels = [];
+
+    /**
+     * @var array<string, string>
+     */
+    #[Serializer\Exclude]
+    protected $descriptions = [];
 
     /**
      * @var string
@@ -35,11 +42,6 @@ abstract class ItemMetadata
      * @var string
      */
     protected $visibleCondition;
-
-    /**
-     * @var string
-     */
-    protected $description;
 
     /**
      * @var string
@@ -61,14 +63,64 @@ abstract class ItemMetadata
         return $this->name;
     }
 
-    public function getLabel(): ?string
+    public function setLabel(string $label, string $locale)
     {
-        return $this->label;
+        $this->labels[$locale] = $label;
     }
 
-    public function setLabel(?string $label): void
+    /**
+     * @return array<string, string>
+     */
+    public function getLabels(): array
     {
-        $this->label = $label;
+        return $this->labels;
+    }
+
+    public function getLabel(string $locale): ?string
+    {
+        if (isset($this->labels[$locale])) {
+            return $this->labels[$locale];
+        }
+
+        return \count($this->labels) ? $this->labels[\array_key_first($this->labels)] : null;
+    }
+
+    /**
+     * @param array<string, string> $labels
+     */
+    public function setLabels(array $labels): void
+    {
+        $this->labels = $labels;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getDescriptions(): array
+    {
+        return $this->descriptions;
+    }
+
+    public function getDescription(string $locale): ?string
+    {
+        if (isset($this->descriptions[$locale])) {
+            return $this->descriptions[$locale];
+        }
+
+        return \count($this->descriptions) ? $this->descriptions[\array_key_first($this->descriptions)] : null;
+    }
+
+    /**
+     * @param array<string, string> $descriptions
+     */
+    public function setDescriptions(array $descriptions): void
+    {
+        $this->descriptions = $descriptions;
+    }
+
+    public function setDescription(string $description, string $locale)
+    {
+        $this->descriptions[$locale] = $description;
     }
 
     public function getDisabledCondition(): ?string
@@ -89,16 +141,6 @@ abstract class ItemMetadata
     public function setVisibleCondition(?string $visibleCondition): void
     {
         $this->visibleCondition = $visibleCondition;
-    }
-
-    public function getDescription(): ?string
-    {
-        return $this->description;
-    }
-
-    public function setDescription(?string $description): void
-    {
-        $this->description = $description;
     }
 
     public function getColSpan(): int

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
+use JMS\Serializer\Annotation as Serializer;
+
 class OptionMetadata
 {
     public const TYPE_STRING = 'string';
@@ -35,19 +37,22 @@ class OptionMetadata
     protected $value;
 
     /**
-     * @var ?string
+     * @var array<string, string>
      */
-    protected $title;
+    #[Serializer\Exclude]
+    protected $titles = [];
 
     /**
-     * @var ?string
+     * @var array<string, string>
      */
-    protected $placeholder;
+    #[Serializer\Exclude]
+    protected $placeholders = [];
 
     /**
-     * @var ?string
+     * @var array<string, string>
      */
-    protected $infoText;
+    #[Serializer\Exclude]
+    protected $infoTexts = [];
 
     /**
      * @return null|string|int|float
@@ -100,33 +105,83 @@ class OptionMetadata
         $this->value[] = $option;
     }
 
-    public function getTitle(): ?string
+    public function getTitle(string $locale): ?string
     {
-        return $this->title;
+        if (\array_key_exists($locale, $this->titles)) {
+            return $this->titles[$locale];
+        }
+
+        return \count($this->titles) ? $this->titles[\array_key_first($this->titles)] : null;
     }
 
-    public function setTitle(?string $title = null): void
+    /**
+     * @param array<string, string> $titles
+     */
+    public function setTitles(array $titles): void
     {
-        $this->title = $title;
+        $this->titles = $titles;
     }
 
-    public function getPlaceholder(): ?string
+    public function setTitle(string $title, string $locale)
     {
-        return $this->placeholder;
+        $this->titles[$locale] = $title;
     }
 
-    public function setPlaceholder(?string $placeholder = null): void
+    /**
+     * @return array<string, string>
+     */
+    public function getTitles(): array
     {
-        $this->placeholder = $placeholder;
+        return $this->titles;
     }
 
-    public function getInfotext(): ?string
+    public function getInfotext(string $locale): ?string
     {
-        return $this->infoText;
+        if (\array_key_exists($locale, $this->infoTexts)) {
+            return $this->infoTexts[$locale];
+        }
+
+        return \count($this->infoTexts) ? $this->infoTexts[\array_key_first($this->infoTexts)] : null;
     }
 
-    public function setInfotext(?string $infoText = null): void
+    /**
+     * @param array<string, string> $infoTexts
+     */
+    public function setInfoTexts(array $infoTexts): void
     {
-        $this->infoText = $infoText;
+        $this->infoTexts = $infoTexts;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getInfoTexts(): array
+    {
+        return $this->infoTexts;
+    }
+
+    public function getPlaceholder(string $locale): ?string
+    {
+        if (\array_key_exists($locale, $this->placeholders)) {
+            return $this->placeholders[$locale];
+        }
+
+        return \count($this->placeholders) ? $this->placeholders[\array_key_first($this->placeholders)] : null;
+    }
+
+    /**
+     * @param array<string, string> $placeholders
+     */
+    public function setPlaceholders(array $placeholders): void
+    {
+        $this->placeholders = $placeholders;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getPlaceholders(): array
+    {
+        return $this->placeholders;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -163,8 +163,8 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
             $form = new FormMetadata();
             $form->setTags($this->formMetadataMapper->mapTags($structureMetadata->getTags()));
             $form->setName($structureMetadata->getName());
-            $form->setTitle($structureMetadata->getTitle($locale) ?? \ucfirst($structureMetadata->getName()));
-            $form->setItems($this->formMetadataMapper->mapChildren($structureMetadata->getChildren(), $locale));
+            $form->setTitles($structureMetadata->getTitles());
+            $form->setItems($this->formMetadataMapper->mapChildren($structureMetadata->getChildren()));
 
             $schema = $this->formMetadataMapper->mapSchema($structureMetadata->getProperties());
             $xmlSchema = $structureMetadata->getSchema();

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitor.php
@@ -46,7 +46,7 @@ class LocalesOptionFormMetadataVisitor implements FormMetadataVisitorInterface
             $option = new OptionMetadata();
             $option->setName($locale);
             $option->setValue($locale);
-            $option->setTitle($locale);
+            $option->setTitle($locale, $locale);
 
             return $option;
         }, $locales));

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -244,6 +244,12 @@
             <tag name="jms_serializer.event_subscriber"/>
         </service>
 
+        <service id="sulu_admin.item_metadata_serializer_subscriber"
+            class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\MetadataSubscriber"
+        >
+            <tag name="jms_serializer.event_subscriber"/>
+        </service>
+
         <service id="sulu_admin.save_with_form_dialog_toolbar_action_subscriber"
             class="Sulu\Bundle\AdminBundle\Serializer\Subscriber\SaveWithFormDialogToolbarActionSubscriber"
         >

--- a/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/MetadataSubscriber.php
+++ b/src/Sulu/Bundle/AdminBundle/Serializer/Subscriber/MetadataSubscriber.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Serializer\Subscriber;
+
+use JMS\Serializer\EventDispatcher\Events;
+use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
+use JMS\Serializer\EventDispatcher\ObjectEvent;
+use JMS\Serializer\JsonSerializationVisitor;
+use JMS\Serializer\Metadata\StaticPropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
+
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
+class MetadataSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @return array<array{
+     *     event: string,
+     *     format: string,
+     *     method: string,
+     *     class: class-string,
+     * }>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'onPostSerializeFormMetadata',
+                'class' => FormMetadata::class,
+            ],
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'onPostSerializeItemMetadata',
+                'class' => ItemMetadata::class,
+            ],
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'onPostSerializeItemMetadata',
+                'class' => FieldMetadata::class,
+            ],
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'onPostSerializeItemMetadata',
+                'class' => SectionMetadata::class,
+            ],
+            [
+                'event' => Events::POST_SERIALIZE,
+                'format' => 'json',
+                'method' => 'onPostSerializeOptionMetadata',
+                'class' => OptionMetadata::class,
+            ],
+        ];
+    }
+
+    public function onPostSerializeFormMetadata(ObjectEvent $event): void
+    {
+        /** @var FormMetadata $formMetadata */
+        $formMetadata = $event->getObject();
+        $groups = $this->extractGroups($event);
+        $locale = $this->extractLocale($event);
+
+        if (null === $locale
+            || \in_array('admin_form_metadata_keys_only', $groups)
+        ) {
+            return;
+        }
+
+        $this->addProperties($event, [
+            'title' => $formMetadata->getTitle($locale),
+        ]);
+    }
+
+    public function onPostSerializeItemMetadata(ObjectEvent $event): void
+    {
+        /** @var ItemMetadata $itemMetadata */
+        $itemMetadata = $event->getObject();
+        $groups = $this->extractGroups($event);
+        $locale = $this->extractLocale($event);
+
+        if (null === $locale
+            || \in_array('admin_form_metadata_keys_only', $groups)
+        ) {
+            return;
+        }
+
+        $this->addProperties($event, [
+            'label' => $itemMetadata->getLabel($locale),
+            'description' => $itemMetadata->getDescription($locale),
+        ]);
+    }
+
+    public function onPostSerializeOptionMetadata(ObjectEvent $event): void
+    {
+        /** @var OptionMetadata $optionMetadata */
+        $optionMetadata = $event->getObject();
+        $groups = $this->extractGroups($event);
+        $locale = $this->extractLocale($event);
+
+        if (null === $locale
+            || \in_array('admin_form_metadata_keys_only', $groups)
+        ) {
+            return;
+        }
+
+        $this->addProperties($event, [
+            'title' => $optionMetadata->getTitle($locale),
+            'infoText' => $optionMetadata->getInfoText($locale),
+            'placeholder' => $optionMetadata->getPlaceholder($locale),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     */
+    private function addProperties(ObjectEvent $event, array $properties): void
+    {
+        /** @var JsonSerializationVisitor $visitor */
+        $visitor = $event->getVisitor();
+
+        foreach ($properties as $name => $value) {
+            if (null === $value) {
+                continue;
+            }
+
+            $visitor->visitProperty(new StaticPropertyMetadata('', $name, $value), $value);
+            $visitor->setData($name, $value);
+        }
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function extractGroups(ObjectEvent $event): array
+    {
+        $groups = $event->getContext()->getAttribute('groups');
+
+        return \is_array($groups) ? $groups : [];
+    }
+
+    private function extractLocale(ObjectEvent $event): ?string
+    {
+        $locale = $event->getContext()->getAttribute('locale');
+
+        return \is_string($locale) ? $locale : null;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -13,10 +13,15 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\AdminBundle\Tests\Functional\Controller;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sulu\Bundle\AdminBundle\Controller\AdminController;
+use Sulu\Bundle\AdminBundle\Serializer\Subscriber\MetadataSubscriber;
 use Sulu\Bundle\MediaBundle\DataFixtures\ORM\LoadCollectionTypes;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
+#[CoversClass(AdminController::class)]
+#[CoversClass(MetadataSubscriber::class)]
 class AdminControllerTest extends SuluTestCase
 {
     /**
@@ -181,11 +186,11 @@ class AdminControllerTest extends SuluTestCase
         $defaultMetadata = $metaData['types']['default'];
         $overviewMetadata = $metaData['types']['overview'];
         $this->assertSame(
-            \json_decode((string) \file_get_contents(__DIR__ . '/fixtures/default.json'), true),
-            $defaultMetadata);
-        $this->assertSame(
             \json_decode((string) \file_get_contents(__DIR__ . '/fixtures/overview.json'), true),
             $overviewMetadata);
+        $this->assertSame(
+            \json_decode((string) \file_get_contents(__DIR__ . '/fixtures/default.json'), true),
+            $defaultMetadata);
     }
 
     public function testGetMetaDataGhostLocale(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -1,12 +1,9 @@
 {
     "name": "default",
-    "title": "Animals",
     "form": {
         "title": {
-            "label": "Animals",
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "text_line",
             "colSpan": 12,
             "options": [],
@@ -24,13 +21,12 @@
                     "priority": 100,
                     "attributes": []
                 }
-            ]
+            ],
+            "label": "Animals"
         },
         "url": {
-            "label": "Resourcelocator",
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "resource_locator",
             "colSpan": 12,
             "options": [],
@@ -48,13 +44,12 @@
                     "priority": null,
                     "attributes": []
                 }
-            ]
+            ],
+            "label": "Resourcelocator"
         },
         "blog": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "text_area",
             "colSpan": 12,
             "options": [],
@@ -69,10 +64,8 @@
             "tags": []
         },
         "localized_blog": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "text_area",
             "colSpan": 12,
             "options": [],
@@ -87,34 +80,26 @@
             "tags": []
         },
         "content": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": null,
             "type": "section",
             "colSpan": 12,
             "items": {
                 "blocks": {
-                    "label": null,
                     "disabledCondition": null,
                     "visibleCondition": null,
-                    "description": "",
                     "type": "block",
                     "colSpan": 12,
                     "options": {
                         "settings_form_key": {
                             "name": "settings_form_key",
                             "type": null,
-                            "value": "page_block_settings",
-                            "title": null,
-                            "placeholder": null,
-                            "infoText": null
+                            "value": "page_block_settings"
                         }
                     },
                     "types": {
                         "text_block": {
                             "name": "text_block",
-                            "title": "Text Block",
                             "form": [],
                             "schema": {
                                 "type": [
@@ -135,11 +120,11 @@
                                         "global_block": "text_block"
                                     }
                                 }
-                            ]
+                            ],
+                            "title": "Text Block"
                         },
                         "text_block2": {
                             "name": "text_block2",
-                            "title": "Text Block 2",
                             "form": [],
                             "schema": {
                                 "type": [
@@ -160,17 +145,15 @@
                                         "global_block": "text_block2"
                                     }
                                 }
-                            ]
+                            ],
+                            "title": "Text Block 2"
                         },
                         "editor": {
                             "name": "editor",
-                            "title": "Editor",
                             "form": {
                                 "text_editor": {
-                                    "label": "Text Editor",
                                     "disabledCondition": null,
                                     "visibleCondition": null,
-                                    "description": "",
                                     "type": "text_editor",
                                     "colSpan": 12,
                                     "options": [],
@@ -182,7 +165,8 @@
                                     "minOccurs": null,
                                     "maxOccurs": null,
                                     "onInvalid": null,
-                                    "tags": []
+                                    "tags": [],
+                                    "label": "Text Editor"
                                 }
                             },
                             "schema": {
@@ -196,17 +180,15 @@
                                 ]
                             },
                             "key": null,
-                            "tags": []
+                            "tags": [],
+                            "title": "Editor"
                         },
                         "block": {
                             "name": "block",
-                            "title": "Block",
                             "form": {
                                 "title": {
-                                    "label": null,
                                     "disabledCondition": null,
                                     "visibleCondition": null,
-                                    "description": "",
                                     "type": "text_line",
                                     "colSpan": 12,
                                     "options": [],
@@ -221,26 +203,20 @@
                                     "tags": []
                                 },
                                 "blocks": {
-                                    "label": null,
                                     "disabledCondition": null,
                                     "visibleCondition": null,
-                                    "description": "",
                                     "type": "block",
                                     "colSpan": 12,
                                     "options": {
                                         "settings_form_key": {
                                             "name": "settings_form_key",
                                             "type": null,
-                                            "value": "page_block_settings",
-                                            "title": null,
-                                            "placeholder": null,
-                                            "infoText": null
+                                            "value": "page_block_settings"
                                         }
                                     },
                                     "types": {
                                         "text_block2": {
                                             "name": "text_block2",
-                                            "title": "Text Block 2",
                                             "form": [],
                                             "schema": {
                                                 "type": [
@@ -261,11 +237,11 @@
                                                         "global_block": "text_block2"
                                                     }
                                                 }
-                                            ]
+                                            ],
+                                            "title": "Text Block 2"
                                         },
                                         "text_block3": {
                                             "name": "text_block3",
-                                            "title": "Text Block 3",
                                             "form": [],
                                             "schema": {
                                                 "type": [
@@ -286,7 +262,8 @@
                                                         "global_block": "text_block3"
                                                     }
                                                 }
-                                            ]
+                                            ],
+                                            "title": "Text Block 3"
                                         }
                                     },
                                     "defaultType": "text_block2",
@@ -310,7 +287,8 @@
                                 ]
                             },
                             "key": null,
-                            "tags": []
+                            "tags": [],
+                            "title": "Block"
                         }
                     },
                     "defaultType": "text_block",
@@ -626,5 +604,6 @@
                 "value": "test-value"
             }
         }
-    ]
+    ],
+    "title": "Animals"
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
@@ -1,12 +1,9 @@
 {
     "name": "overview",
-    "title": "Overview",
     "form": {
         "title": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "text_line",
             "colSpan": 12,
             "options": [],
@@ -27,10 +24,8 @@
             ]
         },
         "tags": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "text_line",
             "colSpan": 12,
             "options": [],
@@ -45,10 +40,8 @@
             "tags": []
         },
         "url": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "resource_locator",
             "colSpan": 12,
             "options": [],
@@ -69,10 +62,8 @@
             ]
         },
         "article": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "text_area",
             "colSpan": 12,
             "options": [],
@@ -87,10 +78,8 @@
             "tags": []
         },
         "blog": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "text_area",
             "colSpan": 12,
             "options": [],
@@ -105,10 +94,8 @@
             "tags": []
         },
         "external": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "url",
             "colSpan": 12,
             "options": [],
@@ -123,32 +110,24 @@
             "tags": []
         },
         "blocks": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "block",
             "colSpan": 12,
             "options": {
                 "settings_form_key": {
                     "name": "settings_form_key",
                     "type": null,
-                    "value": "page_block_settings",
-                    "title": null,
-                    "placeholder": null,
-                    "infoText": null
+                    "value": "page_block_settings"
                 }
             },
             "types": {
                 "editor": {
                     "name": "editor",
-                    "title": "Editor",
                     "form": {
                         "text_editor": {
-                            "label": "Text Editor",
                             "disabledCondition": null,
                             "visibleCondition": null,
-                            "description": "",
                             "type": "text_editor",
                             "colSpan": 12,
                             "options": [],
@@ -160,7 +139,8 @@
                             "minOccurs": null,
                             "maxOccurs": null,
                             "onInvalid": null,
-                            "tags": []
+                            "tags": [],
+                            "label": "Text Editor"
                         }
                     },
                     "schema": {
@@ -174,7 +154,8 @@
                         ]
                     },
                     "key": null,
-                    "tags": []
+                    "tags": [],
+                    "title": "Editor"
                 }
             },
             "defaultType": "editor",
@@ -187,32 +168,24 @@
             "tags": []
         },
         "blocks_with_custom_settings_form_key": {
-            "label": null,
             "disabledCondition": null,
             "visibleCondition": null,
-            "description": "",
             "type": "block",
             "colSpan": 12,
             "options": {
                 "settings_form_key": {
                     "name": "settings_form_key",
                     "type": "string",
-                    "value": "custom_block_settings",
-                    "title": null,
-                    "placeholder": null,
-                    "infoText": null
+                    "value": "custom_block_settings"
                 }
             },
             "types": {
                 "editor": {
                     "name": "editor",
-                    "title": "Editor",
                     "form": {
                         "text_editor": {
-                            "label": "Text Editor",
                             "disabledCondition": null,
                             "visibleCondition": null,
-                            "description": "",
                             "type": "text_editor",
                             "colSpan": 12,
                             "options": [],
@@ -224,7 +197,8 @@
                             "minOccurs": null,
                             "maxOccurs": null,
                             "onInvalid": null,
-                            "tags": []
+                            "tags": [],
+                            "label": "Text Editor"
                         }
                     },
                     "schema": {
@@ -238,7 +212,8 @@
                         ]
                     },
                     "key": null,
-                    "tags": []
+                    "tags": [],
+                    "title": "Editor"
                 }
             },
             "defaultType": "editor",
@@ -373,5 +348,6 @@
             "priority": null,
             "attributes": []
         }
-    ]
+    ],
+    "title": "Overview"
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -46,7 +46,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $overviewForm = $typedForm->getForms()['overview'];
         $this->assertInstanceOf(FormMetadata::class, $overviewForm);
         $this->assertEquals('overview', $overviewForm->getName());
-        $this->assertEquals('Overview', $overviewForm->getTitle());
+        $this->assertEquals('Overview', $overviewForm->getTitle('en'));
         $this->assertCount(8, $overviewForm->getItems());
         $this->assertCount(1, $overviewForm->getTags());
         $this->assertNotNull($overviewForm->getSchema());
@@ -59,7 +59,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $defaultForm = $typedForm->getForms()['default'];
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
         $this->assertEquals('default', $defaultForm->getName());
-        $this->assertEquals('Animals', $defaultForm->getTitle());
+        $this->assertEquals('Animals', $defaultForm->getTitle('en'));
         $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
@@ -81,7 +81,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $overviewForm = $typedForm->getForms()['overview'];
         $this->assertInstanceOf(FormMetadata::class, $overviewForm);
         $this->assertEquals('overview', $overviewForm->getName());
-        $this->assertEquals('Overview', $overviewForm->getTitle());
+        $this->assertEquals('Overview', $overviewForm->getTitle('de'));
         $this->assertCount(8, $overviewForm->getItems());
         $this->assertCount(1, $overviewForm->getTags());
         $this->assertNotNull($overviewForm->getSchema());
@@ -90,7 +90,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $defaultForm = $typedForm->getForms()['default'];
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
         $this->assertEquals('default', $defaultForm->getName());
-        $this->assertEquals('Tiers', $defaultForm->getTitle());
+        $this->assertEquals('Tiers', $defaultForm->getTitle('de'));
         $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());
@@ -131,7 +131,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
         $defaultForm = $typedForm->getForms()['default'];
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
         $this->assertEquals('default', $defaultForm->getName());
-        $this->assertEquals('Tiers', $defaultForm->getTitle());
+        $this->assertEquals('Tiers', $defaultForm->getTitle('de'));
         $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());
         $this->assertNotNull($defaultForm->getSchema());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -100,7 +100,7 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     public function testGetMetadataWithoutLabel(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_without_label', 'en');
-        $this->assertNull($form->getItems()['name']->getLabel());
+        $this->assertNull($form->getItems()['name']->getLabel('en'));
     }
 
     public function testGetMetadataFromMultipleFiles(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -84,7 +84,7 @@ class FormMetadataMapperTest extends TestCase
         $form = $this->createFormWithBasicProperties();
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'en'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(3, $newForm->getItems());
         $this->assertContains('property1', \array_keys($newForm->getItems()));
@@ -95,8 +95,8 @@ class FormMetadataMapperTest extends TestCase
         $this->assertInstanceOf(FieldMetadata::class, $newProperty1);
         $this->assertEquals('property1', $newProperty1->getName());
         $this->assertEquals('text_line', $newProperty1->getType());
-        $this->assertEquals('English', $newProperty1->getLabel());
-        $this->assertEquals('Description', $newProperty1->getDescription());
+        $this->assertEquals('English', $newProperty1->getLabel('en'));
+        $this->assertEquals('Description', $newProperty1->getDescription('en'));
         $this->assertEquals('disabledCondition', $newProperty1->getDisabledCondition());
         $this->assertEquals('visibleCondition', $newProperty1->getVisibleCondition());
         $this->assertEquals(6, $newProperty1->getColSpan());
@@ -111,7 +111,7 @@ class FormMetadataMapperTest extends TestCase
         $form = $this->createFormWithBasicProperties();
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'de'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(3, $newForm->getItems());
         $this->assertContains('property1', \array_keys($newForm->getItems()));
@@ -122,8 +122,8 @@ class FormMetadataMapperTest extends TestCase
         $this->assertInstanceOf(FieldMetadata::class, $property1);
         $this->assertEquals('property1', $property1->getName());
         $this->assertEquals('text_line', $property1->getType());
-        $this->assertEquals('Deutsch', $property1->getLabel());
-        $this->assertEquals('Beschreibung', $property1->getDescription());
+        $this->assertEquals('Deutsch', $property1->getLabel('de'));
+        $this->assertEquals('Beschreibung', $property1->getDescription('de'));
         $this->assertEquals('disabledCondition', $property1->getDisabledCondition());
         $this->assertEquals('visibleCondition', $property1->getVisibleCondition());
         $this->assertEquals(6, $property1->getColSpan());
@@ -137,7 +137,7 @@ class FormMetadataMapperTest extends TestCase
         $form = $this->createFormWithAdvancedProperty();
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'en'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(1, $newForm->getItems());
         $this->assertContains('name', \array_keys($newForm->getItems()));
@@ -195,7 +195,7 @@ class FormMetadataMapperTest extends TestCase
         $property->defaultComponentName = 'component1';
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'en'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(1, $newForm->getItems());
         $this->assertContains('name', \array_keys($newForm->getItems()));
@@ -209,13 +209,13 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals(2, $item->getMaxOccurs());
 
         $this->assertEquals('component1', $item->getTypes()['component1']->getName());
-        $this->assertEquals('First Component', $item->getTypes()['component1']->getTitle());
+        $this->assertEquals('First Component', $item->getTypes()['component1']->getTitle('en'));
         $this->assertCount(2, $item->getTypes()['component1']->getItems());
         $this->assertContains('property1', \array_keys($item->getTypes()['component1']->getItems()));
         $this->assertContains('property2', \array_keys($item->getTypes()['component1']->getItems()));
 
         $this->assertEquals('component2', $item->getTypes()['component2']->getName());
-        $this->assertEquals('Second Component', $item->getTypes()['component2']->getTitle());
+        $this->assertEquals('Second Component', $item->getTypes()['component2']->getTitle('en'));
         $this->assertCount(2, $item->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($item->getTypes()['component2']->getItems()));
         $this->assertContains('property4', \array_keys($item->getTypes()['component2']->getItems()));
@@ -260,7 +260,7 @@ class FormMetadataMapperTest extends TestCase
         $property->defaultComponentName = 'component1';
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'en'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(1, $newForm->getItems());
         $this->assertContains('name', \array_keys($newForm->getItems()));
@@ -274,11 +274,11 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals(2, $item->getMaxOccurs());
 
         $this->assertEquals('component1', $item->getTypes()['component1']->getName());
-        $this->assertEquals('First Component', $item->getTypes()['component1']->getTitle());
+        $this->assertEquals('First Component', $item->getTypes()['component1']->getTitle('en'));
         $this->assertCount(0, $item->getTypes()['component1']->getItems());
 
         $this->assertEquals('component2', $item->getTypes()['component2']->getName());
-        $this->assertEquals('Second Component', $item->getTypes()['component2']->getTitle());
+        $this->assertEquals('Second Component', $item->getTypes()['component2']->getTitle('en'));
         $this->assertCount(2, $item->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($item->getTypes()['component2']->getItems()));
         $this->assertContains('property4', \array_keys($item->getTypes()['component2']->getItems()));
@@ -289,7 +289,7 @@ class FormMetadataMapperTest extends TestCase
         $form = $this->createFormWithAdvancedProperty();
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'en'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(1, $newForm->getItems());
         $this->assertContains('name', \array_keys($newForm->getItems()));
@@ -302,17 +302,18 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals('label', $item->getOptions()['label']->getName());
         $this->assertEquals('string', $item->getOptions()['label']->getType());
         $this->assertEquals(1, $item->getOptions()['label']->getValue());
-        $this->assertEquals('LabelEnglish', $item->getOptions()['label']->getTitle());
-        $this->assertNull($item->getOptions()['label']->getPlaceholder());
-        $this->assertNull($item->getOptions()['label']->getInfoText());
+        $this->assertEquals('LabelEnglish', $item->getOptions()['label']->getTitle('en'));
+        $this->assertNull($item->getOptions()['label']->getPlaceholder('en'));
+        $this->assertNull($item->getOptions()['label']->getInfoText('en'));
 
         $this->assertEquals('form_options', $item->getOptions()['form_options']->getName());
         $this->assertEquals('collection', $item->getOptions()['form_options']->getType());
         $this->assertEquals('webspace', $item->getOptions()['form_options']->getValue()[0]->getName());
         $this->assertEquals(10, $item->getOptions()['form_options']->getValue()[0]->getValue());
         $this->assertNull($item->getOptions()['form_options']->getValue()[0]->getType());
-        $this->assertNull($item->getOptions()['form_options']->getValue()[0]->getPlaceholder());
-        $this->assertNull($item->getOptions()['form_options']->getValue()[0]->getInfoText());
+        $this->assertNull($item->getOptions()['form_options']->getValue()[0]->getTitle('en'));
+        $this->assertNull($item->getOptions()['form_options']->getValue()[0]->getPlaceholder('en'));
+        $this->assertNull($item->getOptions()['form_options']->getValue()[0]->getInfoText('en'));
     }
 
     public function testMapPropertiesWithParametersGerman(): void
@@ -320,7 +321,7 @@ class FormMetadataMapperTest extends TestCase
         $form = $this->createFormWithAdvancedProperty();
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'de'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(1, $newForm->getItems());
         $this->assertContains('name', \array_keys($newForm->getItems()));
@@ -333,7 +334,7 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals('label', $item->getOptions()['label']->getName());
         $this->assertEquals('string', $item->getOptions()['label']->getType());
         $this->assertEquals(1, $item->getOptions()['label']->getValue());
-        $this->assertEquals('LabelDeutsch', $item->getOptions()['label']->getTitle());
+        $this->assertEquals('LabelDeutsch', $item->getOptions()['label']->getTitle('de'));
     }
 
     public function testMapChildrenWithSection(): void
@@ -341,7 +342,7 @@ class FormMetadataMapperTest extends TestCase
         $form = $this->createFormWithSection();
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'en'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(2, $newForm->getItems());
         $this->assertContains('section', \array_keys($newForm->getItems()));
@@ -367,7 +368,7 @@ class FormMetadataMapperTest extends TestCase
         $form = $this->createFormWithBlock();
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'en'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(1, $newForm->getItems());
         $this->assertContains('block', \array_keys($newForm->getItems()));
@@ -380,13 +381,13 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals(2, $block->getMaxOccurs());
 
         $this->assertEquals('component1', $block->getTypes()['component1']->getName());
-        $this->assertEquals('First Component', $block->getTypes()['component1']->getTitle());
+        $this->assertEquals('First Component', $block->getTypes()['component1']->getTitle('en'));
         $this->assertCount(2, $block->getTypes()['component1']->getItems());
         $this->assertContains('property1', \array_keys($block->getTypes()['component1']->getItems()));
         $this->assertContains('property2', \array_keys($block->getTypes()['component1']->getItems()));
 
         $this->assertEquals('component2', $block->getTypes()['component2']->getName());
-        $this->assertEquals('Second Component', $block->getTypes()['component2']->getTitle());
+        $this->assertEquals('Second Component', $block->getTypes()['component2']->getTitle('en'));
         $this->assertCount(2, $block->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($block->getTypes()['component2']->getItems()));
         $this->assertContains('property4', \array_keys($block->getTypes()['component2']->getItems()));
@@ -397,7 +398,7 @@ class FormMetadataMapperTest extends TestCase
         $form = $this->createFormWithBlock();
 
         $newForm = new FormMetadata();
-        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren(), 'de'));
+        $newForm->setItems($this->formMetadataMapper->mapChildren($form->getChildren()));
 
         $this->assertCount(1, $newForm->getItems());
         $this->assertContains('block', \array_keys($newForm->getItems()));
@@ -410,13 +411,13 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals(2, $block->getMaxOccurs());
 
         $this->assertEquals('component1', $block->getTypes()['component1']->getName());
-        $this->assertEquals('Erste Komponente', $block->getTypes()['component1']->getTitle());
+        $this->assertEquals('Erste Komponente', $block->getTypes()['component1']->getTitle('de'));
         $this->assertCount(2, $block->getTypes()['component1']->getItems());
         $this->assertContains('property1', \array_keys($block->getTypes()['component1']->getItems()));
         $this->assertContains('property2', \array_keys($block->getTypes()['component1']->getItems()));
 
         $this->assertEquals('component2', $block->getTypes()['component2']->getName());
-        $this->assertEquals('Zweite Komponente', $block->getTypes()['component2']->getTitle());
+        $this->assertEquals('Zweite Komponente', $block->getTypes()['component2']->getTitle('de'));
         $this->assertCount(2, $block->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($block->getTypes()['component2']->getItems()));
         $this->assertContains('property4', \array_keys($block->getTypes()['component2']->getItems()));

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormXmlLoaderTest.php
@@ -144,23 +144,23 @@ class FormXmlLoaderTest extends TestCase
 
         $this->assertInstanceOf(FormMetadata::class, $formMetadataEn);
         $this->assertCount(4, $formMetadataEn->getItems());
-        $this->assertEquals('en_form_of_address', $formMetadataEn->getItems()['formOfAddress']->getLabel());
-        $this->assertEquals('en_first_name', $formMetadataEn->getItems()['firstName']->getLabel());
-        $this->assertEquals('en_last_name', $formMetadataEn->getItems()['lastName']->getLabel());
-        $this->assertEquals('en_salutation', $formMetadataEn->getItems()['salutation']->getLabel());
+        $this->assertEquals('en_form_of_address', $formMetadataEn->getItems()['formOfAddress']->getLabel('en'));
+        $this->assertEquals('en_first_name', $formMetadataEn->getItems()['firstName']->getLabel('en'));
+        $this->assertEquals('en_last_name', $formMetadataEn->getItems()['lastName']->getLabel('en'));
+        $this->assertEquals('en_salutation', $formMetadataEn->getItems()['salutation']->getLabel('en'));
         $this->assertEquals('en_mr', $formMetadataEn->getItems()['formOfAddress']->getOptions()['values']
-            ->getValue()[0]->getTitle());
+            ->getValue()[0]->getTitle('en'));
         $this->assertEquals('en_ms', $formMetadataEn->getItems()['formOfAddress']->getOptions()['values']
-            ->getValue()[1]->getTitle());
+            ->getValue()[1]->getTitle('en'));
 
         $formMetadataDe = $formMetadataCollection->get('de');
         $this->assertCount(4, $formMetadataDe->getItems());
-        $this->assertEquals('de_form_of_address', $formMetadataDe->getItems()['formOfAddress']->getLabel());
-        $this->assertEquals('de_first_name', $formMetadataDe->getItems()['firstName']->getLabel());
-        $this->assertEquals('Deutscher Nachname', $formMetadataDe->getItems()['lastName']->getLabel());
-        $this->assertEquals('de_salutation', $formMetadataDe->getItems()['salutation']->getLabel());
-        $this->assertEquals('de_mr', $formMetadataDe->getItems()['formOfAddress']->getOptions()['values']->getValue()[0]->getTitle());
-        $this->assertEquals('de_ms', $formMetadataDe->getItems()['formOfAddress']->getOptions()['values']->getValue()[1]->getTitle());
+        $this->assertEquals('de_form_of_address', $formMetadataDe->getItems()['formOfAddress']->getLabel('de'));
+        $this->assertEquals('de_first_name', $formMetadataDe->getItems()['firstName']->getLabel('de'));
+        $this->assertEquals('Deutscher Nachname', $formMetadataDe->getItems()['lastName']->getLabel('de'));
+        $this->assertEquals('de_salutation', $formMetadataDe->getItems()['salutation']->getLabel('de'));
+        $this->assertEquals('de_mr', $formMetadataDe->getItems()['formOfAddress']->getOptions()['values']->getValue()[0]->getTitle('de'));
+        $this->assertEquals('de_ms', $formMetadataDe->getItems()['formOfAddress']->getOptions()['values']->getValue()[1]->getTitle('de'));
 
         $schemaMetadataEn = $formMetadataEn->getSchema();
         $this->assertInstanceOf(SchemaMetadata::class, $schemaMetadataEn);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -145,7 +145,7 @@ class StructureFormMetadataLoaderTest extends TestCase
         $structure->setResource(\tempnam(static::CACHE_DIR, 'some_template'));
 
         $this->formMetadataMapper->mapTags([])->willReturn([]);
-        $this->formMetadataMapper->mapChildren([], 'en')->willReturn([$propertyMetadata, $sectionMetadata, $blockMetadata]);
+        $this->formMetadataMapper->mapChildren([])->willReturn([$propertyMetadata, $sectionMetadata, $blockMetadata]);
 
         $schemaMetadata = new SchemaMetadata();
         $this->formMetadataMapper->mapSchema([])->willReturn($schemaMetadata);

--- a/src/Sulu/Bundle/SecurityBundle/Metadata/PasswordPolicyFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/SecurityBundle/Metadata/PasswordPolicyFormMetadataVisitor.php
@@ -42,7 +42,10 @@ class PasswordPolicyFormMetadataVisitor implements FormMetadataVisitorInterface
 
         /** @var FieldMetadata $passwordField */
         $passwordField = $formMetadata->getItems()['password'];
-        $passwordField->setDescription($this->translator->trans($this->passwordInformationTranslationKey, [], 'admin'));
+        $passwordField->setDescription(
+            $this->translator->trans($this->passwordInformationTranslationKey, [], 'admin'),
+            $this->translator->getLocale(),
+        );
 
         $schema = new SchemaMetadata(
             [new PropertyMetadata('password', false, new StringMetadata(null, null, $this->passwordPattern))]

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Metadata/PasswordPolicyFormMetadataVisitorTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Metadata/PasswordPolicyFormMetadataVisitorTest.php
@@ -32,6 +32,7 @@ class PasswordPolicyFormMetadataVisitorTest extends TestCase
         $translator->trans(Argument::any(), [], 'admin')->will(function($arguments) {
             return $arguments[0];
         });
+        $translator->getLocale()->willReturn('en');
 
         return new PasswordPolicyFormMetadataVisitor(
             $translator->reveal(),
@@ -51,7 +52,7 @@ class PasswordPolicyFormMetadataVisitorTest extends TestCase
 
         $instance = $this->createInstance();
         $instance->visitFormMetadata($formMetadata, 'en');
-        $this->assertNull($passwordMetadata->getDescription());
+        $this->assertNull($passwordMetadata->getDescription('en'));
         $this->assertSame([
             'type' => [
                 'number',
@@ -76,7 +77,7 @@ class PasswordPolicyFormMetadataVisitorTest extends TestCase
 
         $instance = $this->createInstance('.{8,}', 'test_key');
         $instance->visitFormMetadata($formMetadata, 'en');
-        $this->assertNull($passwordMetadata->getDescription());
+        $this->assertNull($passwordMetadata->getDescription('en'));
         $this->assertSame([
             'type' => [
                 'number',
@@ -101,7 +102,7 @@ class PasswordPolicyFormMetadataVisitorTest extends TestCase
 
         $instance = $this->createInstance('.{8,}', 'test_key');
         $instance->visitFormMetadata($formMetadata, 'en');
-        $this->assertSame('test_key', $passwordMetadata->getDescription());
+        $this->assertSame('test_key', $passwordMetadata->getDescription('en'));
         $this->assertSame([
             'allOf' => [
                 [
@@ -139,7 +140,7 @@ class PasswordPolicyFormMetadataVisitorTest extends TestCase
 
         $instance = $this->createInstance('.{8,}', 'test_key');
         $instance->visitFormMetadata($formMetadata, 'en');
-        $this->assertSame('test_key', $passwordMetadata->getDescription());
+        $this->assertSame('test_key', $passwordMetadata->getDescription('en'));
         $this->assertSame([
             'allOf' => [
                 [

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -390,7 +390,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             $metadata = $this->formMetadataProvider->getMetadata('page', $user->getLocale(), []);
 
             foreach ($metadata->getForms() as $form) {
-                $types[] = ['type' => $form->getName(), 'title' => $form->getTitle()];
+                $types[] = ['type' => $form->getName(), 'title' => $form->getTitle($user->getLocale())];
             }
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -204,11 +204,11 @@ class PageDataProviderTest extends TestCase
 
         $formMetadata1 = new FormMetadata();
         $formMetadata1->setName('template-1');
-        $formMetadata1->setTitle('translated-template-1');
+        $formMetadata1->setTitle('translated-template-1', 'en');
 
         $formMetadata2 = new FormMetadata();
         $formMetadata2->setName('template-2');
-        $formMetadata2->setTitle('translated-template-2');
+        $formMetadata2->setTitle('translated-template-2', 'en');
 
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('template-1', $formMetadata1);

--- a/src/Sulu/Component/Content/Tests/Unit/Types/Metadata/GlobalBlocksTypedFormMetadataVisitorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/Metadata/GlobalBlocksTypedFormMetadataVisitorTest.php
@@ -84,7 +84,7 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
 
         $globalBlockFormTypeMetadata->setSchema(new SchemaMetadata());
         $globalBlockFormTypeMetadata->setName($globalBlockName);
-        $globalBlockFormTypeMetadata->setTitle('Test Block Title');
+        $globalBlockFormTypeMetadata->setTitles(['en' => 'Test Block Title']);
 
         $this->metadataProviderProphecy->getMetadata('block', $locale, [
             'ignore_global_blocks' => true,
@@ -107,7 +107,7 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
             $definitions
         );
 
-        $this->assertSame('Test Block Title', $fieldType1->getTitle());
+        $this->assertSame('Test Block Title', $fieldType1->getTitle($locale));
     }
 
     public function testDefinitionIsAddedInFormDataForGlobalBlock(): void
@@ -142,7 +142,7 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $globalBlockFormMetadata->addForm($globalBlockName, $globalBlockFormTypeMetadata);
 
         $globalBlockFormTypeMetadata->setName($globalBlockName);
-        $globalBlockFormTypeMetadata->setTitle('Test Block Title');
+        $globalBlockFormTypeMetadata->setTitles(['en' => 'Test Block Title']);
 
         $this->metadataProviderProphecy->getMetadata('block', $locale, [
             'ignore_global_blocks' => true,
@@ -164,7 +164,7 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
             $definitions
         );
 
-        $this->assertSame('Test Block Title', $fieldType1->getTitle());
+        $this->assertSame('Test Block Title', $fieldType1->getTitle($locale));
     }
 
     public function testDefinitionIgnore(): void
@@ -201,7 +201,7 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $globalBlockFormMetadata->addForm($globalBlockName, $globalBlockFormTypeMetadata);
 
         $globalBlockFormTypeMetadata->setName($globalBlockName);
-        $globalBlockFormTypeMetadata->setTitle('Test Block Title');
+        $globalBlockFormTypeMetadata->setTitles(['en' => 'Test Block Title']);
 
         $this->metadataProviderProphecy->getMetadata('block', $locale, [
             'ignore_global_blocks' => true,

--- a/src/Sulu/Component/Content/Types/Metadata/GlobalBlocksTypedFormMetadataVisitor.php
+++ b/src/Sulu/Component/Content/Types/Metadata/GlobalBlocksTypedFormMetadataVisitor.php
@@ -77,7 +77,7 @@ class GlobalBlocksTypedFormMetadataVisitor implements TypedFormMetadataVisitorIn
                     continue;
                 }
 
-                $type->setTitle($blockMetadata->getTitle());
+                $type->setTitles($blockMetadata->getTitles());
 
                 $rootSchema->addDefinition($blockMetadata->getName(), $blockMetadata->getSchema());
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Make new metadata not locale aware.

#### Why?

We want to remove the old metadata classes but to avoid that the metadata is loaded per locale again we need 

With the removal of the old metadata classes xml would be parsed per locale to avoid this we change the metadata to keep all admin locales in them.