### PR TITLE
Make backwards compatibility virtual parameters real

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1256,3 +1256,25 @@ separate permission contexts, so you'll need to grant permissions for each group
 1. Log in to the Sulu admin interface
 2. Navigate to Settings → User Roles
 3. Edit each role and grant permissions for the new template groups under the Articles section
+
+
+### Changing deprecated signatures
+
+To maintain backward compatibility in previous versions, new arguments were previously added as doc comments only. These
+arguments are now explicitly defined in the function signatures (with default values), which may result in breaking
+changes for subclasses or overrides relying on the older method definitions.
+
+Affected classes / interfaces:
+- `Sulu\Bundle\CategoryBundle\Category\CategoryManager::delete` (added `bool $forceRemoveChildren`)
+- `Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface::delete` (added `bool $forceRemoveChildren`)
+- `Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManager::delete` (added `bool $forceRemoveChildren`)
+- `Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface::delete` (added `bool $forceRemoveChildren`)
+- `Sulu\Bundle\MediaBundle\Entity\MediaRepository::findMediaByIdForRendering` (added `?int $version`)
+- `Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface::findMediaByIdForRendering` (added `?int $version`)
+- `Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManager::returnImage` (added `?int $version`)
+- `Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface::returnImage` (added `?int $version`)
+- `Sulu\Bundle\MediaBundle\Media\ImageConverter\MediaImageExtractor::extract` (added `string $resourceType`)
+- `Sulu\Bundle\MediaBundle\Media\ImageConverter\MediaImageExtractorInterface::extract` (added `string $resourceType`)
+- `Sulu\Bundle\TagBundle\Search\TagsConverter::convert` (added `?Document`)
+- `Sulu\Bundle\WebsiteBundle\Cache\CacheClearer::clear` (added `?array $tags`)
+- `Sulu\Bundle\WebsiteBundle\Cache\CacheClearerInterface::clear` (added `?array $tags`)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9211,12 +9211,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/CategoryManagerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Category\\CategoryManagerInterface\:\:delete\(\) invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/CategoryManagerTest.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Tests\\Unit\\Category\\CategoryManagerTest\:\:testMove\(\) has parameter \$id with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -23209,18 +23203,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaRepositoryInterface\:\:findMediaByIdForRendering\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Media\\FormatManager\\FormatManagerInterface\:\:returnImage\(\) invoked with 4 parameters, 3 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
-
-		-
 			message: '#^Offset 0 on non\-empty\-list\<string\> on left side of \?\? always exists and is not nullable\.$#'
 			identifier: nullCoalesce.offset
 			count: 1
@@ -24727,12 +24709,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Entity\\MediaRepositoryInterface\:\:findMediaByIdForRendering\(\) invoked with 3 parameters, 2 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Media\\FormatManager\\FormatManager\:\:__construct\(\) has parameter \$formats with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -25075,12 +25051,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Media\\ImageConverter\\MediaImageExtractorInterface\:\:extract\(\) invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
-
-		-
 			message: '#^PHPDoc tag @var with type Imagine\\Image\\ImageInterface is not subtype of native type null\.$#'
 			identifier: varTag.nativeType
 			count: 1
@@ -25226,12 +25196,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$stream of function rewind expects resource, resource\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
-
-		-
-			message: '#^Parameter \#2 \$filename of function fnmatch expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -28803,12 +28767,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Unit\\Media\\ImageConverter\\MediaImageExtractorTest\:\:createUnseekableResource\(\) should return resource but returns resource\|false\.$#'
 			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/MediaImageExtractorTest.php
-
-		-
-			message: '#^Parameter \#1 \$resource of method Sulu\\Bundle\\MediaBundle\\Media\\ImageConverter\\MediaImageExtractor\:\:extract\(\) expects resource, resource\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/MediaImageExtractorTest.php
 
@@ -34861,12 +34819,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Analytics/AnalyticsManagerInterface.php
 
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Cache\\CacheClearer\:\:__construct\(\) has parameter \$kernelEnvironment with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -34875,18 +34827,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Cache\\CacheClearer\:\:clear\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
-
-		-
-			message: '#^Parameter \#1 \$tag of method Sulu\\Bundle\\HttpCacheBundle\\Cache\\CacheManager\:\:invalidateTag\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
-
-		-
-			message: '#^Parameter \#1 \$tags of class Sulu\\Bundle\\WebsiteBundle\\Event\\CacheClearEvent constructor expects array\<string\>\|null, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
 
@@ -34933,12 +34873,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Cache\\CacheClearerInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 4
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Controller\\AnalyticsController\:\:buildContent\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -34967,12 +34901,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Cache\\CacheClearerInterface\:\:clear\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
 
 		-
 			message: '#^Parameter \#1 \$name of method Twig\\Loader\\LoaderInterface\:\:exists\(\) expects string, string\|null given\.$#'

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -259,10 +259,8 @@ class CategoryManager implements CategoryManagerInterface
         );
     }
 
-    public function delete($id/*, bool $forceRemoveChildren = false*/)
+    public function delete($id, bool $forceRemoveChildren = false)
     {
-        $forceRemoveChildren = \func_num_args() >= 2 ? (bool) \func_get_arg(1) : false;
-
         if (!$entity = $this->categoryRepository->findCategoryById($id)) {
             throw new CategoryIdNotFoundException($id);
         }

--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManagerInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManagerInterface.php
@@ -103,7 +103,7 @@ interface CategoryManagerInterface
      *
      * @throws CategoryIdNotFoundException if the given id is not assigned to an existing category
      */
-    public function delete($id/*, bool $forceRemoveChildren = false*/);
+    public function delete($id, bool $forceRemoveChildren = false);
 
     /**
      * Returns an API-Object for a given category-entity. The API-Object wraps the entity

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -567,10 +567,8 @@ class CollectionManager implements CollectionManagerInterface
         );
     }
 
-    public function delete($id/*, bool $forceRemoveChildren = false*/)
+    public function delete($id, bool $forceRemoveChildren = false)
     {
-        $forceRemoveChildren = \func_num_args() >= 2 ? (bool) \func_get_arg(1) : false;
-
         $collectionEntity = $this->collectionRepository->findCollectionById($id);
 
         if (!$collectionEntity) {

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
@@ -121,7 +121,7 @@ interface CollectionManagerInterface
      *
      * @param int $id the id of the category to delete
      */
-    public function delete($id/*, bool $forceRemoveChildren = false*/);
+    public function delete($id, bool $forceRemoveChildren = false);
 
     /**
      * Moves a collection into another collection

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
@@ -64,7 +64,8 @@ class FormatCacheRegenerateCommand extends Command
             $this->formatManager->returnImage(
                 $fileInformation['id'],
                 $fileInformation['formatKey'],
-                $fileInformation['fileName']
+                $fileInformation['fileName'],
+                version: null
             );
 
             $progressBar->advance();

--- a/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
@@ -65,7 +65,6 @@ class FormatCacheRegenerateCommand extends Command
                 $fileInformation['id'],
                 $fileInformation['formatKey'],
                 $fileInformation['fileName'],
-                version: null
             );
 
             $progressBar->advance();

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -82,10 +82,8 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
         }
     }
 
-    public function findMediaByIdForRendering($id, $formatKey /*, $version = null */)
+    public function findMediaByIdForRendering($id, $formatKey, ?int $version = null)
     {
-        $version = \func_num_args() > 2 ? \func_get_arg(2) : null;
-
         try {
             $queryBuilder = $this->createQueryBuilder('media')
                 ->leftJoin('media.files', 'file')

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
@@ -41,7 +41,7 @@ interface MediaRepositoryInterface extends RepositoryInterface
      *
      * @return MediaInterface|null
      */
-    public function findMediaByIdForRendering($id, $formatKey /*, int<1, max>|null $version = null */);
+    public function findMediaByIdForRendering($id, $formatKey, ?int $version = null);
 
     /**
      * Finds all media, can be filtered with parent.

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -87,8 +87,8 @@ class FormatManager implements FormatManagerInterface
                 throw new ImageProxyMediaNotFoundException(\sprintf('Media with id "%s" was not found.', $id));
             }
 
-            $latestFileVersion = $this->getLatestFileVersion($media);
-            $version ??= $latestFileVersion->getVersion(); // TODO remove this line in Sulu 3.0 currently bc layer when version is not given
+            $fileVersion = $this->getLatestFileVersion($media);
+            $version = null !== $version ? $version : $fileVersion->getVersion(); // TODO remove this line in Sulu 3.0 currently bc layer when version is not given
 
             /** @var File|null $file */
             $file = $media->getFiles()[0] ?? null;
@@ -104,15 +104,8 @@ class FormatManager implements FormatManagerInterface
                 throw new ImageProxyMediaNotFoundException(\sprintf('FileVersion "%s" for media with id "%s" was not found.', $requestedFileVersion->getVersion(), $id));
             }
 
-            // Generate a redirect for old versions
-            if ($latestFileVersion->getVersion() !== $requestedFileVersion->getVersion()) {
-                $formats = $this->getFormats(
-                    $id,
-                    $latestFileVersion->getName(),
-                    $latestFileVersion->getVersion(),
-                    $latestFileVersion->getSubVersion(),
-                    $latestFileVersion->getMimeType(),
-                );
+            if ($fileVersion->getVersion() !== $requestedFileVersion->getVersion()) {
+                $formats = $this->getFormats($id, $fileVersion->getName(), $fileVersion->getVersion(), $fileVersion->getSubVersion(), $fileVersion->getMimeType());
 
                 $formatUrl = $formats[$formatKey . '.' . $imageFormat] ?? null;
                 if (null === $formatUrl) {
@@ -122,10 +115,9 @@ class FormatManager implements FormatManagerInterface
                 return new RedirectResponse($formatUrl, 301);
             }
 
-            // Generate the current version
-            $supportedImageFormats = $this->converter->getSupportedOutputImageFormats($latestFileVersion->getMimeType());
+            $supportedImageFormats = $this->converter->getSupportedOutputImageFormats($fileVersion->getMimeType());
             if (empty($supportedImageFormats)) {
-                throw new InvalidMimeTypeForPreviewException($latestFileVersion->getMimeType() ?? '-null-');
+                throw new InvalidMimeTypeForPreviewException($fileVersion->getMimeType() ?? '-null-');
             }
 
             if (!\in_array($imageFormat, $supportedImageFormats)) {
@@ -138,7 +130,7 @@ class FormatManager implements FormatManagerInterface
             }
 
             // Convert Media to format.
-            $responseContent = $this->converter->convert($latestFileVersion, $formatKey, $imageFormat);
+            $responseContent = $this->converter->convert($fileVersion, $formatKey, $imageFormat);
 
             // HTTP Headers
             $status = 200;
@@ -152,7 +144,7 @@ class FormatManager implements FormatManagerInterface
                 $this->formatCache->save(
                     $responseContent,
                     $media->getId(),
-                    $this->replaceExtension($latestFileVersion->getName(), $imageFormat),
+                    $this->replaceExtension($fileVersion->getName(), $imageFormat),
                     $formatKey
                 );
             }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -68,7 +68,7 @@ class FormatManager implements FormatManagerInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    public function returnImage($id, $formatKey, $fileName, ?int $version)
+    public function returnImage($id, $formatKey, $fileName, ?int $version = null)
     {
         $setExpireHeaders = false;
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -68,15 +68,8 @@ class FormatManager implements FormatManagerInterface
         $this->logger = $logger ?: new NullLogger();
     }
 
-    public function returnImage($id, $formatKey, $fileName /*, int<1, max>|null $version = null */)
+    public function returnImage($id, $formatKey, $fileName, ?int $version)
     {
-        /** @var int|null $version */
-        $version = \func_num_args() > 3 ? \func_get_arg(3) : null;
-
-        if (null === $version) {
-            @trigger_deprecation('sulu/sulu', '2.5', 'The $version parameter in ' . __CLASS__ . '::' . __METHOD__ . ' is required.');
-        }
-
         $setExpireHeaders = false;
 
         try {
@@ -94,8 +87,8 @@ class FormatManager implements FormatManagerInterface
                 throw new ImageProxyMediaNotFoundException(\sprintf('Media with id "%s" was not found.', $id));
             }
 
-            $fileVersion = $this->getLatestFileVersion($media);
-            $version = null !== $version ? $version : $fileVersion->getVersion(); // TODO remove this line in Sulu 3.0 currently bc layer when version is not given
+            $latestFileVersion = $this->getLatestFileVersion($media);
+            $version ??= $latestFileVersion->getVersion(); // TODO remove this line in Sulu 3.0 currently bc layer when version is not given
 
             /** @var File|null $file */
             $file = $media->getFiles()[0] ?? null;
@@ -111,8 +104,15 @@ class FormatManager implements FormatManagerInterface
                 throw new ImageProxyMediaNotFoundException(\sprintf('FileVersion "%s" for media with id "%s" was not found.', $requestedFileVersion->getVersion(), $id));
             }
 
-            if ($fileVersion->getVersion() !== $requestedFileVersion->getVersion()) {
-                $formats = $this->getFormats($id, $fileVersion->getName(), $fileVersion->getVersion(), $fileVersion->getSubVersion(), $fileVersion->getMimeType());
+            // Generate a redirect for old versions
+            if ($latestFileVersion->getVersion() !== $requestedFileVersion->getVersion()) {
+                $formats = $this->getFormats(
+                    $id,
+                    $latestFileVersion->getName(),
+                    $latestFileVersion->getVersion(),
+                    $latestFileVersion->getSubVersion(),
+                    $latestFileVersion->getMimeType(),
+                );
 
                 $formatUrl = $formats[$formatKey . '.' . $imageFormat] ?? null;
                 if (null === $formatUrl) {
@@ -122,9 +122,10 @@ class FormatManager implements FormatManagerInterface
                 return new RedirectResponse($formatUrl, 301);
             }
 
-            $supportedImageFormats = $this->converter->getSupportedOutputImageFormats($fileVersion->getMimeType());
+            // Generate the current version
+            $supportedImageFormats = $this->converter->getSupportedOutputImageFormats($latestFileVersion->getMimeType());
             if (empty($supportedImageFormats)) {
-                throw new InvalidMimeTypeForPreviewException($fileVersion->getMimeType() ?? '-null-');
+                throw new InvalidMimeTypeForPreviewException($latestFileVersion->getMimeType() ?? '-null-');
             }
 
             if (!\in_array($imageFormat, $supportedImageFormats)) {
@@ -137,7 +138,7 @@ class FormatManager implements FormatManagerInterface
             }
 
             // Convert Media to format.
-            $responseContent = $this->converter->convert($fileVersion, $formatKey, $imageFormat);
+            $responseContent = $this->converter->convert($latestFileVersion, $formatKey, $imageFormat);
 
             // HTTP Headers
             $status = 200;
@@ -151,7 +152,7 @@ class FormatManager implements FormatManagerInterface
                 $this->formatCache->save(
                     $responseContent,
                     $media->getId(),
-                    $this->replaceExtension($fileVersion->getName(), $imageFormat),
+                    $this->replaceExtension($latestFileVersion->getName(), $imageFormat),
                     $formatKey
                 );
             }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -35,7 +35,7 @@ interface FormatManagerInterface
      *
      * @return Response
      */
-    public function returnImage($id, $formatKey, $imageFormat, ?int $version);
+    public function returnImage($id, $formatKey, $imageFormat, ?int $version = null);
 
     /**
      * @param int $id

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -35,7 +35,7 @@ interface FormatManagerInterface
      *
      * @return Response
      */
-    public function returnImage($id, $formatKey, $imageFormat /*, int<1, max>|null $version = null */);
+    public function returnImage($id, $formatKey, $imageFormat, ?int $version);
 
     /**
      * @param int $id

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -93,9 +93,12 @@ class ImagineImageConverter implements ImageConverterInterface
 
     public function convert(FileVersion $fileVersion, $formatKey, $imageFormat)
     {
+        $rawResource = $this->storage->load($fileVersion->getStorageOptions());
+        /** @var string $mimeType */
+        $mimeType = \mime_content_type($rawResource);
         $imageResource = $this->mediaImageExtractor->extract(
-            $this->storage->load($fileVersion->getStorageOptions()),
-            $fileVersion->getMimeType()
+            $rawResource,
+            $fileVersion->getMimeType() ?? $mimeType,
         );
 
         $imagine = $this->imagine;

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -95,7 +95,7 @@ class ImagineImageConverter implements ImageConverterInterface
     {
         $imageResource = $this->mediaImageExtractor->extract(
             $this->storage->load($fileVersion->getStorageOptions()),
-            $fileVersion->getMimeType()
+            $fileVersion->getMimeType() ?? '-null-', // validated already in FormatManager, as mimetype can not be extract from storage as they may return none seekable resources
         );
 
         $imagine = $this->imagine;

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -93,12 +93,9 @@ class ImagineImageConverter implements ImageConverterInterface
 
     public function convert(FileVersion $fileVersion, $formatKey, $imageFormat)
     {
-        $rawResource = $this->storage->load($fileVersion->getStorageOptions());
-        /** @var string $mimeType */
-        $mimeType = \mime_content_type($rawResource);
         $imageResource = $this->mediaImageExtractor->extract(
-            $rawResource,
-            $fileVersion->getMimeType() ?? $mimeType,
+            $this->storage->load($fileVersion->getStorageOptions()),
+            $fileVersion->getMimeType()
         );
 
         $imagine = $this->imagine;

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -32,29 +32,17 @@ class MediaImageExtractor implements MediaImageExtractorInterface
     ) {
     }
 
-    public function extract($resource/*, string $resourceMimeType*/)
+    public function extract($resource, string $resourceMimeType)
     {
-        if (\func_num_args() <= 1) {
-            @trigger_deprecation(
-                'sulu/sulu',
-                '2.2',
-                \sprintf('Calling "%s()" without $resourceMimeType parameter is deprecated.', __METHOD__)
-            );
-
-            $mimeType = \mime_content_type($resource);
-        } else {
-            $mimeType = \func_get_arg(1);
-        }
-
-        if ('application/pdf' === $mimeType) {
+        if ('application/pdf' === $resourceMimeType) {
             return $this->convertPdfToImage($resource);
         }
 
-        if ('image/vnd.adobe.photoshop' === $mimeType) {
+        if ('image/vnd.adobe.photoshop' === $resourceMimeType) {
             return $this->convertPsdToImage($resource);
         }
 
-        if (\fnmatch('video/*', $mimeType)) {
+        if (\fnmatch('video/*', $resourceMimeType)) {
             return $this->convertVideoToImage($resource);
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractorInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractorInterface.php
@@ -23,5 +23,5 @@ interface MediaImageExtractorInterface
      *
      * @return resource
      */
-    public function extract($resource/*, string $resourceMimeType */);
+    public function extract($resource, string $resourceMimeType);
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateCommandTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateCommandTest.php
@@ -36,13 +36,13 @@ class FormatCacheRegenerateCommandTest extends TestCase
 
     public function testExecute(): void
     {
-        $this->formatManager->returnImage(1, '50x50', 'test.svg', null)
+        $this->formatManager->returnImage(1, '50x50', 'test.svg')
             ->shouldBeCalled();
 
-        $this->formatManager->returnImage(2, '200x', 'test.svg', null)
+        $this->formatManager->returnImage(2, '200x', 'test.svg')
             ->shouldBeCalled();
 
-        $this->formatManager->returnImage(3, '400x400-inset', '2020-test-test.svg', null)
+        $this->formatManager->returnImage(3, '400x400-inset', '2020-test-test.svg')
             ->shouldBeCalled();
 
         $this->executeCommand(__DIR__ . '/../../Fixtures/regenerate-formats');

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateCommandTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Command/FormatCacheRegenerateCommandTest.php
@@ -36,13 +36,13 @@ class FormatCacheRegenerateCommandTest extends TestCase
 
     public function testExecute(): void
     {
-        $this->formatManager->returnImage(1, '50x50', 'test.svg')
+        $this->formatManager->returnImage(1, '50x50', 'test.svg', null)
             ->shouldBeCalled();
 
-        $this->formatManager->returnImage(2, '200x', 'test.svg')
+        $this->formatManager->returnImage(2, '200x', 'test.svg', null)
             ->shouldBeCalled();
 
-        $this->formatManager->returnImage(3, '400x400-inset', '2020-test-test.svg')
+        $this->formatManager->returnImage(3, '400x400-inset', '2020-test-test.svg', null)
             ->shouldBeCalled();
 
         $this->executeCommand(__DIR__ . '/../../Fixtures/regenerate-formats');

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/MediaImageExtractorTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/MediaImageExtractorTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter;
 
-use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -57,27 +56,6 @@ class MediaImageExtractorTest extends TestCase
         $this->assertSame(
             $resource,
             $this->mediaImageExtractor->extract($resource, 'image/jpeg')
-        );
-    }
-
-    public function testPsdConvertWithoutMimeType(): void
-    {
-        $resource = \fopen(\dirname(\dirname(\dirname(__DIR__))) . '/Fixtures/files/1x1.psd', 'r');
-
-        $image = $this->prophesize(ImageInterface::class);
-        $image->layers()->willReturn([$image->reveal()]);
-
-        $image->get('png')
-            ->shouldBeCalled()
-            ->willReturn('PNG Content');
-
-        $this->imagine->read($resource)
-            ->willReturn($image->reveal())
-            ->shouldBeCalled();
-
-        $this->assertSame(
-            'PNG Content',
-            \stream_get_contents($this->mediaImageExtractor->extract($resource))
         );
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearer.php
@@ -76,14 +76,8 @@ class CacheClearer implements CacheClearerInterface
         $this->tagsEnabled = $tagsEnabled;
     }
 
-    public function clear(/*?array $tags = null*/)
+    public function clear(?array $tags = null)
     {
-        if (0 === \func_num_args()) {
-            @trigger_deprecation('sulu/sulu', '2.3', 'Calling "%s()" without $tags parameter is deprecated.', __METHOD__);
-        }
-
-        $tags = \func_num_args() >= 1 ? \func_get_arg(0) : null;
-
         if (null !== $tags && $this->tagsEnabled && $this->cacheManager && $this->cacheManager->supportsTags()) {
             foreach ($tags as $tag) {
                 $this->cacheManager->invalidateTag($tag);

--- a/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearerInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Cache/CacheClearerInterface.php
@@ -18,6 +18,8 @@ interface CacheClearerInterface
 {
     /**
      * Clear the website cache.
+     *
+     * @param array<string>|null $tags
      */
-    public function clear(/*?array $tags = null*/);
+    public function clear(?array $tags = null);
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Making optional Parameters in 2.6 now required.

#### Why?
PHPstan does not like when the parameters aren't officially there.