### PR TITLE
Add ListMetadataVisitor for expressions

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ExpressionListMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/ListMetadata/ExpressionListMetadataVisitor.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\ListMetadata;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * @internal This class is internal. Create a separate visitor if you want to manipulate the metadata in your project.
+ */
+class ExpressionListMetadataVisitor implements ListMetadataVisitorInterface
+{
+    public function __construct(
+        private ExpressionLanguage $expressionLanguage
+    ) {
+    }
+
+    public function visitListMetadata(ListMetadata $listMetadata, string $key, string $locale, array $metadataOptions = []): void
+    {
+        $expressionContext = $this->getExpressionContext($locale, $metadataOptions);
+
+        foreach ($listMetadata->getFields() as $fieldMetadata) {
+            $filterTypeParameters = $fieldMetadata->getFilterTypeParameters();
+
+            if (!\is_array($filterTypeParameters)) {
+                continue;
+            }
+
+            foreach ($filterTypeParameters as $name => $filterTypeParameter) {
+                if (!\is_array($filterTypeParameter) || ($filterTypeParameter['type'] ?? null) !== 'expression') {
+                    continue;
+                }
+
+                /** @var string $value */
+                $value = $filterTypeParameter['value'];
+                $filterTypeParameters[$name] = $this->expressionLanguage->evaluate($value, $expressionContext);
+            }
+
+            $fieldMetadata->setFilterTypeParameters($filterTypeParameters);
+        }
+    }
+
+    /**
+     * @param mixed[] $metadataOptions
+     *
+     * @return mixed[]
+     */
+    private function getExpressionContext(string $locale, array $metadataOptions): array
+    {
+        return \array_merge(['locale' => $locale], $metadataOptions);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -107,6 +107,14 @@
             <tag name="sulu_admin.list_metadata_loader"/>
         </service>
 
+        <service
+            id="sulu_admin.expression_list_metadata_visitor"
+            class="Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ExpressionListMetadataVisitor"
+        >
+            <argument type="service" id="sulu_core.expression_language" />
+            <tag name="sulu_admin.list_metadata_visitor" />
+        </service>
+
         <service id="sulu_admin.view_builder_factory" class="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory" />
         <service
             id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/ListXmlLoader.php
@@ -256,9 +256,9 @@ class ListXmlLoader
                 );
 
                 if (null === $name) {
-                    $parameters[] = $value;
+                    $parameters[] = 'expression' === $type ? ['type' => $type, 'value' => $value] : $value;
                 } else {
-                    $parameters[$name] = $value;
+                    $parameters[$name] = 'expression' === $type ? ['type' => $type, 'value' => $value] : $value;
                 }
             }
         }

--- a/src/Sulu/Component/Rest/ListBuilder/Metadata/Resources/schema/list-2.0.xsd
+++ b/src/Sulu/Component/Rest/ListBuilder/Metadata/Resources/schema/list-2.0.xsd
@@ -105,6 +105,7 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="collection"/>
             <xs:enumeration value="string"/>
+            <xs:enumeration value="expression"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds a ExpressionListMetadataVisitor and allows expressions in filter selects.

#### Why?

To support expresions for filters, like in the select field.

#### Example Usage

```php
        <property name="mainSite" visibility="yes" translation="app.main_site" searchability="yes">
            <field-name>mainSite</field-name>
            <entity-name>App\Model\Example</entity-name>

            <filter type="select">
                <params>
                    <param name="options" type="expression"
                           value="service('App\\Content\\Provider\\SiteSelectProvider').getFilterValues()"
                    />
                </params>
            </filter>
        </property>
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
