### PR TITLE
Replace form metadata name property with key property

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -553,6 +553,8 @@ Removed deprecated functions and properties:
 - `Sulu\Bundle\ContactBundle\Controller\PositionController::$entityKey`
 - `Sulu\Component\Cache\Memoize::memoize()`
 - `Sulu\Component\Cache\MemoizeInterface::memoize()`
+- `Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::setName()` (use `setKey()` instead)
+- `Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata::getName()` (use `getKey()` instead)
 
 Removed unused arguments:
 

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
@@ -340,7 +340,7 @@ class RoutableDataMapperTest extends TestCase
     private function createTypedFormMetadataWithRoute(string $propertyName = 'url'): TypedFormMetadata
     {
         $formMetadata = new FormMetadata();
-        $formMetadata->setName('Default');
+        $formMetadata->setTitle('Default', 'en');
         $formMetadata->setKey('default');
 
         $routeProperty = new FieldMetadata($propertyName);
@@ -359,7 +359,7 @@ class RoutableDataMapperTest extends TestCase
     private function createTypedFormMetadataWithTextLine(string $propertyName = 'url'): TypedFormMetadata
     {
         $formMetadata = new FormMetadata();
-        $formMetadata->setName('Default');
+        $formMetadata->setTitle('Default', 'en');
         $formMetadata->setKey('default');
 
         $routeProperty = new FieldMetadata($propertyName);

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
@@ -218,7 +218,7 @@ class TemplateDataMapperTest extends TestCase
     private function createTypedFormMetadata(array $properties = [], ?string $defaultTemplateKey = null): TypedFormMetadata
     {
         $formMetadata = new FormMetadata();
-        $formMetadata->setName('Example Template');
+        $formMetadata->setTitle('Example Template', 'en');
         $formMetadata->setKey('template-key');
 
         $unlocalizedPropertyMetadata = new FieldMetadata('unlocalizedField');

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/BlockPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/BlockPropertyResolverTest.php
@@ -119,7 +119,6 @@ class BlockPropertyResolverTest extends TestCase
         $locale = 'en';
 
         $formMetadata = new FormMetadata();
-        $formMetadata->setName('text_block');
         $formMetadata->setKey('text_block');
         $blockFieldMetadata = new FieldMetadata('text_block');
         $blockFieldMetadata->addType($formMetadata);
@@ -165,7 +164,6 @@ class BlockPropertyResolverTest extends TestCase
         $locale = 'en';
 
         $formMetadata = new FormMetadata();
-        $formMetadata->setName('text_block');
         $formMetadata->setKey('text_block');
         $tag = new TagMetadata();
         $tag->setName('sulu.global_block');
@@ -181,7 +179,6 @@ class BlockPropertyResolverTest extends TestCase
         ];
 
         $globalFormMetadata = new FormMetadata();
-        $globalFormMetadata->setName('text_block');
         $globalFormMetadata->setKey('text_block');
         $globalBlockFieldMetadata = new FieldMetadata('text_block');
         $globalBlockFieldMetadata->addType($globalFormMetadata);
@@ -235,7 +232,6 @@ class BlockPropertyResolverTest extends TestCase
         $locale = 'en';
 
         $formMetadata = new FormMetadata();
-        $formMetadata->setName('text_block');
         $formMetadata->setKey('text_block');
         $blockFieldMetadata = new FieldMetadata('text_block');
         $blockFieldMetadata->addType($formMetadata);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1951,6 +1951,12 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
+			message: '#^Parameter \#1 \$key of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setKey\(\) expects string, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+
+		-
 			message: '#^Parameter \#1 \$labels of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setLabels\(\) expects array\<string, string\>, array given\.$#'
 			identifier: argument.type
 			count: 2
@@ -1964,12 +1970,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\SectionMetadata constructor expects string, float\|int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
-			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setName\(\) expects string, float\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -2096,12 +2096,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setKey\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setName\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -3229,6 +3223,12 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
+			message: '#^Parameter \#1 \$key of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setKey\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
 			message: '#^Parameter \#1 \$labels of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\ItemMetadata\:\:setLabels\(\) expects array\<string, string\>, mixed given\.$#'
 			identifier: argument.type
 			count: 2
@@ -3248,12 +3248,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$name of class Sulu\\Component\\Content\\Exception\\InvalidDefaultTypeException constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
-
-		-
-			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setName\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -3517,13 +3511,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
 
 		-
-			message: '#^Parameter \#1 \$key of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findWebspaceByKey\(\) expects string\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$key of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setKey\(\) expects string, float\|int\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
 
 		-
-			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FormMetadata\:\:setName\(\) expects string, float\|int\|string given\.$#'
+			message: '#^Parameter \#1 \$key of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findWebspaceByKey\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -114,7 +114,7 @@ class FormMetadataMapper
 
         foreach ($property->getComponents() as $component) {
             $type = new FormMetadata();
-            $type->setName($component->getName());
+            $type->setKey($component->getName());
             $type->setTitles($component->getTitles());
             $type->setTags($this->mapTags($component->getTags()));
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
@@ -103,7 +103,7 @@ class FieldMetadata extends ItemMetadata
 
     public function addType(FormMetadata $type): void
     {
-        $this->types[$type->getName()] = $type;
+        $this->types[$type->getKey()] = $type;
     }
 
     public function isRequired(): bool

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -70,7 +70,7 @@ class FormMetadata extends AbstractMetadata
     }
 
     /**
-     * @deprecated since 3.0, use setKey() instead
+     * @deprecated since 3.0, use setName() instead
      */
     #[VirtualProperty]
     #[SerializedName('name')]
@@ -119,7 +119,7 @@ class FormMetadata extends AbstractMetadata
 
         return \count($this->titles)
             ? $this->titles[\array_key_first($this->titles)]
-            : ($this->key ? \ucfirst($this->key) : '');
+            : ($this->key ? \ucfirst(\str_replace(['_', '-'], ' ', $this->key)) : '');
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -13,17 +13,12 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\VirtualProperty;
 use Sulu\Bundle\AdminBundle\Metadata\AbstractMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 
 class FormMetadata extends AbstractMetadata
 {
-    /**
-     * @var string
-     */
-    #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
-    private $name;
-
     /**
      * @var array<string, string>
      */
@@ -74,14 +69,15 @@ class FormMetadata extends AbstractMetadata
         $this->schema = new SchemaMetadata();
     }
 
-    public function setName(string $name)
-    {
-        $this->name = $name;
-    }
-
+    /**
+     * @deprecated since 3.0, use setKey() instead
+     */
+    #[VirtualProperty]
+    #[SerializedName('name')]
+    #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
     public function getName(): string
     {
-        return $this->name;
+        return $this->key;
     }
 
     public function setKey(string $key)
@@ -123,7 +119,7 @@ class FormMetadata extends AbstractMetadata
 
         return \count($this->titles)
             ? $this->titles[\array_key_first($this->titles)]
-            : ($this->name ? \ucfirst($this->name) : '');
+            : ($this->key ? \ucfirst($this->key) : '');
     }
 
     /**
@@ -250,9 +246,6 @@ class FormMetadata extends AbstractMetadata
     {
         $mergedForm = new self();
         $mergedForm->setKey($this->getKey());
-        if ($this->name) {
-            $mergedForm->setName($this->name);
-        }
         if ($this->titles) {
             $mergedForm->setTitles($this->titles);
         }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -399,7 +399,7 @@ class PropertiesXmlParser
         $types = $data['types'];
         foreach ($types as $name => $typeData) {
             $type = new FormMetadata();
-            $type->setName($name);
+            $type->setKey($name);
             $type->setTitles($typeData['meta']['title'] ?? []);
 
             if (!$typeData['ref']) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/StructureFormMetadataLoader.php
@@ -143,7 +143,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
                 $structure = $this->mapStructureMetadata($structuresMetadata, $locale);
 
                 foreach ($structure->getForms() as $formMetadata) {
-                    $this->validateItems($formMetadata->getItems(), $formMetadata->getName());
+                    $this->validateItems($formMetadata->getItems(), $formMetadata->getKey());
                 }
 
                 $configCache = $this->getConfigCache($structureType, $locale);
@@ -169,7 +169,7 @@ class StructureFormMetadataLoader implements FormMetadataLoaderInterface, CacheW
         foreach ($structuresMetadata as $structureMetadata) {
             $form = new FormMetadata();
             $form->setTags($this->formMetadataMapper->mapTags($structureMetadata->getTags()));
-            $form->setName($structureMetadata->getName());
+            $form->setKey($structureMetadata->getName());
             $form->setTitles($structureMetadata->getTitles());
             $form->setItems($this->formMetadataMapper->mapChildren($structureMetadata->getChildren()));
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -111,7 +111,7 @@
                                     "null"
                                 ]
                             },
-                            "key": null,
+                            "key": "text_block",
                             "tags": [
                                 {
                                     "name": "sulu.global_block",
@@ -136,7 +136,7 @@
                                     "null"
                                 ]
                             },
-                            "key": null,
+                            "key": "text_block2",
                             "tags": [
                                 {
                                     "name": "sulu.global_block",
@@ -179,7 +179,7 @@
                                     "null"
                                 ]
                             },
-                            "key": null,
+                            "key": "editor",
                             "tags": [],
                             "title": "Editor"
                         },
@@ -228,7 +228,7 @@
                                                     "null"
                                                 ]
                                             },
-                                            "key": null,
+                                            "key": "text_block2",
                                             "tags": [
                                                 {
                                                     "name": "sulu.global_block",
@@ -253,7 +253,7 @@
                                                     "null"
                                                 ]
                                             },
-                                            "key": null,
+                                            "key": "text_block3",
                                             "tags": [
                                                 {
                                                     "name": "sulu.global_block",
@@ -286,7 +286,7 @@
                                     "null"
                                 ]
                             },
-                            "key": null,
+                            "key": "block",
                             "tags": [],
                             "title": "Block"
                         }
@@ -581,7 +581,7 @@
             }
         }
     },
-    "key": null,
+    "key": "default",
     "tags": [
         {
             "name": "test",

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
@@ -153,7 +153,7 @@
                             "null"
                         ]
                     },
-                    "key": null,
+                    "key": "editor",
                     "tags": [],
                     "title": "Editor"
                 }
@@ -211,7 +211,7 @@
                             "null"
                         ]
                     },
-                    "key": null,
+                    "key": "editor",
                     "tags": [],
                     "title": "Editor"
                 }
@@ -341,7 +341,7 @@
             "url"
         ]
     },
-    "key": null,
+    "key": "overview",
     "tags": [
         {
             "name": "test3",

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -45,7 +45,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
 
         $overviewForm = $typedForm->getForms()['overview'];
         $this->assertInstanceOf(FormMetadata::class, $overviewForm);
-        $this->assertEquals('overview', $overviewForm->getName());
+        $this->assertEquals('overview', $overviewForm->getKey());
         $this->assertEquals('Overview', $overviewForm->getTitle('en'));
         $this->assertCount(8, $overviewForm->getItems());
         $this->assertCount(1, $overviewForm->getTags());
@@ -58,7 +58,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
 
         $defaultForm = $typedForm->getForms()['default'];
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
-        $this->assertEquals('default', $defaultForm->getName());
+        $this->assertEquals('default', $defaultForm->getKey());
         $this->assertEquals('Animals', $defaultForm->getTitle('en'));
         $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());
@@ -80,7 +80,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
 
         $overviewForm = $typedForm->getForms()['overview'];
         $this->assertInstanceOf(FormMetadata::class, $overviewForm);
-        $this->assertEquals('overview', $overviewForm->getName());
+        $this->assertEquals('overview', $overviewForm->getKey());
         $this->assertEquals('Overview', $overviewForm->getTitle('de'));
         $this->assertCount(8, $overviewForm->getItems());
         $this->assertCount(1, $overviewForm->getTags());
@@ -89,7 +89,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
 
         $defaultForm = $typedForm->getForms()['default'];
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
-        $this->assertEquals('default', $defaultForm->getName());
+        $this->assertEquals('default', $defaultForm->getKey());
         $this->assertEquals('Tiers', $defaultForm->getTitle('de'));
         $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());
@@ -130,7 +130,7 @@ class StructureFormMetadataLoaderTest extends KernelTestCase
 
         $defaultForm = $typedForm->getForms()['default'];
         $this->assertInstanceOf(FormMetadata::class, $defaultForm);
-        $this->assertEquals('default', $defaultForm->getName());
+        $this->assertEquals('default', $defaultForm->getKey());
         $this->assertEquals('Tiers', $defaultForm->getTitle('de'));
         $this->assertCount(5, $defaultForm->getItems());
         $this->assertCount(3, $defaultForm->getTags());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -147,9 +147,9 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
         $types = $blocks->getTypes();
 
         $this->assertCount(3, $types);
-        $this->assertEquals('editor', $types['editor']->getName());
-        $this->assertEquals('editor_image', $types['editor_image']->getName());
-        $this->assertEquals('text_block', $types['text_block']->getName());
+        $this->assertEquals('editor', $types['editor']->getKey());
+        $this->assertEquals('editor_image', $types['editor_image']->getKey());
+        $this->assertEquals('text_block', $types['text_block']->getKey());
     }
 
     public function testGetMetadataWithPropertyWithTypes(): void
@@ -164,10 +164,10 @@ class XmlFormMetadataLoaderTest extends KernelTestCase
 
         $types = $image->getTypes();
         $this->assertCount(2, $types);
-        $this->assertEquals('editor', $types['editor']->getName());
+        $this->assertEquals('editor', $types['editor']->getKey());
         $this->assertCount(1, $types['editor']->getItems());
         $this->assertEquals('article', $types['editor']->getItems()['article']->getName());
-        $this->assertEquals('editor_image', $types['editor_image']->getName());
+        $this->assertEquals('editor_image', $types['editor_image']->getKey());
         $this->assertCount(2, $types['editor_image']->getItems());
         $this->assertEquals('images', $types['editor_image']->getItems()['images']->getName());
         $this->assertEquals('article', $types['editor_image']->getItems()['article']->getName());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -193,13 +193,13 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals(1, $item->getMinOccurs());
         $this->assertEquals(2, $item->getMaxOccurs());
 
-        $this->assertEquals('component1', $item->getTypes()['component1']->getName());
+        $this->assertEquals('component1', $item->getTypes()['component1']->getKey());
         $this->assertEquals('First Component', $item->getTypes()['component1']->getTitle('en'));
         $this->assertCount(2, $item->getTypes()['component1']->getItems());
         $this->assertContains('property1', \array_keys($item->getTypes()['component1']->getItems()));
         $this->assertContains('property2', \array_keys($item->getTypes()['component1']->getItems()));
 
-        $this->assertEquals('component2', $item->getTypes()['component2']->getName());
+        $this->assertEquals('component2', $item->getTypes()['component2']->getKey());
         $this->assertEquals('Second Component', $item->getTypes()['component2']->getTitle('en'));
         $this->assertCount(2, $item->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($item->getTypes()['component2']->getItems()));
@@ -258,11 +258,11 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals(1, $item->getMinOccurs());
         $this->assertEquals(2, $item->getMaxOccurs());
 
-        $this->assertEquals('component1', $item->getTypes()['component1']->getName());
+        $this->assertEquals('component1', $item->getTypes()['component1']->getKey());
         $this->assertEquals('First Component', $item->getTypes()['component1']->getTitle('en'));
         $this->assertCount(0, $item->getTypes()['component1']->getItems());
 
-        $this->assertEquals('component2', $item->getTypes()['component2']->getName());
+        $this->assertEquals('component2', $item->getTypes()['component2']->getKey());
         $this->assertEquals('Second Component', $item->getTypes()['component2']->getTitle('en'));
         $this->assertCount(2, $item->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($item->getTypes()['component2']->getItems()));
@@ -365,13 +365,13 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals(1, $block->getMinOccurs());
         $this->assertEquals(2, $block->getMaxOccurs());
 
-        $this->assertEquals('component1', $block->getTypes()['component1']->getName());
+        $this->assertEquals('component1', $block->getTypes()['component1']->getKey());
         $this->assertEquals('First Component', $block->getTypes()['component1']->getTitle('en'));
         $this->assertCount(2, $block->getTypes()['component1']->getItems());
         $this->assertContains('property1', \array_keys($block->getTypes()['component1']->getItems()));
         $this->assertContains('property2', \array_keys($block->getTypes()['component1']->getItems()));
 
-        $this->assertEquals('component2', $block->getTypes()['component2']->getName());
+        $this->assertEquals('component2', $block->getTypes()['component2']->getKey());
         $this->assertEquals('Second Component', $block->getTypes()['component2']->getTitle('en'));
         $this->assertCount(2, $block->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($block->getTypes()['component2']->getItems()));
@@ -395,13 +395,13 @@ class FormMetadataMapperTest extends TestCase
         $this->assertEquals(1, $block->getMinOccurs());
         $this->assertEquals(2, $block->getMaxOccurs());
 
-        $this->assertEquals('component1', $block->getTypes()['component1']->getName());
+        $this->assertEquals('component1', $block->getTypes()['component1']->getKey());
         $this->assertEquals('Erste Komponente', $block->getTypes()['component1']->getTitle('de'));
         $this->assertCount(2, $block->getTypes()['component1']->getItems());
         $this->assertContains('property1', \array_keys($block->getTypes()['component1']->getItems()));
         $this->assertContains('property2', \array_keys($block->getTypes()['component1']->getItems()));
 
-        $this->assertEquals('component2', $block->getTypes()['component2']->getName());
+        $this->assertEquals('component2', $block->getTypes()['component2']->getKey());
         $this->assertEquals('Zweite Komponente', $block->getTypes()['component2']->getTitle('de'));
         $this->assertCount(2, $block->getTypes()['component2']->getItems());
         $this->assertContains('property3', \array_keys($block->getTypes()['component2']->getItems()));

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/StructureFormMetadataLoaderTest.php
@@ -106,10 +106,9 @@ class StructureFormMetadataLoaderTest extends TestCase
     /**
      * @param ItemMetadata[] $items
      */
-    private function createFormMetadata(string $name, string $key, array $items = []): FormMetadata
+    private function createFormMetadata(string $key, array $items = []): FormMetadata
     {
         $formMetadata = new FormMetadata();
-        $formMetadata->setName($name);
         $formMetadata->setKey($key);
         $formMetadata->setItems([]);
 
@@ -140,7 +139,7 @@ class StructureFormMetadataLoaderTest extends TestCase
         $sectionPropertyMetadata = $this->createFieldMetadata('some_section_property', 'text_line');
         $sectionMetadata = $this->createSectionMetadata('some_section', [$sectionPropertyMetadata]);
         $blockPropertyMetadata = $this->createFieldMetadata('some_block_property', 'text_line');
-        $blockTypeMetadata = $this->createFormMetadata('some_block_type', 'some_block_type_key', [$blockPropertyMetadata]);
+        $blockTypeMetadata = $this->createFormMetadata('some_block_type_key', [$blockPropertyMetadata]);
         $blockMetadata = $this->createFieldMetadata('some_block', 'block', [$blockTypeMetadata]);
 
         $structure = new StructureMetadata();

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Validation/BlockFieldMetadataValidatorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Validation/BlockFieldMetadataValidatorTest.php
@@ -52,10 +52,10 @@ class BlockFieldMetadataValidatorTest extends TestCase
     /**
      * @param ItemMetadata[] $items
      */
-    private function createFormMetadata(string $name, array $items = []): FormMetadata
+    private function createFormMetadata(string $key, array $items = []): FormMetadata
     {
         $formMetadata = new FormMetadata();
-        $formMetadata->setName($name);
+        $formMetadata->setKey($key);
 
         foreach ($items as $item) {
             $formMetadata->addItem($item);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Validation/TypesPropertyFieldMetadataValidatorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Validation/TypesPropertyFieldMetadataValidatorTest.php
@@ -52,10 +52,10 @@ class TypesPropertyFieldMetadataValidatorTest extends TestCase
     /**
      * @param ItemMetadata[] $items
      */
-    private function createFormMetadata(string $name, array $items = []): FormMetadata
+    private function createFormMetadata(string $key, array $items = []): FormMetadata
     {
         $formMetadata = new FormMetadata();
-        $formMetadata->setName($name);
+        $formMetadata->setKey($key);
 
         foreach ($items as $item) {
             $formMetadata->addItem($item);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -81,10 +81,9 @@ class XmlFormMetadataLoaderTest extends TestCase
     /**
      * @param ItemMetadata[] $items
      */
-    private function createFormMetadata(string $name, string $key, array $items = []): FormMetadata
+    private function createFormMetadata(string $key, array $items = []): FormMetadata
     {
         $formMetadata = new FormMetadata();
-        $formMetadata->setName($name);
         $formMetadata->setKey($key);
         $formMetadata->setItems([]);
 
@@ -115,9 +114,9 @@ class XmlFormMetadataLoaderTest extends TestCase
         $sectionPropertyMetadata = $this->createFieldMetadata('some_section_property', 'text_line');
         $sectionMetadata = $this->createSectionMetadata('some_section', [$sectionPropertyMetadata]);
         $blockPropertyMetadata = $this->createFieldMetadata('some_block_property', 'text_line');
-        $blockTypeMetadata = $this->createFormMetadata('some_block_type', 'some_block_type_key', [$blockPropertyMetadata]);
+        $blockTypeMetadata = $this->createFormMetadata('some_block_type_key', [$blockPropertyMetadata]);
         $blockMetadata = $this->createFieldMetadata('some_block', 'block', [$blockTypeMetadata]);
-        $formMetadata = $this->createFormMetadata('some_form', 'some_form_key', [$propertyMetadata, $sectionMetadata, $blockMetadata]);
+        $formMetadata = $this->createFormMetadata('some_form_key', [$propertyMetadata, $sectionMetadata, $blockMetadata]);
 
         $this->formXmlLoader->load(Argument::cetera())
             ->willReturn($formMetadata);

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
@@ -466,7 +466,7 @@ class ImageMapContentType extends ComplexContentType implements ContentTypeExpor
 
                 $blockTypeSchemas[] = new IfThenElseMetadata(
                     new SchemaMetadata([
-                        new PropertyMetadata('type', true, new ConstMetadata($blockType->getName())),
+                        new PropertyMetadata('type', true, new ConstMetadata($blockType->getKey())),
                     ]),
                     new RefSchemaMetadata('#/definitions/' . $blockName)
                 );
@@ -476,7 +476,7 @@ class ImageMapContentType extends ComplexContentType implements ContentTypeExpor
 
             $blockTypeSchemas[] = new IfThenElseMetadata(
                 new SchemaMetadata([
-                    new PropertyMetadata('type', true, new ConstMetadata($blockType->getName())),
+                    new PropertyMetadata('type', true, new ConstMetadata($blockType->getKey())),
                 ]),
                 $this->schemaMetadataProvider->getMetadata($blockType->getItems()),
             );

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/collection_details.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/collection_details.json
@@ -1,5 +1,5 @@
 {
-    "name": null,
+    "name": "collection_details",
     "form": {
         "title": {
             "disabledCondition": null,
@@ -70,5 +70,5 @@
     },
     "key": "collection_details",
     "tags": [],
-    "title": ""
+    "title": "Collection details"
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/media_details.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/media_details.json
@@ -1,5 +1,5 @@
 {
-    "name": null,
+    "name": "media_details",
     "form": {
         "media_upload": {
             "disabledCondition": null,
@@ -338,5 +338,5 @@
     },
     "key": "media_details",
     "tags": [],
-    "title": ""
+    "title": "Media details"
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/ImageMapContentTypeTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Content/Types/ImageMapContentTypeTest.php
@@ -1208,7 +1208,6 @@ class ImageMapContentTypeTest extends TestCase
         $metadata->setRequired(true);
         foreach ($types as $key => $config) {
             $type = new FormMetadata();
-            $type->setName($key);
             $type->setKey($key);
 
             $isGlobalBlock = $config['isGlobalBlock'] ?? false;
@@ -1296,7 +1295,6 @@ class ImageMapContentTypeTest extends TestCase
         $metadata->setRequired(false);
         foreach ($types as $key => $config) {
             $type = new FormMetadata();
-            $type->setName($key);
             $type->setKey($key);
 
             $isGlobalBlock = $config['isGlobalBlock'] ?? false;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
@@ -262,7 +262,7 @@ class ImageMapPropertyResolverTest extends TestCase
         $data = ['imageId' => 1, 'hotspots' => [['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'], ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2']]];
 
         $textFormMetadata = new FormMetadata();
-        $textFormMetadata->setName('text');
+        $textFormMetadata->setKey('text');
         $itemMetadata = new FieldMetadata('title');
         $itemMetadata->setType('text_line');
         $textFormMetadata->addItem($itemMetadata);
@@ -312,7 +312,7 @@ class ImageMapPropertyResolverTest extends TestCase
         $fieldMetadata->setDefaultType('text');
 
         $textFormMetadata = new FormMetadata();
-        $textFormMetadata->setName('text');
+        $textFormMetadata->setKey('text');
         $itemMetadata = new FieldMetadata('title');
         $itemMetadata->setType('text_line');
         $textFormMetadata->addItem($itemMetadata);
@@ -329,7 +329,7 @@ class ImageMapPropertyResolverTest extends TestCase
         $fieldMetadata->setDefaultType('text');
 
         $textFormMetadata = new FormMetadata();
-        $textFormMetadata->setName('text');
+        $textFormMetadata->setKey('text');
 
         $tag = new TagMetadata();
         $tag->setName('sulu.global_block');

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Metadata/ImageMapFieldMetadataValidatorTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Metadata/ImageMapFieldMetadataValidatorTest.php
@@ -52,10 +52,10 @@ class ImageMapFieldMetadataValidatorTest extends TestCase
     /**
      * @param ItemMetadata[] $items
      */
-    private function createFormMetadata(string $name, array $items = []): FormMetadata
+    private function createFormMetadata(string $key, array $items = []): FormMetadata
     {
         $formMetadata = new FormMetadata();
-        $formMetadata->setName($name);
+        $formMetadata->setKey($key);
 
         foreach ($items as $item) {
             $formMetadata->addItem($item);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/role_details.json
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/role_details.json
@@ -1,5 +1,5 @@
 {
-    "name": null,
+    "name": "role_details",
     "form": {
         "name": {
             "disabledCondition": null,
@@ -133,5 +133,5 @@
     },
     "key": "role_details",
     "tags": [],
-    "title": ""
+    "title": "Role details"
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/user_details.json
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/user_details.json
@@ -1,5 +1,5 @@
 {
-    "name": null,
+    "name": "user_details",
     "form": {
         "username": {
             "disabledCondition": null,
@@ -161,5 +161,5 @@
     },
     "key": "user_details",
     "tags": [],
-    "title": ""
+    "title": "User details"
 }

--- a/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
+++ b/src/Sulu/Component/Content/SmartContent/PageDataProvider.php
@@ -390,7 +390,7 @@ class PageDataProvider implements DataProviderInterface, DataProviderAliasInterf
             $metadata = $this->formMetadataProvider->getMetadata('page', $user->getLocale(), []);
 
             foreach ($metadata->getForms() as $form) {
-                $types[] = ['type' => $form->getName(), 'title' => $form->getTitle($user->getLocale())];
+                $types[] = ['type' => $form->getKey(), 'title' => $form->getTitle($user->getLocale())];
             }
         }
 

--- a/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/SmartContent/PageDataProviderTest.php
@@ -203,11 +203,11 @@ class PageDataProviderTest extends TestCase
             ->willReturn('en');
 
         $formMetadata1 = new FormMetadata();
-        $formMetadata1->setName('template-1');
+        $formMetadata1->setKey('template-1');
         $formMetadata1->setTitle('translated-template-1', 'en');
 
         $formMetadata2 = new FormMetadata();
-        $formMetadata2->setName('template-2');
+        $formMetadata2->setKey('template-2');
         $formMetadata2->setTitle('translated-template-2', 'en');
 
         $typedFormMetadata = new TypedFormMetadata();

--- a/src/Sulu/Component/Content/Tests/Unit/Types/Metadata/GlobalBlocksTypedFormMetadataVisitorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/Metadata/GlobalBlocksTypedFormMetadataVisitorTest.php
@@ -70,12 +70,12 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $fieldTag->setAttributes(['global_block' => $globalBlockName]);
 
         $fieldType1 = new FormMetadata();
-        $fieldType1->setName('test3');
+        $fieldType1->setKey('test3');
         $fieldType1->addTag($fieldTag);
         $fieldMetadata->addType($fieldType1);
 
         $fieldType2 = new FormMetadata();
-        $fieldType2->setName('test4');
+        $fieldType2->setKey('test4');
         $fieldMetadata->addType($fieldType2);
 
         $globalBlockFormMetadata = new TypedFormMetadata();
@@ -83,7 +83,7 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $globalBlockFormMetadata->addForm($globalBlockName, $globalBlockFormTypeMetadata);
 
         $globalBlockFormTypeMetadata->setSchema(new SchemaMetadata());
-        $globalBlockFormTypeMetadata->setName($globalBlockName);
+        $globalBlockFormTypeMetadata->setKey($globalBlockName);
         $globalBlockFormTypeMetadata->setTitles(['en' => 'Test Block Title']);
 
         $this->metadataProviderProphecy->getMetadata('block', $locale, [
@@ -129,19 +129,19 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $fieldTag->setAttributes(['global_block' => $globalBlockName]);
 
         $fieldType1 = new FormMetadata();
-        $fieldType1->setName('test3');
+        $fieldType1->setKey('test3');
         $fieldType1->addTag($fieldTag);
         $fieldMetadata->addType($fieldType1);
 
         $fieldType2 = new FormMetadata();
-        $fieldType2->setName('test4');
+        $fieldType2->setKey('test4');
         $fieldMetadata->addType($fieldType2);
 
         $globalBlockFormMetadata = new TypedFormMetadata();
         $globalBlockFormTypeMetadata = new FormMetadata();
         $globalBlockFormMetadata->addForm($globalBlockName, $globalBlockFormTypeMetadata);
 
-        $globalBlockFormTypeMetadata->setName($globalBlockName);
+        $globalBlockFormTypeMetadata->setKey($globalBlockName);
         $globalBlockFormTypeMetadata->setTitles(['en' => 'Test Block Title']);
 
         $this->metadataProviderProphecy->getMetadata('block', $locale, [
@@ -188,19 +188,19 @@ class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
         $fieldTag->setAttributes(['global_block' => $globalBlockName]);
 
         $fieldType1 = new FormMetadata();
-        $fieldType1->setName('test3');
+        $fieldType1->setKey('test3');
         $fieldType1->addTag($fieldTag);
         $fieldMetadata->addType($fieldType1);
 
         $fieldType2 = new FormMetadata();
-        $fieldType2->setName('test4');
+        $fieldType2->setKey('test4');
         $fieldMetadata->addType($fieldType2);
 
         $globalBlockFormMetadata = new TypedFormMetadata();
         $globalBlockFormTypeMetadata = new FormMetadata();
         $globalBlockFormMetadata->addForm($globalBlockName, $globalBlockFormTypeMetadata);
 
-        $globalBlockFormTypeMetadata->setName($globalBlockName);
+        $globalBlockFormTypeMetadata->setKey($globalBlockName);
         $globalBlockFormTypeMetadata->setTitles(['en' => 'Test Block Title']);
 
         $this->metadataProviderProphecy->getMetadata('block', $locale, [

--- a/src/Sulu/Component/Content/Types/BlockContentType.php
+++ b/src/Sulu/Component/Content/Types/BlockContentType.php
@@ -479,7 +479,7 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
 
                 $blockTypeSchemas[] = new IfThenElseMetadata(
                     new SchemaMetadata([
-                        new PropertyMetadata('type', true, new ConstMetadata($blockType->getName())),
+                        new PropertyMetadata('type', true, new ConstMetadata($blockType->getKey())),
                     ]),
                     new RefSchemaMetadata('#/definitions/' . $blockName)
                 );
@@ -489,7 +489,7 @@ class BlockContentType extends ComplexContentType implements ContentTypeExportIn
 
             $blockTypeSchemas[] = new IfThenElseMetadata(
                 new SchemaMetadata([
-                    new PropertyMetadata('type', true, new ConstMetadata($blockType->getName())),
+                    new PropertyMetadata('type', true, new ConstMetadata($blockType->getKey())),
                 ]),
                 $this->schemaMetadataProvider->getMetadata($blockType->getItems()),
             );

--- a/src/Sulu/Component/Content/Types/Metadata/GlobalBlocksTypedFormMetadataVisitor.php
+++ b/src/Sulu/Component/Content/Types/Metadata/GlobalBlocksTypedFormMetadataVisitor.php
@@ -79,7 +79,7 @@ class GlobalBlocksTypedFormMetadataVisitor implements TypedFormMetadataVisitorIn
 
                 $type->setTitles($blockMetadata->getTitles());
 
-                $rootSchema->addDefinition($blockMetadata->getName(), $blockMetadata->getSchema());
+                $rootSchema->addDefinition($blockMetadata->getKey(), $blockMetadata->getSchema());
 
                 $this->enhanceGlobalBlockTypes($blockMetadata->getItems(), $locale, $rootSchema);
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | yes 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Replace form metadata name with key.

#### Why?

Beside the `name` also a `key` was introduced in https://github.com/sulu/sulu/pull/4643 Pull Request. But seems like this are just two fields.

Currently it is very confusing as seen in a lot of tests where the setName was called with a value which make more sense for setTitle (e.g. `setName('Example Template')`). It is kind of intransparent here where name and where key is used and its not filled up in all cases correctly.

Both `<form>` and `<template>` xml both uses the `<key>` and as it we personally mostly talk about template or form keys I would go here with getKey and setKey methods over the names. The only case where `FormMetadata` is created by a `name` is inside block / image map every `<type name="text_block">` is also an own form metadata. Still I would for bc reasons not rename the type attribute name here to key, but internal I would set by the name attribute the form key.

#### Example Usage

```diff
- $formMetadata->getName();
+ $formMetadata->getKey();
```

#### To Do

- [x] Add breaking changes to UPGRADE.md
