### PR TITLE
Use snapshots for security and media metadata tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -45475,18 +45475,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
 
 		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access offset 1 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
-
-		-
 			message: '#^Cannot access offset 2 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -45502,24 +45490,6 @@ parameters:
 			message: '#^Cannot access property \$Sulu on mixed\.$#'
 			identifier: property.nonObject
 			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access property \$allOf on mixed\.$#'
-			identifier: property.nonObject
-			count: 3
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access property \$anyOf on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access property \$form on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
 
 		-
@@ -45541,21 +45511,9 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
 
 		-
-			message: '#^Cannot access property \$required on mixed\.$#'
-			identifier: property.nonObject
-			count: 4
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
-
-		-
 			message: '#^Cannot access property \$routes on mixed\.$#'
 			identifier: property.nonObject
 			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access property \$schema on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
 
 		-
@@ -45591,13 +45549,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
 			identifier: argument.type
-			count: 3
-			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
-
-		-
-			message: '#^Parameter \#1 \$object_or_class of function property_exists expects object\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 4
+			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
 
 		-
@@ -61399,7 +61351,7 @@ parameters:
 			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php
 
 		-
-			message: '#^PHPDoc tag @var with type array\<string\> is not subtype of native type list\<string\>\|false\.$#'
+			message: '#^PHPDoc tag @var with type array\<string\> is not subtype of native type list\<array\{string, int\<0, max\>\}\|string\>\|false\.$#'
 			identifier: varTag.nativeType
 			count: 1
 			path: src/Sulu/Component/Content/Query/ListToTreeConverter.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -30421,39 +30421,9 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: '#^Cannot access property \$form on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
 			message: '#^Cannot access property \$image_format on mixed\.$#'
 			identifier: property.nonObject
 			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access property \$items on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access property \$media_details on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access property \$required on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
-			message: '#^Cannot access property \$schema on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
@@ -30463,27 +30433,9 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\AdminControllerTest\:\:getEmptyArraySchema\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\AdminControllerTest\:\:getNullSchema\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
 			identifier: argument.type
-			count: 4
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
-			message: '#^Parameter \#1 \$object_or_class of function property_exists expects object\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 8
+			count: 2
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/collection_details.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/collection_details.json
@@ -1,0 +1,74 @@
+{
+    "name": null,
+    "form": {
+        "title": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "text_line",
+            "colSpan": 12,
+            "options": {
+                "headline": {
+                    "name": "headline",
+                    "type": "string",
+                    "value": true
+                }
+            },
+            "types": [],
+            "defaultType": null,
+            "required": true,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "Title"
+        },
+        "description": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "text_area",
+            "colSpan": 12,
+            "options": [],
+            "types": [],
+            "defaultType": null,
+            "required": false,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "Description"
+        }
+    },
+    "schema": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "minLength": 1
+            },
+            "description": {
+                "anyOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "type": "string",
+                        "maxLength": 0
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        "required": [
+            "title"
+        ]
+    },
+    "key": "collection_details",
+    "tags": [],
+    "title": ""
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/form_image.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/form_image.json
@@ -1,0 +1,25 @@
+{
+    "anyOf": [
+        {
+            "type": "null"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "displayOption": {
+                    "type": "string"
+                }
+            }
+        }
+    ]
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/form_images.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/form_images.json
@@ -1,0 +1,42 @@
+{
+    "anyOf": [
+        {
+            "type": "null"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "anyOf": [
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": [
+                                    "number",
+                                    "string",
+                                    "boolean",
+                                    "object",
+                                    "array",
+                                    "null"
+                                ]
+                            },
+                            "maxItems": 0
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            },
+                            "minItems": 2,
+                            "maxItems": 3,
+                            "uniqueItems": true
+                        }
+                    ]
+                },
+                "displayOption": {
+                    "type": "string"
+                }
+            }
+        }
+    ]
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/media_details.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/media_details.json
@@ -1,0 +1,342 @@
+{
+    "name": null,
+    "form": {
+        "media_upload": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "section",
+            "colSpan": 4,
+            "items": {
+                "media_version_upload": {
+                    "disabledCondition": null,
+                    "visibleCondition": null,
+                    "type": "media_version_upload",
+                    "colSpan": 12,
+                    "options": [],
+                    "types": [],
+                    "defaultType": null,
+                    "required": false,
+                    "multilingual": true,
+                    "spaceAfter": null,
+                    "minOccurs": null,
+                    "maxOccurs": null,
+                    "onInvalid": null,
+                    "tags": []
+                }
+            }
+        },
+        "media_details": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "section",
+            "colSpan": 8,
+            "items": {
+                "title": {
+                    "disabledCondition": null,
+                    "visibleCondition": null,
+                    "type": "text_line",
+                    "colSpan": 12,
+                    "options": {
+                        "headline": {
+                            "name": "headline",
+                            "type": "string",
+                            "value": true
+                        }
+                    },
+                    "types": [],
+                    "defaultType": null,
+                    "required": true,
+                    "multilingual": true,
+                    "spaceAfter": null,
+                    "minOccurs": null,
+                    "maxOccurs": null,
+                    "onInvalid": null,
+                    "tags": [],
+                    "label": "Title"
+                },
+                "description": {
+                    "disabledCondition": null,
+                    "visibleCondition": null,
+                    "type": "text_area",
+                    "colSpan": 12,
+                    "options": [],
+                    "types": [],
+                    "defaultType": null,
+                    "required": false,
+                    "multilingual": true,
+                    "spaceAfter": null,
+                    "minOccurs": null,
+                    "maxOccurs": null,
+                    "onInvalid": null,
+                    "tags": [],
+                    "label": "Description"
+                },
+                "license": {
+                    "disabledCondition": null,
+                    "visibleCondition": null,
+                    "type": "section",
+                    "colSpan": 12,
+                    "items": {
+                        "copyright": {
+                            "disabledCondition": null,
+                            "visibleCondition": null,
+                            "type": "text_area",
+                            "colSpan": 12,
+                            "options": [],
+                            "types": [],
+                            "defaultType": null,
+                            "required": false,
+                            "multilingual": true,
+                            "spaceAfter": null,
+                            "minOccurs": null,
+                            "maxOccurs": null,
+                            "onInvalid": null,
+                            "tags": [],
+                            "label": "Copyright Information"
+                        },
+                        "credits": {
+                            "disabledCondition": null,
+                            "visibleCondition": null,
+                            "type": "text_area",
+                            "colSpan": 12,
+                            "options": [],
+                            "types": [],
+                            "defaultType": null,
+                            "required": false,
+                            "multilingual": true,
+                            "spaceAfter": null,
+                            "minOccurs": null,
+                            "maxOccurs": null,
+                            "onInvalid": null,
+                            "tags": [],
+                            "label": "Credits"
+                        }
+                    },
+                    "label": "License"
+                },
+                "taxonomies": {
+                    "disabledCondition": null,
+                    "visibleCondition": null,
+                    "type": "section",
+                    "colSpan": 12,
+                    "items": {
+                        "categories": {
+                            "disabledCondition": null,
+                            "visibleCondition": null,
+                            "type": "category_selection",
+                            "colSpan": 12,
+                            "options": [],
+                            "types": [],
+                            "defaultType": null,
+                            "required": false,
+                            "multilingual": true,
+                            "spaceAfter": null,
+                            "minOccurs": null,
+                            "maxOccurs": null,
+                            "onInvalid": null,
+                            "tags": [],
+                            "label": "Categories"
+                        },
+                        "targetGroups": {
+                            "disabledCondition": null,
+                            "visibleCondition": null,
+                            "type": "target_group_selection",
+                            "colSpan": 12,
+                            "options": [],
+                            "types": [],
+                            "defaultType": null,
+                            "required": false,
+                            "multilingual": true,
+                            "spaceAfter": null,
+                            "minOccurs": null,
+                            "maxOccurs": null,
+                            "onInvalid": "ignore",
+                            "tags": [],
+                            "label": "Target groups"
+                        },
+                        "tags": {
+                            "disabledCondition": null,
+                            "visibleCondition": null,
+                            "type": "tag_selection",
+                            "colSpan": 12,
+                            "options": [],
+                            "types": [],
+                            "defaultType": null,
+                            "required": false,
+                            "multilingual": true,
+                            "spaceAfter": null,
+                            "minOccurs": null,
+                            "maxOccurs": null,
+                            "onInvalid": null,
+                            "tags": [],
+                            "label": "Tags"
+                        }
+                    },
+                    "label": "Taxonomies"
+                }
+            }
+        }
+    },
+    "schema": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "minLength": 1
+            },
+            "description": {
+                "anyOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "type": "string",
+                        "maxLength": 0
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
+            },
+            "copyright": {
+                "anyOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "type": "string",
+                        "maxLength": 0
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
+            },
+            "credits": {
+                "anyOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "type": "string",
+                        "maxLength": 0
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
+            },
+            "categories": {
+                "anyOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "number",
+                                "string",
+                                "boolean",
+                                "object",
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "maxItems": 0
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        "uniqueItems": true
+                    }
+                ]
+            },
+            "targetGroups": {
+                "anyOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "number",
+                                "string",
+                                "boolean",
+                                "object",
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "maxItems": 0
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        "uniqueItems": true
+                    }
+                ]
+            },
+            "tags": {
+                "anyOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": [
+                                "number",
+                                "string",
+                                "boolean",
+                                "object",
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "maxItems": 0
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "number"
+                                }
+                            ]
+                        },
+                        "uniqueItems": true
+                    }
+                ]
+            }
+        },
+        "required": [
+            "title"
+        ]
+    },
+    "key": "media_details",
+    "tags": [],
+    "title": ""
+}

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
@@ -11,10 +11,13 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Controller;
 
+use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class AdminControllerTest extends SuluTestCase
 {
+    use AssertSnapshotTrait;
+
     public function testRouteConfig(): void
     {
         $client = $this->createAuthenticatedClient();
@@ -50,18 +53,8 @@ class AdminControllerTest extends SuluTestCase
         $client->jsonRequest('GET', '/admin/metadata/form/user_details');
 
         $this->assertHttpStatusCode(200, $client->getResponse());
-        $response = \json_decode($client->getResponse()->getContent());
 
-        $form = $response->form;
-
-        $this->assertTrue(\property_exists($form, 'username'));
-        $this->assertTrue(\property_exists($form, 'password'));
-
-        $schema = $response->schema;
-
-        $this->assertEquals(['username', 'locale'], $schema->allOf[0]->required);
-        $this->assertEquals(['id'], $schema->allOf[1]->anyOf[0]->required);
-        $this->assertEquals(['password'], $schema->allOf[1]->anyOf[1]->required);
+        $this->assertSnapshot('user_details.json', $client->getResponse()->getContent() ?: '');
     }
 
     public function testRoleMetadataAction(): void
@@ -71,15 +64,7 @@ class AdminControllerTest extends SuluTestCase
         $client->jsonRequest('GET', '/admin/metadata/form/role_details');
 
         $this->assertHttpStatusCode(200, $client->getResponse());
-        $response = \json_decode($client->getResponse()->getContent());
 
-        $form = $response->form;
-
-        $this->assertTrue(\property_exists($form, 'name'));
-        $this->assertTrue(\property_exists($form, 'system'));
-
-        $schema = $response->schema;
-
-        $this->assertEquals(['name', 'system'], $schema->required);
+        $this->assertSnapshot('role_details.json', $client->getResponse()->getContent() ?: '');
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/role_details.json
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/role_details.json
@@ -1,0 +1,137 @@
+{
+    "name": null,
+    "form": {
+        "name": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "text_line",
+            "colSpan": 12,
+            "options": {
+                "headline": {
+                    "name": "headline",
+                    "type": "string",
+                    "value": true
+                }
+            },
+            "types": [],
+            "defaultType": null,
+            "required": true,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "Name"
+        },
+        "system": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "single_select",
+            "colSpan": 3,
+            "options": {
+                "values": {
+                    "name": "values",
+                    "type": "expression",
+                    "value": [
+                        {
+                            "name": "Sulu",
+                            "title": "Sulu"
+                        },
+                        {
+                            "name": "Sulu CMF",
+                            "title": "Sulu CMF"
+                        }
+                    ]
+                },
+                "default_value": {
+                    "name": "default_value",
+                    "type": "expression",
+                    "value": "Sulu"
+                }
+            },
+            "types": [],
+            "defaultType": null,
+            "required": true,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "System"
+        },
+        "key": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "text_line",
+            "colSpan": 9,
+            "options": [],
+            "types": [],
+            "defaultType": null,
+            "required": false,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "Key"
+        },
+        "permissions_section": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "section",
+            "colSpan": 12,
+            "items": {
+                "permissions": {
+                    "disabledCondition": null,
+                    "visibleCondition": null,
+                    "type": "permissions",
+                    "colSpan": 12,
+                    "options": [],
+                    "types": [],
+                    "defaultType": null,
+                    "required": false,
+                    "multilingual": true,
+                    "spaceAfter": null,
+                    "minOccurs": null,
+                    "maxOccurs": null,
+                    "onInvalid": null,
+                    "tags": []
+                }
+            },
+            "label": "System"
+        }
+    },
+    "schema": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "minLength": 1
+            },
+            "key": {
+                "anyOf": [
+                    {
+                        "type": "null"
+                    },
+                    {
+                        "type": "string",
+                        "maxLength": 0
+                    },
+                    {
+                        "type": "string"
+                    }
+                ]
+            }
+        },
+        "required": [
+            "name",
+            "system"
+        ]
+    },
+    "key": "role_details",
+    "tags": [],
+    "title": ""
+}

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/user_details.json
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/user_details.json
@@ -1,0 +1,165 @@
+{
+    "name": null,
+    "form": {
+        "username": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "text_line",
+            "colSpan": 6,
+            "options": [],
+            "types": [],
+            "defaultType": null,
+            "required": true,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "Username"
+        },
+        "email": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "email",
+            "colSpan": 6,
+            "options": [],
+            "types": [],
+            "defaultType": null,
+            "required": false,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "Email"
+        },
+        "password": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "password_confirmation",
+            "colSpan": 12,
+            "options": [],
+            "types": [],
+            "defaultType": null,
+            "required": false,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "Password"
+        },
+        "locale": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "single_select",
+            "colSpan": 6,
+            "options": {
+                "values": {
+                    "name": "values",
+                    "type": "expression",
+                    "value": [
+                        {
+                            "name": "de",
+                            "title": "Deutsch"
+                        },
+                        {
+                            "name": "en",
+                            "title": "English"
+                        }
+                    ]
+                }
+            },
+            "types": [],
+            "defaultType": null,
+            "required": true,
+            "multilingual": true,
+            "spaceAfter": null,
+            "minOccurs": null,
+            "maxOccurs": null,
+            "onInvalid": null,
+            "tags": [],
+            "label": "System language"
+        },
+        "permission": {
+            "disabledCondition": null,
+            "visibleCondition": null,
+            "type": "section",
+            "colSpan": 12,
+            "items": {
+                "userRoles": {
+                    "disabledCondition": null,
+                    "visibleCondition": null,
+                    "type": "role_assignments",
+                    "colSpan": 12,
+                    "options": [],
+                    "types": [],
+                    "defaultType": null,
+                    "required": false,
+                    "multilingual": true,
+                    "spaceAfter": null,
+                    "minOccurs": null,
+                    "maxOccurs": null,
+                    "onInvalid": null,
+                    "tags": [],
+                    "label": "User roles"
+                }
+            },
+            "label": "Permissions"
+        }
+    },
+    "schema": {
+        "allOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "username": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "email": {
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            },
+                            {
+                                "type": "string",
+                                "format": "idn-email"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "username",
+                    "locale"
+                ]
+            },
+            {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "required": [
+                            "id"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "password"
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "key": "user_details",
+    "tags": [],
+    "title": ""
+}

--- a/src/Sulu/Bundle/TestBundle/Testing/AssertSnapshotTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/AssertSnapshotTrait.php
@@ -61,7 +61,7 @@ trait AssertSnapshotTrait
             [$this->getCalledClassFolder(), $this->getSnapshotFolder(), $snapshotPatternFilename],
         );
 
-        $this->assertFileExists($snapshotFilePath, 'Unable to find snapshot file');
+        $this->assertFileExists($snapshotFilePath, 'Unable to find snapshot file: ' . $snapshotFilePath);
         $snapshotPattern = \file_get_contents($snapshotFilePath);
         $this->assertIsString($snapshotPattern, 'Unable to open snapshot file: ' . $snapshotFilePath);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7943
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use snapshots for security metadata tests.

#### Why?

This helps us to find regression in https://github.com/sulu/sulu/pull/7943.
