### PR TITLE
Add parsing of template metadata

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\MetaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TemplateXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
 
@@ -44,6 +45,7 @@ class TemplateXmlLoader extends AbstractLoader
         private SchemaXmlParser $schemaXmlParser,
         private TagXmlParser $tagXmlParser,
         private MetaXmlParser $metaXmlParser,
+        private TemplateXmlParser $templateXmlParser,
         private SchemaMetadataProvider $schemaMetadataProvider,
     ) {
         parent::__construct(
@@ -74,6 +76,8 @@ class TemplateXmlLoader extends AbstractLoader
         if (\array_key_exists('title', $meta)) {
             $form->setTitles($meta['title']);
         }
+
+        $form->setTemplate($this->templateXmlParser->load($xpath, $templateNode));
 
         $propertiesNode = ($xpath->query('/x:template/x:properties') ?: null)?->item(0);
         \assert(null !== $propertiesNode, 'Expected <properties> be defined for "' . $resource . '".');

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
@@ -23,7 +23,7 @@ class SchemaXmlParser
 {
     use XmlParserTrait;
 
-    public function load(\DOMXPath $xpath, \DOMNode $contextNode)
+    public function load(\DOMXPath $xpath, \DOMNode $contextNode): SchemaMetadata
     {
         $allOfNode = $xpath->query('x:allOf', $contextNode)->item(0);
         $allOfs = [];

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TemplateXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TemplateXmlParser.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\CacheLifetimeMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TemplateMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\XmlParserTrait;
+use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
+
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
+class TemplateXmlParser
+{
+    use XmlParserTrait;
+
+    public function load(\DOMXPath $xpath, \DOMNode $contextNode): TemplateMetadata
+    {
+        $templateMetadata = new TemplateMetadata();
+
+        $controllerValue = $this->getValueFromXPath('x:controller', $xpath, $contextNode);
+
+        if ($controllerValue) {
+            \assert(\is_string($controllerValue), 'The <controller> value must be a "string", got "' . \get_debug_type($controllerValue) . '".');
+
+            $templateMetadata->setController($controllerValue);
+        }
+
+        $viewValue = $this->getValueFromXPath('x:view', $xpath, $contextNode);
+
+        if ($viewValue) {
+            \assert(\is_string($viewValue), 'The <view> value must be a "string", got "' . \get_debug_type($viewValue) . '".');
+
+            $templateMetadata->setView($viewValue);
+        }
+
+        $cacheLifeTimeNode = ($xpath->query('x:cacheLifetime', $contextNode) ?: null)?->item(0);
+
+        if ($cacheLifeTimeNode) {
+            $templateMetadata->setCacheLifetime($this->parseCacheLifeTime($cacheLifeTimeNode));
+        }
+
+        return $templateMetadata;
+    }
+
+    private function parseCacheLifeTime(\DOMNode $cacheLifeTimeNode): CacheLifetimeMetadata
+    {
+        $cacheLifeTimeValue = $cacheLifeTimeNode->nodeValue;
+        $cacheLifeTimeType =
+            $cacheLifeTimeNode->attributes?->getNamedItem('type')?->nodeValue
+            ?? CacheLifetimeResolverInterface::TYPE_SECONDS;
+
+        \assert(
+            \in_array($cacheLifeTimeType, [
+                CacheLifetimeResolverInterface::TYPE_SECONDS,
+                CacheLifetimeResolverInterface::TYPE_EXPRESSION,
+            ]),
+            'The <cache_lifetime type="..."> must be one of the defined types (' . CacheLifetimeResolverInterface::TYPE_SECONDS . ', ' . CacheLifetimeResolverInterface::TYPE_EXPRESSION . '), got "' . $cacheLifeTimeType . '".',
+        );
+
+        return new CacheLifetimeMetadata($cacheLifeTimeType, $cacheLifeTimeValue);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TemplateMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TemplateMetadata.php
@@ -13,14 +13,11 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 class TemplateMetadata
 {
-    protected ?string $controller = null;
-
-    protected ?string $view = null;
-
-    protected ?CacheLifetimeMetadata $cacheLifetime = null;
-
-    public function __construct()
-    {
+    public function __construct(
+        protected ?string $controller = null,
+        protected ?string $view = null,
+        protected ?CacheLifetimeMetadata $cacheLifetime = null,
+    ) {
     }
 
     public function getController(): ?string

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -92,6 +92,11 @@
                  public="false">
         </service>
 
+        <service id="sulu_admin.template_xml_parser"
+                 class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TemplateXmlParser"
+                 public="false">
+        </service>
+
         <service id="sulu_admin.tag_xml_parser"
                  class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser"
                  public="false">
@@ -182,6 +187,7 @@
             <argument type="service" id="sulu_admin.schema_xml_parser"/>
             <argument type="service" id="sulu_admin.tag_xml_parser"/>
             <argument type="service" id="sulu_admin.meta_xml_parser"/>
+            <argument type="service" id="sulu_admin.template_xml_parser"/>
             <argument type="service" id="sulu_admin.schema_metadata_provider"/>
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
@@ -7,9 +7,9 @@
 
     <key>overview</key>
 
-    <view>page.html.twig</view>
+    <view>page</view>
     <controller>SuluPageBundle:Default:index</controller>
-    <cacheLifetime>2400</cacheLifetime>
+    <cacheLifetime type="expression">0 2 * * *</cacheLifetime>
 
     <tag name="test3"/>
 
@@ -68,4 +68,3 @@
         </block>
     </properties>
 </template>
-

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/TemplateXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/TemplateXmlLoaderTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\MetaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\PropertiesXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\SchemaXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TagXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TemplateXmlParser;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SchemaMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
@@ -55,6 +56,7 @@ class TemplateXmlLoaderTest extends TestCase
             $metaXmlParser,
         );
         $schemaXmlParser = new SchemaXmlParser();
+        $templateXmlParser = new TemplateXmlParser();
 
         $container = new Container();
         $propertyMetadataMapperRegistry = new PropertyMetadataMapperRegistry($container);
@@ -66,7 +68,7 @@ class TemplateXmlLoaderTest extends TestCase
         );
         $container->set('block', $blockMetadataProvider);
 
-        $this->loader = new TemplateXmlLoader($propertiesXmlParser, $schemaXmlParser, $tagXmlParser, $metaXmlParser, $schemaMetadataProvider);
+        $this->loader = new TemplateXmlLoader($propertiesXmlParser, $schemaXmlParser, $tagXmlParser, $metaXmlParser, $templateXmlParser, $schemaMetadataProvider);
     }
 
     public function testLoadDefaultTemplate(): void
@@ -74,6 +76,14 @@ class TemplateXmlLoaderTest extends TestCase
         $formMetadata = $this->loader->load($this->getTemplatesDirectory() . 'default.xml');
 
         $this->assertSame([
+            'template' => [
+                'controller' => 'Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction',
+                'view' => 'ClientWebsiteBundle:templates:animals',
+                'cacheLifetime' => [
+                    'type' => 'seconds',
+                    'value' => '2400',
+                ],
+            ],
             'titles' => [
                 'de' => 'Tiers',
                 'en' => 'Animals',
@@ -252,12 +262,215 @@ class TemplateXmlLoaderTest extends TestCase
         ], $this->metadataToArray($formMetadata));
     }
 
+    public function testLoadOverviewTemplate(): void
+    {
+        $formMetadata = $this->loader->load($this->getTemplatesDirectory() . 'overview.xml');
+
+        $this->assertSame([
+            'template' => [
+                'controller' => 'SuluPageBundle:Default:index',
+                'view' => 'page',
+                'cacheLifetime' => [
+                    'type' => 'expression',
+                    'value' => '0 2 * * *',
+                ],
+            ],
+            'titles' => [
+                'de' => 'Tiers',
+                'en' => 'Animals',
+            ],
+            'tags' => [
+                [
+                    'name' => 'test3',
+                    'priority' => null,
+                    'attributes' => [],
+                ],
+            ],
+            'schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'blocks' => [
+                        'type' => 'array',
+                        'items' => [
+                            'allOf' => [
+                                [
+                                    'if' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'type' => [
+                                                'const' => 'editor',
+                                            ],
+                                        ],
+                                        'required' => ['type'],
+                                    ],
+                                    'then' => [
+                                        'type' => [
+                                            'number',
+                                            'string',
+                                            'boolean',
+                                            'object',
+                                            'array',
+                                            'null',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'blocks_with_custom_settings_form_key' => [
+                        'type' => 'array',
+                        'items' => [
+                            'allOf' => [
+                                [
+                                    'if' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'type' => [
+                                                'const' => 'editor',
+                                            ],
+                                        ],
+                                        'required' => ['type'],
+                                    ],
+                                    'then' => [
+                                        'type' => [
+                                            'number',
+                                            'string',
+                                            'boolean',
+                                            'object',
+                                            'array',
+                                            'null',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'required' => [
+                    'title',
+                    'url',
+                ],
+            ],
+        ], $this->metadataToArray($formMetadata));
+    }
+
+    public function testLoadSnippetTemplate(): void
+    {
+        $formMetadata = $this->loader->load($this->getTemplatesDirectory() . '../snippets/default.xml');
+
+        $this->assertSame([
+            'template' => [
+                'controller' => null,
+                'view' => null,
+                'cacheLifetime' => null,
+            ],
+            'titles' => [
+                'de' => 'Tiers',
+                'en' => 'Animals',
+            ],
+            'tags' => [],
+            'schema' => [
+                'type' => 'object',
+                'required' => [
+                    0 => 'title',
+                ],
+            ],
+        ], $this->metadataToArray($formMetadata));
+    }
+
+    public function testLoadBlockTemplate(): void
+    {
+        $formMetadata = $this->loader->load($this->getTemplatesDirectory() . '../blocks/text_block.xml');
+
+        $this->assertSame([
+            'template' => [
+                'controller' => null,
+                'view' => null,
+                'cacheLifetime' => null,
+            ],
+            'titles' => [
+                'de' => 'Tiers',
+                'en' => 'Animals',
+            ],
+            'tags' => [],
+            'schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'blocks' => [
+                        'type' => 'array',
+                        'items' => [
+                            'allOf' => [
+                                [
+                                    'if' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'type' => [
+                                                'const' => 'text_block2',
+                                            ],
+                                        ],
+                                        'required' => [
+                                            'type',
+                                        ],
+                                    ],
+                                    'then' => [
+                                        '$ref' => '#/definitions/text_block2',
+                                    ],
+                                ],
+                                [
+                                    'if' => [
+                                        'type' => 'object',
+                                        'properties' => [
+                                            'type' => [
+                                                'const' => 'editor',
+                                            ],
+                                        ],
+                                        'required' => [
+                                            'type',
+                                        ],
+                                    ],
+                                    'then' => [
+                                        'type' => [
+                                            'number',
+                                            'string',
+                                            'boolean',
+                                            'object',
+                                            'array',
+                                            'null',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'required' => [
+                    'title',
+                ],
+            ],
+        ], $this->metadataToArray($formMetadata));
+    }
+
     /**
      * @return array<string, mixed>
      */
     private function metadataToArray(FormMetadata $formMetadata): array
     {
         return [
+            'template' => (function() use ($formMetadata) {
+                $template = $formMetadata->getTemplate();
+                if (null === $template) {
+                    return null;
+                }
+
+                return [
+                    'controller' => $template->getController(),
+                    'view' => $template->getView(),
+                    'cacheLifetime' => $template->getCacheLifetime() ? [
+                        'type' => $template->getCacheLifetime()->getType(),
+                        'value' => $template->getCacheLifetime()->getValue(),
+                    ] : null,
+                ];
+            })(),
             'titles' => [
                 'de' => 'Tiers',
                 'en' => 'Animals',

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/TemplateXmlParserTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/TemplateXmlParserTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Parser\TemplateXmlParser;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TemplateMetadata;
+
+class TemplateXmlParserTest extends TestCase
+{
+    private TemplateXmlParser $templateXmlParser;
+
+    protected function setUp(): void
+    {
+        $this->templateXmlParser = new TemplateXmlParser();
+    }
+
+    public function testParseDefault(): void
+    {
+        $resource = $this->getTemplatesDirectory() . 'default.xml';
+        $xpath = $this->loadXmlFile($resource);
+        $templateNode = ($xpath->query('/x:template') ?: null)?->item(0);
+        \assert(null !== $templateNode, 'Expected <template> be defined for "' . $resource . '".');
+
+        $templateMetadata = $this->templateXmlParser->load($xpath, $templateNode);
+
+        $this->assertSame([
+            'controller' => 'Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction',
+            'view' => 'ClientWebsiteBundle:templates:animals',
+            'cacheLifetime' => [
+                'type' => 'seconds',
+                'value' => '2400',
+            ],
+        ], $this->templateMetadataToArray($templateMetadata));
+    }
+
+    public function testParseOverview(): void
+    {
+        $resource = $this->getTemplatesDirectory() . 'overview.xml';
+        $xpath = $this->loadXmlFile($resource);
+        $templateNode = ($xpath->query('/x:template') ?: null)?->item(0);
+        \assert(null !== $templateNode, 'Expected <template> be defined for "' . $resource . '".');
+
+        $templateMetadata = $this->templateXmlParser->load($xpath, $templateNode);
+
+        $this->assertSame([
+            'controller' => 'SuluPageBundle:Default:index',
+            'view' => 'page',
+            'cacheLifetime' => [
+                'type' => 'expression',
+                'value' => '0 2 * * *',
+            ],
+        ], $this->templateMetadataToArray($templateMetadata));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function templateMetadataToArray(TemplateMetadata $templateMetadata): array
+    {
+        return [
+            'controller' => $templateMetadata->getController(),
+            'view' => $templateMetadata->getView(),
+            'cacheLifetime' => $templateMetadata->getCacheLifetime() ? [
+                'type' => $templateMetadata->getCacheLifetime()->getType(),
+                'value' => $templateMetadata->getCacheLifetime()->getValue(),
+            ] : null,
+        ];
+    }
+
+    private function loadXmlFile(string $resource): \DOMXPath
+    {
+        $xmlDocument = new \DOMDocument();
+        $xmlDocument->load($resource);
+
+        $xpath = new \DOMXPath($xmlDocument);
+        $xpath->registerNamespace('x', TemplateXmlLoader::SCHEMA_NAMESPACE_URI);
+
+        return $xpath;
+    }
+
+    private function getTemplatesDirectory(): string
+    {
+        return \dirname(__DIR__, 4) . \DIRECTORY_SEPARATOR
+            . 'Application' . \DIRECTORY_SEPARATOR . 'config' . \DIRECTORY_SEPARATOR . 'templates' . \DIRECTORY_SEPARATOR . 'pages' . \DIRECTORY_SEPARATOR;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7982
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add parsing of template metadata.

#### Why?

We want to get rid of the old structure metadata completly.

