### PR TITLE
Use new template metadata for ContentRouteDefaultsProvider

### DIFF
--- a/packages/content/config/services.xml
+++ b/packages/content/config/services.xml
@@ -98,7 +98,7 @@
         <service id="sulu_content.route_defaults_provider" class="Sulu\Content\Infrastructure\Sulu\Route\ContentRouteDefaultsProvider">
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="sulu_content.content_aggregator"/>
-            <argument type="service" id="sulu_content.content_structure_bridge_factory"/>
+            <argument type="service" id="sulu_admin.metadata_provider_registry"/>
             <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
 
             <tag name="sulu_route.route_defaults_provider" resource-key="examples"/>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2215,12 +2215,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
 
 		-
-			message: '#^Parameter \#1 \$schema of method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata\:\:merge\(\) expects Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/FormXmlLoader.php
-
-		-
 			message: '#^Cannot call method count\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -2229,12 +2223,6 @@ parameters:
 		-
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
-
-		-
-			message: '#^Parameter \#1 \$schema of method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata\:\:merge\(\) expects Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\SchemaMetadata, mixed given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
 
@@ -3304,12 +3292,6 @@ parameters:
 			message: '#^Cannot call method item\(\) on DOMNodeList\<DOMNode\>\|false\.$#'
 			identifier: method.nonObject
 			count: 3
-			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\SchemaXmlParser\:\:load\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/SchemaXmlParser.php
 
 		-

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TemplateXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/TemplateXmlParser.php
@@ -55,17 +55,21 @@ class TemplateXmlParser
     private function parseCacheLifeTime(\DOMNode $cacheLifeTimeNode): CacheLifetimeMetadata
     {
         $cacheLifeTimeValue = $cacheLifeTimeNode->nodeValue;
+        \assert(\is_string($cacheLifeTimeValue), 'The <cache_lifetime> value must be a "string", got "' . \get_debug_type($cacheLifeTimeValue) . '".');
+
         $cacheLifeTimeType =
-            $cacheLifeTimeNode->attributes?->getNamedItem('type')?->nodeValue
+            $cacheLifeTimeNode->attributes?->getNamedItem('type')->nodeValue
             ?? CacheLifetimeResolverInterface::TYPE_SECONDS;
 
-        \assert(
-            \in_array($cacheLifeTimeType, [
-                CacheLifetimeResolverInterface::TYPE_SECONDS,
-                CacheLifetimeResolverInterface::TYPE_EXPRESSION,
-            ]),
-            'The <cache_lifetime type="..."> must be one of the defined types (' . CacheLifetimeResolverInterface::TYPE_SECONDS . ', ' . CacheLifetimeResolverInterface::TYPE_EXPRESSION . '), got "' . $cacheLifeTimeType . '".',
-        );
+        \assert(\in_array($cacheLifeTimeType, [
+            CacheLifetimeResolverInterface::TYPE_SECONDS,
+            CacheLifetimeResolverInterface::TYPE_EXPRESSION,
+        ]), \sprintf(
+            'The <cache_lifetime type="..."> must be one of the defined types (%s, %s), got "%s".',
+            CacheLifetimeResolverInterface::TYPE_SECONDS,
+            CacheLifetimeResolverInterface::TYPE_EXPRESSION,
+            $cacheLifeTimeType,
+        ));
 
         return new CacheLifetimeMetadata($cacheLifeTimeType, $cacheLifeTimeValue);
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/TemplateXmlParserTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/TemplateXmlParserTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Parser;
 
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7987
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use new metadata for content controller.

#### Why?

Get rid of the old structure metadata.