### PR TITLE
Use new metadata for Preview ContentObjectProvider

### DIFF
--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -206,7 +206,7 @@ final class SuluArticleBundle extends AbstractBundle
         $services->set('sulu_article.article_preview_provider')
             ->class(ContentObjectProvider::class)
             ->args([
-                new Reference('sulu_content.content_structure_bridge_factory'),
+                new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_content.content_data_mapper'),

--- a/packages/content/tests/Application/ExampleTestBundle/Resources/config/services.yaml
+++ b/packages/content/tests/Application/ExampleTestBundle/Resources/config/services.yaml
@@ -83,7 +83,7 @@ services:
     example_test.example_preview_object_provider:
         class: Sulu\Content\Infrastructure\Sulu\Preview\ContentObjectProvider
         arguments:
-            - '@sulu_content.content_structure_bridge_factory'
+            - '@sulu_admin.metadata_provider_registry'
             - '@doctrine.orm.entity_manager'
             - '@sulu_content.content_aggregator'
             - '@sulu_content.content_data_mapper'

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Admin/ContentViewBuilderFactoryTest.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\FormViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\PreviewFormViewBuilderInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistry;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistryInterface;
@@ -45,7 +46,6 @@ use Sulu\Content\Domain\Model\WorkflowTrait;
 use Sulu\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactory;
 use Sulu\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface;
 use Sulu\Content\Infrastructure\Sulu\Preview\ContentObjectProvider;
-use Sulu\Content\Infrastructure\Sulu\Structure\ContentStructureBridgeFactory;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
@@ -92,14 +92,14 @@ class ContentViewBuilderFactoryTest extends TestCase
      * @return ContentObjectProvider<B, T>
      */
     protected function createContentObjectProvider(
-        ContentStructureBridgeFactory $contentStructureBridgeFactory,
+        MetadataProviderRegistry $metadataProviderRegistry,
         EntityManagerInterface $entityManager,
         ContentAggregatorInterface $contentAggregator,
         ContentDataMapperInterface $contentDataMapper,
         string $entityClass
     ): ContentObjectProvider {
         return new ContentObjectProvider(
-            $contentStructureBridgeFactory,
+            $metadataProviderRegistry,
             $entityManager,
             $contentAggregator,
             $contentDataMapper,
@@ -173,7 +173,6 @@ class ContentViewBuilderFactoryTest extends TestCase
     {
         $securityChecker = $this->prophesize(SecurityCheckerInterface::class);
 
-        $contentStructureBridgeFactory = $this->prophesize(ContentStructureBridgeFactory::class);
         $entityManager = $this->prophesize(EntityManagerInterface::class);
         $contentMetadataInspector = $this->prophesize(ContentMetadataInspectorInterface::class);
         $contentMetadataInspector->getDimensionContentClass(Example::class)
@@ -183,7 +182,7 @@ class ContentViewBuilderFactoryTest extends TestCase
         $contentDataMapper = $this->prophesize(ContentDataMapperInterface::class);
 
         $contentObjectProvider = $this->createContentObjectProvider(
-            $contentStructureBridgeFactory->reveal(),
+            new MetadataProviderRegistry(),
             $entityManager->reveal(),
             $contentAggregator->reveal(),
             $contentDataMapper->reveal(),

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -272,7 +272,7 @@ final class SuluPageBundle extends AbstractBundle
         $services->set('sulu_page.page_preview_provider')
             ->class(ContentObjectProvider::class)
             ->args([
-                new Reference('sulu_content.content_structure_bridge_factory'),
+                new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_content.content_data_mapper'),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7988
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use new metadata for Preview ContentObjectProvider.

#### Why?

Get rid of the old structure metadata.