### PR TITLE
Fix xliff export number values

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -144,7 +144,7 @@
         <service id="sulu.content.type.number" class="%sulu.content.type.number.class%">
             <tag name="sulu_admin.property_metadata_mapper" type="number"/>
             <tag name="sulu.content.type" alias="number"/>
-            <tag name="sulu.content.export" format="1.2.xliff" translate="true" />
+            <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
         <service id="sulu.content.type.text_line" class="%sulu.content.type.text_line.class%">
             <tag name="sulu.content.type" alias="text_line"/>

--- a/src/Sulu/Component/Content/SimpleContentType.php
+++ b/src/Sulu/Component/Content/SimpleContentType.php
@@ -145,6 +145,10 @@ abstract class SimpleContentType implements ContentTypeInterface, ContentTypeExp
             return \json_encode($propertyValue);
         }
 
+        if (\is_numeric($propertyValue)) {
+            return (string) $propertyValue;
+        }
+
         return '';
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7954
| Related issues/PRs | #7954
| License | MIT
| Documentation PR | /

#### What's in this PR?

Include Number fields in the exports. Change Number to non-translateable in the metadata mapper.

#### Why?

Value of Number fields were not included in the export, see #7954

#### Example Usage

- Add a number field to a template
- Do a webspace export & import it again