### PR TITLE
Add resources to new form metadata

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -61,6 +61,14 @@ class FormMetadata extends AbstractMetadata
     #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
     protected $tags = [];
 
+    /**
+     * The resources from which this structure was loaded (useful for debugging).
+     *
+     * @var array<string>
+     */
+    #[Exclude()]
+    protected $resources = [];
+
     public function __construct()
     {
         $this->schema = new SchemaMetadata();
@@ -195,6 +203,27 @@ class FormMetadata extends AbstractMetadata
         $this->tags = $tags;
     }
 
+    public function addResource(string $resource): void
+    {
+        $this->resources[] = $resource;
+    }
+
+    /**
+     * @param array<string> $resources
+     */
+    public function setResources(array $resources): void
+    {
+        $this->resources = $resources;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getResources(): array
+    {
+        return $this->resources;
+    }
+
     public function merge(self $otherForm): FormMetadata
     {
         $mergedForm = new self();
@@ -208,6 +237,7 @@ class FormMetadata extends AbstractMetadata
 
         $mergedForm->setTags(\array_merge($this->getTags(), $otherForm->getTags()));
         $mergedForm->setItems(\array_merge($this->getItems(), $otherForm->getItems()));
+        $mergedForm->setResources(\array_merge($this->getResources(), $otherForm->getResources()));
         $mergedForm->setSchema($this->getSchema()->merge($otherForm->getSchema()));
 
         return $mergedForm;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -75,6 +75,7 @@ class FormXmlLoader extends AbstractLoader
     private function mapFormsMetadata(ExternalFormMetadata $formMetadata): FormMetadata
     {
         $form = new FormMetadata();
+        $form->addResource($formMetadata->getResource());
         $form->setTags($this->formMetadataMapper->mapTags($formMetadata->getTags()));
         $form->setItems($this->formMetadataMapper->mapChildren($formMetadata->getChildren()));
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add resources to new form metadata.

#### Why?

The old metadata has a `resource` information from where the resources are created from. As new metadata always could have been merged its now a array of resources. This info is more for debug information how the metadata was constructed and for cache busting eventually not for functionality also thats why its excluded from serialization.