### PR TITLE
Add template metadata to form metadata

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2167,6 +2167,12 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
 
 		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTemplate\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+
+		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTitle\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/CacheLifetimeMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/CacheLifetimeMetadata.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
+
+class CacheLifetimeMetadata
+{
+    private string $type;
+
+    private string $value;
+
+    public function __construct(string $type, string $value)
+    {
+        $this->type = $type;
+        $this->value = $value;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): void
+    {
+        $this->type = $type;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -44,6 +44,12 @@ class FormMetadata extends AbstractMetadata
     private $schema;
 
     /**
+     * @var TemplateMetadata|null
+     */
+    #[Exclude()]
+    private $template;
+
+    /**
      * @var string
      */
     #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
@@ -141,6 +147,16 @@ class FormMetadata extends AbstractMetadata
     public function getSchema(): SchemaMetadata
     {
         return $this->schema;
+    }
+
+    public function setTemplate(?TemplateMetadata $template)
+    {
+        $this->template = $template;
+    }
+
+    public function getTemplate(): ?TemplateMetadata
+    {
+        return $this->template;
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TemplateMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TemplateMetadata.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
+
+class TemplateMetadata
+{
+    protected ?string $controller = null;
+
+    protected ?string $view = null;
+
+    protected ?CacheLifetimeMetadata $cacheLifetime = null;
+
+    public function __construct()
+    {
+    }
+
+    public function getController(): ?string
+    {
+        return $this->controller;
+    }
+
+    public function setController(?string $controller): void
+    {
+        $this->controller = $controller;
+    }
+
+    public function getView(): ?string
+    {
+        return $this->view;
+    }
+
+    public function setView(?string $view): void
+    {
+        $this->view = $view;
+    }
+
+    public function getCacheLifetime(): ?CacheLifetimeMetadata
+    {
+        return $this->cacheLifetime;
+    }
+
+    public function setCacheLifetime(?CacheLifetimeMetadata $cacheLifetime): void
+    {
+        $this->cacheLifetime = $cacheLifetime;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7928
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add template metadata to form metadata.

#### Why?

We want to get rid of the structure for this we need to missing properties:

https://github.com/sulu/sulu/blob/33e8b72844761ffc7483a3a95649445c0f48c424/src/Sulu/Bundle/TestBundle/Resources/structures/pages/default.xml#L10-L12

to the new metadata. So in future we can use the template metadata instead of the structure or old metadata classes.