### PR TITLE
Add XmlTemplateFormMetadataLoader to replace old structure based metadata loading

### DIFF
--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -275,7 +275,7 @@ final class SuluArticleBundle extends AbstractBundle
                         ],
                     ],
                     'templates' => [
-                        'articles' => [
+                        ArticleInterface::TEMPLATE_TYPE => [
                             'default_type' => null,
                             'directories' => [
                                 'app' => '%kernel.project_dir%/config/templates/articles',

--- a/packages/content/tests/Application/ExampleTestBundle/DependencyInjection/ExampleTestExtension.php
+++ b/packages/content/tests/Application/ExampleTestBundle/DependencyInjection/ExampleTestExtension.php
@@ -62,6 +62,14 @@ class ExampleTestExtension extends Extension implements PrependExtensionInterfac
                             ],
                         ],
                     ],
+                    'templates' => [
+                        Example::TEMPLATE_TYPE => [
+                            'default_type' => 'default', // TODO should not be hardcoded?
+                            'directories' => [
+                                'app' => '%kernel.project_dir%/config/templates/examples',
+                            ],
+                        ],
+                    ],
                 ]
             );
         }

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Form/SettingsFormMetadataVisitorTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Form/SettingsFormMetadataVisitorTest.php
@@ -20,7 +20,6 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\XmlFormMetadataLoader;
-use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 use Sulu\Content\Infrastructure\Sulu\Form\SettingsFormMetadataVisitor;
 
@@ -70,31 +69,6 @@ class SettingsFormMetadataVisitorTest extends TestCase
             ->shouldNotBeCalled();
 
         $this->settingsFormMetadataVisitor->visitFormMetadata($formMetadata->reveal(), 'de', []);
-    }
-
-    public function testVisitFormMetadataInvalidSubFormMetadata(): void
-    {
-        $formMetadata = $this->prophesize(FormMetadata::class);
-        $formMetadata->getKey()
-            ->shouldBeCalled()
-            ->willReturn('content_settings');
-
-        $formMetadata->setItems(Argument::any())
-            ->shouldNotBeCalled();
-        $formMetadata->setSchema(Argument::any())
-            ->shouldNotBeCalled();
-
-        $subFormMetadata = $this->prophesize(MetadataInterface::class);
-
-        $metadataOptions = [
-            'forms' => ['content_settings_author'],
-        ];
-
-        $this->xmlFormMetadataLoader->getMetadata('content_settings_author', 'de', $metadataOptions)
-            ->shouldBeCalled()
-            ->willReturn($subFormMetadata->reveal());
-
-        $this->settingsFormMetadataVisitor->visitFormMetadata($formMetadata->reveal(), 'de', $metadataOptions);
     }
 
     public function testVisitFormMetadataSubFormMetadataIsNull(): void

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -361,7 +361,7 @@ final class SuluPageBundle extends AbstractBundle
                         ],
                     ],
                     'templates' => [
-                        'pages' => [
+                        PageInterface::TEMPLATE_TYPE => [
                             'default_type' => null,
                             'directories' => [
                                 'app' => '%kernel.project_dir%/config/templates/pages',

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -262,7 +262,7 @@ final class SuluSnippetBundle extends AbstractBundle
                         ],
                     ],
                     'templates' => [
-                        'snippets' => [
+                        SnippetInterface::TEMPLATE_TYPE => [
                             'default_type' => null,
                             'directories' => [
                                 'app' => '%kernel.project_dir%/config/templates/snippets',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2053,34 +2053,16 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Cannot call method getType\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ExpressionFormMetadataVisitor.php
-
-		-
-			message: '#^Cannot call method getValue\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ExpressionFormMetadataVisitor.php
-
-		-
-			message: '#^Cannot call method setValue\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ExpressionFormMetadataVisitor.php
-
-		-
-			message: '#^Parameter \#1 \$expression of method Symfony\\Component\\ExpressionLanguage\\ExpressionLanguage\:\:evaluate\(\) expects string\|Symfony\\Component\\ExpressionLanguage\\Expression, mixed given\.$#'
+			message: '#^Parameter \#1 \$expression of method Symfony\\Component\\ExpressionLanguage\\ExpressionLanguage\:\:evaluate\(\) expects string\|Symfony\\Component\\ExpressionLanguage\\Expression, array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ExpressionFormMetadataVisitor.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:getOptions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setValue\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ExpressionFormMetadataVisitor.php
 
 		-
 			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:\$onInvalid \(string\) does not accept string\|null\.$#'
@@ -4195,12 +4177,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
 			message: '#^Cannot call method getType\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -4209,7 +4185,7 @@ parameters:
 		-
 			message: '#^Cannot call method getValue\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
@@ -4843,7 +4819,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
+			message: '#^Cannot access offset 0 on array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 6
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -4861,21 +4837,27 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getInfoText\(\) on mixed\.$#'
+			message: '#^Cannot call method getInfoText\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
 			message: '#^Cannot call method getName\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 6
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getPlaceholder\(\) on mixed\.$#'
+			message: '#^Cannot call method getName\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+
+		-
+			message: '#^Cannot call method getPlaceholder\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
+			identifier: method.nonObject
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
@@ -4885,21 +4867,21 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getTitle\(\) on mixed\.$#'
+			message: '#^Cannot call method getTitle\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getType\(\) on mixed\.$#'
+			message: '#^Cannot call method getType\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getValue\(\) on mixed\.$#'
+			message: '#^Cannot call method getValue\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
-			count: 9
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
@@ -5077,31 +5059,25 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
 
 		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
+			message: '#^Cannot access offset 0 on array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
 
 		-
-			message: '#^Cannot access offset 1 on mixed\.$#'
+			message: '#^Cannot access offset 1 on array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
 
 		-
-			message: '#^Cannot call method getType\(\) on mixed\.$#'
+			message: '#^Cannot call method getValue\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
-			count: 2
+			count: 4
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
 
 		-
-			message: '#^Cannot call method getValue\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 11
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
-
-		-
-			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
+			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|int\|string given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2239,6 +2239,24 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
 
 		-
+			message: '#^Cannot call method count\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+
+		-
+			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+
+		-
+			message: '#^Parameter \#1 \$schema of method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata\:\:merge\(\) expects Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+
+		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:getType\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3589,18 +3607,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\XmlFormMetadataLoader\:\:getMetadata\(\) should return Sulu\\Bundle\\AdminBundle\\Metadata\\MetadataInterface\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
-
-		-
-			message: '#^Parameter \#1 \$data of function unserialize expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
-
-		-
 			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\XmlFormMetadataLoader\:\:\$formDirectories \(array\<string\>\) does not accept array\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -4195,9 +4201,27 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
 
 		-
-			message: '#^Call to an undefined method Sulu\\Bundle\\AdminBundle\\Metadata\\MetadataInterface\:\:getItems\(\)\.$#'
+			message: '#^Call to an undefined method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:getItems\(\)\.$#'
 			identifier: method.notFound
 			count: 3
+			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+
+		-
+			message: '#^Call to an undefined method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:getOnInvalid\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+
+		-
+			message: '#^Call to an undefined method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:getOptions\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+
+		-
+			message: '#^Call to an undefined method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:getTypes\(\)\.$#'
+			identifier: method.notFound
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
@@ -4207,37 +4231,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
-			message: '#^Cannot access offset ''allOf'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot access offset ''audience_targeting_groups'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot access offset ''block'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot access offset ''blocks'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
 			message: '#^Cannot access offset ''formOfAddress'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot access offset ''highlight'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -4249,15 +4243,9 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
-			message: '#^Cannot access offset ''image'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
 			message: '#^Cannot access offset ''name'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
@@ -4267,27 +4255,9 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
-			message: '#^Cannot access offset ''salutation'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
 			message: '#^Cannot access offset ''test'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot access offset ''test1'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot access offset ''test2'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
@@ -4305,25 +4275,13 @@ parameters:
 		-
 			message: '#^Cannot call method getDisabledCondition\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot call method getItems\(\) on Sulu\\Bundle\\AdminBundle\\Metadata\\MetadataInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 17
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
 			message: '#^Cannot call method getItems\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 5
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot call method getLabel\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
@@ -4333,33 +4291,9 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
-			message: '#^Cannot call method getOnInvalid\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot call method getOptions\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot call method getSchema\(\) on Sulu\\Bundle\\AdminBundle\\Metadata\\MetadataInterface\|null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
 			message: '#^Cannot call method getType\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot call method getTypes\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
@@ -4371,25 +4305,13 @@ parameters:
 		-
 			message: '#^Cannot call method getVisibleCondition\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Cannot call method toJsonSchema\(\) on mixed\.$#'
-			identifier: method.nonObject
 			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Parameter \#1 \$array of function array_keys expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 4
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-
 			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2895,19 +2895,13 @@ parameters:
 		-
 			message: '#^Argument of an invalid type DOMNodeList\<DOMNode\>\|false supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 4
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 6
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Binary operation "\." between mixed and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
+			count: 5
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
@@ -2955,7 +2949,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''name'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 11
+			count: 6
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
@@ -2997,13 +2991,13 @@ parameters:
 		-
 			message: '#^Cannot access offset ''type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 3
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
 			message: '#^Cannot access offset ''types'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
@@ -3021,7 +3015,7 @@ parameters:
 		-
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
@@ -3049,98 +3043,32 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadBlock\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMeta\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMetaTag\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadMetaTag\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParam\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParams\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParams\(\) has parameter \$path with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) should return array\<string, array\<string, mixed\>\> but returns array\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParam\(\) should return array\{name\: string\|null, type\: string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, collection\?\: array\<mixed\>\} but returns array\{name\: bool\|int\|string\|null, type\: bool\|int\|string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, value\: array\<array\{name\: string\|null, type\: string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, collection\?\: array\<mixed\>\}\>\|bool\|int\|string\|null\}\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperty\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperty\(\) should return array\{name\: string, type\: string, default\-type\: string\|null, minOccurs\: int\|null, maxOccurs\: int\|null, colspan\: int\|null, cssClass\: string\|null, spaceAfter\: int\|null, \.\.\.\} but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadSection\(\) should return array\{name\: string, colspan\: int\|null, cssClass\: string\|null, disabledCondition\: string\|null, visibleCondition\: string\|null, type\: string, params\: array\<array\{name\: string\|null, type\: string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, collection\?\: array\<mixed\>\}\>, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, \.\.\.\} but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTags\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadTypes\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadType\(\) should return array\{name\: string\|null, ref\: bool, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, properties\?\: array\<string, array\<string, mixed\>\>\} but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has parameter \$keys with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadValues\(\) has parameter \$prefix with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
@@ -3224,12 +3152,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$descriptions of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setDescriptions\(\) expects array\<string, string\>, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Parameter \#1 \$expression of method DOMXPath\:\:query\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -3355,18 +3277,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadProperties\(\) expects DOMNode, DOMNode\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
 			message: '#^Parameter \#2 \$defaultType of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3391,13 +3301,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Parameter \#3 \$availableTypes of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects array\<string\>, array given\.$#'
+			message: '#^Parameter \#3 \$availableTypes of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects array\<string\>, array\<string, string\|null\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between null and \(int\|string\) will always evaluate to true\.$#'
+			message: '#^Strict comparison using \!\=\= between null and string will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
@@ -68,6 +68,9 @@ class FieldMetadata extends ItemMetadata
         $this->type = $type;
     }
 
+    /**
+     * @return array<OptionMetadata>
+     */
     public function getOptions(): array
     {
         return $this->options;
@@ -94,7 +97,7 @@ class FieldMetadata extends ItemMetadata
     }
 
     /**
-     * @return FormMetadata[]
+     * @return array<FormMetadata>
      */
     public function getTypes(): array
     {
@@ -167,7 +170,7 @@ class FieldMetadata extends ItemMetadata
     }
 
     /**
-     * @return TagMetadata[]
+     * @return array<TagMetadata>
      */
     public function getTags(): array
     {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
@@ -28,8 +28,14 @@ class FormXmlLoader extends AbstractLoader
 {
     use XmlParserTrait;
 
+    /**
+     * @var string
+     */
     public const SCHEMA_PATH = '/schema/form-1.0.xsd';
 
+    /**
+     * @var string
+     */
     public const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
 
     public function __construct(

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
@@ -28,8 +28,14 @@ class TemplateXmlLoader extends AbstractLoader
 {
     use XmlParserTrait;
 
+    /**
+     * @var string
+     */
     public const SCHEMA_PATH = '/schema/template-1.0.xsd';
 
+    /**
+     * @var string
+     */
     public const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
 
     public function __construct(

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader;
+
+use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
+
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ *
+ * @extends AbstractLoader<FormMetadata>
+ */
+class TemplateXmlLoader extends AbstractLoader
+{
+    use XmlParserTrait;
+
+    public const SCHEMA_PATH = '/schema/template-1.0.xsd';
+
+    public const SCHEMA_NAMESPACE_URI = 'http://schemas.sulu.io/template/template';
+
+    public function __construct(
+        private PropertiesXmlParser $propertiesXmlParser,
+        private SchemaXmlParser $schemaXmlParser,
+        private TagXmlParser $tagXmlParser,
+        private SchemaMetadataProvider $schemaMetadataProvider,
+    ) {
+        parent::__construct(
+            self::SCHEMA_PATH,
+            self::SCHEMA_NAMESPACE_URI
+        );
+    }
+
+    protected function parse(string $resource, \DOMXPath $xpath, ?string $type): FormMetadata
+    {
+        if (0 === $xpath->query('/x:template')->count()) {
+            throw new InvalidRootTagException($resource, 'template');
+        }
+
+        $form = new FormMetadata();
+        $form->addResource($resource);
+        $formKey = $this->getValueFromXPath('/x:template/x:key', $xpath);
+        \assert(\is_string($formKey), 'Expected the template key of "' . $resource . '" to be defined.');
+        $form->setKey($formKey);
+
+        $tagNodes = $xpath->query('/x:template/x:tag') ?: [];
+        $form->setTags($this->tagXmlParser->load($xpath, $tagNodes));
+
+        $propertiesNode = ($xpath->query('/x:template/x:properties') ?: null)?->item(0);
+        \assert(null !== $propertiesNode, 'Expected properties be defined for "' . $resource . '".');
+        $properties = $this->propertiesXmlParser->load(
+            $xpath,
+            $propertiesNode,
+            $form->getKey()
+        );
+
+        $schema = $this->schemaMetadataProvider->getMetadata($properties);
+        $schemaNode = $xpath->query('/x:template/x:schema')->item(0);
+
+        if ($schemaNode) {
+            $schema = $schema->merge($this->schemaXmlParser->load($xpath, $schemaNode));
+        }
+        $form->setSchema($schema);
+
+        foreach ($properties as $property) {
+            $form->addItem($property);
+        }
+
+        return $form;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader;
 
 use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\MetaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
@@ -42,6 +43,7 @@ class TemplateXmlLoader extends AbstractLoader
         private PropertiesXmlParser $propertiesXmlParser,
         private SchemaXmlParser $schemaXmlParser,
         private TagXmlParser $tagXmlParser,
+        private MetaXmlParser $metaXmlParser,
         private SchemaMetadataProvider $schemaMetadataProvider,
     ) {
         parent::__construct(
@@ -58,15 +60,23 @@ class TemplateXmlLoader extends AbstractLoader
 
         $form = new FormMetadata();
         $form->addResource($resource);
-        $formKey = $this->getValueFromXPath('/x:template/x:key', $xpath);
-        \assert(\is_string($formKey), 'Expected the template key of "' . $resource . '" to be defined.');
-        $form->setKey($formKey);
+        $templateKey = $this->getValueFromXPath('/x:template/x:key', $xpath);
+        \assert(\is_string($templateKey), 'Expected the template key of "' . $resource . '" to be defined.');
+        $form->setKey($templateKey);
 
         $tagNodes = $xpath->query('/x:template/x:tag') ?: [];
         $form->setTags($this->tagXmlParser->load($xpath, $tagNodes));
 
+        $templateNode = ($xpath->query('/x:template') ?: null)?->item(0);
+        \assert(null !== $templateNode, 'Expected <template> be defined for "' . $resource . '".');
+        $meta = $this->metaXmlParser->load($xpath, $templateNode);
+
+        if (\array_key_exists('title', $meta)) {
+            $form->setTitles($meta['title']);
+        }
+
         $propertiesNode = ($xpath->query('/x:template/x:properties') ?: null)?->item(0);
-        \assert(null !== $propertiesNode, 'Expected properties be defined for "' . $resource . '".');
+        \assert(null !== $propertiesNode, 'Expected <properties> be defined for "' . $resource . '".');
         $properties = $this->propertiesXmlParser->load(
             $xpath,
             $propertiesNode,

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/MetaXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/MetaXmlParser.php
@@ -46,7 +46,7 @@ class MetaXmlParser
     public function load(\DOMXPath $xpath, \DOMNode $context): array
     {
         $result = [];
-        $metaNode = $xpath->query('x:meta', $context)->item(0);
+        $metaNode = ($xpath->query('x:meta', $context) ?: null)?->item(0);
 
         if (!$metaNode) {
             return $result;
@@ -59,15 +59,17 @@ class MetaXmlParser
         return $result;
     }
 
-    private function loadMetaTag($path, \DOMXPath $xpath, ?\DOMNode $context = null)
+    /**
+     * @return array<string, string>
+     */
+    private function loadMetaTag(string $path, \DOMXPath $xpath, ?\DOMNode $context = null): array
     {
         $result = [];
 
         $translationKey = null;
 
-        /** @var \DOMElement $node */
-        foreach ($xpath->query($path, $context) as $node) {
-            $lang = $this->getValueFromXPath('@lang', $xpath, $node);
+        foreach (($xpath->query($path, $context) ?: []) as $node) {
+            $lang = (string) $this->getValueFromXPath('@lang', $xpath, $node);
 
             if (!$lang) {
                 $translationKey = $node->textContent;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/MetaXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/MetaXmlParser.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser;
+
+use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
+class MetaXmlParser
+{
+    use XmlParserTrait;
+
+    /**
+     * @var string[]
+     */
+    private $locales;
+
+    /**
+     * @param array<string, string> $locales
+     */
+    public function __construct(
+        private TranslatorInterface $translator,
+        array $locales,
+    ) {
+        $this->locales = \array_keys($locales);
+    }
+
+    /**
+     * @return array{
+     *     title?: array<string, string>,
+     *     info_text?: array<string, string>,
+     *     placeholder?: array<string, string>,
+     * }
+     */
+    public function load(\DOMXPath $xpath, \DOMNode $context): array
+    {
+        $result = [];
+        $metaNode = $xpath->query('x:meta', $context)->item(0);
+
+        if (!$metaNode) {
+            return $result;
+        }
+
+        $result['title'] = $this->loadMetaTag('x:title', $xpath, $metaNode);
+        $result['info_text'] = $this->loadMetaTag('x:info_text', $xpath, $metaNode);
+        $result['placeholder'] = $this->loadMetaTag('x:placeholder', $xpath, $metaNode);
+
+        return $result;
+    }
+
+    private function loadMetaTag($path, \DOMXPath $xpath, ?\DOMNode $context = null)
+    {
+        $result = [];
+
+        $translationKey = null;
+
+        /** @var \DOMElement $node */
+        foreach ($xpath->query($path, $context) as $node) {
+            $lang = $this->getValueFromXPath('@lang', $xpath, $node);
+
+            if (!$lang) {
+                $translationKey = $node->textContent;
+
+                continue;
+            }
+
+            $result[$lang] = $node->textContent;
+        }
+
+        if (!$translationKey) {
+            return $result;
+        }
+
+        $missingLocales = \array_diff($this->locales, \array_keys($result));
+        foreach ($missingLocales as $missingLocale) {
+            $result[$missingLocale] = $this->translator->trans($translationKey, [], 'admin', $missingLocale);
+        }
+
+        return $result;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -54,7 +54,7 @@ class PropertiesXmlParser
         $result = [];
 
         /** @var \DOMElement $node */
-        foreach ($xpath->query('x:*', $context) as $node) {
+        foreach (($xpath->query('x:*', $context) ?: []) as $node) {
             if ('property' === $node->tagName) {
                 $value = $this->loadProperty($xpath, $node, $formKey);
                 $result[$value['name']] = $value;
@@ -70,6 +70,49 @@ class PropertiesXmlParser
         return $result;
     }
 
+    /**
+     * @return array{
+     *     name: string,
+     *     type: string,
+     *     default-type: string|null,
+     *     minOccurs: int|null,
+     *     maxOccurs: int|null,
+     *     colspan: int|null,
+     *     cssClass: string|null,
+     *     spaceAfter: int|null,
+     *     disabledCondition: int|null,
+     *     visibleCondition: int|null,
+     *     mandatory: bool,
+     *     multilingual: bool,
+     *     onInvalid: bool,
+     *     tags: TagMetadata[],
+     *     params: array<array{
+     *         name: string|null,
+     *         type: string|null,
+     *         meta: array{
+     *             title?: array<string, string>,
+     *             info_text?: array<string, string>,
+     *             placeholder?: array<string, string>,
+     *         },
+     *         collection?: array<mixed>,
+     *     }>,
+     *     meta: array{
+     *        title?: array<string, string>,
+     *        info_text?: array<string, string>,
+     *        placeholder?: array<string, string>,
+     *     },
+     *     types: array<string, array{
+     *         name: string|null,
+     *         ref: bool,
+     *         meta: array{
+     *             title?: array<string, string>,
+     *             info_text?: array<string, string>,
+     *             placeholder?: array<string, string>,
+     *         },
+     *         properties?: array<string, array<string, mixed>>,
+     *     }>
+     * }
+     */
     private function loadProperty(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
     {
         $result = $this->loadValues(
@@ -114,6 +157,49 @@ class PropertiesXmlParser
         return $result;
     }
 
+    /**
+     * @return array{
+     *     name: string,
+     *     type: string,
+     *     default-type: string|null,
+     *     minOccurs: int|null,
+     *     maxOccurs: int|null,
+     *     colspan: int|null,
+     *     cssClass: string|null,
+     *     spaceAfter: int|null,
+     *     disabledCondition: int|null,
+     *     visibleCondition: int|null,
+     *     mandatory: bool,
+     *     multilingual: bool,
+     *     onInvalid: bool,
+     *     tags: TagMetadata[],
+     *     params: array<array{
+     *         name: string|null,
+     *         type: string|null,
+     *         meta: array{
+     *             title?: array<string, string>,
+     *             info_text?: array<string, string>,
+     *             placeholder?: array<string, string>,
+     *         },
+     *         collection?: array<mixed>,
+     *     }>,
+     *     meta: array{
+     *        title?: array<string, string>,
+     *        info_text?: array<string, string>,
+     *        placeholder?: array<string, string>,
+     *     },
+     *     types: array<string, array{
+     *         name: string|null,
+     *         ref: bool,
+     *         meta: array{
+     *             title?: array<string, string>,
+     *             info_text?: array<string, string>,
+     *             placeholder?: array<string, string>,
+     *         },
+     *         properties?: array<string, array<string, mixed>>,
+     *     }>
+     * }
+     */
     private function loadBlock(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
     {
         $result = $this->loadProperty($xpath, $node, $formKey);
@@ -122,7 +208,33 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadSection(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
+    /**
+     * @return array{
+     *      name: string,
+     *      colspan: int|null,
+     *      cssClass: string|null,
+     *      disabledCondition: string|null,
+     *      visibleCondition: string|null,
+     *      type: string,
+     *      params: array<array{
+     *          name: string|null,
+     *          type: string|null,
+     *          meta: array{
+     *              title?: array<string, string>,
+     *              info_text?: array<string, string>,
+     *              placeholder?: array<string, string>,
+     *          },
+     *          collection?: array<mixed>,
+     *      }>,
+     *      meta: array{
+     *         title?: array<string, string>,
+     *         info_text?: array<string, string>,
+     *         placeholder?: array<string, string>,
+     *      },
+     *      properties?: array<string, array<string, mixed>>,
+     * }
+     */
+    private function loadSection(\DOMXPath $xpath, \DOMNode $node, ?string $formKey): array
     {
         $result = $this->loadValues(
             $xpath,
@@ -134,22 +246,37 @@ class PropertiesXmlParser
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
         $result['meta'] = $this->metaXmlParser->load($xpath, $node);
 
-        $propertiesNode = $xpath->query('x:properties', $node)->item(0);
+        $propertiesNode = ($xpath->query('x:properties', $node) ?: null)?->item(0);
+        \assert(null !== $propertiesNode, 'The properties tag not found in section node.');
         $result['properties'] = $this->loadProperties($xpath, $propertiesNode, $formKey);
 
         return $result;
     }
 
-    private function loadTags(\DOMXPath $xpath, ?\DOMNode $context = null)
+    /**
+     * @return array<TagMetadata>
+     */
+    private function loadTags(\DOMXPath $xpath, ?\DOMNode $context = null): array
     {
         return $this->tagXmlParser->load($xpath, $xpath->query('x:tag', $context));
     }
 
-    private function loadTypes(\DOMXPath $xpath, ?\DOMNode $context, ?string $formKey)
+    /**
+     * @return array<string, array{
+     *      name: string|null,
+     *      ref: bool,
+     *      meta: array{
+     *          title?: array<string, string>,
+     *          info_text?: array<string, string>,
+     *          placeholder?: array<string, string>,
+     *      },
+     *      properties?: array<string, array<string, mixed>>,
+     *  }>
+     */
+    private function loadTypes(\DOMXPath $xpath, ?\DOMNode $context, ?string $formKey): array
     {
         $result = [];
 
-        /** @var \DOMElement $node */
         foreach ($xpath->query('x:types/x:type', $context) as $node) {
             $value = $this->loadType($xpath, $node, $formKey);
             $result[$value['name']] = $value;
@@ -158,7 +285,19 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadType(\DOMXPath $xpath, \DOMNode $node, ?string $formKey)
+    /**
+     * @return array{
+     *     name: string|null,
+     *     ref: bool,
+     *     meta: array{
+     *         title?: array<string, string>,
+     *         info_text?: array<string, string>,
+     *         placeholder?: array<string, string>,
+     *     },
+     *     properties?: array<string, array<string, mixed>>,
+     * }
+     */
+    private function loadType(\DOMXPath $xpath, \DOMNode $node, ?string $formKey): array
     {
         $result = $this->loadValues($xpath, $node, ['name', 'ref']);
         if ($result['ref'] && $result['name']) {
@@ -190,7 +329,10 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadValues(\DOMXPath $xpath, \DOMNode $node, $keys, $prefix = '@')
+    /**
+     * @param array<string> $keys
+     */
+    private function loadValues(\DOMXPath $xpath, \DOMNode $node, array $keys, string $prefix = '@')
     {
         $result = [];
 
@@ -201,19 +343,43 @@ class PropertiesXmlParser
         return $result;
     }
 
-    private function loadParams($path, \DOMXPath $xpath, ?\DOMNode $context = null)
+    /**
+     * @return array<array{
+     *      name: string|null,
+     *      type: string|null,
+     *      meta: array{
+     *          title?: array<string, string>,
+     *          info_text?: array<string, string>,
+     *          placeholder?: array<string, string>,
+     *      },
+     *      collection?: array<mixed>,
+     *  }>
+     */
+    private function loadParams(string $path, \DOMXPath $xpath, ?\DOMNode $context = null): array
     {
         $result = [];
 
         /** @var \DOMElement $node */
-        foreach ($xpath->query($path, $context) as $node) {
+        foreach (($xpath->query($path, $context) ?: []) as $node) {
             $result[] = $this->loadParam($xpath, $node);
         }
 
         return $result;
     }
 
-    private function loadParam(\DOMXPath $xpath, \DOMNode $node)
+    /**
+     * @return array{
+     *     name: string|null,
+     *     type: string|null,
+     *     meta: array{
+     *         title?: array<string, string>,
+     *         info_text?: array<string, string>,
+     *         placeholder?: array<string, string>,
+     *     },
+     *     collection?: array<mixed>,
+     * }
+     */
+    private function loadParam(\DOMXPath $xpath, \DOMNode $node): array
     {
         $result = [
             'name' => $this->getValueFromXPath('@name', $xpath, $node),

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -19,7 +19,6 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
 use Sulu\Component\Content\Exception\InvalidDefaultTypeException;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal this class is not part of the public API and may be changed or removed without further notice
@@ -28,20 +27,10 @@ class PropertiesXmlParser
 {
     use XmlParserTrait;
 
-    /**
-     * @var string[]
-     */
-    private $locales;
-
-    /**
-     * @param array<string, string> $locales
-     */
     public function __construct(
         private TagXmlParser $tagXmlParser,
-        private TranslatorInterface $translator,
-        array $locales,
+        private MetaXmlParser $metaXmlParser,
     ) {
-        $this->locales = \array_keys($locales);
     }
 
     /**
@@ -105,7 +94,7 @@ class PropertiesXmlParser
         $result['onInvalid'] = $this->getValueFromXPath('@onInvalid', $xpath, $node);
         $result['tags'] = $this->loadTags($xpath, $node);
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
-        $result['meta'] = $this->loadMeta($xpath, $node);
+        $result['meta'] = $this->metaXmlParser->load($xpath, $node);
         $result['types'] = $this->loadTypes($xpath, $node, $formKey);
 
         $typeNames = \array_map(function($type) {
@@ -143,7 +132,7 @@ class PropertiesXmlParser
 
         $result['type'] = 'section';
         $result['params'] = $this->loadParams('x:params/x:param', $xpath, $node);
-        $result['meta'] = $this->loadMeta($xpath, $node);
+        $result['meta'] = $this->metaXmlParser->load($xpath, $node);
 
         $propertiesNode = $xpath->query('x:properties', $node)->item(0);
         $result['properties'] = $this->loadProperties($xpath, $propertiesNode, $formKey);
@@ -191,7 +180,7 @@ class PropertiesXmlParser
             $result['ref'] = true;
         }
 
-        $result['meta'] = $this->loadMeta($xpath, $node);
+        $result['meta'] = $this->metaXmlParser->load($xpath, $node);
 
         $propertiesNode = $xpath->query('x:properties', $node)->item(0);
         if ($propertiesNode) {
@@ -207,53 +196,6 @@ class PropertiesXmlParser
 
         foreach ($keys as $key) {
             $result[$key] = $this->getValueFromXPath($prefix . $key, $xpath, $node);
-        }
-
-        return $result;
-    }
-
-    private function loadMeta(\DOMXPath $xpath, ?\DOMNode $context = null)
-    {
-        $result = [];
-        $metaNode = $xpath->query('x:meta', $context)->item(0);
-
-        if (!$metaNode) {
-            return $result;
-        }
-
-        $result['title'] = $this->loadMetaTag('x:title', $xpath, $metaNode);
-        $result['info_text'] = $this->loadMetaTag('x:info_text', $xpath, $metaNode);
-        $result['placeholder'] = $this->loadMetaTag('x:placeholder', $xpath, $metaNode);
-
-        return $result;
-    }
-
-    private function loadMetaTag($path, \DOMXPath $xpath, ?\DOMNode $context = null)
-    {
-        $result = [];
-
-        $translationKey = null;
-
-        /** @var \DOMElement $node */
-        foreach ($xpath->query($path, $context) as $node) {
-            $lang = $this->getValueFromXPath('@lang', $xpath, $node);
-
-            if (!$lang) {
-                $translationKey = $node->textContent;
-
-                continue;
-            }
-
-            $result[$lang] = $node->textContent;
-        }
-
-        if (!$translationKey) {
-            return $result;
-        }
-
-        $missingLocales = \array_diff($this->locales, \array_keys($result));
-        foreach ($missingLocales as $missingLocale) {
-            $result[$missingLocale] = $this->translator->trans($translationKey, [], 'admin', $missingLocale);
         }
 
         return $result;
@@ -276,7 +218,7 @@ class PropertiesXmlParser
         $result = [
             'name' => $this->getValueFromXPath('@name', $xpath, $node),
             'type' => $this->getValueFromXPath('@type', $xpath, $node, 'string'),
-            'meta' => $this->loadMeta($xpath, $node),
+            'meta' => $this->metaXmlParser->load($xpath, $node),
         ];
 
         $result['value'] = match ($result['type']) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TagXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TagXmlParser.php
@@ -33,13 +33,14 @@ class TagXmlParser
         foreach ($tagNodes as $node) {
             $tag = [
                 'name' => null,
+                'priority' => null,
                 'attributes' => [],
             ];
 
             /** @var string $key */
             /** @var \DOMAttr $attr */
             foreach ($node->attributes ?? [] as $key => $attr) {
-                if (\in_array($key, ['name'])) {
+                if (\in_array($key, ['name', 'priority'], true)) {
                     $tag[$key] = $attr->value;
                 } else {
                     $tag['attributes'][$key] = $attr->value;
@@ -53,6 +54,7 @@ class TagXmlParser
 
             $tagMetadata = new TagMetadata();
             $tagMetadata->setName($tag['name']);
+            $tagMetadata->setPriority($tag['priority']);
             $tagMetadata->setAttributes($tag['attributes']);
 
             $result[] = $tagMetadata;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TagXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TagXmlParser.php
@@ -54,7 +54,7 @@ class TagXmlParser
 
             $tagMetadata = new TagMetadata();
             $tagMetadata->setName($tag['name']);
-            $tagMetadata->setPriority($tag['priority']);
+            $tagMetadata->setPriority(\is_numeric($tag['priority']) ? \intval($tag['priority']) : null);
             $tagMetadata->setAttributes($tag['attributes']);
 
             $result[] = $tagMetadata;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitor.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
@@ -38,6 +39,10 @@ class BlockSettingsFormMetadataVisitor implements TypedFormMetadataVisitorInterf
             if ($itemMetadata instanceof SectionMetadata) {
                 $this->enhanceBlockMetadata($itemMetadata->getItems());
 
+                continue;
+            }
+
+            if (!$itemMetadata instanceof FieldMetadata) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitor.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterface;
+
+/**
+ * @internal
+ */
+class BlockSettingsFormMetadataVisitor implements TypedFormMetadataVisitorInterface
+{
+    public function visitTypedFormMetadata(TypedFormMetadata $formMetadata, string $key, string $locale, array $metadataOptions = []): void
+    {
+        foreach ($formMetadata->getForms() as $formMetadata) {
+            $this->enhanceBlockMetadata($formMetadata->getItems());
+        }
+    }
+
+    /**
+     * @param ItemMetadata[] $itemsMetadata
+     */
+    private function enhanceBlockMetadata(array $itemsMetadata): void
+    {
+        foreach ($itemsMetadata as $itemMetadata) {
+            if ($itemMetadata instanceof SectionMetadata) {
+                $this->enhanceBlockMetadata($itemMetadata->getItems());
+
+                continue;
+            }
+
+            foreach ($itemMetadata->getTypes() as $type) {
+                $this->enhanceBlockMetadata($type->getItems());
+            }
+
+            if ('block' !== $itemMetadata->getType()
+                || \array_key_exists('settings_form_key', $itemMetadata->getOptions())
+            ) {
+                continue;
+            }
+
+            $optionMetadata = new OptionMetadata();
+            $optionMetadata->setName('settings_form_key');
+            $optionMetadata->setValue('page_block_settings');
+            $itemMetadata->addOption($optionMetadata);
+        }
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -60,7 +60,7 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
         $this->debug = $debug;
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?MetadataInterface
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?FormMetadata
     {
         $configCache = $this->getConfigCache($key);
 
@@ -72,7 +72,9 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
             $this->warmUp($this->cacheDir);
         }
 
-        $form = \unserialize(\file_get_contents($configCache->getPath()));
+        $form = \unserialize(\file_get_contents($configCache->getPath()) ?: '');
+
+        \assert($form instanceof FormMetadata, 'Expected FormMetadata instance for key: "' . $key . '".');
 
         return $form;
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\FieldMetadataValidatorInterface;
-use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
@@ -36,7 +36,7 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
     ) {
     }
 
-    public function getMetadata(string $key, ?string $locale = null, array $metadataOptions = []): ?MetadataInterface
+    public function getMetadata(string $key, ?string $locale = null, array $metadataOptions = []): ?TypedFormMetadata
     {
         $configCache = $this->getConfigCache($key);
 
@@ -48,7 +48,7 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
             $this->warmUp($this->cacheDir);
         }
 
-        $typedForm = \unserialize(\file_get_contents($configCache->getPath()));
+        $typedForm = \unserialize(\file_get_contents($configCache->getPath()) ?: '');
 
         \assert($typedForm instanceof TypedFormMetadata, 'Expected TypedFormMetadata instance for key: "' . $key . '".');
 
@@ -60,7 +60,7 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
         foreach ($this->templateDirectories as $type => $config) {
             $defaultType = $config['default_type'] ?? null;
             $directories = \array_filter(
-                $config['directories'] ?? [],
+                $config['directories'],
                 fn (string $directory) => \file_exists($directory),
             );
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\FieldMetadataValidatorInterface;
-use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\FieldMetadataValidatorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerInterface
+{
+    /**
+     * @param array<string, array{
+     *      default_type: string|null,
+     *      directories: array<string>,
+     * }> $templateDirectories
+     */
+    public function __construct(
+        private TemplateXmlLoader $templateXmlLoader,
+        private FieldMetadataValidatorInterface $fieldMetadataValidator,
+        private array $templateDirectories,
+        private string $cacheDir,
+        private bool $debug
+    ) {
+    }
+
+    public function getMetadata(string $key, ?string $locale = null, array $metadataOptions = []): ?MetadataInterface
+    {
+        $configCache = $this->getConfigCache($key);
+
+        if (!\file_exists($configCache->getPath())) {
+            return null;
+        }
+
+        if (!$configCache->isFresh()) {
+            $this->warmUp($this->cacheDir);
+        }
+
+        $typedForm = \unserialize(\file_get_contents($configCache->getPath()));
+
+        \assert($typedForm instanceof TypedFormMetadata, 'Expected TypedFormMetadata instance for key: "' . $key . '".');
+
+        return $typedForm;
+    }
+
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
+    {
+        foreach ($this->templateDirectories as $type => $config) {
+            $defaultType = $config['default_type'] ?? null;
+            $directories = \array_filter(
+                $config['directories'] ?? [],
+                fn (string $directory) => \file_exists($directory),
+            );
+
+            $formsMetadataCollection = [];
+            $formsMetadataResources = [];
+
+            $typedFormMetadata = new TypedFormMetadata();
+            if (null !== $defaultType) {
+                $typedFormMetadata->setDefaultType($defaultType);
+            }
+
+            if (0 !== \count($directories)) {
+                $formFinder = (new Finder())->in($directories)->name('*.xml');
+
+                foreach ($formFinder as $formFile) {
+                    $formMetadata = $this->templateXmlLoader->load($formFile->getPathName());
+                    $formKey = $formMetadata->getKey();
+                    $formsMetadataResources[] = $formFile->getPathName();
+                    if (!\array_key_exists($formKey, $formsMetadataCollection)) {
+                        $formsMetadataCollection[$formKey] = $formMetadata;
+                    } else {
+                        $formsMetadataCollection[$formKey] = $formsMetadataCollection[$formKey]->merge($formMetadata);
+                    }
+                }
+            }
+
+            foreach ($formsMetadataCollection as $key => $formMetadata) {
+                $this->validateItems($formMetadata->getItems(), $key);
+                $typedFormMetadata->addForm($formMetadata->getKey(), $formMetadata);
+            }
+
+            $configCache = $this->getConfigCache($type);
+            $configCache->write(
+                \serialize($typedFormMetadata),
+                \array_map(function(string $resource) {
+                    return new FileResource($resource);
+                }, $formsMetadataResources)
+            );
+        }
+
+        return [];
+    }
+
+    /**
+     * @param ItemMetadata[] $items
+     */
+    private function validateItems(array $items, string $formKey): void
+    {
+        foreach ($items as $item) {
+            if ($item instanceof SectionMetadata) {
+                $this->validateItems($item->getItems(), $formKey);
+            }
+
+            if ($item instanceof FieldMetadata) {
+                foreach ($item->getTypes() as $type) {
+                    $this->validateItems($type->getItems(), $formKey);
+                }
+
+                $this->fieldMetadataValidator->validate($item, $formKey);
+            }
+        }
+    }
+
+    public function isOptional(): bool
+    {
+        return false;
+    }
+
+    private function getConfigCache(string $key): ConfigCache
+    {
+        return new ConfigCache(\sprintf('%s%s%s', $this->cacheDir, \DIRECTORY_SEPARATOR, $key), $this->debug);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -360,6 +360,11 @@
             <tag name="sulu_admin.form_metadata_visitor"/>
         </service>
 
+        <service id="sulu_admin.block_settings_form_metadata_visitor"
+                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor\BlockSettingsFormMetadataVisitor">
+            <tag name="sulu_admin.typed_form_metadata_visitor" />
+        </service>
+
         <service id="sulu_admin.icon_controller"
                 class="Sulu\Bundle\AdminBundle\Controller\IconController"
                 public="true">

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -123,8 +123,20 @@
             <argument>%sulu_admin.forms.directories%</argument>
             <argument>%sulu.cache_dir%/forms</argument>
             <argument>%kernel.debug%</argument>
+
             <tag name="sulu_admin.form_metadata_loader"/>
             <tag name="kernel.cache_warmer" />
+        </service>
+
+        <service id="sulu_admin.template_form_metadata_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\XmlTemplateFormMetadataLoader" lazy="true">
+            <argument type="service" id="sulu_admin.form_metadata.template_xml_loader"/>
+            <argument type="service" id="sulu_admin.field_metadata_validator.chain"/>
+            <argument>%sulu_admin.templates.configuration%</argument>
+            <argument>%sulu.cache_dir%/templates</argument>
+            <argument>%kernel.debug%</argument>
+
+            <tag name="sulu_admin.form_metadata_loader"/>
+            <tag name="kernel.cache_warmer" priority="512" />
         </service>
 
         <service
@@ -153,6 +165,13 @@
         />
 
         <service id="sulu_admin.form_metadata.form_xml_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader">
+            <argument type="service" id="sulu_admin.properties_xml_parser"/>
+            <argument type="service" id="sulu_admin.schema_xml_parser"/>
+            <argument type="service" id="sulu_admin.tag_xml_parser"/>
+            <argument type="service" id="sulu_admin.schema_metadata_provider"/>
+        </service>
+
+        <service id="sulu_admin.form_metadata.template_xml_loader" class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader">
             <argument type="service" id="sulu_admin.properties_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_xml_parser"/>
             <argument type="service" id="sulu_admin.tag_xml_parser"/>
@@ -209,7 +228,9 @@
             <argument>%sulu_core.locales%</argument>
             <argument>%sulu.cache_dir%/form-structures</argument>
             <argument>%kernel.debug%</argument>
+            <!--
             <tag name="sulu_admin.form_metadata_loader"/>
+            -->
             <tag name="kernel.cache_warmer" priority="512" />
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -70,6 +70,12 @@
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser"
                  public="false">
             <argument type="service" id="sulu_admin.tag_xml_parser" />
+            <argument type="service" id="sulu_admin.meta_xml_parser" />
+        </service>
+
+        <service id="sulu_admin.meta_xml_parser"
+                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\MetaXmlParser"
+                 public="false">
             <argument type="service" id="translator" />
             <argument>%sulu_core.translated_locales%</argument>
         </service>
@@ -175,6 +181,7 @@
             <argument type="service" id="sulu_admin.properties_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_xml_parser"/>
             <argument type="service" id="sulu_admin.tag_xml_parser"/>
+            <argument type="service" id="sulu_admin.meta_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_metadata_provider"/>
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -270,7 +270,7 @@
                                     "required": false,
                                     "multilingual": true,
                                     "spaceAfter": null,
-                                    "minOccurs": null,
+                                    "minOccurs": 0,
                                     "maxOccurs": null,
                                     "onInvalid": null,
                                     "tags": []
@@ -295,7 +295,7 @@
                     "required": false,
                     "multilingual": true,
                     "spaceAfter": null,
-                    "minOccurs": null,
+                    "minOccurs": 0,
                     "maxOccurs": null,
                     "onInvalid": null,
                     "tags": []

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
@@ -162,7 +162,7 @@
             "required": false,
             "multilingual": true,
             "spaceAfter": null,
-            "minOccurs": null,
+            "minOccurs": 0,
             "maxOccurs": null,
             "onInvalid": null,
             "tags": []
@@ -220,7 +220,7 @@
             "required": false,
             "multilingual": true,
             "spaceAfter": null,
-            "minOccurs": null,
+            "minOccurs": 0,
             "maxOccurs": null,
             "onInvalid": null,
             "tags": []

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -31,6 +31,8 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     public function testGetMetadataWithOnInvalid(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_with_on_invalid', 'en');
+        $this->assertNotNull($form);
+
         $this->assertCount(1, $form->getItems());
         $this->assertEquals(
             'ignore',
@@ -41,6 +43,8 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     public function testGetMetadataWithSchema(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_with_schema', 'en');
+        $this->assertNotNull($form);
+
         $schema = $form->getSchema()->toJsonSchema();
         $this->assertCount(1, \array_keys($schema));
         $this->assertCount(2, $schema['allOf']);
@@ -50,6 +54,7 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     public function testGetMetadataWithEvaluations(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_with_evaluations', 'en');
+        $this->assertNotNull($form);
 
         $this->assertEquals(
             'lastName == \'section_property\'',
@@ -92,6 +97,7 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_with_expression_param', 'en');
         $this->assertNotNull($form);
+
         $this->assertContains('name', \array_keys($form->getItems()));
         $this->assertEquals('expression', $form->getItems()['name']->getOptions()['id']->getType());
         $this->assertEquals('service(\'test\').getId()', $form->getItems()['name']->getOptions()['id']->getValue());
@@ -100,12 +106,16 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     public function testGetMetadataWithoutLabel(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_without_label', 'en');
+        $this->assertNotNull($form);
+
         $this->assertNull($form->getItems()['name']->getLabel('en'));
     }
 
     public function testGetMetadataFromMultipleFiles(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('merged_form', 'en');
+        $this->assertNotNull($form);
+
         $this->assertContains('field1', \array_keys($form->getItems()));
         $this->assertContains('field2', \array_keys($form->getItems()));
 
@@ -116,6 +126,7 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     public function testGetMetadataWithNestedSections(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_with_nested_sections', 'en');
+        $this->assertNotNull($form);
 
         $section1 = $form->getItems()['test1'];
         $section2 = $form->getItems()['test2'];
@@ -133,6 +144,7 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     public function testGetMetadataWithBlocks(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_with_blocks', 'en');
+        $this->assertNotNull($form);
 
         $blocks = $form->getItems()['blocks'];
 
@@ -155,6 +167,7 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
     public function testGetMetadataWithPropertyWithTypes(): void
     {
         $form = $this->xmlFormMetadataLoader->getMetadata('form_with_property_with_types', 'en');
+        $this->assertNotNull($form);
 
         /** @var FieldMetadata $image */
         $image = $form->getItems()['image'];

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
@@ -17,6 +17,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Exception\InvalidRootTagException;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\MetaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
@@ -46,10 +47,13 @@ class FormXmlLoaderTest extends TestCase
     {
         $this->translator = $this->prophesize(TranslatorInterface::class);
         $tagXmlParser = new TagXmlParser();
-        $propertiesXmlParser = new PropertiesXmlParser(
-            $tagXmlParser,
+        $metaXmlParser = new MetaXmlParser(
             $this->translator->reveal(),
             ['en' => 'en', 'de' => 'de', 'fr' => 'fr', 'nl' => 'nl']
+        );
+        $propertiesXmlParser = new PropertiesXmlParser(
+            $tagXmlParser,
+            $metaXmlParser,
         );
         $schemaXmlParser = new SchemaXmlParser();
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/TemplateXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/TemplateXmlLoaderTest.php
@@ -1,0 +1,281 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\MetaXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
+use Sulu\Component\Content\ContentTypeManagerInterface;
+use Sulu\Component\Content\Types\BlockContentType;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TemplateXmlLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var TemplateXmlLoader
+     */
+    private $loader;
+
+    /**
+     * @var ObjectProphecy<TranslatorInterface>
+     */
+    private $translator;
+
+    public function setUp(): void
+    {
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+        $tagXmlParser = new TagXmlParser();
+        $metaXmlParser = new MetaXmlParser(
+            $this->translator->reveal(),
+            ['en' => 'en', 'de' => 'de', 'fr' => 'fr', 'nl' => 'nl']
+        );
+        $propertiesXmlParser = new PropertiesXmlParser(
+            $tagXmlParser,
+            $metaXmlParser,
+        );
+        $schemaXmlParser = new SchemaXmlParser();
+
+        $container = new Container();
+        $propertyMetadataMapperRegistry = new PropertyMetadataMapperRegistry($container);
+        $schemaMetadataProvider = new SchemaMetadataProvider($propertyMetadataMapperRegistry);
+        $blockMetadataProvider = new BlockContentType(
+            $this->prophesize(ContentTypeManagerInterface::class)->reveal(),
+            $schemaMetadataProvider,
+            [],
+        );
+        $container->set('block', $blockMetadataProvider);
+
+        $this->loader = new TemplateXmlLoader($propertiesXmlParser, $schemaXmlParser, $tagXmlParser, $metaXmlParser, $schemaMetadataProvider);
+    }
+
+    public function testLoadDefaultTemplate(): void
+    {
+        $formMetadata = $this->loader->load($this->getTemplatesDirectory() . 'default.xml');
+
+        $this->assertSame([
+            'titles' => [
+                'de' => 'Tiers',
+                'en' => 'Animals',
+            ],
+            'tags' => [
+                [
+                    'name' => 'test',
+                    'priority' => null,
+                    'attributes' => [
+                        'value' => 'test-value',
+                    ],
+                ],
+                [
+                    'name' => 'test2',
+                    'priority' => null,
+                    'attributes' => [
+                        'test' => 'test-value2',
+                    ],
+                ],
+                [
+                    'name' => 'test3',
+                    'priority' => null,
+                    'attributes' => [
+                        'value' => 'test-value',
+                    ],
+                ],
+            ],
+            'schema' => [
+                'allOf' => [
+                    [
+                        'type' => 'object',
+                        'properties' => [
+                            'blocks' => [
+                                'type' => 'array',
+                                'items' => [
+                                    'allOf' => [
+                                        [
+                                            'if' => [
+                                                'type' => 'object',
+                                                'properties' => [
+                                                    'type' => [
+                                                        'const' => 'text_block',
+                                                    ],
+                                                ],
+                                                'required' => [
+                                                    'type',
+                                                ],
+                                            ],
+                                            'then' => [
+                                                '$ref' => '#/definitions/text_block',
+                                            ],
+                                        ],
+                                        [
+                                            'if' => [
+                                                'type' => 'object',
+                                                'properties' => [
+                                                    'type' => [
+                                                        'const' => 'text_block2',
+                                                    ],
+                                                ],
+                                                'required' => [
+                                                    'type',
+                                                ],
+                                            ],
+                                            'then' => [
+                                                '$ref' => '#/definitions/text_block2',
+                                            ],
+                                        ],
+                                        [
+                                            'if' => [
+                                                'type' => 'object',
+                                                'properties' => [
+                                                    'type' => [
+                                                        'const' => 'editor',
+                                                    ],
+                                                ],
+                                                'required' => [
+                                                    'type',
+                                                ],
+                                            ],
+                                            'then' => [
+                                                'type' => [
+                                                    'number',
+                                                    'string',
+                                                    'boolean',
+                                                    'object',
+                                                    'array',
+                                                    'null',
+                                                ],
+                                            ],
+                                        ],
+                                        [
+                                            'if' => [
+                                                'type' => 'object',
+                                                'properties' => [
+                                                    'type' => [
+                                                        'const' => 'block',
+                                                    ],
+                                                ],
+                                                'required' => [
+                                                    'type',
+                                                ],
+                                            ],
+                                            'then' => [
+                                                'type' => 'object',
+                                                'properties' => [
+                                                    'blocks' => [
+                                                        'type' => 'array',
+                                                        'items' => [
+                                                            'allOf' => [
+                                                                [
+                                                                    'if' => [
+                                                                        'type' => 'object',
+                                                                        'properties' => [
+                                                                            'type' => [
+                                                                                'const' => 'text_block2',
+                                                                            ],
+                                                                        ],
+                                                                        'required' => [
+                                                                            'type',
+                                                                        ],
+                                                                    ],
+                                                                    'then' => [
+                                                                        '$ref' => '#/definitions/text_block2',
+                                                                    ],
+                                                                ],
+                                                                [
+                                                                    'if' => [
+                                                                        'type' => 'object',
+                                                                        'properties' => [
+                                                                            'type' => [
+                                                                                'const' => 'text_block3',
+                                                                            ],
+                                                                        ],
+                                                                        'required' => [
+                                                                            'type',
+                                                                        ],
+                                                                    ],
+                                                                    'then' => [
+                                                                        '$ref' => '#/definitions/text_block3',
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'required' => [
+                            'title',
+                            'url',
+                        ],
+                    ],
+                    [
+                        'anyOf' => [
+                            [
+                                'type' => 'object',
+                                'required' => [
+                                    'blog',
+                                ],
+                            ],
+                            [
+                                'type' => 'object',
+                                'required' => [
+                                    'localized_blog',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $this->metadataToArray($formMetadata));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function metadataToArray(FormMetadata $formMetadata): array
+    {
+        return [
+            'titles' => [
+                'de' => 'Tiers',
+                'en' => 'Animals',
+            ],
+            'tags' => \array_map(function(TagMetadata $tagMetadata) {
+                return [
+                    'name' => $tagMetadata->getName(),
+                    'priority' => $tagMetadata->getPriority(),
+                    'attributes' => $tagMetadata->getAttributes(),
+                ];
+            }, $formMetadata->getTags()),
+            'schema' => $formMetadata->getSchema()->toJsonSchema(),
+        ];
+    }
+
+    private function getTemplatesDirectory(): string
+    {
+        return \dirname(__DIR__, 4) . \DIRECTORY_SEPARATOR
+            . 'Application' . \DIRECTORY_SEPARATOR . 'config' . \DIRECTORY_SEPARATOR . 'templates' . \DIRECTORY_SEPARATOR . 'pages' . \DIRECTORY_SEPARATOR;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/MetaXmlParserTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/MetaXmlParserTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\MetaXmlParser;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class MetaXmlParserTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private MetaXmlParser $metaXmlParser;
+
+    protected function setUp(): void
+    {
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $this->metaXmlParser = new MetaXmlParser(
+            $translator->reveal(),
+            ['en' => 'en', 'de' => 'de', 'fr' => 'fr', 'nl' => 'nl']
+        );
+    }
+
+    public function testParse(): void
+    {
+        $resource = $this->getTemplatesDirectory() . 'default.xml';
+        $xpath = $this->loadXmlFile($resource);
+        $templateNode = ($xpath->query('/x:template') ?: null)?->item(0);
+        \assert(null !== $templateNode, 'Expected <template> be defined for "' . $resource . '".');
+
+        $meta = $this->metaXmlParser->load($xpath, $templateNode);
+
+        $this->assertSame([
+            'title' => [
+                'de' => 'Tiers',
+                'en' => 'Animals',
+            ],
+            'info_text' => [],
+            'placeholder' => [],
+        ], $meta);
+    }
+
+    private function loadXmlFile(string $resource): \DOMXPath
+    {
+        $xmlDocument = new \DOMDocument();
+        $xmlDocument->load($resource);
+
+        $xpath = new \DOMXPath($xmlDocument);
+        $xpath->registerNamespace('x', TemplateXmlLoader::SCHEMA_NAMESPACE_URI);
+
+        return $xpath;
+    }
+
+    private function getTemplatesDirectory(): string
+    {
+        return \dirname(__DIR__, 4) . \DIRECTORY_SEPARATOR
+            . 'Application' . \DIRECTORY_SEPARATOR . 'config' . \DIRECTORY_SEPARATOR . 'templates' . \DIRECTORY_SEPARATOR . 'pages' . \DIRECTORY_SEPARATOR;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/TagXmlParserTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/TagXmlParserTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
+
+class TagXmlParserTest extends TestCase
+{
+    private TagXmlParser $tagXmlParser;
+
+    protected function setUp(): void
+    {
+        $this->tagXmlParser = new TagXmlParser();
+    }
+
+    public function testParse(): void
+    {
+        $resource = $this->getTemplatesDirectory() . 'default.xml';
+        $xpath = $this->loadXmlFile($resource);
+
+        $tagNodes = $xpath->query('/x:template/x:tag') ?: [];
+
+        $tagMetadatas = $this->tagXmlParser->load($xpath, $tagNodes);
+
+        $this->assertSame([
+            [
+                'name' => 'test',
+                'priority' => null,
+                'attributes' => [
+                    'value' => 'test-value',
+                ],
+            ],
+            [
+                'name' => 'test2',
+                'priority' => null,
+                'attributes' => [
+                    'test' => 'test-value2',
+                ],
+            ],
+            [
+                'name' => 'test3',
+                'priority' => null,
+                'attributes' => [
+                    'value' => 'test-value',
+                ],
+            ],
+        ], \array_map(function(TagMetadata $tagMetadata) {
+            return [
+                'name' => $tagMetadata->getName(),
+                'priority' => $tagMetadata->getPriority(),
+                'attributes' => $tagMetadata->getAttributes(),
+            ];
+        }, $tagMetadatas));
+    }
+
+    private function loadXmlFile(string $resource): \DOMXPath
+    {
+        $xmlDocument = new \DOMDocument();
+        $xmlDocument->load($resource);
+
+        $xpath = new \DOMXPath($xmlDocument);
+        $xpath->registerNamespace('x', TemplateXmlLoader::SCHEMA_NAMESPACE_URI);
+
+        return $xpath;
+    }
+
+    private function getTemplatesDirectory(): string
+    {
+        return \dirname(__DIR__, 4) . \DIRECTORY_SEPARATOR
+            . 'Application' . \DIRECTORY_SEPARATOR . 'config' . \DIRECTORY_SEPARATOR . 'templates' . \DIRECTORY_SEPARATOR . 'pages' . \DIRECTORY_SEPARATOR;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitorTest.php
@@ -47,7 +47,7 @@ class BlockSettingsFormMetadataVisitorTest extends TestCase
                     'value' => 'page_block_settings',
                 ],
             ],
-            \array_map(function(OptionMetadata $optionMetadata) {
+            \array_map(function(OptionMetadata $optionMetadata): array {
                 return [
                     'name' => $optionMetadata->getName(),
                     'value' => $optionMetadata->getValue(),
@@ -80,7 +80,7 @@ class BlockSettingsFormMetadataVisitorTest extends TestCase
                     'value' => 'other_block_settings',
                 ],
             ],
-            \array_map(function(OptionMetadata $optionMetadata) {
+            \array_map(function(OptionMetadata $optionMetadata): array {
                 return [
                     'name' => $optionMetadata->getName(),
                     'value' => $optionMetadata->getValue(),
@@ -118,7 +118,7 @@ class BlockSettingsFormMetadataVisitorTest extends TestCase
                     'value' => 'page_block_settings',
                 ],
             ],
-            \array_map(function(OptionMetadata $optionMetadata) {
+            \array_map(function(OptionMetadata $optionMetadata): array {
                 return [
                     'name' => $optionMetadata->getName(),
                     'value' => $optionMetadata->getValue(),

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitorTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor\BlockSettingsFormMetadataVisitor;
+
+class BlockSettingsFormMetadataVisitorTest extends TestCase
+{
+    private BlockSettingsFormMetadataVisitor $blockSettingsFormMetadataVisitor;
+
+    public function setUp(): void
+    {
+        $this->blockSettingsFormMetadataVisitor = new BlockSettingsFormMetadataVisitor();
+    }
+
+    public function testVisitTypedFormMetadata(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $typedFormMetadata->addForm($formMetadata->getKey(), $formMetadata);
+
+        $blockMetadata = new FieldMetadata('blocks');
+        $blockMetadata->setType('block');
+        $formMetadata->addItem($blockMetadata);
+
+        $this->blockSettingsFormMetadataVisitor->visitTypedFormMetadata($typedFormMetadata, 'page', 'en', []);
+
+        $this->assertSame(
+            [
+                'settings_form_key' => [
+                    'name' => 'settings_form_key',
+                    'value' => 'page_block_settings',
+                ],
+            ],
+            \array_map(function(OptionMetadata $optionMetadata) {
+                return [
+                    'name' => $optionMetadata->getName(),
+                    'value' => $optionMetadata->getValue(),
+                ];
+            }, $blockMetadata->getOptions()),
+        );
+    }
+
+    public function testVisitTypedFormMetadataKeep(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $typedFormMetadata->addForm($formMetadata->getKey(), $formMetadata);
+
+        $otherBlockMetadata = new FieldMetadata('others');
+        $otherBlockMetadata->setType('block');
+        $optionMetadata = new OptionMetadata();
+        $optionMetadata->setName('settings_form_key');
+        $optionMetadata->setValue('other_block_settings');
+        $otherBlockMetadata->addOption($optionMetadata);
+        $formMetadata->addItem($otherBlockMetadata);
+
+        $this->blockSettingsFormMetadataVisitor->visitTypedFormMetadata($typedFormMetadata, 'page', 'en', []);
+
+        $this->assertSame(
+            [
+                'settings_form_key' => [
+                    'name' => 'settings_form_key',
+                    'value' => 'other_block_settings',
+                ],
+            ],
+            \array_map(function(OptionMetadata $optionMetadata) {
+                return [
+                    'name' => $optionMetadata->getName(),
+                    'value' => $optionMetadata->getValue(),
+                ];
+            }, $otherBlockMetadata->getOptions()),
+        );
+    }
+
+    public function testVisitTypedFormMetadataNested(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $typedFormMetadata->addForm($formMetadata->getKey(), $formMetadata);
+
+        $blockMetadata = new FieldMetadata('blocks');
+        $blockMetadata->setType('block');
+        $formMetadata->addItem($blockMetadata);
+
+        $nestedBlockMetadata = new FieldMetadata('nested');
+        $nestedBlockMetadata->setType('block');
+
+        $blockTypeMetadata = new FormMetadata();
+        $blockTypeMetadata->setKey('default');
+        $blockTypeMetadata->addItem($nestedBlockMetadata);
+
+        $blockMetadata->addType($blockTypeMetadata);
+
+        $this->blockSettingsFormMetadataVisitor->visitTypedFormMetadata($typedFormMetadata, 'page', 'en', []);
+
+        $this->assertSame(
+            [
+                'settings_form_key' => [
+                    'name' => 'settings_form_key',
+                    'value' => 'page_block_settings',
+                ],
+            ],
+            \array_map(function(OptionMetadata $optionMetadata) {
+                return [
+                    'name' => $optionMetadata->getName(),
+                    'value' => $optionMetadata->getValue(),
+                ];
+            }, $nestedBlockMetadata->getOptions()),
+        );
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -78,6 +78,20 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
             ]
         );
 
+        $container->prependExtensionConfig(
+            'sulu_admin',
+            [
+                'templates' => [
+                    'block' => [ // TODO maybe blocks?
+                        'default_type' => null,
+                        'directories' => [
+                            'app' => '%kernel.project_dir%/config/templates/blocks',
+                        ],
+                    ],
+                ],
+            ]
+        );
+
         if ($container->hasExtension('massive_build')) {
             $container->prependExtensionConfig('massive_build', [
                 'command_class' => SuluBuildCommand::class,

--- a/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
+++ b/src/Sulu/Bundle/PageBundle/DependencyInjection/SuluPageExtension.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\PageBundle\Form\Type\PageDocumentType;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Exception\ResourceLocatorAlreadyExistsException;
+use Sulu\Page\Domain\Model\PageInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,6 +44,13 @@ class SuluPageExtension extends Extension implements PrependExtensionInterface
                     'forms' => [
                         'directories' => [
                             __DIR__ . '/../Resources/config/forms',
+                        ],
+                    ],
+                    'templates' => [
+                        PageInterface::TEMPLATE_TYPE => [
+                            'directories' => [
+                                'app' => '%kernel.project_dir%/config/templates/pages',
+                            ],
                         ],
                     ],
                     'resources' => [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7908
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add new XmlTemplateFormMetadataLoader.

#### Why?

To replace old structure based metadata loading.

#### ToDo

 - [x] Settings Form Key handling
 - [x] Template Meta Title
 - [x] Block MinOccurs
 - [x] Tests
