### PR TITLE
Add disabled prop to single_icon_selection

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleIconSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleIconSelection.js
@@ -71,6 +71,7 @@ export default class SingleIconSelection extends React.Component<Props> {
                 } = {},
             } = {},
             value,
+            disabled,
         } = this.props;
 
         if (iconSet === undefined) {
@@ -80,6 +81,7 @@ export default class SingleIconSelection extends React.Component<Props> {
         return (
             <Fragment>
                 <SingleItemSelection
+                    disabled={!!disabled}
                     emptyText={translate('sulu_admin.single_icon_selection.select')}
                     id={value}
                     leftButton={{


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add disabled property to single_icon_selection

#### Why?

So disabledCondition is working on this content-type