### PR TITLE
Fix export twig extension

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24036,11 +24036,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
 
 		-
-			message: "#^Parameter \\#1 \\$object_or_class of function method_exists expects object\\|string, array\\|object given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\PageBundle\\\\Twig\\\\ExportTwigExtension\\:\\:\\$exportManager is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php

--- a/src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Twig/ExportTwigExtension.php
@@ -55,7 +55,11 @@ class ExportTwigExtension extends AbstractExtension
      */
     public function escapeXmlContent($content)
     {
-        if (\is_object($content) || \is_array($content)) {
+        if (\is_array($content)) {
+            return 'ERROR: wrong data';
+        }
+
+        if (\is_object($content)) {
             if (\method_exists($content, 'getUuid')) {
                 return $content->getUuid();
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7941 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Fix for the export extension to properly handle array data.

#### Why?
This code only works for 7.4 and below (for more info see issue)
