### PR TITLE
Add new properties parser which returns new metadata for sulu form xmls

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1885,19 +1885,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Binary operation "\." between ''\#/definitions/'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
 			message: '#^Cannot access offset ''attributes'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
-			message: '#^Cannot access offset ''global_block'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -1939,19 +1927,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapSchemaProperties\(\) should return array\<Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata\> but returns array\<array\<Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata\>\|Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata\>\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapTags\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$attributes of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:setAttributes\(\) expects array, mixed given\.$#'
+			message: '#^Parameter \#1 \$attributes of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:setAttributes\(\) expects array\<string, string\>, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -1984,12 +1966,6 @@ parameters:
 			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\SectionMetadata constructor expects string, float\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 2
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
@@ -2179,12 +2155,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
 
 		-
-			message: '#^Cannot access property \$nodeValue on DOMNode\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
 			message: '#^Cannot call method count\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -2193,12 +2163,6 @@ parameters:
 		-
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
-			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Loader\\FormXmlLoader\:\:parse\(\) has parameter \$resource with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
 
@@ -2209,43 +2173,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
 
 		-
-			message: '#^Parameter \#1 \$child of method Sulu\\Component\\Content\\Metadata\\ItemMetadata\:\:addChild\(\) expects Sulu\\Component\\Content\\Metadata\\ItemMetadata, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
-			message: '#^Parameter \#1 \$key of method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadata\:\:setKey\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
-			message: '#^Parameter \#1 \$resource of class Sulu\\Bundle\\AdminBundle\\Exception\\InvalidRootTagException constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
-			message: '#^Parameter \#1 \$resource of method Sulu\\Component\\Content\\Metadata\\PropertiesMetadata\:\:setResource\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
-			message: '#^Parameter \#1 \$schema of method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadata\:\:setSchema\(\) expects Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
-			message: '#^Parameter \#1 \$tags of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTags\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\>, array given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
-			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\DeprecatedPropertiesXmlParser\:\:load\(\) expects DOMNode, DOMNode\|null given\.$#'
+			message: '#^Parameter \#1 \$schema of method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata\:\:merge\(\) expects Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -2437,12 +2365,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
-			message: '#^Cannot access property \$length on DOMNodeList\<DOMNode\>\|false\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
-
-		-
 			message: '#^Cannot access property \$value on mixed\.$#'
 			identifier: property.nonObject
 			count: 2
@@ -2451,7 +2373,7 @@ parameters:
 		-
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 3
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/DeprecatedPropertiesXmlParser.php
 
 		-
@@ -2895,19 +2817,523 @@ parameters:
 		-
 			message: '#^Argument of an invalid type DOMNodeList\<DOMNode\>\|false supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
+			count: 4
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Cannot access property \$length on DOMNodeList\<DOMNode\>\|false\.$#'
-			identifier: property.nonObject
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 6
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Binary operation "\." between mixed and mixed results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''colspan'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''default\-type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''disabledCondition'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''info_text'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''mandatory'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''meta'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 6
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''multilingual'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''name'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 11
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''onInvalid'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''params'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''properties'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''ref'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 5
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''tags'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''title'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''type'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 4
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''types'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''value'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 3
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot access offset ''visibleCondition'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^If condition is always true\.$#'
+			identifier: if.alwaysTrue
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createProperty\(\) has parameter \$propertyData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createSection\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createSection\(\) has parameter \$propertyName with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadBlock\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMeta\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMetaTag\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMetaTag\(\) has parameter \$path with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParam\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParams\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParams\(\) has parameter \$path with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) should return array\<string, array\<string, mixed\>\> but returns array\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperty\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTags\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has parameter \$keys with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has parameter \$prefix with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapMeta\(\) has parameter \$meta with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapOptionMeta\(\) has parameter \$parameterValue with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapProperty\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizeConditionData\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizeConditionData\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizeItem\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizeItem\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizePropertyData\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:normalizePropertyData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$attributes of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:setAttributes\(\) expects array\<string, string\>, array\<string, mixed\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$colSpan of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setColSpan\(\) expects int, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$data of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapProperties\(\) expects array\<string, array\<string, mixed\>\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$defaultType of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:setDefaultType\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$descriptions of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setDescriptions\(\) expects array\<string, string\>, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$expression of method DOMXPath\:\:query\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$infoTexts of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setInfoTexts\(\) expects array\<string, string\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$labels of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setLabels\(\) expects array\<string, string\>, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$multilingual of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:setMultilingual\(\) expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\SectionMetadata constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$name of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setName\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setName\(\) expects float\|int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$object of function get_class expects object, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$onInvalid of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:setOnInvalid\(\) expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$parameterValue of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:mapOptionMeta\(\) expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$placeholders of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setPlaceholders\(\) expects array\<string, string\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$propertyName of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createProperty\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$required of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:setRequired\(\) expects bool, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$spaceAfter of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:setSpaceAfter\(\) expects int\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$tags of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:setTags\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$titles of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setTitles\(\) expects array\<string, string\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$titles of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setTitles\(\) expects array\<string, string\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$type of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:setType\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setValue\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects DOMNode, DOMNode\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#2 \$defaultType of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#2 \$propertyData of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:createProperty\(\) expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#2 \$tagNodes of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\TagXmlParser\:\:load\(\) expects iterable\<DOMNode\>, DOMNodeList\<DOMNode\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge_recursive expects array, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#3 \$availableTypes of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects array\<string\>, array given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and \(int\|string\) will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Argument of an invalid type DOMNodeList\<DOMNode\>\|false supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 3
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
 
 		-
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 3
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
 
 		-
@@ -3073,31 +3499,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagFilterTypedFormMetadataVisitor.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:getAttribute\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:getAttributes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:hasAttributes\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:setAttributes\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\TagMetadata\:\:\$attributes type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
@@ -3271,28 +3673,10 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadata.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadataMapperRegistry\:\:__construct\(\) has parameter \$locator with generic class Symfony\\Component\\DependencyInjection\\ServiceLocator but does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapperRegistry.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadataMapperRegistry\:\:get\(\) should return Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadataMapperInterface but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapperRegistry.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadataMapperRegistry\:\:\$locator with generic class Symfony\\Component\\DependencyInjection\\ServiceLocator does not specify its types\: T$#'
-			identifier: missingType.generics
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapperRegistry.php
-
-		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMinMaxValueResolver.php
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata\:\:toJsonSchema\(\) return type has no value type specified in iterable type array\.$#'
@@ -3319,12 +3703,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SelectionPropertyMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SelectionPropertyMetadataMapper.php
-
-		-
 			message: '#^Parameter \#2 \$minItems of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\ArrayMetadata constructor expects int\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3335,12 +3713,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SelectionPropertyMetadataMapper.php
-
-		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SingleSelectionPropertyMetadataMapper.php
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\StringMetadata\:\:toJsonSchema\(\) return type has no value type specified in iterable type array\.$#'
@@ -3361,31 +3733,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
 
 		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
-
-		-
 			message: '#^Parameter \#1 \$minLength of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\StringMetadata constructor expects int\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
-
-		-
 			message: '#^Parameter \#2 \$maxLength of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\StringMetadata constructor expects int\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
-
-		-
-			message: '#^Parameter \#3 \$pattern of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\StringMetadata constructor expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
@@ -4597,15 +4951,9 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Sulu\\\\Bundle\\\\AdminBundle\\\\Metadata\\\\SchemaMetadata\\\\SchemaMetadata'' and Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
-
-		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 9
+			count: 6
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
@@ -4660,12 +5008,6 @@ parameters:
 			message: '#^Cannot call method getValue\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 9
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
-
-		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
@@ -4773,7 +5115,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 3
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
 
 		-
@@ -4837,46 +5179,10 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
 
 		-
-			message: '#^Parameter \#1 \$type of class Sulu\\Bundle\\AdminBundle\\Exception\\PropertyMetadataMapperNotFoundException constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
-
-		-
 			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
 			identifier: argument.type
 			count: 6
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
-
-		-
-			message: '#^Parameter \#1 \$cacheDir of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\StructureFormMetadataLoader\:\:warmUp\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
-
-		-
-			message: '#^Parameter \#1 \$directory of function mkdir expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
-
-		-
-			message: '#^Parameter \#1 \$directory of function tempnam expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
-
-		-
-			message: '#^Parameter \#1 \$filename of function file_exists expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
-
-		-
-			message: '#^Parameter \#7 \$cacheDir of class Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\StructureFormMetadataLoader constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
 
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
@@ -26047,12 +26353,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
 
 		-
-			message: '#^Cannot access offset ''global_block'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
-
-		-
 			message: '#^Cannot access offset ''hotspot'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
@@ -26407,12 +26707,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
 
 		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
-
-		-
 			message: '#^Parameter \#2 \$minItems of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\ArrayMetadata constructor expects int\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -26492,12 +26786,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
-
-		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -35923,12 +36211,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Content/Types/DateTime.php
 
 		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Content/Types/Email.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\PageBundle\\Content\\Types\\PageSelection\:\:exportData\(\) should return string but returns string\|false\.$#'
 			identifier: return.type
 			count: 1
@@ -40648,12 +40930,6 @@ parameters:
 			message: '#^Parameter \#1 \$json of function json_decode expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
-
-		-
-			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
 
 		-
@@ -60061,12 +60337,6 @@ parameters:
 			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
 
 		-
-			message: '#^Cannot access property \$length on DOMNodeList\<DOMNode\>\|false\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
-
-		-
 			message: '#^Cannot assign offset mixed to array\<string\>\|string\.$#'
 			identifier: offsetAssign.dimType
 			count: 1
@@ -60075,12 +60345,6 @@ parameters:
 		-
 			message: '#^Cannot assign offset mixed to array\<string\>\|string\|null\.$#'
 			identifier: offsetAssign.dimType
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
-
-		-
-			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
-			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
 
@@ -60111,12 +60375,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\AbstractLoader\:\:loadStructureTags\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\AbstractLoader\:\:parse\(\) has parameter \$resource with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
 
@@ -60273,7 +60531,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$length on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
@@ -60297,7 +60555,7 @@ parameters:
 		-
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 3
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
 
 		-
@@ -60416,12 +60674,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:normalizeStructureData\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Metadata\\Loader\\StructureXmlLoader\:\:parse\(\) has parameter \$resource with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Content/Metadata/Loader/StructureXmlLoader.php
@@ -64423,6 +64675,12 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
 
 		-
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setValue\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string, float given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
+
+		-
 			message: '#^Property Sulu\\Component\\Content\\Tests\\Unit\\Types\\NumberTest\:\:\$template is never written, only read\.$#'
 			identifier: property.onlyRead
 			count: 1
@@ -64505,12 +64763,6 @@ parameters:
 			identifier: ternary.alwaysTrue
 			count: 1
 			path: src/Sulu/Component/Content/Types/Block/SegmentBlockVisitor.php
-
-		-
-			message: '#^Argument of an invalid type iterable\<Sulu\\Component\\Content\\Types\\Block\\BlockVisitorInterface\>\|null supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Sulu/Component/Content/Types/BlockContentType.php
 
 		-
 			message: '#^Cannot access offset ''type'' on mixed\.$#'
@@ -64737,24 +64989,6 @@ parameters:
 		-
 			message: '#^Parameter \#7 \$segmentKey of method Sulu\\Component\\Content\\ContentTypeExportInterface\:\:importData\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Content/Types/BlockContentType.php
-
-		-
-			message: '#^Property Sulu\\Component\\Content\\Types\\BlockContentType\:\:\$languageNamespace is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/Sulu/Component/Content/Types/BlockContentType.php
-
-		-
-			message: '#^Property Sulu\\Component\\Content\\Types\\BlockContentType\:\:\$requestAnalyzer is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/Sulu/Component/Content/Types/BlockContentType.php
-
-		-
-			message: '#^Property Sulu\\Component\\Content\\Types\\BlockContentType\:\:\$targetGroupStore is never read, only written\.$#'
-			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/Content/Types/BlockContentType.php
 

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -26,10 +26,6 @@ use Sulu\Component\Content\Metadata\SectionMetadata as ContentSectionMetadata;
  */
 class FormMetadataMapper
 {
-    public function __construct()
-    {
-    }
-
     /**
      * @return ItemMetadata[]
      */

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -17,7 +17,6 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
 use Sulu\Component\Content\Metadata\BlockMetadata as ContentBlockMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\Metadata\SectionMetadata as ContentSectionMetadata;
@@ -27,7 +26,7 @@ use Sulu\Component\Content\Metadata\SectionMetadata as ContentSectionMetadata;
  */
 class FormMetadataMapper
 {
-    public function __construct(private PropertyMetadataMapperRegistry $propertyMetadataMapperRegistry)
+    public function __construct()
     {
     }
 

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -17,16 +17,8 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AllOfsMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ArrayMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ConstMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\IfThenElseMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\RefSchemaMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Component\Content\Metadata\BlockMetadata as ContentBlockMetadata;
-use Sulu\Component\Content\Metadata\ItemMetadata as ContentItemMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\Metadata\SectionMetadata as ContentSectionMetadata;
 
@@ -58,14 +50,6 @@ class FormMetadataMapper
         }
 
         return $items;
-    }
-
-    /**
-     * @param ContentItemMetadata[] $itemsMetadata
-     */
-    public function mapSchema(array $itemsMetadata): SchemaMetadata
-    {
-        return new SchemaMetadata($this->mapSchemaProperties($itemsMetadata));
     }
 
     /**
@@ -196,60 +180,5 @@ class FormMetadataMapper
                     break;
             }
         }
-    }
-
-    /**
-     * @param ContentItemMetadata[] $itemsMetadata
-     *
-     * @return PropertyMetadata[]
-     */
-    private function mapSchemaProperties(array $itemsMetadata): array
-    {
-        return \array_filter(\array_map(function(ContentItemMetadata $itemMetadata) {
-            if ($itemMetadata instanceof ContentSectionMetadata) {
-                return $this->mapSchemaProperties($itemMetadata->getChildren());
-            }
-
-            if ($itemMetadata instanceof ContentBlockMetadata) {
-                $blockTypeSchemas = [];
-                foreach ($itemMetadata->getComponents() as $blockType) {
-                    $metadata = new SchemaMetadata($this->mapSchemaProperties($blockType->getChildren()));
-                    if ($blockType->hasTag('sulu.global_block')) {
-                        $definitionName = $blockType->getTag('sulu.global_block')['attributes']['global_block'];
-                        $metadata = new RefSchemaMetadata('#/definitions/' . $definitionName);
-                    }
-
-                    $blockTypeSchemas[] = new IfThenElseMetadata(
-                        new SchemaMetadata([
-                            new PropertyMetadata('type', true, new ConstMetadata($blockType->getName())),
-                        ]),
-                        $metadata
-                    );
-                }
-
-                return new PropertyMetadata(
-                    $itemMetadata->getName(),
-                    $itemMetadata->isRequired(),
-                    new ArrayMetadata(
-                        new AllOfsMetadata($blockTypeSchemas)
-                    )
-                );
-            }
-
-            /** @var ContentPropertyMetadata $propertyMetadata */
-            $propertyMetadata = $itemMetadata;
-            $type = $propertyMetadata->getType();
-
-            if ($this->propertyMetadataMapperRegistry->has($type)) {
-                return $this->propertyMetadataMapperRegistry
-                    ->get($type)
-                    ->mapPropertyMetadata($propertyMetadata);
-            }
-
-            return new PropertyMetadata(
-                $propertyMetadata->getName(),
-                $propertyMetadata->isRequired()
-            );
-        }, $itemsMetadata));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
@@ -31,7 +31,7 @@ class FieldMetadata extends ItemMetadata
     /**
      * @var bool
      */
-    protected $required;
+    protected $required = false;
 
     /**
      * @var bool
@@ -76,6 +76,11 @@ class FieldMetadata extends ItemMetadata
     public function addOption(OptionMetadata $option): void
     {
         $this->options[$option->getName()] = $option;
+    }
+
+    public function findOption(string $name): ?OptionMetadata
+    {
+        return $this->options[$name] ?? null;
     }
 
     public function getDefaultType(): ?string

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
@@ -61,7 +61,7 @@ class FieldMetadata extends ItemMetadata
     /**
      * @var TagMetadata[]
      */
-    protected $tags;
+    protected $tags = [];
 
     public function setType(string $type): void
     {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -190,6 +190,28 @@ class FormMetadata extends AbstractMetadata
         return $tags;
     }
 
+    public function hasTag(string $name): bool
+    {
+        foreach ($this->getTags() as $tag) {
+            if ($tag->getName() === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function findTag(string $name): ?TagMetadata
+    {
+        foreach ($this->getTags() as $tag) {
+            if ($tag->getName() === $name) {
+                return $tag;
+            }
+        }
+
+        return null;
+    }
+
     public function addTag(TagMetadata $tag): void
     {
         $this->tags[] = $tag;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ItemMetadata.php
@@ -51,7 +51,7 @@ abstract class ItemMetadata
     /**
      * @var int
      */
-    protected $colSpan;
+    protected $colSpan = 12;
 
     public function __construct(string $name)
     {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
 use Sulu\Component\Content\Metadata\Loader\AbstractLoader;
 
@@ -32,6 +33,7 @@ class FormXmlLoader extends AbstractLoader
     public function __construct(
         private PropertiesXmlParser $propertiesXmlParser,
         private SchemaXmlParser $schemaXmlParser,
+        private TagXmlParser $tagXmlParser,
         private SchemaMetadataProvider $schemaMetadataProvider,
     ) {
         parent::__construct(
@@ -49,7 +51,9 @@ class FormXmlLoader extends AbstractLoader
         $form = new FormMetadata();
         $form->addResource($resource);
         $form->setKey($xpath->query('/x:form/x:key')->item(0)->nodeValue);
-        $form->setTags($this->loadStructureTags('/x:form/x:tag', $xpath));
+
+        $tagNodes = $xpath->query('/x:form/x:tag') ?: [];
+        $form->setTags($this->tagXmlParser->load($xpath, $tagNodes));
 
         $propertiesNode = $xpath->query('/x:form/x:properties')->item(0);
         $properties = $this->propertiesXmlParser->load(

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
 use Sulu\Component\Content\Metadata\Loader\AbstractLoader;
 
 /**
@@ -26,6 +27,8 @@ use Sulu\Component\Content\Metadata\Loader\AbstractLoader;
  */
 class FormXmlLoader extends AbstractLoader
 {
+    use XmlParserTrait;
+
     public const SCHEMA_PATH = '/schema/form-1.0.xsd';
 
     public const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
@@ -50,12 +53,15 @@ class FormXmlLoader extends AbstractLoader
 
         $form = new FormMetadata();
         $form->addResource($resource);
-        $form->setKey($xpath->query('/x:form/x:key')->item(0)->nodeValue);
+        $formKey = $this->getValueFromXPath('/x:form/x:key', $xpath);
+        \assert(\is_string($formKey), 'Expected the form key of "' . $resource . '" to be defined.');
+        $form->setKey($formKey);
 
         $tagNodes = $xpath->query('/x:form/x:tag') ?: [];
         $form->setTags($this->tagXmlParser->load($xpath, $tagNodes));
 
-        $propertiesNode = $xpath->query('/x:form/x:properties')->item(0);
+        $propertiesNode = ($xpath->query('/x:form/x:properties') ?: null)?->item(0);
+        \assert(null !== $propertiesNode, 'Expected properties be defined for "' . $resource . '".');
         $properties = $this->propertiesXmlParser->load(
             $xpath,
             $propertiesNode,

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -60,8 +60,9 @@ class FormXmlLoader extends AbstractLoader
 
         $schema = $this->schemaMetadataProvider->getMetadata($properties);
         $schemaNode = $xpath->query('/x:form/x:schema')->item(0);
+
         if ($schemaNode) {
-            $schema->merge($this->schemaXmlParser->load($xpath, $schemaNode));
+            $schema = $schema->merge($this->schemaXmlParser->load($xpath, $schemaNode));
         }
         $form->setSchema($schema);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -12,11 +12,10 @@
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader;
 
 use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
-use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadata as ExternalFormMetadata;
-use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
 use Sulu\Component\Content\Metadata\Loader\AbstractLoader;
 
 /**
@@ -31,9 +30,9 @@ class FormXmlLoader extends AbstractLoader
     public const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
 
     public function __construct(
-        private DeprecatedPropertiesXmlParser $propertiesXmlParser,
+        private PropertiesXmlParser $propertiesXmlParser,
         private SchemaXmlParser $schemaXmlParser,
-        private FormMetadataMapper $formMetadataMapper
+        private SchemaMetadataProvider $schemaMetadataProvider,
     ) {
         parent::__construct(
             self::SCHEMA_PATH,
@@ -47,8 +46,8 @@ class FormXmlLoader extends AbstractLoader
             throw new InvalidRootTagException($resource, 'form');
         }
 
-        $form = new ExternalFormMetadata();
-        $form->setResource($resource);
+        $form = new FormMetadata();
+        $form->addResource($resource);
         $form->setKey($xpath->query('/x:form/x:key')->item(0)->nodeValue);
         $form->setTags($this->loadStructureTags('/x:form/x:tag', $xpath));
 
@@ -59,34 +58,16 @@ class FormXmlLoader extends AbstractLoader
             $form->getKey()
         );
 
+        $schema = $this->schemaMetadataProvider->getMetadata($properties);
         $schemaNode = $xpath->query('/x:form/x:schema')->item(0);
         if ($schemaNode) {
-            $form->setSchema($this->schemaXmlParser->load($xpath, $schemaNode));
+            $schema->merge($this->schemaXmlParser->load($xpath, $schemaNode));
         }
+        $form->setSchema($schema);
 
         foreach ($properties as $property) {
-            $form->addChild($property);
+            $form->addItem($property);
         }
-        $form->burnProperties();
-
-        return $this->mapFormsMetadata($form);
-    }
-
-    private function mapFormsMetadata(ExternalFormMetadata $formMetadata): FormMetadata
-    {
-        $form = new FormMetadata();
-        $form->addResource($formMetadata->getResource());
-        $form->setTags($this->formMetadataMapper->mapTags($formMetadata->getTags()));
-        $form->setItems($this->formMetadataMapper->mapChildren($formMetadata->getChildren()));
-
-        $schema = $this->formMetadataMapper->mapSchema($formMetadata->getProperties());
-        $xmlSchema = $formMetadata->getSchema();
-        if ($xmlSchema) {
-            $schema = $schema->merge($xmlSchema);
-        }
-
-        $form->setSchema($schema);
-        $form->setKey($formMetadata->getKey());
 
         return $form;
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
@@ -32,7 +32,7 @@ class OptionMetadata
     protected $type;
 
     /**
-     * @var string|int|OptionMetadata[]
+     * @var string|float|int|OptionMetadata[]
      */
     protected $value;
 
@@ -81,7 +81,7 @@ class OptionMetadata
     }
 
     /**
-     * @return int|string|OptionMetadata[]
+     * @return int|float|string|OptionMetadata[]
      */
     public function getValue()
     {
@@ -89,7 +89,7 @@ class OptionMetadata
     }
 
     /**
-     * @param int|string|OptionMetadata[] $value
+     * @param int|float|string|OptionMetadata[] $value
      */
     public function setValue($value): void
     {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
@@ -32,7 +32,7 @@ class OptionMetadata
     protected $type;
 
     /**
-     * @var string|float|int|OptionMetadata[]
+     * @var string|int|OptionMetadata[]
      */
     protected $value;
 
@@ -81,7 +81,7 @@ class OptionMetadata
     }
 
     /**
-     * @return int|float|string|OptionMetadata[]
+     * @return int|string|OptionMetadata[]
      */
     public function getValue()
     {
@@ -89,7 +89,7 @@ class OptionMetadata
     }
 
     /**
-     * @param int|float|string|OptionMetadata[] $value
+     * @param int|string|OptionMetadata[] $value
      */
     public function setValue($value): void
     {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -33,8 +33,11 @@ class PropertiesXmlParser
      */
     private $locales;
 
-    public function __construct(private TranslatorInterface $translator, array $locales)
-    {
+    public function __construct(
+        private TagXmlParser $tagXmlParser,
+        private TranslatorInterface $translator,
+        array $locales,
+    ) {
         $this->locales = \array_keys($locales);
     }
 
@@ -113,34 +116,6 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function validateTag(&$tags, $tag)
-    {
-        if (!isset($tags[$tag['name']])) {
-            $tags[$tag['name']] = [];
-        }
-
-        $tags[$tag['name']][] = $tag['priority'];
-    }
-
-    private function loadTag(\DOMXPath $xpath, \DOMNode $node)
-    {
-        $tag = [
-            'name' => null,
-            'priority' => null,
-            'attributes' => [],
-        ];
-
-        foreach ($node->attributes as $key => $attr) {
-            if (\in_array($key, ['name', 'priority'])) {
-                $tag[$key] = $attr->value;
-            } else {
-                $tag['attributes'][$key] = $attr->value;
-            }
-        }
-
-        return $tag;
-    }
-
     private function loadBlock(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
     {
         $result = $this->loadProperty($xpath, $node, $formKey);
@@ -169,18 +144,7 @@ class PropertiesXmlParser
 
     private function loadTags(\DOMXPath $xpath, ?\DOMNode $context = null)
     {
-        $tags = [];
-        $result = [];
-
-        /** @var \DOMElement $node */
-        foreach ($xpath->query('x:tag', $context) as $node) {
-            $tag = $this->loadTag($xpath, $node);
-            $this->validateTag($tags, $tag);
-
-            $result[] = $tag;
-        }
-
-        return $result;
+        return $this->tagXmlParser->load($xpath, $xpath->query('x:tag', $context));
     }
 
     private function loadTypes(\DOMXPath $xpath, ?\DOMNode $context, ?string $formKey)
@@ -387,14 +351,7 @@ class PropertiesXmlParser
             $property->setColSpan($data['colspan']);
         }
         $property->setSpaceAfter($data['spaceAfter']);
-        foreach ($data['tags'] as $tagData) {
-            $tag = new TagMetadata();
-            $tag->setName($tagData['name']);
-            $tag->setPriority($tagData['priority'] ?? null);
-            $tag->setAttributes($tagData['attributes'] ?? []);
-
-            $property->addTag($tag);
-        }
+        $property->setTags($data['tags'] ?? []);
         $property->setMinOccurs(null !== $data['minOccurs'] ? \intval($data['minOccurs']) : null);
         $property->setMaxOccurs(null !== $data['maxOccurs'] ? \intval($data['maxOccurs']) : null);
         $property->setDisabledCondition($this->normalizeConditionData($data['disabledCondition'] ?? null));

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -33,6 +33,9 @@ class PropertiesXmlParser
      */
     private $locales;
 
+    /**
+     * @param array<string, string> $locales
+     */
     public function __construct(
         private TagXmlParser $tagXmlParser,
         private TranslatorInterface $translator,
@@ -41,6 +44,9 @@ class PropertiesXmlParser
         $this->locales = \array_keys($locales);
     }
 
+    /**
+     * @return array<FieldMetadata|SectionMetadata>
+     */
     public function load(
         \DOMXPath $xpath,
         \DOMNode $context,
@@ -51,6 +57,9 @@ class PropertiesXmlParser
         return $this->mapProperties($propertyData);
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
     private function loadProperties(\DOMXPath $xpath, \DOMNode $context, ?string $formKey): array
     {
         $result = [];

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -1,0 +1,529 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
+use Sulu\Component\Content\Exception\InvalidDefaultTypeException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
+class PropertiesXmlParser
+{
+    use XmlParserTrait;
+
+    /**
+     * @var string[]
+     */
+    private $locales;
+
+    public function __construct(private TranslatorInterface $translator, array $locales)
+    {
+        $this->locales = \array_keys($locales);
+    }
+
+    public function load(
+        \DOMXPath $xpath,
+        \DOMNode $context,
+        ?string $formKey = null
+    ): array {
+        $propertyData = $this->loadProperties($xpath, $context, $formKey);
+
+        return $this->mapProperties($propertyData);
+    }
+
+    private function loadProperties(\DOMXPath $xpath, \DOMNode $context, ?string $formKey): array
+    {
+        $result = [];
+
+        /** @var \DOMElement $node */
+        foreach ($xpath->query('x:*', $context) as $node) {
+            if ('property' === $node->tagName) {
+                $value = $this->loadProperty($xpath, $node, $formKey);
+                $result[$value['name']] = $value;
+            } elseif ('block' === $node->tagName) {
+                $value = $this->loadBlock($xpath, $node, $formKey);
+                $result[$value['name']] = $value;
+            } elseif ('section' === $node->tagName) {
+                $value = $this->loadSection($xpath, $node, $formKey);
+                $result[$value['name']] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    private function loadProperty(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
+    {
+        $result = $this->loadValues(
+            $xpath,
+            $node,
+            [
+                'name',
+                'type',
+                'default-type',
+                'minOccurs',
+                'maxOccurs',
+                'colspan',
+                'cssClass',
+                'spaceAfter',
+                'disabledCondition',
+                'visibleCondition',
+            ]
+        );
+
+        $result['mandatory'] = $this->getValueFromXPath('@mandatory', $xpath, $node, false);
+        $result['multilingual'] = $this->getValueFromXPath('@multilingual', $xpath, $node, true);
+        $result['onInvalid'] = $this->getValueFromXPath('@onInvalid', $xpath, $node);
+        $result['tags'] = $this->loadTags($xpath, $node);
+        $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
+        $result['meta'] = $this->loadMeta($xpath, $node);
+        $result['types'] = $this->loadTypes($xpath, $node, $formKey);
+
+        $typeNames = \array_map(function($type) {
+            return $type['name'];
+        }, $result['types']);
+
+        if (!empty($typeNames)) {
+            if (!$result['default-type'] && null !== ($key = \array_key_first($typeNames))) {
+                $result['default-type'] = $typeNames[$key];
+            }
+
+            if (!\in_array($result['default-type'], $typeNames)) {
+                throw new InvalidDefaultTypeException($result['name'], $result['default-type'], $typeNames);
+            }
+        }
+
+        return $result;
+    }
+
+    private function validateTag(&$tags, $tag)
+    {
+        if (!isset($tags[$tag['name']])) {
+            $tags[$tag['name']] = [];
+        }
+
+        $tags[$tag['name']][] = $tag['priority'];
+    }
+
+    private function loadTag(\DOMXPath $xpath, \DOMNode $node)
+    {
+        $tag = [
+            'name' => null,
+            'priority' => null,
+            'attributes' => [],
+        ];
+
+        foreach ($node->attributes as $key => $attr) {
+            if (\in_array($key, ['name', 'priority'])) {
+                $tag[$key] = $attr->value;
+            } else {
+                $tag['attributes'][$key] = $attr->value;
+            }
+        }
+
+        return $tag;
+    }
+
+    private function loadBlock(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
+    {
+        $result = $this->loadProperty($xpath, $node, $formKey);
+        $result['type'] = 'block';
+
+        return $result;
+    }
+
+    private function loadSection(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
+    {
+        $result = $this->loadValues(
+            $xpath,
+            $node,
+            ['name', 'colspan', 'cssClass', 'disabledCondition', 'visibleCondition']
+        );
+
+        $result['type'] = 'section';
+        $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
+        $result['meta'] = $this->loadMeta($xpath, $node);
+
+        $propertiesNode = $xpath->query('x:properties', $node)->item(0);
+        $result['properties'] = $this->loadProperties($xpath, $propertiesNode, $formKey);
+
+        return $result;
+    }
+
+    private function loadTags(\DOMXPath $xpath, ?\DOMNode $context = null)
+    {
+        $tags = [];
+        $result = [];
+
+        /** @var \DOMElement $node */
+        foreach ($xpath->query('x:tag', $context) as $node) {
+            $tag = $this->loadTag($xpath, $node);
+            $this->validateTag($tags, $tag);
+
+            $result[] = $tag;
+        }
+
+        return $result;
+    }
+
+    private function loadTypes(\DOMXPath $xpath, ?\DOMNode $context, ?string $formKey)
+    {
+        $result = [];
+
+        /** @var \DOMElement $node */
+        foreach ($xpath->query('x:types/x:type', $context) as $node) {
+            $value = $this->loadType($xpath, $node, $formKey);
+            $result[$value['name']] = $value;
+        }
+
+        return $result;
+    }
+
+    private function loadType(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
+    {
+        $result = $this->loadValues($xpath, $node, ['name', 'ref']);
+        if ($result['ref'] && $result['name']) {
+            throw new \InvalidArgumentException(\sprintf(
+                "Element '{http://schemas.sulu.io/template/template}type', attribute 'name' / 'ref': The attribute 'name' and 'ref' is not allowed at the same time. (in %s - line %s)",
+                $node->baseURI,
+                $node->getLineNo()
+            ));
+        } elseif (!$result['ref'] && !$result['name']) {
+            throw new \InvalidArgumentException(\sprintf(
+                "Element '{http://schemas.sulu.io/template/template}type', attribute 'name' / 'ref': The attribute 'name' or 'ref' is required. (in %s - line %s)",
+                $node->baseURI,
+                $node->getLineNo()
+            ));
+        }
+
+        if ($result['ref']) {
+            $result['name'] = $result['ref'];
+            $result['ref'] = true;
+        }
+
+        $result['meta'] = $this->loadMeta($xpath, $node);
+
+        $propertiesNode = $xpath->query('x:properties', $node)->item(0);
+        if ($propertiesNode) {
+            $result['properties'] = $this->loadProperties($xpath, $propertiesNode, $formKey);
+        }
+
+        return $result;
+    }
+
+    private function loadValues(\DOMXPath $xpath, \DOMNode $node, $keys, $prefix = '@')
+    {
+        $result = [];
+
+        foreach ($keys as $key) {
+            $result[$key] = $this->getValueFromXPath($prefix . $key, $xpath, $node);
+        }
+
+        return $result;
+    }
+
+    private function loadMeta(\DOMXPath $xpath, ?\DOMNode $context = null)
+    {
+        $result = [];
+        $metaNode = $xpath->query('x:meta', $context)->item(0);
+
+        if (!$metaNode) {
+            return $result;
+        }
+
+        $result['title'] = $this->loadMetaTag('x:title', $xpath, $metaNode);
+        $result['info_text'] = $this->loadMetaTag('x:info_text', $xpath, $metaNode);
+        $result['placeholder'] = $this->loadMetaTag('x:placeholder', $xpath, $metaNode);
+
+        return $result;
+    }
+
+    private function loadMetaTag($path, \DOMXPath $xpath, ?\DOMNode $context = null)
+    {
+        $result = [];
+
+        $translationKey = null;
+
+        /** @var \DOMElement $node */
+        foreach ($xpath->query($path, $context) as $node) {
+            $lang = $this->getValueFromXPath('@lang', $xpath, $node);
+
+            if (!$lang) {
+                $translationKey = $node->textContent;
+
+                continue;
+            }
+
+            $result[$lang] = $node->textContent;
+        }
+
+        if (!$translationKey) {
+            return $result;
+        }
+
+        $missingLocales = \array_diff($this->locales, \array_keys($result));
+        foreach ($missingLocales as $missingLocale) {
+            $result[$missingLocale] = $this->translator->trans($translationKey, [], 'admin', $missingLocale);
+        }
+
+        return $result;
+    }
+
+    private function loadParams($path, \DOMXPath $xpath, ?\DOMNode $context = null)
+    {
+        $result = [];
+
+        /** @var \DOMElement $node */
+        foreach ($xpath->query($path, $context) as $node) {
+            $result[] = $this->loadParam($xpath, $node);
+        }
+
+        return $result;
+    }
+
+    private function loadParam(\DOMXPath $xpath, \DOMNode $node)
+    {
+        $result = [
+            'name' => $this->getValueFromXPath('@name', $xpath, $node),
+            'type' => $this->getValueFromXPath('@type', $xpath, $node, 'string'),
+            'meta' => $this->loadMeta($xpath, $node),
+        ];
+
+        $result['value'] = match ($result['type']) {
+            'collection' => $this->loadParams('x:param', $xpath, $node),
+            default => $this->getValueFromXPath('@value', $xpath, $node),
+        };
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $data
+     *
+     * @return array<FieldMetadata|SectionMetadata>
+     */
+    private function mapProperties(array $data): array
+    {
+        $properties = [];
+        foreach ($data as $propertyName => $dataProperty) {
+            $property = $this->createProperty($propertyName, $dataProperty);
+
+            if ($property) {
+                $properties[] = $property;
+            }
+        }
+
+        return $properties;
+    }
+
+    private function createProperty(string $propertyName, array $propertyData): FieldMetadata|SectionMetadata
+    {
+        if ('section' === $propertyData['type']) {
+            return $this->createSection($propertyName, $propertyData);
+        }
+
+        $property = new FieldMetadata($propertyName);
+        $this->mapProperty($property, $propertyData);
+
+        return $property;
+    }
+
+    private function createSection($propertyName, $data): SectionMetadata
+    {
+        $section = new SectionMetadata($propertyName);
+        if (isset($data['colspan'])) {
+            $section->setColSpan($data['colspan']);
+        }
+
+        if (isset($data['meta']['title'])) {
+            $section->setLabels($data['meta']['title']);
+        }
+
+        if (isset($data['meta']['info_text'])) {
+            $section->setDescriptions($data['meta']['info_text']);
+        }
+
+        if (isset($data['disabledCondition'])) {
+            $section->setDisabledCondition($this->normalizeConditionData($data['disabledCondition']));
+        }
+
+        if (isset($data['visibleCondition'])) {
+            $section->setVisibleCondition($this->normalizeConditionData($data['visibleCondition']));
+        }
+
+        foreach ($data['properties'] as $name => $property) {
+            $section->addItem($this->createProperty($name, $property));
+        }
+
+        return $section;
+    }
+
+    private function mapProperty(FieldMetadata $property, $data): void
+    {
+        $data = $this->normalizePropertyData($data);
+
+        $property->setDefaultType($data['default-type']);
+        $property->setType($data['type']);
+        $property->setMultilingual($data['multilingual']);
+        $property->setRequired($data['mandatory']);
+        if (isset($data['colspan'])) {
+            $property->setColSpan($data['colspan']);
+        }
+        $property->setSpaceAfter($data['spaceAfter']);
+        foreach ($data['tags'] as $tagData) {
+            $tag = new TagMetadata();
+            $tag->setName($tagData['name']);
+            $tag->setPriority($tagData['priority'] ?? null);
+            $tag->setAttributes($tagData['attributes'] ?? []);
+
+            $property->addTag($tag);
+        }
+        $property->setMinOccurs(null !== $data['minOccurs'] ? \intval($data['minOccurs']) : null);
+        $property->setMaxOccurs(null !== $data['maxOccurs'] ? \intval($data['maxOccurs']) : null);
+        $property->setDisabledCondition($this->normalizeConditionData($data['disabledCondition'] ?? null));
+        $property->setVisibleCondition($this->normalizeConditionData($data['visibleCondition'] ?? null));
+        $property->setOnInvalid(\array_key_exists('onInvalid', $data) ? $data['onInvalid'] : null);
+
+        // TODO schema
+
+        foreach ($data['params'] as $parameter) {
+            $option = new OptionMetadata();
+            $option->setName($parameter['name']);
+            $option->setType($parameter['type']);
+
+            if (OptionMetadata::TYPE_COLLECTION === $parameter['type']) {
+                foreach ($parameter['value'] as $parameterName => $parameterValue) {
+                    $valueOption = new OptionMetadata();
+                    $valueOption->setName($parameterValue['name']);
+                    $valueOption->setValue($parameterValue['value']);
+
+                    $this->mapOptionMeta($parameterValue, $valueOption);
+
+                    $option->addValueOption($valueOption);
+                }
+            } elseif (OptionMetadata::TYPE_STRING === $parameter['type'] || OptionMetadata::TYPE_EXPRESSION === $parameter['type']) {
+                $option->setValue($parameter['value']);
+                $this->mapOptionMeta($parameter, $option);
+            } else {
+                throw new \Exception('Unsupported parameter given "' . \get_class($parameter) . '"');
+            }
+
+            $property->addOption($option);
+        }
+
+        $this->mapMeta($property, $data['meta']);
+
+        $types = $data['types'];
+        foreach ($types as $name => $typeData) {
+            $type = new FormMetadata();
+            $type->setName($name);
+            $type->setTitles($typeData['meta']['title'] ?? []);
+
+            if (!$typeData['ref']) {
+                foreach ($this->mapProperties($typeData['properties']) as $childProperty) {
+                    $type->addItem($childProperty);
+                }
+            } else {
+                $tagMetadata = new TagMetadata();
+                $tagMetadata->setName('sulu.global_block');
+                $tagMetadata->setAttributes([
+                    'global_block' => $name,
+                ]);
+
+                $type->addTag($tagMetadata);
+            }
+
+            $property->addType($type);
+        }
+    }
+
+    private function normalizePropertyData($data): array
+    {
+        $data = \array_replace_recursive(
+            [
+                'type' => null,
+                'multilingual' => true,
+                'mandatory' => true,
+                'colspan' => null,
+                'cssClass' => null,
+                'minOccurs' => null,
+                'maxOccurs' => null,
+                'spaceAfter' => null,
+            ],
+            $this->normalizeItem($data)
+        );
+
+        return $data;
+    }
+
+    private function normalizeConditionData($data): ?string
+    {
+        if (\is_bool($data)) {
+            return $data ? 'true' : 'false';
+        }
+
+        return $data;
+    }
+
+    private function normalizeItem($data): array
+    {
+        $data = \array_merge_recursive(
+            [
+                'meta' => [
+                    'title' => [],
+                    'info_text' => [],
+                    'placeholders' => [],
+                ],
+                'params' => [],
+                'tags' => [],
+            ],
+            $data
+        );
+
+        return $data;
+    }
+
+    private function mapOptionMeta(array $parameterValue, OptionMetadata $option): void
+    {
+        if (!\array_key_exists('meta', $parameterValue)) {
+            return;
+        }
+
+        foreach ($parameterValue['meta'] as $metaKey => $metaValues) {
+            switch ($metaKey) {
+                case 'title':
+                    $option->setTitles($metaValues);
+                    break;
+                case 'info_text':
+                    $option->setInfotexts($metaValues);
+                    break;
+                case 'placeholder':
+                    $option->setPlaceholders($metaValues);
+                    break;
+            }
+        }
+    }
+
+    private function mapMeta(ItemMetadata $item, $meta): void
+    {
+        $item->setLabels($meta['title']);
+        $item->setDescriptions($meta['info_text']);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TagXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TagXmlParser.php
@@ -36,6 +36,7 @@ class TagXmlParser
                 'attributes' => [],
             ];
 
+            /** @var string $key */
             /** @var \DOMAttr $attr */
             foreach ($node->attributes ?? [] as $key => $attr) {
                 if (\in_array($key, ['name'])) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TagXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TagXmlParser.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
+
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
+class TagXmlParser
+{
+    use XmlParserTrait;
+
+    /**
+     * @param \DOMNode[] $tagNodes
+     *
+     * @return array<TagMetadata>
+     */
+    public function load(\DOMXPath $xpath, iterable $tagNodes): array
+    {
+        $result = [];
+
+        foreach ($tagNodes as $node) {
+            $tag = [
+                'name' => null,
+                'attributes' => [],
+            ];
+
+            /** @var \DOMAttr $attr */
+            foreach ($node->attributes ?? [] as $key => $attr) {
+                if (\in_array($key, ['name'])) {
+                    $tag[$key] = $attr->value;
+                } else {
+                    $tag['attributes'][$key] = $attr->value;
+                }
+            }
+
+            if (!isset($tag['name'])) {
+                // this should not happen because of the XSD validation
+                throw new \InvalidArgumentException('Tag does not have a name in template definition');
+            }
+
+            $tagMetadata = new TagMetadata();
+            $tagMetadata->setName($tag['name']);
+            $tagMetadata->setAttributes($tag['attributes']);
+
+            $result[] = $tagMetadata;
+        }
+
+        return $result;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/SchemaMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/SchemaMetadataProvider.php
@@ -52,10 +52,12 @@ class SchemaMetadataProvider
 
             $type = $itemMetadata->getType();
 
-            if ($this->propertyMetadataMapperRegistry->has($type) && false) {
+            if ($this->propertyMetadataMapperRegistry->has($type)) {
                 yield $this->propertyMetadataMapperRegistry
                     ->get($type)
                     ->mapPropertyMetadata($itemMetadata);
+
+                continue;
             }
 
             yield new PropertyMetadata(

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/SchemaMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/SchemaMetadataProvider.php
@@ -29,33 +29,39 @@ class SchemaMetadataProvider
      */
     public function getMetadata(array $itemsMetadata): SchemaMetadata
     {
-        return new SchemaMetadata($this->getSchemaProperties($itemsMetadata));
+        return new SchemaMetadata([...$this->getSchemaProperties($itemsMetadata)]);
     }
 
     /**
      * @param ItemMetadata[] $itemsMetadata
+     *
+     * @return \Generator<int, PropertyMetadata>
      */
-    private function getSchemaProperties(array $itemsMetadata): array
+    private function getSchemaProperties(array $itemsMetadata): \Generator
     {
-        return \array_filter(\array_map(function(ItemMetadata $itemMetadata) {
+        foreach ($itemsMetadata as $itemMetadata) {
             if ($itemMetadata instanceof SectionMetadata) {
-                return $this->getSchemaProperties($itemMetadata->getItems());
+                foreach ($this->getSchemaProperties($itemMetadata->getItems()) as $propertyMetadata) {
+                    yield $propertyMetadata;
+                }
+
+                continue;
             }
 
             \assert($itemMetadata instanceof FieldMetadata, 'ItemMetadata is expected to be FieldMetadata');
 
             $type = $itemMetadata->getType();
 
-            if ($this->propertyMetadataMapperRegistry->has($type)) {
-                return $this->propertyMetadataMapperRegistry
+            if ($this->propertyMetadataMapperRegistry->has($type) && false) {
+                yield $this->propertyMetadataMapperRegistry
                     ->get($type)
                     ->mapPropertyMetadata($itemMetadata);
             }
 
-            return new PropertyMetadata(
+            yield new PropertyMetadata(
                 $itemMetadata->getName(),
                 $itemMetadata->isRequired()
             );
-        }, $itemsMetadata));
+        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/SchemaMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/SchemaMetadataProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
+
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
+class SchemaMetadataProvider
+{
+    public function __construct(private PropertyMetadataMapperRegistry $propertyMetadataMapperRegistry)
+    {
+    }
+
+    /**
+     * @param ItemMetadata[] $itemsMetadata
+     */
+    public function getMetadata(array $itemsMetadata): SchemaMetadata
+    {
+        return new SchemaMetadata($this->getSchemaProperties($itemsMetadata));
+    }
+
+    /**
+     * @param ItemMetadata[] $itemsMetadata
+     */
+    private function getSchemaProperties(array $itemsMetadata): array
+    {
+        return \array_filter(\array_map(function(ItemMetadata $itemMetadata) {
+            if ($itemMetadata instanceof SectionMetadata) {
+                return $this->getSchemaProperties($itemMetadata->getItems());
+            }
+
+            \assert($itemMetadata instanceof FieldMetadata, 'ItemMetadata is expected to be FieldMetadata');
+
+            $type = $itemMetadata->getType();
+
+            if ($this->propertyMetadataMapperRegistry->has($type)) {
+                return $this->propertyMetadataMapperRegistry
+                    ->get($type)
+                    ->mapPropertyMetadata($itemMetadata);
+            }
+
+            return new PropertyMetadata(
+                $itemMetadata->getName(),
+                $itemMetadata->isRequired()
+            );
+        }, $itemsMetadata));
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -35,6 +35,11 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
     private $formMetadataMapper;
 
     /**
+     * @var SchemaMetadataProvider
+     */
+    private $schemaMetadataProvider;
+
+    /**
      * @var WebspaceManagerInterface
      */
     private $webspaceManager;
@@ -67,6 +72,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
     public function __construct(
         StructureMetadataFactoryInterface $structureMetadataFactory,
         FormMetadataMapper $formMetadataMapper,
+        SchemaMetadataProvider $schemaMetadataProvider,
         WebspaceManagerInterface $webspaceManager,
         FieldMetadataValidatorInterface $fieldMetadataValidator,
         array $defaultTypes,
@@ -76,6 +82,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
     ) {
         $this->structureMetadataFactory = $structureMetadataFactory;
         $this->formMetadataMapper = $formMetadataMapper;
+        $this->schemaMetadataProvider = $schemaMetadataProvider;
         $this->webspaceManager = $webspaceManager;
         $this->fieldMetadataValidator = $fieldMetadataValidator;
         $this->defaultTypes = $defaultTypes;
@@ -166,7 +173,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
             $form->setTitles($structureMetadata->getTitles());
             $form->setItems($this->formMetadataMapper->mapChildren($structureMetadata->getChildren()));
 
-            $schema = $this->formMetadataMapper->mapSchema($structureMetadata->getProperties());
+            $schema = $this->schemaMetadataProvider->getMetadata($form->getItems());
             $xmlSchema = $structureMetadata->getSchema();
             if ($xmlSchema) {
                 $schema = $schema->merge($xmlSchema);

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TagMetadata.php
@@ -24,7 +24,7 @@ class TagMetadata
     private $priority;
 
     /**
-     * @var array
+     * @var array<string, string>
      */
     private $attributes = [];
 
@@ -48,16 +48,25 @@ class TagMetadata
         $this->priority = $priority;
     }
 
+    /**
+     * @param array<string, string> $attributes
+     */
     public function setAttributes(array $attributes): void
     {
         $this->attributes = $attributes;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getAttributes()
     {
         return $this->attributes;
     }
 
+    /**
+     * @return mixed
+     */
     public function getAttribute(string $name)
     {
         return $this->attributes[$name] ?? null;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapperInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapperInterface.php
@@ -11,9 +11,9 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata;
 
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 
 interface PropertyMetadataMapperInterface
 {
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata;
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata;
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapperRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapperRegistry.php
@@ -11,18 +11,18 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata;
 
+use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Sulu\Bundle\AdminBundle\Exception\PropertyMetadataMapperNotFoundException;
-use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class PropertyMetadataMapperRegistry
 {
     /**
-     * @var ServiceLocator
+     * @var ContainerInterface
      */
     private $locator;
 
-    public function __construct(ServiceLocator $locator)
+    public function __construct(ContainerInterface $locator)
     {
         $this->locator = $locator;
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMinMaxValueResolver.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMinMaxValueResolver.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata;
 
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Webmozart\Assert\Assert;
 
 class PropertyMetadataMinMaxValueResolver
@@ -26,17 +26,17 @@ class PropertyMetadataMinMaxValueResolver
      * @throws \InvalidArgumentException
      */
     public function resolveMinMaxValue(
-        ContentPropertyMetadata $propertyMetadata,
+        FieldMetadata $fieldMetadata,
         string $minParamName = 'min',
         string $maxParamName = 'max'
     ): object {
-        $mandatory = $propertyMetadata->isRequired();
+        $mandatory = $fieldMetadata->isRequired();
 
-        $min = $propertyMetadata->getParameter($minParamName)['value'] ?? null;
+        $min = $fieldMetadata->findOption($minParamName)?->getValue();
         Assert::nullOrIntegerish($min, \sprintf(
             'Parameter "%s" of property "%s" needs to be either null or of type int',
             $minParamName,
-            $propertyMetadata->getName()
+            $fieldMetadata->getName()
         ));
 
         if (null !== $min) {
@@ -46,7 +46,7 @@ class PropertyMetadataMinMaxValueResolver
         Assert::nullOrGreaterThanEq($min, 0, \sprintf(
             'Parameter "%s" of property "%s" needs to be greater than or equal "0"',
             $minParamName,
-            $propertyMetadata->getName()
+            $fieldMetadata->getName()
         ));
 
         if ($mandatory) {
@@ -56,16 +56,16 @@ class PropertyMetadataMinMaxValueResolver
 
             Assert::greaterThanEq($min, 1, \sprintf(
                 'Because property "%s" is mandatory, parameter "%s" needs to be greater than or equal "1"',
-                $propertyMetadata->getName(),
+                $fieldMetadata->getName(),
                 $minParamName
             ));
         }
 
-        $max = $propertyMetadata->getParameter($maxParamName)['value'] ?? null;
+        $max = $fieldMetadata->findOption($maxParamName)?->getValue();
         Assert::nullOrIntegerish($max, \sprintf(
             'Parameter "%s" of property "%s" needs to be either null or of type int',
             $maxParamName,
-            $propertyMetadata->getName()
+            $fieldMetadata->getName()
         ));
 
         if (null !== $max) {
@@ -75,14 +75,14 @@ class PropertyMetadataMinMaxValueResolver
         Assert::nullOrGreaterThanEq($max, 1, \sprintf(
             'Parameter "%s" of property "%s" needs to be greater than or equal "1"',
             $maxParamName,
-            $propertyMetadata->getName()
+            $fieldMetadata->getName()
         ));
 
         if (null !== $min) {
             Assert::nullOrGreaterThanEq($max, $min, \sprintf(
                 'Because parameter "%1$s" of property "%2$s" has value "%4$d", parameter "%3$s" needs to be greater than or equal "%4$d"',
                 $minParamName,
-                $propertyMetadata->getName(),
+                $fieldMetadata->getName(),
                 $maxParamName,
                 $min
             ));

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SelectionPropertyMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SelectionPropertyMetadataMapper.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata;
 
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 
 class SelectionPropertyMetadataMapper implements PropertyMetadataMapperInterface
 {
@@ -25,10 +25,10 @@ class SelectionPropertyMetadataMapper implements PropertyMetadataMapperInterface
         $this->propertyMetadataMinMaxValueResolver = $propertyMetadataMinMaxValueResolver;
     }
 
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        $mandatory = $propertyMetadata->isRequired();
-        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $mandatory = $fieldMetadata->isRequired();
+        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
 
         $selectionMetadata = new ArrayMetadata(
             new AnyOfsMetadata([
@@ -48,6 +48,6 @@ class SelectionPropertyMetadataMapper implements PropertyMetadataMapperInterface
             ]);
         }
 
-        return new PropertyMetadata($propertyMetadata->getName(), $mandatory, $selectionMetadata);
+        return new PropertyMetadata($fieldMetadata->getName(), $mandatory, $selectionMetadata);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SingleSelectionPropertyMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SingleSelectionPropertyMetadataMapper.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata;
 
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 
 class SingleSelectionPropertyMetadataMapper implements PropertyMetadataMapperInterface
 {
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        $mandatory = $propertyMetadata->isRequired();
+        $mandatory = $fieldMetadata->isRequired();
 
         $anyOfs = [
             new StringMetadata(),
@@ -33,7 +33,7 @@ class SingleSelectionPropertyMetadataMapper implements PropertyMetadataMapperInt
         }
 
         return new PropertyMetadata(
-            $propertyMetadata->getName(),
+            $fieldMetadata->getName(),
             $mandatory,
             new AnyOfsMetadata($anyOfs)
         );

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
@@ -11,7 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata;
 
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 
 class TextPropertyMetadataMapper implements PropertyMetadataMapperInterface
 {
@@ -25,9 +25,9 @@ class TextPropertyMetadataMapper implements PropertyMetadataMapperInterface
         $this->propertyMetadataMinMaxValueResolver = $propertyMetadataMinMaxValueResolver;
     }
 
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        $mandatory = $propertyMetadata->isRequired();
+        $mandatory = $fieldMetadata->isRequired();
 
         $minMaxValue = (object) [
             'min' => null,
@@ -36,13 +36,13 @@ class TextPropertyMetadataMapper implements PropertyMetadataMapperInterface
 
         if (null !== $this->propertyMetadataMinMaxValueResolver) {
             $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue(
-                $propertyMetadata,
+                $fieldMetadata,
                 'min_length',
                 'max_length'
             );
         }
 
-        $pattern = $propertyMetadata->getParameter('pattern')['value'] ?? null;
+        $pattern = $fieldMetadata->findOption('pattern')?->getValue();
 
         $textLineMetadata = new StringMetadata(
             $minMaxValue->min,
@@ -59,8 +59,8 @@ class TextPropertyMetadataMapper implements PropertyMetadataMapperInterface
         }
 
         return new PropertyMetadata(
-            $propertyMetadata->getName(),
-            $propertyMetadata->isRequired(),
+            $fieldMetadata->getName(),
+            $fieldMetadata->isRequired(),
             $textLineMetadata
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextPropertyMetadataMapper.php
@@ -43,6 +43,7 @@ class TextPropertyMetadataMapper implements PropertyMetadataMapperInterface
         }
 
         $pattern = $fieldMetadata->findOption('pattern')?->getValue();
+        \assert(\is_string($pattern) || null === $pattern, 'The option "pattern" must be a string or null.');
 
         $textLineMetadata = new StringMetadata(
             $minMaxValue->min,

--- a/src/Sulu/Bundle/AdminBundle/Metadata/XmlParserTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/XmlParserTrait.php
@@ -27,6 +27,11 @@ trait XmlParserTrait
     {
         try {
             $result = $xpath->query($path, $context);
+
+            if (false === $result) {
+                return $default;
+            }
+
             if (0 === $result->length) {
                 return $default;
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -69,6 +69,7 @@
         <service id="sulu_admin.properties_xml_parser"
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser"
                  public="false">
+            <argument type="service" id="sulu_admin.tag_xml_parser" />
             <argument type="service" id="translator" />
             <argument>%sulu_core.translated_locales%</argument>
         </service>
@@ -82,6 +83,11 @@
 
         <service id="sulu_admin.schema_xml_parser"
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser"
+                 public="false">
+        </service>
+
+        <service id="sulu_admin.tag_xml_parser"
+                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser"
                  public="false">
         </service>
 
@@ -149,6 +155,7 @@
         <service id="sulu_admin.form_metadata.form_xml_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader">
             <argument type="service" id="sulu_admin.properties_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_xml_parser"/>
+            <argument type="service" id="sulu_admin.tag_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_metadata_provider"/>
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -66,6 +66,13 @@
             </argument>
         </service>
 
+        <service id="sulu_admin.properties_xml_parser"
+                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser"
+                 public="false">
+            <argument type="service" id="translator" />
+            <argument>%sulu_core.translated_locales%</argument>
+        </service>
+
         <service id="sulu_admin.deprecated_properties_xml_parser"
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser"
                  public="false">
@@ -140,9 +147,9 @@
         />
 
         <service id="sulu_admin.form_metadata.form_xml_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader">
-            <argument type="service" id="sulu_admin.deprecated_properties_xml_parser"/>
+            <argument type="service" id="sulu_admin.properties_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_xml_parser"/>
-            <argument type="service" id="sulu_admin.form_metadata.form_metadata_mapper"/>
+            <argument type="service" id="sulu_admin.schema_metadata_provider"/>
         </service>
 
         <service
@@ -175,6 +182,12 @@
             class="Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SingleSelectionPropertyMetadataMapper"/>
 
         <service
+            id="sulu_admin.schema_metadata_provider"
+            class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider">
+            <argument type="service" id="sulu_admin.property_metadata_mapper_registry"/>
+        </service>
+
+        <service
             id="sulu_admin.form_metadata.form_metadata_mapper"
             class="Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper">
             <argument type="service" id="sulu_admin.property_metadata_mapper_registry"/>
@@ -183,6 +196,7 @@
         <service id="sulu_admin.structure_form_metadata_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader" lazy="true">
             <argument type="service" id="sulu_page.structure.factory"/>
             <argument type="service" id="sulu_admin.form_metadata.form_metadata_mapper"/>
+            <argument type="service" id="sulu_admin.schema_metadata_provider"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_admin.field_metadata_validator.chain"/>
             <argument>%sulu.content.structure.default_types%</argument>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -197,7 +197,6 @@
         <service
             id="sulu_admin.form_metadata.form_metadata_mapper"
             class="Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper">
-            <argument type="service" id="sulu_admin.property_metadata_mapper_registry"/>
         </service>
 
         <service id="sulu_admin.structure_form_metadata_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader" lazy="true">

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_blocks.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_blocks.xml
@@ -63,6 +63,7 @@
                         </property>
                     </properties>
                 </type>
+                <type ref="text_block" />
             </types>
         </block>
     </properties>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -145,9 +145,11 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
         $this->assertEquals('test_block_settings', $options['settings_form_key']->getValue());
 
         $types = $blocks->getTypes();
-        $this->assertCount(2, $types);
+
+        $this->assertCount(3, $types);
         $this->assertEquals('editor', $types['editor']->getName());
         $this->assertEquals('editor_image', $types['editor_image']->getName());
+        $this->assertEquals('text_block', $types['text_block']->getName());
     }
 
     public function testGetMetadataWithPropertyWithTypes(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -13,13 +13,11 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\FormMetadata;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadata as ExternalFormMetadata;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
 use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\ComponentMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\FormMetadata;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadata as ExternalFormMetadata;
@@ -20,10 +19,7 @@ use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata as SchemaPropertyMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperInterface;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
-use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\ComponentMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
@@ -421,158 +417,6 @@ class FormMetadataMapperTest extends TestCase
         $this->assertCount(2, $block->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($block->getTypes()['component2']->getItems()));
         $this->assertContains('property4', \array_keys($block->getTypes()['component2']->getItems()));
-    }
-
-    public function testMapSchema(): void
-    {
-        $form = $this->createFormWithRequiredProperties();
-
-        $propertyMetadataMapper = $this->prophesize(PropertyMetadataMapperInterface::class);
-        $this->propertyMetadataMapperRegistry->has(Argument::cetera())->willReturn(true);
-        $this->propertyMetadataMapperRegistry->get(Argument::cetera())->willReturn($propertyMetadataMapper->reveal());
-        $propertyMetadataMapper->mapPropertyMetadata(Argument::cetera())->will(function($arguments) {
-            /** @var PropertyMetadata $propertyMetadata */
-            $propertyMetadata = $arguments[0];
-
-            return new SchemaPropertyMetadata((string) $propertyMetadata->getName(), $propertyMetadata->isRequired());
-        });
-
-        $schema = $this->formMetadataMapper->mapSchema($form->getChildren());
-
-        $this->assertInstanceOf(SchemaMetadata::class, $schema);
-        $this->assertEquals([
-            'required' => [
-                'property1',
-                'property2',
-                'property3',
-            ],
-            'type' => 'object',
-        ], $schema->toJsonSchema());
-    }
-
-    public function testMapSchemaWithoutMapper(): void
-    {
-        $form = $this->createFormWithRequiredProperties();
-
-        $this->propertyMetadataMapperRegistry->has(Argument::cetera())->willReturn(false);
-
-        $schema = $this->formMetadataMapper->mapSchema($form->getChildren());
-
-        $this->assertInstanceOf(SchemaMetadata::class, $schema);
-        $this->assertEquals([
-            'required' => [
-                'property1',
-                'property2',
-                'property3',
-            ],
-            'type' => 'object',
-        ], $schema->toJsonSchema());
-    }
-
-    public function testMapSchemaWithBlock(): void
-    {
-        $form = $this->createFormWithBlock();
-
-        $propertyMetadataMapper = $this->prophesize(PropertyMetadataMapperInterface::class);
-        $this->propertyMetadataMapperRegistry->has(Argument::cetera())->willReturn(true);
-        $this->propertyMetadataMapperRegistry->get(Argument::cetera())->willReturn($propertyMetadataMapper->reveal());
-        $propertyMetadataMapper->mapPropertyMetadata(Argument::cetera())->will(function($arguments) {
-            /** @var PropertyMetadata $propertyMetadata */
-            $propertyMetadata = $arguments[0];
-
-            return new SchemaPropertyMetadata($propertyMetadata->getName(), $propertyMetadata->isRequired());
-        });
-
-        $schema = $this->formMetadataMapper->mapSchema($form->getChildren());
-
-        $this->assertInstanceOf(SchemaMetadata::class, $schema);
-        $this->assertEquals([
-            'properties' => [
-                'block' => [
-                    'type' => 'array',
-                    'items' => [
-                        'allOf' => [
-                            [
-                                'if' => [
-                                    'properties' => [
-                                        'type' => [
-                                            'const' => 'component1',
-                                        ],
-                                    ],
-                                    'required' => ['type'],
-                                    'type' => 'object',
-                                ],
-                                'then' => [
-                                    'required' => ['property2'],
-                                    'type' => 'object',
-                                ],
-                            ],
-                            [
-                                'if' => [
-                                    'properties' => [
-                                        'type' => [
-                                            'const' => 'component2',
-                                        ],
-                                    ],
-                                    'required' => ['type'],
-                                    'type' => 'object',
-                                ],
-                                'then' => [
-                                    'required' => ['property3'],
-                                    'type' => 'object',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'type' => 'object',
-        ], $schema->toJsonSchema());
-    }
-
-    public function testMapSchemaWithGlobalBlock(): void
-    {
-        $form = $this->createFormWithGlobalBlock();
-
-        $propertyMetadataMapper = $this->prophesize(PropertyMetadataMapperInterface::class);
-        $this->propertyMetadataMapperRegistry->has(Argument::cetera())->willReturn(true);
-        $this->propertyMetadataMapperRegistry->get(Argument::cetera())->willReturn($propertyMetadataMapper->reveal());
-        $propertyMetadataMapper->mapPropertyMetadata(Argument::cetera())->will(function($arguments) {
-            /** @var PropertyMetadata $propertyMetadata */
-            $propertyMetadata = $arguments[0];
-
-            return new SchemaPropertyMetadata((string) $propertyMetadata->getName(), $propertyMetadata->isRequired());
-        });
-
-        $schema = $this->formMetadataMapper->mapSchema($form->getChildren());
-
-        $this->assertInstanceOf(SchemaMetadata::class, $schema);
-        $this->assertEquals([
-            'properties' => [
-                'block' => [
-                    'type' => 'array',
-                    'items' => [
-                        'allOf' => [
-                            [
-                                'if' => [
-                                    'properties' => [
-                                        'type' => [
-                                            'const' => 'component1',
-                                        ],
-                                    ],
-                                    'required' => ['type'],
-                                    'type' => 'object',
-                                ],
-                                'then' => [
-                                    '$ref' => '#/definitions/component1',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            'type' => 'object',
-        ], $schema->toJsonSchema());
     }
 
     private function createFormWithBasicProperties(): ExternalFormMetadata

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -34,18 +34,9 @@ class FormMetadataMapperTest extends TestCase
      */
     private $formMetadataMapper;
 
-    /**
-     * @var ObjectProphecy<PropertyMetadataMapperRegistry>
-     */
-    private $propertyMetadataMapperRegistry;
-
     public function setUp(): void
     {
-        $this->propertyMetadataMapperRegistry = $this->prophesize(PropertyMetadataMapperRegistry::class);
-
-        $this->formMetadataMapper = new FormMetadataMapper(
-            $this->propertyMetadataMapperRegistry->reveal()
-        );
+        $this->formMetadataMapper = new FormMetadataMapper();
     }
 
     public function testMapTags(): void
@@ -567,59 +558,6 @@ class FormMetadataMapperTest extends TestCase
         $block->setType('block');
 
         $form->addChild($block);
-
-        return $form;
-    }
-
-    private function createFormWithGlobalBlock(): ExternalFormMetadata
-    {
-        $form = new ExternalFormMetadata();
-        $block = new BlockMetadata('block');
-
-        $component1 = new ComponentMetadata('component1');
-        $component1->setTitles([
-            'en' => 'First Component',
-            'de' => 'Erste Komponente',
-        ]);
-        $component1->addTag([
-            'name' => 'sulu.global_block',
-            'attributes' => [
-                'global_block' => 'component1',
-            ],
-        ]);
-
-        $block->addComponent($component1);
-        $block->setMinOccurs(1);
-        $block->setMaxOccurs(2);
-        $block->defaultComponentName = 'component1';
-        $block->setType('block');
-
-        $form->addChild($block);
-
-        return $form;
-    }
-
-    private function createFormWithRequiredProperties(): ExternalFormMetadata
-    {
-        $form = new ExternalFormMetadata();
-
-        $property1 = new PropertyMetadata('property1');
-        $property1->setType('text_line');
-        $property1->setRequired(true);
-        $property2 = new PropertyMetadata('property2');
-        $property2->setType('text_area');
-        $property2->setRequired(true);
-        $property3 = new PropertyMetadata('property3');
-        $property3->setType('checkbox');
-        $property3->setRequired(true);
-        $property4 = new PropertyMetadata('property4');
-        $property4->setType('type');
-        $property4->setRequired(false);
-
-        $form->addChild($property1);
-        $form->addChild($property2);
-        $form->addChild($property3);
-        $form->addChild($property4);
 
         return $form;
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FieldMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FieldMetadataTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+
+class FieldMetadataTest extends TestCase
+{
+    public function testFindOption(): void
+    {
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(2);
+        $fieldMetadata->addOption($minOption);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(3);
+        $fieldMetadata->addOption($maxOption);
+
+        $this->assertSame(
+            $minOption,
+            $fieldMetadata->findOption('min')
+        );
+
+        $this->assertSame(
+            $maxOption,
+            $fieldMetadata->findOption('max')
+        );
+
+        $this->assertNull($fieldMetadata->findOption('not-existing'));
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FormMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FormMetadataTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
+
+class FormMetadataTest extends TestCase
+{
+    public function testFindTag(): void
+    {
+        $formMetadata = new FormMetadata();
+        $tag1 = new TagMetadata();
+        $tag1->setName('tag1');
+        $formMetadata->addTag($tag1);
+        $tag2 = new TagMetadata();
+        $tag2->setName('tag2');
+        $formMetadata->addTag($tag2);
+
+        $this->assertSame(
+            $tag1,
+            $formMetadata->findTag('tag1')
+        );
+
+        $this->assertSame(
+            $tag2,
+            $formMetadata->findTag('tag2')
+        );
+
+        $this->assertNull($formMetadata->findTag('not-existing'));
+    }
+
+    public function testHasTag(): void
+    {
+        $formMetadata = new FormMetadata();
+        $tag1 = new TagMetadata();
+        $tag1->setName('tag1');
+        $formMetadata->addTag($tag1);
+        $tag2 = new TagMetadata();
+        $tag2->setName('tag2');
+        $formMetadata->addTag($tag2);
+
+        $this->assertTrue($formMetadata->hasTag('tag1'));
+        $this->assertTrue($formMetadata->hasTag('tag2'));
+        $this->assertFalse($formMetadata->hasTag('not-existing'));
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
@@ -12,20 +12,20 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Loader;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
-use Sulu\Bundle\AdminBundle\Exception\PropertyMetadataMapperNotFoundException;
-use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+use Sulu\Component\Content\ContentTypeManagerInterface;
+use Sulu\Component\Content\Types\BlockContentType;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FormXmlLoaderTest extends TestCase
@@ -45,20 +45,25 @@ class FormXmlLoaderTest extends TestCase
     public function setUp(): void
     {
         $this->translator = $this->prophesize(TranslatorInterface::class);
+        $tagXmlParser = new TagXmlParser();
         $propertiesXmlParser = new PropertiesXmlParser(
+            $tagXmlParser,
             $this->translator->reveal(),
             ['en' => 'en', 'de' => 'de', 'fr' => 'fr', 'nl' => 'nl']
         );
         $schemaXmlParser = new SchemaXmlParser();
 
-        $propertyMetadataMapperRegistry = $this->prophesize(PropertyMetadataMapperRegistry::class);
-        $propertyMetadataMapperRegistry->has(Argument::cetera())->willReturn(false);
-        $propertyMetadataMapperRegistry->get(Argument::cetera())->will(function($arguments) {
-            throw new PropertyMetadataMapperNotFoundException($arguments[0]);
-        });
+        $container = new Container();
+        $propertyMetadataMapperRegistry = new PropertyMetadataMapperRegistry($container);
+        $schemaMetadataProvider = new SchemaMetadataProvider($propertyMetadataMapperRegistry);
+        $blockMetadataProvider = new BlockContentType(
+            $this->prophesize(ContentTypeManagerInterface::class)->reveal(),
+            $schemaMetadataProvider,
+            [],
+        );
+        $container->set('block', $blockMetadataProvider);
 
-        $schemaMetadataProvider = new SchemaMetadataProvider($propertyMetadataMapperRegistry->reveal());
-        $this->loader = new FormXmlLoader($propertiesXmlParser, $schemaXmlParser, $schemaMetadataProvider);
+        $this->loader = new FormXmlLoader($propertiesXmlParser, $schemaXmlParser, $tagXmlParser, $schemaMetadataProvider);
     }
 
     public function testLoadForm(): void
@@ -69,6 +74,7 @@ class FormXmlLoaderTest extends TestCase
 
         $this->assertCount(1, $formMetadata->getTags());
         $this->assertCount(1, $formMetadata->getTagsByName('test'));
+
         $this->assertEquals('test', $formMetadata->getTagsByName('test')[0]->getName());
         $this->assertEquals(['value' => 'test-value'], $formMetadata->getTagsByName('test')[0]->getAttributes());
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
@@ -316,6 +316,20 @@ class FormXmlLoaderTest extends TestCase
                                         'type' => 'object',
                                     ],
                                 ],
+                                [
+                                    'if' => [
+                                        'properties' => [
+                                            'type' => [
+                                                'const' => 'text_block',
+                                            ],
+                                        ],
+                                        'required' => ['type'],
+                                        'type' => 'object',
+                                    ],
+                                    'then' => [
+                                        '$ref' => '#/definitions/text_block',
+                                    ],
+                                ],
                             ],
                         ],
                     ],

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
@@ -21,7 +21,9 @@ use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\DeprecatedPropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -43,7 +45,7 @@ class FormXmlLoaderTest extends TestCase
     public function setUp(): void
     {
         $this->translator = $this->prophesize(TranslatorInterface::class);
-        $propertiesXmlParser = new DeprecatedPropertiesXmlParser(
+        $propertiesXmlParser = new PropertiesXmlParser(
             $this->translator->reveal(),
             ['en' => 'en', 'de' => 'de', 'fr' => 'fr', 'nl' => 'nl']
         );
@@ -55,8 +57,8 @@ class FormXmlLoaderTest extends TestCase
             throw new PropertyMetadataMapperNotFoundException($arguments[0]);
         });
 
-        $formMetadataMapper = new FormMetadataMapper($propertyMetadataMapperRegistry->reveal());
-        $this->loader = new FormXmlLoader($propertiesXmlParser, $schemaXmlParser, $formMetadataMapper);
+        $schemaMetadataProvider = new SchemaMetadataProvider($propertyMetadataMapperRegistry->reveal());
+        $this->loader = new FormXmlLoader($propertiesXmlParser, $schemaXmlParser, $schemaMetadataProvider);
     }
 
     public function testLoadForm(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -32,6 +32,9 @@ class StructureFormMetadataLoaderTest extends TestCase
 {
     use ProphecyTrait;
 
+    /**
+     * @var string
+     */
     public const CACHE_DIR = __DIR__ . '/../../../../../../../tests/Resources/cache';
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
@@ -156,7 +157,7 @@ class StructureFormMetadataLoaderTest extends TestCase
         $this->formMetadataMapper->mapChildren([])->willReturn([$propertyMetadata, $sectionMetadata, $blockMetadata]);
 
         $schemaMetadata = new SchemaMetadata();
-        $this->schemaMetadataProvider->getMetadata([])->willReturn($schemaMetadata);
+        $this->schemaMetadataProvider->getMetadata(Argument::cetera())->willReturn($schemaMetadata);
 
         $this->structureMetadataFactory->getStructureTypes()->willReturn(['page']);
         $this->structureMetadataFactory->getStructures('page')->willReturn([$structure]);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\AdminBundle\FormMetadata\FormMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\StructureFormMetadataLoader;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\FieldMetadataValidatorInterface;
@@ -43,6 +44,11 @@ class StructureFormMetadataLoaderTest extends TestCase
     private $formMetadataMapper;
 
     /**
+     * @var ObjectProphecy<SchemaMetadataProvider>
+     */
+    private $schemaMetadataProvider;
+
+    /**
      * @var ObjectProphecy<WebspaceManagerInterface>
      */
     private $webspaceManager;
@@ -61,12 +67,14 @@ class StructureFormMetadataLoaderTest extends TestCase
     {
         $this->structureMetadataFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
         $this->formMetadataMapper = $this->prophesize(FormMetadataMapper::class);
+        $this->schemaMetadataProvider = $this->prophesize(SchemaMetadataProvider::class);
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->fieldMetadataValidator = $this->prophesize(FieldMetadataValidatorInterface::class);
 
         $this->structureFormMetadataLoader = new StructureFormMetadataLoader(
             $this->structureMetadataFactory->reveal(),
             $this->formMetadataMapper->reveal(),
+            $this->schemaMetadataProvider->reveal(),
             $this->webspaceManager->reveal(),
             $this->fieldMetadataValidator->reveal(),
             [],
@@ -148,7 +156,7 @@ class StructureFormMetadataLoaderTest extends TestCase
         $this->formMetadataMapper->mapChildren([])->willReturn([$propertyMetadata, $sectionMetadata, $blockMetadata]);
 
         $schemaMetadata = new SchemaMetadata();
-        $this->formMetadataMapper->mapSchema([])->willReturn($schemaMetadata);
+        $this->schemaMetadataProvider->getMetadata([])->willReturn($schemaMetadata);
 
         $this->structureMetadataFactory->getStructureTypes()->willReturn(['page']);
         $this->structureMetadataFactory->getStructures('page')->willReturn([$structure]);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataMinMaxValueResolverTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataMinMaxValueResolverTest.php
@@ -12,8 +12,9 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\SchemaMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMinMaxValueResolver;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
 
 class PropertyMetadataMinMaxValueResolverTest extends TestCase
 {
@@ -29,14 +30,17 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
     public function testResolveMinMaxValue(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-            ['name' => 'max', 'value' => 3],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(2);
+        $fieldMetadata->addOption($minOption);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(3);
+        $fieldMetadata->addOption($maxOption);
 
-        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
 
         $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(2, $minMaxValue->min);
@@ -46,13 +50,13 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
     public function testResolveMinMaxValueMinOnly(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(2);
+        $fieldMetadata->addOption($minOption);
 
-        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
 
         $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(2, $minMaxValue->min);
@@ -62,13 +66,13 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
     public function testResolveMinMaxValueMaxOnly(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(2);
+        $fieldMetadata->addOption($maxOption);
 
-        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
 
         $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertNull($minMaxValue->min);
@@ -78,10 +82,9 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
     public function testResolveMinMaxValueWithoutParams(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
+        $fieldMetadata = new FieldMetadata('property-name');
 
-        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
 
         $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertNull($minMaxValue->min);
@@ -91,11 +94,10 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
     public function testResolveMinMaxValueWithoutParamsRequired(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
 
-        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
 
         $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(1, $minMaxValue->min);
@@ -105,14 +107,18 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
     public function testResolveMinMaxValueWithIntegerishValues(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => '2'],
-            ['name' => 'max', 'value' => '3'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(2);
+        $fieldMetadata->addOption($minOption);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(3);
+        $fieldMetadata->addOption($maxOption);
 
-        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
 
         $this->assertTrue(\property_exists($minMaxValue, 'min'));
         $this->assertSame(2, $minMaxValue->min);
@@ -122,15 +128,19 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
 
     public function testResolveMinMaxValueWithDifferentParamNames(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'minItems', 'value' => 2],
-            ['name' => 'maxItems', 'value' => 3],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
+        $minOption = new OptionMetadata();
+        $minOption->setName('minItems');
+        $minOption->setValue(2);
+        $fieldMetadata->addOption($minOption);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('maxItems');
+        $maxOption->setValue(3);
+        $fieldMetadata->addOption($maxOption);
 
         $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue(
-            $propertyMetadata,
+            $fieldMetadata,
             'minItems',
             'maxItems'
         );
@@ -145,79 +155,84 @@ class PropertyMetadataMinMaxValueResolverTest extends TestCase
     {
         $this->expectExceptionMessage('Parameter "min" of property "property-name" needs to be either null or of type int');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue('invalid-value');
+        $fieldMetadata->addOption($minOption);
 
-        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
     }
 
     public function testResolveMinMaxValueMinTooLow(): void
     {
         $this->expectExceptionMessage('Parameter "min" of property "property-name" needs to be greater than or equal "0"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => -1],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(-1);
+        $fieldMetadata->addOption($minOption);
 
-        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
     }
 
     public function testResolveMinMaxValueMandatoryMinTooLow(): void
     {
         $this->expectExceptionMessage('Because property "property-name" is mandatory, parameter "min" needs to be greater than or equal "1"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 0],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(0);
+        $fieldMetadata->addOption($minOption);
 
-        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
     }
 
     public function testResolveMinMaxValueMaxInvalidType(): void
     {
         $this->expectExceptionMessage('Parameter "max" of property "property-name" needs to be either null or of type int');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue('invalid-value');
+        $fieldMetadata->addOption($maxOption);
 
-        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
     }
 
     public function testResolveMinMaxValueMaxTooLow(): void
     {
         $this->expectExceptionMessage('Parameter "max" of property "property-name" needs to be greater than or equal "1"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max', 'value' => 0],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(0);
+        $fieldMetadata->addOption($maxOption);
 
-        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
     }
 
     public function testResolveMinMaxValueMaxLowerThanMin(): void
     {
         $this->expectExceptionMessage('Because parameter "min" of property "property-name" has value "2", parameter "max" needs to be greater than or equal "2"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-            ['name' => 'max', 'value' => 1],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(2);
+        $fieldMetadata->addOption($minOption);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(1);
+        $fieldMetadata->addOption($maxOption);
 
-        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+        $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SelectionPropertyMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SelectionPropertyMetadataMapperTest.php
@@ -12,9 +12,10 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\SchemaMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMinMaxValueResolver;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SelectionPropertyMetadataMapper;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
 
 class SelectionPropertyMetadataMapperTest extends TestCase
 {
@@ -50,10 +51,9 @@ class SelectionPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadata(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
+        $fieldMetadata = new FieldMetadata('property-name');
 
-        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -75,11 +75,10 @@ class SelectionPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataRequired(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
 
-        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'type' => 'array',
@@ -96,14 +95,17 @@ class SelectionPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMax(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-            ['name' => 'max', 'value' => 3],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min');
+        $option->setValue(2);
+        $fieldMetadata->addOption($option);
+        $option = new OptionMetadata();
+        $option->setName('max');
+        $option->setValue(3);
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -127,13 +129,13 @@ class SelectionPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxMinOnly(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min');
+        $option->setValue(2);
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -156,13 +158,13 @@ class SelectionPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxMaxOnly(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('max');
+        $option->setValue(2);
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -185,14 +187,17 @@ class SelectionPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxWithIntegerishValues(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => '2'],
-            ['name' => 'max', 'value' => '3'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min');
+        $option->setValue('2');
+        $fieldMetadata->addOption($option);
+        $option = new OptionMetadata();
+        $option->setName('max');
+        $option->setValue('3');
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -218,79 +223,82 @@ class SelectionPropertyMetadataMapperTest extends TestCase
     {
         $this->expectExceptionMessage('Parameter "min" of property "property-name" needs to be either null or of type int');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min');
+        $option->setValue('invalid-value');
+        $fieldMetadata->addOption($option);
 
-        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMinTooLow(): void
     {
         $this->expectExceptionMessage('Parameter "min" of property "property-name" needs to be greater than or equal "0"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => -1],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min');
+        $option->setValue(-1);
+        $fieldMetadata->addOption($option);
 
-        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMandatoryMinTooLow(): void
     {
         $this->expectExceptionMessage('Because property "property-name" is mandatory, parameter "min" needs to be greater than or equal "1"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 0],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
+        $option = new OptionMetadata();
+        $option->setName('min');
+        $option->setValue(0);
+        $fieldMetadata->addOption($option);
 
-        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMaxInvalidType(): void
     {
         $this->expectExceptionMessage('Parameter "max" of property "property-name" needs to be either null or of type int');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('max');
+        $option->setValue('invalid-value');
+        $fieldMetadata->addOption($option);
 
-        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMaxTooLow(): void
     {
         $this->expectExceptionMessage('Parameter "max" of property "property-name" needs to be greater than or equal "1"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max', 'value' => 0],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('max');
+        $option->setValue(0);
+        $fieldMetadata->addOption($option);
 
-        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMaxLowerThanMin(): void
     {
         $this->expectExceptionMessage('Because parameter "min" of property "property-name" has value "2", parameter "max" needs to be greater than or equal "2"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-            ['name' => 'max', 'value' => 1],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min');
+        $option->setValue(2);
+        $fieldMetadata->addOption($option);
+        $option = new OptionMetadata();
+        $option->setName('max');
+        $option->setValue(1);
+        $fieldMetadata->addOption($option);
 
-        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->selectionPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SingleSelectionPropertyMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SingleSelectionPropertyMetadataMapperTest.php
@@ -12,8 +12,8 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\SchemaMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SingleSelectionPropertyMetadataMapper;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
 
 class SingleSelectionPropertyMetadataMapperTest extends TestCase
 {
@@ -44,8 +44,7 @@ class SingleSelectionPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadata(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
+        $propertyMetadata = new FieldMetadata('property-name');
 
         $jsonSchema = $this->singleSelectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
 
@@ -62,8 +61,7 @@ class SingleSelectionPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataRequired(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
+        $propertyMetadata = new FieldMetadata('property-name');
         $propertyMetadata->setRequired(true);
 
         $jsonSchema = $this->singleSelectionPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/TextPropertyMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/TextPropertyMetadataMapperTest.php
@@ -12,9 +12,10 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\SchemaMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMinMaxValueResolver;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\TextPropertyMetadataMapper;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
 
 class TextPropertyMetadataMapperTest extends TestCase
 {
@@ -47,10 +48,9 @@ class TextPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadata(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
+        $fieldMetadata = new FieldMetadata('property-name');
 
-        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -65,11 +65,10 @@ class TextPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataRequired(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
 
-        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'type' => 'string',
@@ -79,13 +78,13 @@ class TextPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataPattern(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'pattern', 'value' => '^[^,]*$'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('pattern');
+        $option->setValue('^[^,]*$');
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -101,14 +100,17 @@ class TextPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMax(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min_length', 'value' => 2],
-            ['name' => 'max_length', 'value' => 3],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min_length');
+        $option->setValue(2);
+        $fieldMetadata->addOption($option);
+        $option = new OptionMetadata();
+        $option->setName('max_length');
+        $option->setValue(3);
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -125,13 +127,13 @@ class TextPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxMinOnly(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min_length', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min_length');
+        $option->setValue(2);
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -147,13 +149,13 @@ class TextPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxMaxOnly(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max_length', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('max_length');
+        $option->setValue(2);
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -169,14 +171,17 @@ class TextPropertyMetadataMapperTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxWithIntegerishValues(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min_length', 'value' => '2'],
-            ['name' => 'max_length', 'value' => '3'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min_length');
+        $option->setValue('2');
+        $fieldMetadata->addOption($option);
+        $option = new OptionMetadata();
+        $option->setName('max_length');
+        $option->setValue('3');
+        $fieldMetadata->addOption($option);
 
-        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -195,79 +200,82 @@ class TextPropertyMetadataMapperTest extends TestCase
     {
         $this->expectExceptionMessage('Parameter "min_length" of property "property-name" needs to be either null or of type int');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min_length', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min_length');
+        $option->setValue('invalid-value');
+        $fieldMetadata->addOption($option);
 
-        $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMinTooLow(): void
     {
         $this->expectExceptionMessage('Parameter "min_length" of property "property-name" needs to be greater than or equal "0"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min_length', 'value' => -1],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min_length');
+        $option->setValue(-1);
+        $fieldMetadata->addOption($option);
 
-        $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMandatoryMinTooLow(): void
     {
         $this->expectExceptionMessage('Because property "property-name" is mandatory, parameter "min_length" needs to be greater than or equal "1"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
-        $propertyMetadata->setParameters([
-            ['name' => 'min_length', 'value' => 0],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
+        $option = new OptionMetadata();
+        $option->setName('min_length');
+        $option->setValue(0);
+        $fieldMetadata->addOption($option);
 
-        $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMaxInvalidType(): void
     {
         $this->expectExceptionMessage('Parameter "max_length" of property "property-name" needs to be either null or of type int');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max_length', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('max_length');
+        $option->setValue('invalid-value');
+        $fieldMetadata->addOption($option);
 
-        $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMaxTooLow(): void
     {
         $this->expectExceptionMessage('Parameter "max_length" of property "property-name" needs to be greater than or equal "1"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max_length', 'value' => 0],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('max_length');
+        $option->setValue(0);
+        $fieldMetadata->addOption($option);
 
-        $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMaxLowerThanMin(): void
     {
         $this->expectExceptionMessage('Because parameter "min_length" of property "property-name" has value "2", parameter "max_length" needs to be greater than or equal "2"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min_length', 'value' => 2],
-            ['name' => 'max_length', 'value' => 1],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $option = new OptionMetadata();
+        $option->setName('min_length');
+        $option->setValue(2);
+        $fieldMetadata->addOption($option);
+        $option = new OptionMetadata();
+        $option->setName('max_length');
+        $option->setValue(1);
+        $fieldMetadata->addOption($option);
 
-        $this->textPropertyMetadataMapper->mapPropertyMetadata($propertyMetadata);
+        $this->textPropertyMetadataMapper->mapPropertyMetadata($fieldMetadata);
     }
 }

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -183,12 +183,12 @@
         <!-- complex content types -->
         <service id="sulu.content.type.block" class="%sulu.content.type.block.class%">
             <argument type="service" id="sulu.content.type_manager"/>
-            <argument>%sulu.content.language.namespace%</argument>
-            <argument type="service" id="sulu_core.webspace.request_analyzer" />
-            <argument type="service" id="sulu_audience_targeting.target_group_store" on-invalid="null" />
+            <argument type="service" id="sulu_admin.schema_metadata_provider"/>
             <argument type="tagged" tag="sulu_content.deprecated_block_visitor" />
+
             <tag name="sulu.content.type" alias="block"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
+            <tag name="sulu_admin.property_metadata_mapper" type="block" />
         </service>
 
         <service

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/MediaSelectionContentType.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Content\Types;
 
 use PHPCR\NodeInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AnyOfsMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ArrayMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\EmptyArrayMetadata;
@@ -32,7 +33,6 @@ use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Content\ComplexContentType;
 use Sulu\Component\Content\ContentTypeExportInterface;
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Util\ArrayableInterface;
@@ -184,9 +184,9 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
         }
     }
 
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        $mandatory = $propertyMetadata->isRequired();
+        $mandatory = $fieldMetadata->isRequired();
 
         $minMaxValue = (object) [
             'min' => null,
@@ -194,7 +194,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
         ];
 
         if (null !== $this->propertyMetadataMinMaxValueResolver) {
-            $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+            $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
         }
 
         $idsMetadata = new ArrayMetadata(
@@ -223,7 +223,7 @@ class MediaSelectionContentType extends ComplexContentType implements ContentTyp
             ]);
         }
 
-        return new PropertyMetadata($propertyMetadata->getName(), $mandatory, $mediaSelectionMetadata);
+        return new PropertyMetadata($fieldMetadata->getName(), $mandatory, $mediaSelectionMetadata);
     }
 
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/SingleMediaSelection.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Content\Types;
 
 use PHPCR\NodeInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AnyOfsMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NullMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NumberMetadata;
@@ -29,7 +30,6 @@ use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollectorInterfac
 use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Content\SimpleContentType;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -137,9 +137,9 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
         return \json_decode($value, true);
     }
 
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        $mandatory = $propertyMetadata->isRequired();
+        $mandatory = $fieldMetadata->isRequired();
 
         $idMetadata = new NumberMetadata();
 
@@ -162,7 +162,7 @@ class SingleMediaSelection extends SimpleContentType implements PreResolvableCon
             ]);
         }
 
-        return new PropertyMetadata($propertyMetadata->getName(), $mandatory, $singleMediaSelectionMetadata);
+        return new PropertyMetadata($fieldMetadata->getName(), $mandatory, $singleMediaSelectionMetadata);
     }
 
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -357,7 +357,7 @@
 
         <service id="sulu_media.type.image_map" class="Sulu\Bundle\MediaBundle\Content\Types\ImageMapContentType">
             <argument type="service" id="sulu.content.type_manager"/>
-            <argument type="service" id="sulu_admin.form_metadata.form_metadata_mapper"/>
+            <argument type="service" id="sulu_admin.schema_metadata_provider"/>
 
             <tag name="sulu.content.type" alias="image_map"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/SingleMediaSelectionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/SingleMediaSelectionTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Content\Types\SingleMediaSelection;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
@@ -27,7 +28,6 @@ use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
 use Sulu\Component\Content\Compat\Metadata;
 use Sulu\Component\Content\Compat\Property;
 use Sulu\Component\Content\Compat\StructureInterface;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
@@ -357,10 +357,9 @@ class SingleMediaSelectionTest extends TestCase
 
     public function testMapPropertyMetadata(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
+        $fieldMetadata = new FieldMetadata('property-name');
 
-        $jsonSchema = $this->singleMediaSelection->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->singleMediaSelection->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -385,11 +384,10 @@ class SingleMediaSelectionTest extends TestCase
 
     public function testMapPropertyMetadataRequired(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
 
-        $jsonSchema = $this->singleMediaSelection->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->singleMediaSelection->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'type' => 'object',

--- a/src/Sulu/Bundle/PageBundle/Content/Types/Email.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/Email.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Bundle\PageBundle\Content\Types;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AnyOfsMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\EmptyStringMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NullMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperInterface;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\SimpleContentType;
 
 /**
@@ -30,9 +30,9 @@ class Email extends SimpleContentType implements PropertyMetadataMapperInterface
         parent::__construct('Email', '');
     }
 
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        $mandatory = $propertyMetadata->isRequired();
+        $mandatory = $fieldMetadata->isRequired();
 
         $emailMetadata = new StringMetadata(
             null,
@@ -50,7 +50,7 @@ class Email extends SimpleContentType implements PropertyMetadataMapperInterface
         }
 
         return new PropertyMetadata(
-            $propertyMetadata->getName(),
+            $fieldMetadata->getName(),
             $mandatory,
             $emailMetadata
         );

--- a/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\PageBundle\Teaser;
 
 use PHPCR\NodeInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AnyOfsMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ArrayMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\EmptyArrayMetadata;
@@ -28,7 +29,6 @@ use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreNotExistsException;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStorePoolInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Content\SimpleContentType;
 
@@ -161,9 +161,9 @@ class TeaserContentType extends SimpleContentType implements PreResolvableConten
         return \array_merge($default, $property->getValue());
     }
 
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        $mandatory = $propertyMetadata->isRequired();
+        $mandatory = $fieldMetadata->isRequired();
 
         $minMaxValue = (object) [
             'min' => null,
@@ -171,7 +171,7 @@ class TeaserContentType extends SimpleContentType implements PreResolvableConten
         ];
 
         if (null !== $this->propertyMetadataMinMaxValueResolver) {
-            $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($propertyMetadata);
+            $minMaxValue = $this->propertyMetadataMinMaxValueResolver->resolveMinMaxValue($fieldMetadata);
         }
 
         $itemsMetadata = new ArrayMetadata(
@@ -209,6 +209,6 @@ class TeaserContentType extends SimpleContentType implements PreResolvableConten
             ]);
         }
 
-        return new PropertyMetadata($propertyMetadata->getName(), $mandatory, $teaserSelectionMetadata);
+        return new PropertyMetadata($fieldMetadata->getName(), $mandatory, $teaserSelectionMetadata);
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
+++ b/src/Sulu/Bundle/RouteBundle/Content/Type/PageTreeRouteContentType.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use PHPCR\ItemNotFoundException;
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AnyOfsMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NullMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ObjectMetadata;
@@ -26,7 +27,6 @@ use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;
 use Sulu\Bundle\RouteBundle\Generator\ChainRouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\SimpleContentType;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\DocumentRegistry;
@@ -227,9 +227,9 @@ class PageTreeRouteContentType extends SimpleContentType implements PropertyMeta
         return $this->entityManager->getRepository(Route::class);
     }
 
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        $mandatory = $propertyMetadata->isRequired();
+        $mandatory = $fieldMetadata->isRequired();
 
         $pageMetadata = new ObjectMetadata([
             new PropertyMetadata('uuid', $mandatory, new StringMetadata()),
@@ -256,6 +256,6 @@ class PageTreeRouteContentType extends SimpleContentType implements PropertyMeta
             ]);
         }
 
-        return new PropertyMetadata((string) $propertyMetadata->getName(), $mandatory, $pageTreeRouteMetadata);
+        return new PropertyMetadata($fieldMetadata->getName(), $mandatory, $pageTreeRouteMetadata);
     }
 }

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Content/PageTreeRouteContentTypeTest.php
@@ -17,6 +17,7 @@ use PHPCR\PropertyType;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\RouteBundle\Content\Type\PageTreeRouteContentType;
@@ -26,7 +27,6 @@ use Sulu\Bundle\RouteBundle\Generator\ChainRouteGeneratorInterface;
 use Sulu\Bundle\RouteBundle\Manager\ConflictResolverInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\DocumentRegistry;
 use Sulu\Component\Route\Document\Behavior\RoutableBehavior;
@@ -461,10 +461,9 @@ class PageTreeRouteContentTypeTest extends TestCase
 
     public function testMapPropertyMetadata(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
+        $fieldMetadata = new FieldMetadata('property-name');
 
-        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->contentType->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -496,11 +495,10 @@ class PageTreeRouteContentTypeTest extends TestCase
 
     public function testMapPropertyMetadataRequired(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
 
-        $jsonSchema = $this->contentType->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->contentType->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'type' => 'object',

--- a/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
@@ -82,6 +82,8 @@ abstract class AbstractLoader implements LoaderInterface
     }
 
     /**
+     * @param string $resource
+     *
      * @return T
      */
     abstract protected function parse($resource, \DOMXPath $xpath, $type);

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
@@ -17,7 +17,6 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
-use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
 use Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType;
 use Sulu\Bundle\MediaBundle\Content\Types\SingleMediaSelection;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
 use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
 use Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType;
 use Sulu\Bundle\MediaBundle\Content\Types\SingleMediaSelection;
@@ -97,18 +98,18 @@ class BlockContentTypeTest extends TestCase
 
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->contentTypeManager = $this->prophesize(ContentTypeManager::class);
-        $this->targetGroupStore = $this->prophesize(TargetGroupStoreInterface::class);
         $this->blockVisitor1 = $this->prophesize(BlockVisitorInterface::class);
         $this->blockVisitor2 = $this->prophesize(BlockVisitorInterface::class);
+        $this->targetGroupStore = $this->prophesize(TargetGroupStoreInterface::class);
 
         $this->blockVisitor1->visit(Argument::any())->will(function($arguments) {return $arguments[0]; });
         $this->blockVisitor2->visit(Argument::any())->will(function($arguments) {return $arguments[0]; });
 
+        $this->schemaMetadataProvider = $this->prophesize(SchemaMetadataProvider::class);
+
         $this->blockContentType = new BlockContentType(
             $this->contentTypeManager->reveal(),
-            'not in use',
-            $this->requestAnalyzer->reveal(),
-            $this->targetGroupStore->reveal(),
+            $this->schemaMetadataProvider->reveal(),
             [
                 $this->blockVisitor1->reveal(),
                 $this->blockVisitor2->reveal(),

--- a/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Block/BlockContentTypeTest.php
@@ -68,14 +68,9 @@ class BlockContentTypeTest extends TestCase
     private $contentTypeValueMap;
 
     /**
-     * @var ObjectProphecy<RequestAnalyzerInterface>
+     * @var ObjectProphecy<SchemaMetadataProvider>
      */
-    private $requestAnalyzer;
-
-    /**
-     * @var ObjectProphecy<TargetGroupStoreInterface>
-     */
-    private $targetGroupStore;
+    private $schemaMetadataProvider;
 
     /**
      * @var ObjectProphecy<ContentTypeManager>
@@ -96,11 +91,9 @@ class BlockContentTypeTest extends TestCase
     {
         parent::setUp();
 
-        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->contentTypeManager = $this->prophesize(ContentTypeManager::class);
         $this->blockVisitor1 = $this->prophesize(BlockVisitorInterface::class);
         $this->blockVisitor2 = $this->prophesize(BlockVisitorInterface::class);
-        $this->targetGroupStore = $this->prophesize(TargetGroupStoreInterface::class);
 
         $this->blockVisitor1->visit(Argument::any())->will(function($arguments) {return $arguments[0]; });
         $this->blockVisitor2->visit(Argument::any())->will(function($arguments) {return $arguments[0]; });

--- a/src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
@@ -18,8 +18,9 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Component\Content\Compat\PropertyInterface;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Types\Number;
 
 class NumberTest extends TestCase
@@ -129,10 +130,9 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadata(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
+        $fieldMetadata = new FieldMetadata('property-name');
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -146,11 +146,10 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadataRequired(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setRequired(true);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $fieldMetadata->setRequired(true);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'type' => 'number',
@@ -159,13 +158,13 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadataMultipleOfFloat(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'multiple_of', 'value' => 0.5],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $multipleOfOption = new OptionMetadata();
+        $multipleOfOption->setName('multiple_of');
+        $multipleOfOption->setValue(0.5);
+        $fieldMetadata->addOption($multipleOfOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -180,13 +179,13 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadataMultipleOfIntegerish(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'multiple_of', 'value' => '2'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $multipleOfOption = new OptionMetadata();
+        $multipleOfOption->setName('multiple_of');
+        $multipleOfOption->setValue('2');
+        $fieldMetadata->addOption($multipleOfOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -201,13 +200,13 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadataMultipleOfInteger(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'multiple_of', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $multipleOfOption = new OptionMetadata();
+        $multipleOfOption->setName('multiple_of');
+        $multipleOfOption->setValue(2);
+        $fieldMetadata->addOption($multipleOfOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -224,38 +223,41 @@ class NumberTest extends TestCase
     {
         $this->expectExceptionMessage('Parameter "multiple_of" of property "property-name" needs to be greater than "0"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'multiple_of', 'value' => 0],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $multipleOfOption = new OptionMetadata();
+        $multipleOfOption->setName('multiple_of');
+        $multipleOfOption->setValue(0);
+        $fieldMetadata->addOption($multipleOfOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $this->number->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMultipleOfInvalidType(): void
     {
         $this->expectExceptionMessage('Parameter "multiple_of" of property "property-name" needs to be either null or numeric');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'multiple_of', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $multipleOfOption = new OptionMetadata();
+        $multipleOfOption->setName('multiple_of');
+        $multipleOfOption->setValue('invalid-value');
+        $fieldMetadata->addOption($multipleOfOption);
 
-        $this->number->mapPropertyMetadata($propertyMetadata);
+        $this->number->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMax(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-            ['name' => 'max', 'value' => 3],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(2);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(3);
+        $fieldMetadata->addOption($minOption);
+        $fieldMetadata->addOption($maxOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -271,13 +273,13 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxMinOnly(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(2);
+        $fieldMetadata->addOption($minOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -292,20 +294,20 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxMaxOnly(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max', 'value' => 2],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(3);
+        $fieldMetadata->addOption($maxOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
                 $this->getNullSchema(),
                 [
                     'type' => 'number',
-                    'maximum' => 2,
+                    'maximum' => 3,
                 ],
             ],
         ], $jsonSchema);
@@ -313,14 +315,17 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxWithIntegerishValues(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => '2'],
-            ['name' => 'max', 'value' => '3'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue('2');
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue('3');
+        $fieldMetadata->addOption($minOption);
+        $fieldMetadata->addOption($maxOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -336,14 +341,17 @@ class NumberTest extends TestCase
 
     public function testMapPropertyMetadataMinAndMaxWithFloatValues(): void
     {
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 1.2],
-            ['name' => 'max', 'value' => 3.4],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(1.2);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(3.4);
+        $fieldMetadata->addOption($minOption);
+        $fieldMetadata->addOption($maxOption);
 
-        $jsonSchema = $this->number->mapPropertyMetadata($propertyMetadata)->toJsonSchema();
+        $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
 
         $this->assertEquals([
             'anyOf' => [
@@ -361,39 +369,42 @@ class NumberTest extends TestCase
     {
         $this->expectExceptionMessage('Parameter "min" of property "property-name" needs to be either null or numeric');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue('invalid-value');
+        $fieldMetadata->addOption($minOption);
 
-        $this->number->mapPropertyMetadata($propertyMetadata);
+        $this->number->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMaxInvalidType(): void
     {
         $this->expectExceptionMessage('Parameter "max" of property "property-name" needs to be either null or numeric');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'max', 'value' => 'invalid-value'],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue('invalid-value');
+        $fieldMetadata->addOption($maxOption);
 
-        $this->number->mapPropertyMetadata($propertyMetadata);
+        $this->number->mapPropertyMetadata($fieldMetadata);
     }
 
     public function testMapPropertyMetadataMinAndMaxMaxLowerThanMin(): void
     {
         $this->expectExceptionMessage('Because parameter "min" of property "property-name" has value "2", parameter "max" needs to be greater than or equal "2"');
 
-        $propertyMetadata = new PropertyMetadata();
-        $propertyMetadata->setName('property-name');
-        $propertyMetadata->setParameters([
-            ['name' => 'min', 'value' => 2],
-            ['name' => 'max', 'value' => 1],
-        ]);
+        $fieldMetadata = new FieldMetadata('property-name');
+        $minOption = new OptionMetadata();
+        $minOption->setName('min');
+        $minOption->setValue(2);
+        $maxOption = new OptionMetadata();
+        $maxOption->setName('max');
+        $maxOption->setValue(1);
+        $fieldMetadata->addOption($minOption);
+        $fieldMetadata->addOption($maxOption);
 
-        $this->number->mapPropertyMetadata($propertyMetadata);
+        $this->number->mapPropertyMetadata($fieldMetadata);
     }
 }

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -23,7 +23,6 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperInterface;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\RefSchemaMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
-use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
 use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollectorInterface;
 use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
 use Sulu\Component\Content\Compat\Block\BlockPropertyInterface;
@@ -38,7 +37,6 @@ use Sulu\Component\Content\Document\Subscriber\PHPCR\SuluNode;
 use Sulu\Component\Content\Exception\UnexpectedPropertyType;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
 use Sulu\Component\Content\Types\Block\BlockVisitorInterface;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 
 /**
  * content type for block.

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -475,7 +475,7 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
             $tag = $blockType->findTag('sulu.global_block');
             if ($tag instanceof TagMetadata) {
                 $blockName = $tag->getAttributes()['global_block'] ?? null;
-                \assert(null !== $blockName, 'Global block name is expected to be not null.');
+                \assert(\is_string($blockName), 'Global block name is expected to be defined and a string.');
 
                 $blockTypeSchemas[] = new IfThenElseMetadata(
                     new SchemaMetadata([

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -12,6 +12,17 @@
 namespace Sulu\Component\Content\Types;
 
 use PHPCR\NodeInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AllOfsMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ArrayMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ConstMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\IfThenElseMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperInterface;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\RefSchemaMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStoreInterface;
 use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollectorInterface;
 use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
@@ -32,32 +43,16 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 /**
  * content type for block.
  */
-class BlockContentType extends ComplexContentType implements ContentTypeExportInterface, PreResolvableContentTypeInterface, ReferenceContentTypeInterface
+class BlockContentType extends ComplexContentType implements ContentTypeExportInterface, PreResolvableContentTypeInterface, ReferenceContentTypeInterface, PropertyMetadataMapperInterface
 {
     /**
-     * @param string $languageNamespace
+     * @param BlockVisitorInterface[] $blockVisitors
      */
     public function __construct(
         private ContentTypeManagerInterface $contentTypeManager,
-        private $languageNamespace,
-        /**
-         * @deprecated This property is not needed anymore and will be removed in Sulu 3.0
-         */
-        private RequestAnalyzerInterface $requestAnalyzer,
-        /**
-         * @deprecated This property is not needed anymore and will be removed in Sulu 3.0
-         */
-        private ?TargetGroupStoreInterface $targetGroupStore = null,
-        /**
-         * @var BlockVisitorInterface[]
-         */
-        private ?iterable $blockVisitors = null
+        private SchemaMetadataProvider $schemaMetadataProvider,
+        private iterable $blockVisitors,
     ) {
-        if (null === $this->blockVisitors) {
-            @trigger_deprecation('sulu/sulu', '2.3', 'Instantiating BlockContentType without the $blockVisitors argument is deprecated.');
-
-            $this->blockVisitors = [];
-        }
     }
 
     public function read(
@@ -473,5 +468,41 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
                 $child->setValue($oldValue);
             }
         }
+    }
+
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
+    {
+        $blockTypeSchemas = [];
+        foreach ($fieldMetadata->getTypes() as $blockType) {
+            $tag = $blockType->findTag('sulu.global_block');
+            if ($tag instanceof TagMetadata) {
+                $blockName = $tag->getAttributes()['global_block'] ?? null;
+                \assert(null !== $blockName, 'Global block name is expected to be not null.');
+
+                $blockTypeSchemas[] = new IfThenElseMetadata(
+                    new SchemaMetadata([
+                        new PropertyMetadata('type', true, new ConstMetadata($blockType->getName())),
+                    ]),
+                    new RefSchemaMetadata('#/definitions/' . $blockName)
+                );
+
+                continue;
+            }
+
+            $blockTypeSchemas[] = new IfThenElseMetadata(
+                new SchemaMetadata([
+                    new PropertyMetadata('type', true, new ConstMetadata($blockType->getName())),
+                ]),
+                $this->schemaMetadataProvider->getMetadata($blockType->getItems()),
+            );
+        }
+
+        return new PropertyMetadata(
+            $fieldMetadata->getName(),
+            $fieldMetadata->isRequired(),
+            new ArrayMetadata(
+                new AllOfsMetadata($blockTypeSchemas)
+            )
+        );
     }
 }

--- a/src/Sulu/Component/Content/Types/Number.php
+++ b/src/Sulu/Component/Content/Types/Number.php
@@ -13,13 +13,13 @@ namespace Sulu\Component\Content\Types;
 
 use PHPCR\NodeInterface;
 use PHPCR\PropertyType;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AnyOfsMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NullMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NumberMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
-use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
 use Sulu\Component\Content\SimpleContentType;
 use Webmozart\Assert\Assert;
 
@@ -65,16 +65,15 @@ class Number extends SimpleContentType implements PropertyMetadataMapperInterfac
         return $value;
     }
 
-    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
     {
-        /** @var string $propertyName */
-        $propertyName = $propertyMetadata->getName();
-        $mandatory = $propertyMetadata->isRequired();
+        $propertyName = $fieldMetadata->getName();
+        $mandatory = $fieldMetadata->isRequired();
 
-        $min = $this->getFloatParam($propertyMetadata, 'min');
-        $max = $this->getFloatParam($propertyMetadata, 'max');
-        $multipleOf = $this->getFloatParam($propertyMetadata, 'multiple_of');
-        $step = $this->getFloatParam($propertyMetadata, 'step');
+        $min = $this->getFloatParam($fieldMetadata, 'min');
+        $max = $this->getFloatParam($fieldMetadata, 'max');
+        $multipleOf = $this->getFloatParam($fieldMetadata, 'multiple_of');
+        $step = $this->getFloatParam($fieldMetadata, 'step');
 
         Assert::nullOrGreaterThan($multipleOf, 0, \sprintf(
             'Parameter "%s" of property "%s" needs to be greater than "0"',
@@ -138,11 +137,9 @@ class Number extends SimpleContentType implements PropertyMetadataMapperInterfac
         return 0.0 === $value - (int) (\floor($value / $multipleOf) * $multipleOf);
     }
 
-    private function getFloatParam(ContentPropertyMetadata $propertyMetadata, string $paramName): ?float
+    private function getFloatParam(FieldMetadata $fieldMetadata, string $paramName): ?float
     {
-        /** @var mixed[]|null $param */
-        $param = $propertyMetadata->getParameter($paramName);
-        $value = $param['value'] ?? null;
+        $value = $fieldMetadata->findOption($paramName)?->getValue();
 
         if (null === $value) {
             return null;
@@ -151,7 +148,7 @@ class Number extends SimpleContentType implements PropertyMetadataMapperInterfac
         Assert::numeric($value, \sprintf(
             'Parameter "%s" of property "%s" needs to be either null or numeric',
             $paramName,
-            $propertyMetadata->getName()
+            $fieldMetadata->getName()
         ));
 
         return (float) $value;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add new properties parser which returns new metadata.

#### Why?

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->

#### Example Usage

This is more internal service. External service should get the metadata via the `MetadataProviderRegistry` service instead of using the underlaying services.

#### To Do (Meta WIP)

- [x] Block `mapPropertyMetadata` similar to old and imagemap integration
- [x] Add `SchemaMetadataProvider` tests, see removed FormMetadataMapperTest.php Schema tests
- [x] Update content type Tests
- [x] Update other Tests
- [x] Fix `Call to a member function toJsonSchema()` on array
- [x] needs further validation and discussions if this can even be a float (i dont think as it comes from xml as string always now) https://github.com/sulu/sulu/pull/7943/files#r2086293858

#### To Do 2

- [x] Add test for `FieldMetadata::findOption`
- [x] Add test for `FormMetadata::findTag`
- [x] Add test for `FormMetadata::hasTag`

#### To Do 3 all test for `mapPropertyMetadata`

Check existing changs

- [x] Update test `ImageMapContentTypeTest` to new Metadata
- [x] Update test `MediaSelectionContentTypeTest` to new Metadata
- [x] Update test `SingleMediaSelectionTest::testMapPropertyMetadata` to new Metadata
- [x] Update test `PageTreeRouteContentTypeTest::testMapPropertyMetadata` to new Metadata
- [x] Update test `NumberTest::testMapPropertyMetadata` new Metadata
- [x] Update test maybe other `testMapPropertyMetadata` unit tests
