### PR TITLE
Fix MimeTypeIndicator fallback in collapsed MediaSelection Block

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/MimeTypeIndicator/MimeTypeIndicator.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/MimeTypeIndicator/MimeTypeIndicator.js
@@ -42,7 +42,10 @@ export default class MimeTypeIndicator extends React.PureComponent<Props> {
         }
 
         return (
-            <div className={mimeTypeIndicatorStyles.mimeTypeIndicator} style={mimeTypeStyles}>
+            <div
+                className={mimeTypeIndicatorStyles.mimeTypeIndicator}
+                style={mimeTypeStyles}
+            >
                 <Icon name={icon} />
             </div>
         );

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {action, isArrayLike, observable} from 'mobx';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
 import {MimeTypeIndicator} from '../../../components';
 import mediaSelectionBlockPreviewTransformerStyles from './mediaSelectionBlockPreviewTransformer.scss';
 import type {Node} from 'react';
@@ -10,16 +11,52 @@ const MAX_LENGTH = 8;
 
 export default class MediaSelectionBlockPreviewTransformer implements BlockPreviewTransformer {
     imageFormatUrl: string;
+    requestedImages: Object;
+    requestedMedia: Object;
     @observable failedImages: Object;
+    @observable media: Object;
 
     constructor(imageFormatUrl: string) {
         this.imageFormatUrl = imageFormatUrl;
+        this.requestedImages = {};
+        this.requestedMedia = {};
         this.failedImages = {};
+        this.media = {};
     }
 
     @action checkForImageError(id: *) {
+        if (this.requestedImages[id] || this.failedImages[id] !== undefined) {
+            return;
+        }
+
+        this.requestedImages[id] = true;
+
         fetch(this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50')
-            .then((r) => this.failedImages[id] = r.status !== 200);
+            .then(action((response) => {
+                this.failedImages[id] = response.status !== 200;
+
+                if (response.status !== 200) {
+                    this.loadMedia(id);
+                }
+            }))
+            .catch(action(() => {
+                this.failedImages[id] = true;
+                this.loadMedia(id);
+            }));
+    }
+
+    loadMedia(id: *) {
+        if (this.requestedMedia[id] || this.media[id]) {
+            return;
+        }
+
+        this.requestedMedia[id] = true;
+
+        ResourceRequester.get('media', {id, locale: 'en'})
+            .then(action((media) => {
+                this.media[id] = media;
+            }))
+            .catch(() => undefined);
     }
 
     @action transform(value: *): Node {
@@ -29,17 +66,16 @@ export default class MediaSelectionBlockPreviewTransformer implements BlockPrevi
             return null;
         }
 
-        ids.forEach((id) => this.checkForImageError(id));
+        ids.slice(0, MAX_LENGTH).forEach((id) => this.checkForImageError(id));
 
         return (
             ids.slice(0, MAX_LENGTH).map((id) => (
-                this.failedImages[id] ?
+                this.failedImages[id] && this.media[id] ?
                     <div className={mediaSelectionBlockPreviewTransformerStyles.mimeTypeIndicator} key={id}>
                         <MimeTypeIndicator
                             height={25}
                             iconSize={16}
-                            key={id}
-                            mimeType="application/pdf"
+                            mimeType={this.media[id].mimeType}
                             width={25}
                         />
                     </div> :

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
-import {isArrayLike} from 'mobx';
+import {action, isArrayLike, observable} from 'mobx';
+import {MimeTypeIndicator} from '../../../components';
 import mediaSelectionBlockPreviewTransformerStyles from './mediaSelectionBlockPreviewTransformer.scss';
 import type {Node} from 'react';
 import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
@@ -9,28 +10,45 @@ const MAX_LENGTH = 8;
 
 export default class MediaSelectionBlockPreviewTransformer implements BlockPreviewTransformer {
     imageFormatUrl: string;
+    @observable failedImages: Object;
 
     constructor(imageFormatUrl: string) {
         this.imageFormatUrl = imageFormatUrl;
+        this.failedImages = {};
     }
 
-    transform(value: *): Node {
+    @action checkForImageError(id: *) {
+        fetch(this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50')
+            .then((r) => this.failedImages[id] = r.status !== 200);
+    }
+
+    @action transform(value: *): Node {
         const {ids} = value;
 
         if ((!isArrayLike(ids)) || ids.length === 0) {
             return null;
         }
 
+        ids.forEach((id) => this.checkForImageError(id));
+
         return (
-            <div>
-                {ids.slice(0, MAX_LENGTH).map((id) => (
+            ids.slice(0, MAX_LENGTH).map((id) => (
+                this.failedImages[id] ?
+                    <div className={mediaSelectionBlockPreviewTransformerStyles.mimeTypeIndicator} key={id}>
+                        <MimeTypeIndicator
+                            height={25}
+                            iconSize={16}
+                            key={id}
+                            mimeType="application/pdf"
+                            width={25}
+                        />
+                    </div> :
                     <img
                         className={mediaSelectionBlockPreviewTransformerStyles.image}
                         key={id}
                         src={this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50'}
                     />
-                ))}
-            </div>
+            ))
         );
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.js
@@ -1,29 +1,48 @@
 // @flow
 import React from 'react';
+import {action, observable} from 'mobx';
+import {MimeTypeIndicator} from '../../../components';
 import singleMediaSelectionBlockPreviewTransformerStyles from './singleMediaSelectionBlockPreviewTransformer.scss';
 import type {Node} from 'react';
 import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
 
 export default class SingleMediaSelectionBlockPreviewTransformer implements BlockPreviewTransformer {
     imageFormatUrl: string;
+    @observable validImage: boolean;
 
     constructor(imageFormatUrl: string) {
         this.imageFormatUrl = imageFormatUrl;
+        this.validImage = true;
     }
 
-    transform(value: *): Node {
+    @action checkForImageError(id: *) {
+        fetch(this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50')
+            .then((r) => this.validImage = r.status === 200);
+    }
+
+    @action transform(value: *): Node {
         const {id} = value;
 
         if (!id) {
             return null;
         }
 
+        this.checkForImageError(id);
+
         return (
-            <img
-                className={singleMediaSelectionBlockPreviewTransformerStyles.image}
-                key={id}
-                src={this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50'}
-            />
+            this.validImage ?
+                <img
+                    className={singleMediaSelectionBlockPreviewTransformerStyles.image}
+                    key={id}
+                    src={this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50'}
+                /> :
+                <MimeTypeIndicator
+                    height={25}
+                    iconSize={16}
+                    key={id}
+                    mimeType="application/pdf"
+                    width={25}
+                />
         );
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {action, observable} from 'mobx';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
 import {MimeTypeIndicator} from '../../../components';
 import singleMediaSelectionBlockPreviewTransformerStyles from './singleMediaSelectionBlockPreviewTransformer.scss';
 import type {Node} from 'react';
@@ -8,16 +9,52 @@ import type {BlockPreviewTransformer} from 'sulu-admin-bundle/types';
 
 export default class SingleMediaSelectionBlockPreviewTransformer implements BlockPreviewTransformer {
     imageFormatUrl: string;
-    @observable validImage: boolean;
+    requestedImages: Object;
+    requestedMedia: Object;
+    @observable imageAvailable: Object;
+    @observable media: Object;
 
     constructor(imageFormatUrl: string) {
         this.imageFormatUrl = imageFormatUrl;
-        this.validImage = true;
+        this.requestedImages = {};
+        this.requestedMedia = {};
+        this.imageAvailable = {};
+        this.media = {};
     }
 
     @action checkForImageError(id: *) {
+        if (this.requestedImages[id] || this.imageAvailable[id] !== undefined) {
+            return;
+        }
+
+        this.requestedImages[id] = true;
+
         fetch(this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50')
-            .then((r) => this.validImage = r.status === 200);
+            .then(action((response) => {
+                this.imageAvailable[id] = response.status === 200;
+
+                if (response.status !== 200) {
+                    this.loadMedia(id);
+                }
+            }))
+            .catch(action(() => {
+                this.imageAvailable[id] = false;
+                this.loadMedia(id);
+            }));
+    }
+
+    loadMedia(id: *) {
+        if (this.requestedMedia[id] || this.media[id]) {
+            return;
+        }
+
+        this.requestedMedia[id] = true;
+
+        ResourceRequester.get('media', {id, locale: 'en'})
+            .then(action((media) => {
+                this.media[id] = media;
+            }))
+            .catch(() => undefined);
     }
 
     @action transform(value: *): Node {
@@ -30,19 +67,21 @@ export default class SingleMediaSelectionBlockPreviewTransformer implements Bloc
         this.checkForImageError(id);
 
         return (
-            this.validImage ?
+            this.imageAvailable[id] !== false ?
                 <img
                     className={singleMediaSelectionBlockPreviewTransformerStyles.image}
                     key={id}
                     src={this.imageFormatUrl.replace(':id', id) + '?locale=en&format=sulu-50x50'}
                 /> :
-                <MimeTypeIndicator
-                    height={25}
-                    iconSize={16}
-                    key={id}
-                    mimeType="application/pdf"
-                    width={25}
-                />
+                this.media[id]
+                    ? <MimeTypeIndicator
+                        height={25}
+                        iconSize={16}
+                        key={id}
+                        mimeType={this.media[id].mimeType}
+                        width={25}
+                    />
+                    : null
         );
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/mediaSelectionBlockPreviewTransformer.scss
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/blockPreviewTransformers/mediaSelectionBlockPreviewTransformer.scss
@@ -1,3 +1,8 @@
 .image {
     margin-right: 10px;
 }
+
+.mimeTypeIndicator {
+    display: inline-block;
+    margin-right: 10px;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.test.js
@@ -1,30 +1,42 @@
 // @flow
 import {render} from '@testing-library/react';
-import {runInAction} from 'mobx';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
 import MediaSelectionBlockPreviewTransformer
     from '../../blockPreviewTransformers/MediaSelectionBlockPreviewTransformer';
 
+jest.mock('sulu-admin-bundle/services', () => ({
+    ResourceRequester: {
+        get: jest.fn(),
+    },
+}));
+
 const MEDIA_URL = '/admin/media/redirect/media/:id';
 
-test('Render a single image if an id is given', () => {
-    const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+const mockFetch = (status: number) => {
     // eslint-disable-next-line no-undef
     global.fetch = jest.fn(() =>
         Promise.resolve({
+            status,
             json: () => Promise.resolve(),
         })
     );
+};
+
+beforeEach(() => {
+    ResourceRequester.get.mockReset();
+});
+
+test('Render a single image if an id is given', () => {
+    const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    mockFetch(200);
+
     expect(mediaSelectionBlockPreviewTransformer.transform({ids: [3, 7]})).toMatchSnapshot();
 });
 
 test('Render only eight images if more are given if an id is given', () => {
     const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() =>
-        Promise.resolve({
-            json: () => Promise.resolve({status: 200}),
-        })
-    );
+    mockFetch(200);
+
     expect(mediaSelectionBlockPreviewTransformer.transform({ids: [3, 7, 9, 11, 13, 2, 1, 4, 5]})).toMatchSnapshot();
 });
 
@@ -40,20 +52,19 @@ test('Render nothing if a wrong type of value is given', () => {
 
 test('Render MimeTypeIndicator if image isn\'t available', async() => {
     const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() =>
-        Promise.resolve({
-            ok: false,
-            status: 404,
-            json: () => Promise.resolve({}),
-        })
-    );
+    mockFetch(404);
+    ResourceRequester.get.mockImplementation((resourceKey, options) => {
+        return Promise.resolve({id: options.id, mimeType: 'application/vnd.ms-excel'});
+    });
 
     const {container, rerender} = render(mediaSelectionBlockPreviewTransformer.transform({ids: [1, 2, 3]}));
     await new Promise((resolve) => setTimeout(resolve));
-    runInAction(() => { });
+    await new Promise((resolve) => setTimeout(resolve));
     rerender(mediaSelectionBlockPreviewTransformer.transform({ids: [1, 2, 3]}));
 
     //eslint-disable-next-line testing-library/no-container
-    expect(container.querySelectorAll('span')).toHaveLength(3);
+    expect(container.querySelectorAll('.mimeTypeIndicator .mimeTypeIndicator')).toHaveLength(3);
+    expect(ResourceRequester.get).toHaveBeenCalledWith('media', {id: 1, locale: 'en'});
+    expect(ResourceRequester.get).toHaveBeenCalledWith('media', {id: 2, locale: 'en'});
+    expect(ResourceRequester.get).toHaveBeenCalledWith('media', {id: 3, locale: 'en'});
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/MediaSelectionBlockPreviewTransformer.test.js
@@ -1,4 +1,6 @@
 // @flow
+import {render} from '@testing-library/react';
+import {runInAction} from 'mobx';
 import MediaSelectionBlockPreviewTransformer
     from '../../blockPreviewTransformers/MediaSelectionBlockPreviewTransformer';
 
@@ -6,11 +8,23 @@ const MEDIA_URL = '/admin/media/redirect/media/:id';
 
 test('Render a single image if an id is given', () => {
     const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            json: () => Promise.resolve(),
+        })
+    );
     expect(mediaSelectionBlockPreviewTransformer.transform({ids: [3, 7]})).toMatchSnapshot();
 });
 
 test('Render only eight images if more are given if an id is given', () => {
     const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            json: () => Promise.resolve({status: 200}),
+        })
+    );
     expect(mediaSelectionBlockPreviewTransformer.transform({ids: [3, 7, 9, 11, 13, 2, 1, 4, 5]})).toMatchSnapshot();
 });
 
@@ -22,4 +36,24 @@ test('Render nothing if no id is given', () => {
 test('Render nothing if a wrong type of value is given', () => {
     const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
     expect(mediaSelectionBlockPreviewTransformer.transform('')).toMatchSnapshot();
+});
+
+test('Render MimeTypeIndicator if image isn\'t available', async() => {
+    const mediaSelectionBlockPreviewTransformer = new MediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            ok: false,
+            status: 404,
+            json: () => Promise.resolve({}),
+        })
+    );
+
+    const {container, rerender} = render(mediaSelectionBlockPreviewTransformer.transform({ids: [1, 2, 3]}));
+    await new Promise((resolve) => setTimeout(resolve));
+    runInAction(() => { });
+    rerender(mediaSelectionBlockPreviewTransformer.transform({ids: [1, 2, 3]}));
+
+    //eslint-disable-next-line testing-library/no-container
+    expect(container.querySelectorAll('span')).toHaveLength(3);
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.test.js
@@ -1,60 +1,63 @@
 // @flow
 import {render} from '@testing-library/react';
-import {runInAction} from 'mobx';
+import {ResourceRequester} from 'sulu-admin-bundle/services';
 import SingleMediaSelectionBlockPreviewTransformer
     from '../../blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer';
 
+jest.mock('sulu-admin-bundle/services', () => ({
+    ResourceRequester: {
+        get: jest.fn(),
+    },
+}));
+
 const MEDIA_URL = '/admin/media/redirect/media/:id';
 
-test('Render a single image if an id is given', () => {
-    const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+const mockFetch = (status: number) => {
     // eslint-disable-next-line no-undef
     global.fetch = jest.fn(() =>
         Promise.resolve({
+            status,
             json: () => Promise.resolve({}),
         })
     );
+};
+
+beforeEach(() => {
+    ResourceRequester.get.mockReset();
+});
+
+test('Render a single image if an id is given', () => {
+    const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    mockFetch(200);
+
     expect(singleMediaSelectionBlockPreviewTransformer.transform({id: 5})).toMatchSnapshot();
 });
 
 test('Render nothing if no id is given', () => {
     const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() =>
-        Promise.resolve({
-            json: () => Promise.resolve({}),
-        })
-    );
+    mockFetch(200);
+
     expect(singleMediaSelectionBlockPreviewTransformer.transform({})).toMatchSnapshot();
 });
 
 test('Render nothing if a wrong type of value is given', () => {
     const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() =>
-        Promise.resolve({
-            json: () => Promise.resolve({}),
-        })
-    );
+    mockFetch(200);
+
     expect(singleMediaSelectionBlockPreviewTransformer.transform('')).toMatchSnapshot();
 });
 
 test('Render MimeTypeIndicator if image isn\'t available', async() => {
     const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
-    // eslint-disable-next-line no-undef
-    global.fetch = jest.fn(() =>
-        Promise.resolve({
-            ok: false,
-            status: 404,
-            json: () => Promise.resolve({}),
-        })
-    );
+    mockFetch(404);
+    ResourceRequester.get.mockResolvedValue({id: 123, mimeType: 'application/vnd.ms-excel'});
 
     const {container, rerender} = render(singleMediaSelectionBlockPreviewTransformer.transform({id: 123}));
     await new Promise((resolve) => setTimeout(resolve));
-    runInAction(() => { });
+    await new Promise((resolve) => setTimeout(resolve));
     rerender(singleMediaSelectionBlockPreviewTransformer.transform({id: 123}));
 
     //eslint-disable-next-line testing-library/no-container
     expect(container.querySelector('.mimeTypeIndicator')).toMatchSnapshot();
+    expect(ResourceRequester.get).toHaveBeenCalledWith('media', {id: 123, locale: 'en'});
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer.test.js
@@ -1,4 +1,6 @@
 // @flow
+import {render} from '@testing-library/react';
+import {runInAction} from 'mobx';
 import SingleMediaSelectionBlockPreviewTransformer
     from '../../blockPreviewTransformers/SingleMediaSelectionBlockPreviewTransformer';
 
@@ -6,15 +8,53 @@ const MEDIA_URL = '/admin/media/redirect/media/:id';
 
 test('Render a single image if an id is given', () => {
     const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            json: () => Promise.resolve({}),
+        })
+    );
     expect(singleMediaSelectionBlockPreviewTransformer.transform({id: 5})).toMatchSnapshot();
 });
 
 test('Render nothing if no id is given', () => {
     const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            json: () => Promise.resolve({}),
+        })
+    );
     expect(singleMediaSelectionBlockPreviewTransformer.transform({})).toMatchSnapshot();
 });
 
 test('Render nothing if a wrong type of value is given', () => {
     const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            json: () => Promise.resolve({}),
+        })
+    );
     expect(singleMediaSelectionBlockPreviewTransformer.transform('')).toMatchSnapshot();
+});
+
+test('Render MimeTypeIndicator if image isn\'t available', async() => {
+    const singleMediaSelectionBlockPreviewTransformer = new SingleMediaSelectionBlockPreviewTransformer(MEDIA_URL);
+    // eslint-disable-next-line no-undef
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            ok: false,
+            status: 404,
+            json: () => Promise.resolve({}),
+        })
+    );
+
+    const {container, rerender} = render(singleMediaSelectionBlockPreviewTransformer.transform({id: 123}));
+    await new Promise((resolve) => setTimeout(resolve));
+    runInAction(() => { });
+    rerender(singleMediaSelectionBlockPreviewTransformer.transform({id: 123}));
+
+    //eslint-disable-next-line testing-library/no-container
+    expect(container.querySelector('.mimeTypeIndicator')).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/MediaSelectionBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/MediaSelectionBlockPreviewTransformer.test.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Render a single image if an id is given 1`] = `
-<div>
+Array [
   <img
     className="image"
     src="/admin/media/redirect/media/3?locale=en&format=sulu-50x50"
-  />
+  />,
   <img
     className="image"
     src="/admin/media/redirect/media/7?locale=en&format=sulu-50x50"
-  />
-</div>
+  />,
+]
 `;
 
 exports[`Render nothing if a wrong type of value is given 1`] = `null`;
@@ -18,38 +18,38 @@ exports[`Render nothing if a wrong type of value is given 1`] = `null`;
 exports[`Render nothing if no id is given 1`] = `null`;
 
 exports[`Render only eight images if more are given if an id is given 1`] = `
-<div>
+Array [
   <img
     className="image"
     src="/admin/media/redirect/media/3?locale=en&format=sulu-50x50"
-  />
+  />,
   <img
     className="image"
     src="/admin/media/redirect/media/7?locale=en&format=sulu-50x50"
-  />
+  />,
   <img
     className="image"
     src="/admin/media/redirect/media/9?locale=en&format=sulu-50x50"
-  />
+  />,
   <img
     className="image"
     src="/admin/media/redirect/media/11?locale=en&format=sulu-50x50"
-  />
+  />,
   <img
     className="image"
     src="/admin/media/redirect/media/13?locale=en&format=sulu-50x50"
-  />
+  />,
   <img
     className="image"
     src="/admin/media/redirect/media/2?locale=en&format=sulu-50x50"
-  />
+  />,
   <img
     className="image"
     src="/admin/media/redirect/media/1?locale=en&format=sulu-50x50"
-  />
+  />,
   <img
     className="image"
     src="/admin/media/redirect/media/4?locale=en&format=sulu-50x50"
-  />
-</div>
+  />,
+]
 `;

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SingleMediaSelectionBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SingleMediaSelectionBlockPreviewTransformer.test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Render MimeTypeIndicator if image isn't available 1`] = `
+<div
+  class="mimeTypeIndicator"
+  style="color: rgb(255, 255, 255); font-size: 16px; background-color: rgb(187, 8, 6); width: 25px; height: 25px;"
+>
+  <span
+    aria-label="fa-file-pdf-o"
+    class="fa fa-file-pdf-o"
+  />
+</div>
+`;
+
 exports[`Render a single image if an id is given 1`] = `
 <img
   className="image"

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SingleMediaSelectionBlockPreviewTransformer.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/FieldBlocks/tests/blockPreviewTransformers/__snapshots__/SingleMediaSelectionBlockPreviewTransformer.test.js.snap
@@ -3,11 +3,11 @@
 exports[`Render MimeTypeIndicator if image isn't available 1`] = `
 <div
   class="mimeTypeIndicator"
-  style="color: rgb(255, 255, 255); font-size: 16px; background-color: rgb(187, 8, 6); width: 25px; height: 25px;"
+  style="color: rgb(255, 255, 255); font-size: 16px; background-color: rgb(0, 114, 58); width: 25px; height: 25px;"
 >
   <span
-    aria-label="fa-file-pdf-o"
-    class="fa fa-file-pdf-o"
+    aria-label="fa-file-excel-o"
+    class="fa fa-file-excel-o"
   />
 </div>
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7638
| Related issues/PRs | #7638
| License | MIT
| Documentation PR | -

#### What's in this PR?

adds a check if the media thumbnail is available and if not, uses the MimeTypeIndicator as a fallback

#### Why?

consistency with expanded Block and #7638

#### Example Usage

no usage
<img width="555" alt="image" src="https://github.com/user-attachments/assets/02af3972-d7f0-4fa9-b8eb-deade088e7b1" />