### PR TITLE
Rename PropertiesXmlParser to DeprecatedPropertiesXmlParser

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2203,7 +2203,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
 
 		-
-			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -2254,619 +2254,601 @@ parameters:
 			message: '#^Argument of an invalid type \(DOMNamedNodeMap&iterable\<DOMAttr\>\)\|null supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Argument of an invalid type DOMNodeList\<DOMNode\>\|false supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 5
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Binary operation "\." between mixed and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access an offset on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''colspan'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''default\-type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''disabledCondition'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''info_text'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 5
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''mandatory'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''meta'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 8
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''multilingual'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''name'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 12
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''onInvalid'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''params'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''priority'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''properties'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''ref'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 5
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''tags'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''title'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''types'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''visibleCondition'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset mixed on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access property \$length on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: property.nonObject
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot assign offset mixed to array\<string\>\|string\|null\.$#'
 			identifier: offsetAssign.dimType
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
 			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:__construct\(\) has parameter \$locales with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:__construct\(\) has parameter \$locales with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createBlock\(\) has parameter \$data with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:createBlock\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createBlock\(\) has parameter \$propertyName with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:createBlock\(\) has parameter \$propertyName with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createProperty\(\) has parameter \$propertyData with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:createProperty\(\) has parameter \$propertyData with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createProperty\(\) never returns null so it can be removed from the return type\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:createProperty\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createSection\(\) has parameter \$data with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:createSection\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createSection\(\) has parameter \$propertyName with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:createSection\(\) has parameter \$propertyName with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:getValueFromXPath\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:getValueFromXPath\(\) has parameter \$default with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:getValueFromXPath\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:load\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadBlock\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadBlock\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadBlock\(\) has parameter \$formKey with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadBlock\(\) has parameter \$formKey with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMeta\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadMeta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMetaTag\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadMetaTag\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMetaTag\(\) has parameter \$path with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadMetaTag\(\) has parameter \$path with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParam\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadParam\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParams\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadParams\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParams\(\) has parameter \$path with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadParams\(\) has parameter \$path with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadProperties\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperty\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadProperty\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperty\(\) has parameter \$formKey with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadProperty\(\) has parameter \$formKey with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadSection\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has parameter \$formKey with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadSection\(\) has parameter \$formKey with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTag\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadTag\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTags\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadTags\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadType\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) has parameter \$formKey with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadType\(\) has parameter \$formKey with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadTypes\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has parameter \$formKey with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadTypes\(\) has parameter \$formKey with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadValues\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has parameter \$keys with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadValues\(\) has parameter \$keys with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has parameter \$prefix with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadValues\(\) has parameter \$prefix with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapMeta\(\) has parameter \$meta with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:mapMeta\(\) has parameter \$meta with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapProperties\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:mapProperties\(\) has parameter \$data with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapProperties\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:mapProperties\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapProperty\(\) has parameter \$data with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:mapProperty\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizeConditionData\(\) has parameter \$data with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:normalizeConditionData\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizeConditionData\(\) should return string\|null but returns mixed\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:normalizeConditionData\(\) should return string\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizeItem\(\) has parameter \$data with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:normalizeItem\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizeItem\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:normalizeItem\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizePropertyData\(\) has parameter \$data with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:normalizePropertyData\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizePropertyData\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:normalizePropertyData\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:validateTag\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:validateTag\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:validateTag\(\) has parameter \$tag with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:validateTag\(\) has parameter \$tag with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:validateTag\(\) has parameter \$tags with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:validateTag\(\) has parameter \$tags with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$child of method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:addChild\(\) expects Sulu\\Component\\Content\\Metadata\\ItemMetadata, Sulu\\Component\\Content\\Metadata\\PropertyMetadata\|Sulu\\Component\\Content\\Metadata\\SectionMetadata\|null given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$child of method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:addChild\(\) expects Sulu\\Component\\Content\\Metadata\\ItemMetadata, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$colSpan of method Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:setColSpan\(\) expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$colSpan of method Sulu\\Component\\Content\\Metadata\\SectionMetadata\:\:setColSpan\(\) expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$cssClass of method Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:setCssClass\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#1 \$data of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapProperties\(\) expects array, mixed given\.$#'
+			message: '#^Parameter \#1 \$data of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:mapProperties\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$descriptions of method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:setDescriptions\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$expression of method DOMXPath\:\:query\(\) expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$localized of method Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:setLocalized\(\) expects bool, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$name of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$name of method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:setName\(\) expects float\|int\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$onInvalid of method Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:setOnInvalid\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$parameters of method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:setParameters\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$placeholders of method Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:setPlaceholders\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#1 \$propertyName of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createProperty\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$propertyName of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:createProperty\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$required of method Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:setRequired\(\) expects bool, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$spaceAfter of method Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:setSpaceAfter\(\) expects int\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$tags of method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:setTags\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$titles of method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:setTitles\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$type of method Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:setType\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects DOMNode, DOMNode\|null given\.$#'
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadProperties\(\) expects DOMNode, DOMNode\|null given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#2 \$defaultType of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#2 \$propertyData of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createProperty\(\) expects array, mixed given\.$#'
+			message: '#^Parameter \#2 \$propertyData of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:createProperty\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge_recursive expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Parameter \#3 \$availableTypes of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects array\<string\>, array given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#3 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#3 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:loadProperties\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Property Sulu\\Component\\Content\\Metadata\\PropertyMetadata\:\:\$defaultComponentName \(string\) does not accept mixed\.$#'
 			identifier: assign.propertyType
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Strict comparison using \!\=\= between null and \(int\|string\) will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
 			message: '#^Argument of an invalid type DOMNodeList\<DOMNode\>\|false supplied for foreach, only iterables are supported\.$#'
@@ -2884,24 +2866,6 @@ parameters:
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
 			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\SchemaXmlParser\:\:getValueFromXPath\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\SchemaXmlParser\:\:getValueFromXPath\(\) has parameter \$default with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\SchemaXmlParser\:\:getValueFromXPath\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
 
 		-
@@ -2935,13 +2899,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
 
 		-
-			message: '#^Parameter \#1 \$expression of method DOMXPath\:\:query\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
-
-		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, bool\|int\|string\|null given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
@@ -2953,7 +2911,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
 
 		-
-			message: '#^Parameter \#1 \$value of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\ConstMetadata constructor expects float\|int\|string\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$value of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\ConstMetadata constructor expects float\|int\|string\|null, bool\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
@@ -2965,7 +2923,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
 
 		-
-			message: '#^Parameter \#2 \$mandatory of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects bool, mixed given\.$#'
+			message: '#^Parameter \#2 \$mandatory of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects bool, bool\|int\|string\|null given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
@@ -60205,24 +60163,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\AbstractLoader\:\:getValueFromXPath\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\AbstractLoader\:\:getValueFromXPath\(\) has parameter \$default with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\AbstractLoader\:\:getValueFromXPath\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
-
-		-
 			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\AbstractLoader\:\:load\(\) has parameter \$type with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -60271,6 +60211,12 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
 
 		-
+			message: '#^PHPDoc tag @template T for method Sulu\\Component\\Content\\Metadata\\Loader\\AbstractLoader\:\:getValueFromXPath\(\) shadows @template T for class Sulu\\Component\\Content\\Metadata\\Loader\\AbstractLoader\.$#'
+			identifier: method.shadowTemplate
+			count: 1
+			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
+
+		-
 			message: '#^Parameter \#1 \$directory of function chdir expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
@@ -60279,7 +60225,13 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$expression of method DOMXPath\:\:query\(\) expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
+			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
+
+		-
+			message: '#^Possibly invalid array key type bool\|int\|string\|T\|null\.$#'
+			identifier: offsetAccess.invalidOffset
+			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
 
 		-
@@ -60469,24 +60421,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:getValueFromXPath\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:getValueFromXPath\(\) has parameter \$default with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:getValueFromXPath\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
 			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:isRequiredPropertyMissing\(\) has parameter \$propertyData with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -60613,12 +60547,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#1 \$expression of method DOMXPath\:\:query\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
 			message: '#^Parameter \#1 \$internal of method Sulu\\Component\\Content\\Metadata\\StructureMetadata\:\:setInternal\(\) expects bool, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -60697,7 +60625,7 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -60727,7 +60655,7 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
-			message: '#^Parameter \#3 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:load\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#3 \$formKey of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:load\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -15,7 +15,7 @@ use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadata as ExternalFormMetadata;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Component\Content\Metadata\Loader\AbstractLoader;
 
@@ -31,7 +31,7 @@ class FormXmlLoader extends AbstractLoader
     public const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
 
     public function __construct(
-        private PropertiesXmlParser $propertiesXmlParser,
+        private DeprecatedPropertiesXmlParser $propertiesXmlParser,
         private SchemaXmlParser $schemaXmlParser,
         private FormMetadataMapper $formMetadataMapper
     ) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal this class is not part of the public API and may be changed or removed without further notice
  */
-class PropertiesXmlParser
+class DeprecatedPropertiesXmlParser
 {
     use XmlParserTrait;
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/XmlParserTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/XmlParserTrait.php
@@ -16,7 +16,14 @@ namespace Sulu\Bundle\AdminBundle\Metadata;
  */
 trait XmlParserTrait
 {
-    private function getValueFromXPath($path, \DOMXPath $xpath, ?\DOMNode $context = null, $default = null)
+    /**
+     * @template T of mixed
+     *
+     * @param T $default
+     *
+     * @return T|bool|int|string|null
+     */
+    private function getValueFromXPath(string $path, \DOMXPath $xpath, ?\DOMNode $context = null, $default = null)
     {
         try {
             $result = $xpath->query($path, $context);

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -66,8 +66,8 @@
             </argument>
         </service>
 
-        <service id="sulu_admin.properties_xml_parser"
-                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser"
+        <service id="sulu_admin.deprecated_properties_xml_parser"
+                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser"
                  public="false">
             <argument type="service" id="translator" />
             <argument>%sulu_core.translated_locales%</argument>
@@ -140,7 +140,7 @@
         />
 
         <service id="sulu_admin.form_metadata.form_xml_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader">
-            <argument type="service" id="sulu_admin.properties_xml_parser"/>
+            <argument type="service" id="sulu_admin.deprecated_properties_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_xml_parser"/>
             <argument type="service" id="sulu_admin.form_metadata.form_metadata_mapper"/>
         </service>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\AdminBundle\Exception\PropertyMetadataMapperNotFoundException;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
@@ -43,7 +43,7 @@ class FormXmlLoaderTest extends TestCase
     public function setUp(): void
     {
         $this->translator = $this->prophesize(TranslatorInterface::class);
-        $propertiesXmlParser = new PropertiesXmlParser(
+        $propertiesXmlParser = new DeprecatedPropertiesXmlParser(
             $this->translator->reveal(),
             ['en' => 'en', 'de' => 'de', 'fr' => 'fr', 'nl' => 'nl']
         );

--- a/src/Sulu/Bundle/PageBundle/Resources/config/structure.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/structure.xml
@@ -8,7 +8,7 @@
                  class="Sulu\Component\Content\Metadata\Loader\StructureXmlLoader"
                  public="false">
             <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
-            <argument type="service" id="sulu_admin.properties_xml_parser"/>
+            <argument type="service" id="sulu_admin.deprecated_properties_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_xml_parser"/>
             <argument type="service" id="sulu.content.type_manager" />
             <argument>%sulu.content.structure.required_properties%</argument>

--- a/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Component\Content\Metadata\Loader;
 
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
@@ -74,7 +74,7 @@ class StructureXmlLoader extends AbstractLoader
      */
     public function __construct(
         private CacheLifetimeResolverInterface $cacheLifetimeResolver,
-        private PropertiesXmlParser $propertiesXmlParser,
+        private DeprecatedPropertiesXmlParser $propertiesXmlParser,
         private SchemaXmlParser $schemaXmlParser,
         private ContentTypeManagerInterface $contentTypeManager,
         private array $requiredPropertyNames,

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Factory/StructureMetadataFactoryTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
@@ -180,7 +180,7 @@ class StructureMetadataFactoryTest extends TestCase
         $cacheLifeTimeResolver->supports(CacheLifetimeResolverInterface::TYPE_SECONDS, Argument::any())
             ->willReturn(true);
 
-        $propertiesXmlLoader = new PropertiesXmlParser(
+        $propertiesXmlLoader = new DeprecatedPropertiesXmlParser(
             $this->translator->reveal(),
             []
         );

--- a/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Metadata/Loader/StructureXmlLoaderTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
@@ -73,7 +73,7 @@ class StructureXmlLoaderTest extends TestCase
     public function setUp(): void
     {
         $this->translator = $this->prophesize(TranslatorInterface::class);
-        $propertiesXmlParser = new PropertiesXmlParser(
+        $propertiesXmlParser = new DeprecatedPropertiesXmlParser(
             $this->translator->reveal(),
             $this->locales
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Rename PropertiesXmlParser to DeprecatedPropertiesXmlParser.

#### Why?

This let me implement a new `PropertiesXmlParser` which is used for `FormXmlLoader` without have to refactor also the `StructureXmlLoader`.
