### PR TITLE
Remove sulu class kernel parameters

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -562,6 +562,11 @@ Removed unused arguments:
 - `Sulu\Bundle\SecurityBundle\UserManager\UserManager::__construct` `$groupRepository` (4th argument) removed
 - `Sulu\Bundle\SecurityBundle\Admin\SecurityAdmin::__construct` `$urlGenerator` (3rd argument) removed
 
+Removed kernel parameters:
+
+- All `sulu_*.class` parameters for services where removed (use compilerpasses to replace class of a service definition)
+- Parameter `%permissions%` was replaced in favor of `%sulu_security.permissions%`
+
 ### Moved classes for 3.0:
 
 - `Sulu\Bundle\CoreBundle\ExpressionLanguage\ContainerExpressionLanguageProvider`: `Sulu\Bundle\AdminBundle\ExpressionLanguage\ContainerExpressionLanguageProvider`

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="sulu_admin.admin_controller.class">Sulu\Bundle\AdminBundle\Controller\AdminController</parameter>
-        <parameter key="sulu_admin.admin_pool.class">Sulu\Bundle\AdminBundle\Admin\AdminPool</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu_admin.admin_controller" class="%sulu_admin.admin_controller.class%" public="true">
+        <service id="sulu_admin.admin_controller" class="Sulu\Bundle\AdminBundle\Controller\AdminController" public="true">
             <argument type="service" id="router"/>
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="sulu_admin.admin_pool"/>
@@ -38,7 +33,7 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
-        <service id="sulu_admin.admin_pool" class="%sulu_admin.admin_pool.class%" public="true">
+        <service id="sulu_admin.admin_pool" class="Sulu\Bundle\AdminBundle\Admin\AdminPool" public="true">
             <tag name="sulu.context" context="admin"/>
         </service>
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/build.xml
@@ -2,31 +2,23 @@
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_core.build.builder.database.class">Sulu\Bundle\CoreBundle\Build\DatabaseBuilder</parameter>
-        <parameter key="sulu_core.build.builder.phpcr.class">Sulu\Bundle\CoreBundle\Build\PhpcrBuilder</parameter>
-        <parameter key="sulu_core.build.builder.phpcr_migrations.class">Sulu\Bundle\CoreBundle\Build\PhpcrMigrationsBuilder</parameter>
-        <parameter key="sulu_core.build.builder.fixtures.class">Sulu\Bundle\CoreBundle\Build\FixturesBuilder</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu_core.build.builder.database" class="%sulu_core.build.builder.database.class%">
+        <service id="sulu_core.build.builder.database" class="Sulu\Bundle\CoreBundle\Build\DatabaseBuilder">
             <tag name="massive_build.builder" />
         </service>
 
-        <service id="sulu_core.build.builder.phpcr" class="%sulu_core.build.builder.phpcr.class%">
+        <service id="sulu_core.build.builder.phpcr" class="Sulu\Bundle\CoreBundle\Build\PhpcrBuilder">
             <tag name="massive_build.builder" />
         </service>
 
-        <service id="sulu_core.build.builder.phpcr_migrations" class="%sulu_core.build.builder.phpcr_migrations.class%">
+        <service id="sulu_core.build.builder.phpcr_migrations" class="Sulu\Bundle\CoreBundle\Build\PhpcrMigrationsBuilder">
             <argument type="service" id="phpcr_migrations.migrator_factory"/>
             <argument type="service" id="phpcr_migrations.version_storage"/>
 
             <tag name="massive_build.builder" />
         </service>
 
-        <service id="sulu_core.build.builder.fixtures" class="%sulu_core.build.builder.fixtures.class%">
+        <service id="sulu_core.build.builder.fixtures" class="Sulu\Bundle\CoreBundle\Build\FixturesBuilder">
             <tag name="massive_build.builder" />
         </service>
     </services>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -2,57 +2,27 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu.content.path_cleaner.replacer_loader.file_locator.class">Symfony\Component\Config\FileLocator</parameter>
-        <parameter key="sulu.content.path_cleaner.replacer_loader.class">Sulu\Bundle\CoreBundle\DataFixtures\ReplacerXmlLoader</parameter>
-        <parameter key="sulu.content.path_cleaner.class">Sulu\Component\PHPCR\PathCleanup</parameter>
-        <parameter key="sulu.content.template_resolver.class">Sulu\Component\Content\Template\TemplateResolver</parameter>
-
-        <parameter key="sulu.content.mapper.class">Sulu\Component\Content\Mapper\ContentMapper</parameter>
-        <parameter key="sulu.content.structure_manager.class">Sulu\Component\Content\Compat\StructureManager</parameter>
-        <parameter key="sulu.content.webspace_structure_provider.class">Sulu\Component\Webspace\StructureProvider\WebspaceStructureProvider</parameter>
-
-        <parameter key="sulu.content.type_manager.class">Sulu\Component\Content\ContentTypeManager</parameter>
-        <parameter key="sulu.content.type.number.class">Sulu\Component\Content\Types\Number</parameter>
-        <parameter key="sulu.content.type.text_line.class">Sulu\Component\Content\Types\TextLine</parameter>
-        <parameter key="sulu.content.type.text_area.class">Sulu\Component\Content\Types\TextArea</parameter>
-        <parameter key="sulu.content.type.text_editor.class">Sulu\Component\Content\Types\TextEditor</parameter>
-        <parameter key="sulu.content.type.resource_locator.class">Sulu\Component\Content\Types\ResourceLocator</parameter>
-        <parameter key="sulu.content.type.link.class">Sulu\Component\Content\Types\Link</parameter>
-        <parameter key="sulu.content.type.single_icon_selection.class">Sulu\Component\Content\Types\SingleIconSelection</parameter>
-        <parameter key="sulu.content.type.block.class">Sulu\Component\Content\Types\BlockContentType</parameter>
-
-        <parameter key="sulu.content.resource_locator.mapper.phpcr.class">Sulu\Component\Content\Types\ResourceLocator\Mapper\PhpcrMapper</parameter>
-
-        <parameter key="sulu.content.query_executor.class">Sulu\Component\Content\Query\ContentQueryExecutor</parameter>
-
-        <parameter key="sulu.cache.warmer.structure.class">Sulu\Bundle\CoreBundle\Cache\StructureWarmer</parameter>
-
-        <parameter key="sulu.util.node_helper.class">Sulu\Component\Util\SuluNodeHelper</parameter>
-    </parameters>
-
     <services>
         <service id="sulu.content.slugger" class="Symfony\Component\String\Slugger\AsciiSlugger" />
 
-        <service id="sulu.content.path_cleaner.replacer_loader.file_locator" class="%sulu.content.path_cleaner.replacer_loader.file_locator.class%" synthetic="false">
+        <service id="sulu.content.path_cleaner.replacer_loader.file_locator" class="Symfony\Component\Config\FileLocator" synthetic="false">
         </service>
 
-        <service id="sulu.content.path_cleaner.replacer_loader" class="%sulu.content.path_cleaner.replacer_loader.class%" synthetic="false">
+        <service id="sulu.content.path_cleaner.replacer_loader" class="Sulu\Bundle\CoreBundle\DataFixtures\ReplacerXmlLoader" synthetic="false">
             <argument type="service" id="sulu.content.path_cleaner.replacer_loader.file_locator"/>
         </service>
 
-        <service id="sulu.content.path_cleaner" class="%sulu.content.path_cleaner.class%" public="true">
+        <service id="sulu.content.path_cleaner" class="Sulu\Component\PHPCR\PathCleanup" public="true">
             <argument type="collection" key="$replacers">
             </argument>
             <argument type="service" key="$slugger" id="sulu.content.slugger"/>
         </service>
         <service id="Sulu\Component\PHPCR\PathCleanupInterface" alias="sulu.content.path_cleaner"/>
 
-        <service id="sulu.content.template_resolver" public="false" class="%sulu.content.template_resolver.class%"/>
+        <service id="sulu.content.template_resolver" public="false" class="Sulu\Component\Content\Template\TemplateResolver"/>
 
         <!-- content mapper -->
-        <service id="sulu.content.mapper" class="%sulu.content.mapper.class%" public="true">
+        <service id="sulu.content.mapper" class="Sulu\Component\Content\Mapper\ContentMapper" public="true">
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="form.factory" />
@@ -71,12 +41,12 @@
         </service>
 
         <!-- content type manager -->
-        <service id="sulu.content.type_manager" class="%sulu.content.type_manager.class%" public="true">
+        <service id="sulu.content.type_manager" class="Sulu\Component\Content\ContentTypeManager" public="true">
             <argument type="service" id="service_container"/>
         </service>
 
         <!-- structure manager -->
-        <service id="sulu.content.structure_manager" class="%sulu.content.structure_manager.class%" public="true">
+        <service id="sulu.content.structure_manager" class="Sulu\Component\Content\Compat\StructureManager" public="true">
             <argument type="service" id="sulu_page.structure.factory" />
             <argument type="service" id="sulu_document_manager.document_inspector" />
             <argument type="service" id="sulu_page.compat.structure.legacy_property_factory" />
@@ -94,7 +64,7 @@
             <argument type="service" id="sulu.content.webspace_structure_provider.cache_adapter" />
         </service>
 
-        <service id="sulu.content.webspace_structure_provider" class="%sulu.content.webspace_structure_provider.class%" public="true">
+        <service id="sulu.content.webspace_structure_provider" class="Sulu\Component\Webspace\StructureProvider\WebspaceStructureProvider" public="true">
             <argument type="service" id="twig"/>
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu.content.webspace_structure_provider.cache"/>
@@ -102,7 +72,7 @@
 
         <!-- rlp mapper -->
         <service id="sulu.content.resource_locator.mapper.phpcr"
-                 class="%sulu.content.resource_locator.mapper.phpcr.class%" public="false">
+                 class="Sulu\Component\Content\Types\ResourceLocator\Mapper\PhpcrMapper" public="false">
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="sulu_document_manager.document_inspector"/>
@@ -148,40 +118,40 @@
         <service id="sulu.content.rlp.strategy.tree" alias="sulu.content.resource_locator.strategy.tree_leaf_edit"/>
 
         <!-- simple content types -->
-        <service id="sulu.content.type.number" class="%sulu.content.type.number.class%">
+        <service id="sulu.content.type.number" class="Sulu\Component\Content\Types\Number">
             <tag name="sulu_admin.property_metadata_mapper" type="number"/>
             <tag name="sulu.content.type" alias="number"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="true" />
         </service>
-        <service id="sulu.content.type.text_line" class="%sulu.content.type.text_line.class%">
+        <service id="sulu.content.type.text_line" class="Sulu\Component\Content\Types\TextLine">
             <tag name="sulu.content.type" alias="text_line"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="true" />
         </service>
-        <service id="sulu.content.type.text_area" class="%sulu.content.type.text_line.class%">
+        <service id="sulu.content.type.text_area" class="Sulu\Component\Content\Types\TextArea">
             <tag name="sulu.content.type" alias="text_area"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="true" />
         </service>
-        <service id="sulu.content.type.text_editor" class="%sulu.content.type.text_editor.class%">
+        <service id="sulu.content.type.text_editor" class="Sulu\Component\Content\Types\TextEditor">
             <argument type="service" id="sulu_markup.parser"/>
             <tag name="sulu.content.type" alias="text_editor"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="true" />
         </service>
-        <service id="sulu.content.type.resource_locator" class="%sulu.content.type.resource_locator.class%">
+        <service id="sulu.content.type.resource_locator" class="Sulu\Component\Content\Types\ResourceLocator">
             <tag name="sulu.content.type" alias="resource_locator"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
-        <service id="sulu.content.type.link" class="%sulu.content.type.link.class%">
+        <service id="sulu.content.type.link" class="Sulu\Component\Content\Types\Link">
             <argument type="service" id="sulu_markup.link_tag.provider_pool"/>
             <tag name="sulu.content.type" alias="link"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
-        <service id="sulu.content.type.single_icon_selection" class="%sulu.content.type.single_icon_selection.class%">
+        <service id="sulu.content.type.single_icon_selection" class="Sulu\Component\Content\Types\SingleIconSelection">
             <tag name="sulu.content.type" alias="single_icon_selection"/>
             <tag name="sulu.content.export" format="1.2.xliff" translate="true" />
         </service>
 
         <!-- complex content types -->
-        <service id="sulu.content.type.block" class="%sulu.content.type.block.class%">
+        <service id="sulu.content.type.block" class="Sulu\Component\Content\Types\BlockContentType">
             <argument type="service" id="sulu.content.type_manager"/>
             <argument type="service" id="sulu_admin.schema_metadata_provider"/>
             <argument type="tagged" tag="sulu_content.deprecated_block_visitor" />
@@ -226,20 +196,20 @@
         </service>
 
         <!-- content query -->
-        <service id="sulu.content.query_executor" class="%sulu.content.query_executor.class%">
+        <service id="sulu.content.query_executor" class="Sulu\Component\Content\Query\ContentQueryExecutor">
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="debug.stopwatch" on-invalid="null"/>
         </service>
 
         <!-- cache warmer for structures -->
-        <service id="sulu.cache.warmer.structure" class="%sulu.cache.warmer.structure.class%">
+        <service id="sulu.cache.warmer.structure" class="Sulu\Bundle\CoreBundle\Cache\StructureWarmer">
             <argument type="service" id="sulu.content.structure_manager" />
             <tag name="kernel.cache_warmer" />
         </service>
 
         <!-- sulu node helper -->
-        <service id="sulu.util.node_helper" class="%sulu.util.node_helper.class%" public="true">
+        <service id="sulu.util.node_helper" class="Sulu\Component\Util\SuluNodeHelper" public="true">
             <argument type="service" id="sulu_document_manager.default_session"/>
             <argument>%sulu.content.language.namespace%</argument>
             <argument type="collection">

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/localization.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/localization.xml
@@ -3,14 +3,8 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu.core.localization_manager.class">Sulu\Component\Localization\Manager\LocalizationManager</parameter>
-        <parameter key="sulu.core.localization_manager.core_provider.class">Sulu\Component\Localization\Provider\LocalizationProvider</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu.core.localization_manager" class="%sulu.core.localization_manager.class%" public="true"/>
+        <service id="sulu.core.localization_manager" class="Sulu\Component\Localization\Manager\LocalizationManager" public="true"/>
         <service id="Sulu\Component\Localization\Manager\LocalizationManagerInterface" alias="sulu.core.localization_manager"/>
     </services>
 </container>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/phpcr.xml
@@ -2,13 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu.phpcr.session.class">Sulu\Component\PHPCR\SessionManager\SessionManager</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu.phpcr.session" class="%sulu.phpcr.session.class%" public="true">
+        <service id="sulu.phpcr.session" class="Sulu\Component\PHPCR\SessionManager\SessionManager" public="true">
             <argument type="service" id="sulu_document_manager.default_session"/>
             <argument type="collection">
                 <argument key="base">%sulu.content.node_names.base%</argument>

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/geolocator.xml
@@ -1,29 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="sulu_location.geolocator.nominatim.class">Sulu\Bundle\LocationBundle\Geolocator\Service\NominatimGeolocator</parameter>
-        <parameter key="sulu_location.geolocator.google.class">Sulu\Bundle\LocationBundle\Geolocator\Service\GoogleGeolocator</parameter>
-        <parameter key="sulu_location.geolocator.mapquest.class">Sulu\Bundle\LocationBundle\Geolocator\Service\MapquestGeolocator</parameter>
-    </parameters>
-
     <services>
         <!-- Geolocator services -->
         <!-- * Nominatim * -->
-        <service id="sulu_location.geolocator.service.nominatim" class="%sulu_location.geolocator.nominatim.class%">
+        <service id="sulu_location.geolocator.service.nominatim" class="Sulu\Bundle\LocationBundle\Geolocator\Service\NominatimGeolocator">
             <argument type="service" id="http_client" />
             <argument>%sulu_location.geolocator.service.nominatim.endpoint%</argument>
             <argument>%sulu_location.geolocator.service.nominatim.api_key%</argument>
         </service>
 
         <!-- * Google * -->
-        <service id="sulu_location.geolocator.service.google" class="%sulu_location.geolocator.google.class%">
+        <service id="sulu_location.geolocator.service.google" class="Sulu\Bundle\LocationBundle\Geolocator\Service\GoogleGeolocator">
             <argument type="service" id="http_client" />
             <argument>%sulu_location.geolocator.service.google.api_key%</argument>
         </service>
 
         <!-- * Mapquest * -->
-        <service id="sulu_location.geolocator.service.mapquest" class="%sulu_location.geolocator.mapquest.class%">
+        <service id="sulu_location.geolocator.service.mapquest" class="Sulu\Bundle\LocationBundle\Geolocator\Service\MapquestGeolocator">
             <argument type="service" id="http_client" />
             <argument>%sulu_location.geolocator.service.mapquest.endpoint%</argument>
             <argument>%sulu_location.geolocator.service.mapquest.api_key%</argument>

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/services.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="sulu_location.content.type.location.class">Sulu\Bundle\LocationBundle\Content\Types\LocationContentType</parameter>
-    </parameters>
-
     <services>
         <!-- content-types -->
-        <service id="sulu_location.content.type.location" class="%sulu_location.content.type.location.class%">
+        <service id="sulu_location.content.type.location" class="Sulu\Bundle\LocationBundle\Content\Types\LocationContentType">
             <tag name="sulu.content.type" alias="location" />
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/search.xml
@@ -4,20 +4,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
     >
-    <parameters>
-        <parameter key="sulu_media.search.subscriber.structure_media.class">Sulu\Bundle\MediaBundle\Search\Subscriber\StructureMediaSearchSubscriber</parameter>
-        <parameter key="sulu_media.search.subscriber.media.class">Sulu\Bundle\MediaBundle\Search\Subscriber\MediaSearchSubscriber</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu_media.search.subscriber.structure_media" class="%sulu_media.search.subscriber.structure_media.class%" >
+        <service id="sulu_media.search.subscriber.structure_media" class="Sulu\Bundle\MediaBundle\Search\Subscriber\StructureMediaSearchSubscriber" >
             <argument type="service" id="sulu_media.media_manager" />
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>
             <argument>%sulu_media.search.default_image_format%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="sulu_media.search.subscriber.media" class="%sulu_media.search.subscriber.media.class%" >
+        <service id="sulu_media.search.subscriber.media" class="Sulu\Bundle\MediaBundle\Search\Subscriber\MediaSearchSubscriber" >
             <argument type="service" id="sulu_media.media_manager" />
             <argument type="service" id="massive_search.factory" />
             <argument>%sulu_media.format_manager.mime_types%</argument>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -1,29 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="sulu_media.admin.class">Sulu\Bundle\MediaBundle\Admin\MediaAdmin</parameter>
-        <parameter key="sulu_media.media_manager.class">Sulu\Bundle\MediaBundle\Media\Manager\MediaManager</parameter>
-        <parameter key="sulu_media.collection_repository.class">Sulu\Bundle\MediaBundle\Entity\CollectionRepository</parameter>
-        <parameter key="sulu_media.file_validator.class">Sulu\Bundle\MediaBundle\Media\FileValidator\FileValidator</parameter>
-        <parameter key="sulu_media.format_manager.class">Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManager</parameter>
-        <parameter key="sulu_media.format_cache_clearer.class">Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearer</parameter>
-        <parameter key="sulu_media.format_cache.class">Sulu\Bundle\MediaBundle\Media\FormatCache\LocalFormatCache</parameter>
-        <parameter key="sulu_media.image.converter.class">Sulu\Bundle\MediaBundle\Media\ImageConverter\ImagineImageConverter</parameter>
-        <parameter key="sulu_media.image.scaler.class">Sulu\Bundle\MediaBundle\Media\ImageConverter\Scaler\Scaler</parameter>
-        <parameter key="sulu_media.image.cropper.class">Sulu\Bundle\MediaBundle\Media\ImageConverter\Cropper\Cropper</parameter>
-        <parameter key="sulu_media.image.transformation_pool.class">Sulu\Bundle\MediaBundle\Media\ImageConverter\TransformationPool</parameter>
-        <parameter key="sulu_media.image.transformation.crop.class">Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\CropTransformation</parameter>
-        <parameter key="sulu_media.media_selection.class">Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType</parameter>
-        <parameter key="sulu_media.collection_manager.class">Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManager</parameter>
-        <parameter key="sulu_media.type_manager.class">Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManager</parameter>
-        <parameter key="sulu_media.format_options_manager.class">Sulu\Bundle\MediaBundle\Media\FormatOptions\FormatOptionsManager</parameter>
         <parameter key="sulu_media.collection_entity">Sulu\Bundle\MediaBundle\Entity\Collection</parameter>
         <parameter key="sulu_media.format_options_entity">Sulu\Bundle\MediaBundle\Entity\FormatOptions</parameter>
         <parameter key="sulu_media.entity.file_version_meta">Sulu\Bundle\MediaBundle\Entity\FileVersionMeta</parameter>
-        <parameter key="sulu_media.twig_extension.disposition_type.class">Sulu\Bundle\MediaBundle\Twig\DispositionTypeTwigExtension</parameter>
-        <parameter key="sulu_media.twig_extension.media.class">Sulu\Bundle\MediaBundle\Twig\MediaTwigExtension</parameter>
-        <parameter key="tmp">Sulu\Bundle\MediaBundle\Twig\MediaTwigExtension</parameter>
-        <parameter key="sulu_media.video_thumbnail_generator.class">Sulu\Bundle\MediaBundle\Media\Video\VideoThumbnailService</parameter>
     </parameters>
 
     <services>
@@ -155,7 +135,7 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
-        <service id="sulu_media.admin" class="%sulu_media.admin.class%">
+        <service id="sulu_media.admin" class="Sulu\Bundle\MediaBundle\Admin\MediaAdmin">
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
@@ -166,7 +146,7 @@
             <argument type="service" id="sulu_activity.activity_list_view_builder_factory" />
             <argument type="service" id="sulu_reference.reference_list_view_builder_factory" />
         </service>
-        <service id="sulu_media.collection_repository" class="%sulu_media.collection_repository.class%" public="true">
+        <service id="sulu_media.collection_repository" class="Sulu\Bundle\MediaBundle\Entity\CollectionRepository" public="true">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>
             <argument>%sulu_media.collection_entity%</argument>
             <call method="setAccessControlQueryEnhancer">
@@ -180,10 +160,9 @@
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>
             <argument>%sulu_media.entity.file_version_meta%</argument>
         </service>
-        <service id="sulu_media.file_validator" class="%sulu_media.file_validator.class%" />
-
-        <service id="sulu_media.format_cache_clearer" class="%sulu_media.format_cache_clearer.class%" />
-        <service id="sulu_media.format_cache" class="%sulu_media.format_cache.class%" public="true">
+        <service id="sulu_media.file_validator" class="Sulu\Bundle\MediaBundle\Media\FileValidator\FileValidator" />
+        <service id="sulu_media.format_cache_clearer" class="Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearer" />
+        <service id="sulu_media.format_cache" class="Sulu\Bundle\MediaBundle\Media\FormatCache\LocalFormatCache" public="true">
             <argument type="service" id="filesystem"/>
             <argument>%sulu_media.format_cache.path%</argument>
             <argument>%sulu_media.format_cache.media_proxy_path%</argument>
@@ -197,7 +176,7 @@
         <service id="sulu_media.adapter.imagick" class="Imagine\Imagick\Imagine" public="false"/>
         <service id="sulu_media.adapter.gmagick" class="Imagine\Gmagick\Imagine" public="false"/>
 
-        <service id="sulu_media.image.converter" class="%sulu_media.image.converter.class%">
+        <service id="sulu_media.image.converter" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\ImagineImageConverter">
             <argument type="service" id="sulu_media.adapter"/>
             <argument type="service" id="sulu_media.storage" />
             <argument type="service" id="sulu_media.image.media_extractor"/>
@@ -217,12 +196,12 @@
         </service>
 
         <service id="sulu_media.image.focus" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Focus\Focus"/>
-        <service id="sulu_media.image.scaler" class="%sulu_media.image.scaler.class%" />
-        <service id="sulu_media.image.cropper" class="%sulu_media.image.cropper.class%" />
+        <service id="sulu_media.image.scaler" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Scaler\Scaler" />
+        <service id="sulu_media.image.cropper" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Cropper\Cropper" />
 
-        <service id="sulu_media.image.transformation_pool" class="%sulu_media.image.transformation_pool.class%" />
+        <service id="sulu_media.image.transformation_pool" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\TransformationPool" />
 
-        <service id="sulu_media.image.transformation.crop" class="%sulu_media.image.transformation.crop.class%">
+        <service id="sulu_media.image.transformation.crop" class="Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\CropTransformation">
             <tag name="sulu_media.image.transformation" alias="crop" />
         </service>
 
@@ -253,7 +232,7 @@
             <tag name="sulu_media.image.transformation" alias="sharpen" />
         </service>
 
-        <service id="sulu_media.media_manager" class="%sulu_media.media_manager.class%" public="true">
+        <service id="sulu_media.media_manager" class="Sulu\Bundle\MediaBundle\Media\Manager\MediaManager" public="true">
             <argument type="service" id="sulu.repository.media" />
             <argument type="service" id="sulu_media.collection_repository" />
             <argument type="service" id="sulu.repository.user" />
@@ -284,7 +263,7 @@
             <tag name="sulu_media.media_properties_provider"/>
         </service>
 
-        <service id="sulu_media.type_manager" class="%sulu_media.type_manager.class%">
+        <service id="sulu_media.type_manager" class="Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManager">
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument>%sulu_media.media.types%</argument>
             <argument>%sulu_media.media.blocked_file_types%</argument>
@@ -297,7 +276,7 @@
             <argument>%sulu_media.format_options_entity%</argument>
         </service>
 
-        <service id="sulu_media.format_options_manager" class="%sulu_media.format_options_manager.class%" public="true">
+        <service id="sulu_media.format_options_manager" class="Sulu\Bundle\MediaBundle\Media\FormatOptions\FormatOptionsManager" public="true">
             <argument type="service" id="doctrine.orm.entity_manager" />
             <argument type="service" id="sulu_media.format_options_repository" />
             <argument type="service" id="sulu_media.media_manager" />
@@ -306,7 +285,7 @@
             <argument>%sulu_media.image.formats%</argument>
         </service>
 
-        <service id="sulu_media.format_manager" class="%sulu_media.format_manager.class%" public="true">
+        <service id="sulu_media.format_manager" class="Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManager" public="true">
             <argument type="service" id="sulu.repository.media" />
             <argument type="service" id="sulu_media.format_cache" />
             <argument type="service" id="sulu_media.image.converter" />
@@ -332,7 +311,7 @@
             <tag name="sulu.content.export" format="1.2.xliff" translate="false" />
         </service>
 
-        <service id="sulu_media.type.media_selection" class="%sulu_media.media_selection.class%">
+        <service id="sulu_media.type.media_selection" class="Sulu\Bundle\MediaBundle\Content\Types\MediaSelectionContentType">
             <argument type="service" id="sulu_media.media_manager"/>
             <argument type="service" id="sulu_media.reference_store.media"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer"/>
@@ -364,7 +343,7 @@
             <tag name="sulu_admin.property_metadata_mapper" type="image_map" />
         </service>
 
-        <service id="sulu_media.collection_manager" class="%sulu_media.collection_manager.class%" public="true">
+        <service id="sulu_media.collection_manager" class="Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManager" public="true">
             <argument type="service" id="sulu_media.collection_repository" />
             <argument type="service" id="sulu.repository.media" />
             <argument type="service" id="sulu_media.format_manager" />
@@ -377,17 +356,16 @@
             <argument>%sulu_security.permissions%</argument>
         </service>
 
-        <service id="sulu_media.twig_extension.disposition_type" class="%sulu_media.twig_extension.disposition_type.class%">
+        <service id="sulu_media.twig_extension.disposition_type" class="Sulu\Bundle\MediaBundle\Twig\DispositionTypeTwigExtension">
             <tag name="twig.extension"/>
         </service>
 
-        <service id="sulu_media.twig_extension.media" class="%sulu_media.twig_extension.media.class%">
+        <service id="sulu_media.twig_extension.media" class="Sulu\Bundle\MediaBundle\Twig\MediaTwigExtension">
             <argument type="service" id="sulu_media.media_manager"/>
-
             <tag name="twig.extension"/>
         </service>
 
-        <service id="sulu_media.video_thumbnail_generator" class="%sulu_media.video_thumbnail_generator.class%">
+        <service id="sulu_media.video_thumbnail_generator" class="Sulu\Bundle\MediaBundle\Media\Video\VideoThumbnailService">
             <argument type="service" id="sulu_media.ffmpeg" on-invalid="null"/>
         </service>
 

--- a/src/Sulu/Bundle/PageBundle/Resources/config/extension.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/extension.xml
@@ -2,15 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_page.extension.manager.class">Sulu\Component\Content\Extension\ExtensionManager</parameter>
-    </parameters>
-
     <services>
-
-        <service id="sulu_page.extension.manager" class="%sulu_page.extension.manager.class%" public="true" />
-
+        <service id="sulu_page.extension.manager" class="Sulu\Component\Content\Extension\ExtensionManager" public="true" />
     </services>
-
 </container>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/search.xml
@@ -3,15 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="sulu_page.search.metadata.provider.structure.class">Sulu\Bundle\PageBundle\Search\Metadata\StructureProvider</parameter>
-        <parameter key="sulu_page.search.event_subscriber.blame_timestamp.class">Sulu\Bundle\PageBundle\Search\EventSubscriber\BlameTimestampSubscriber</parameter>
-        <parameter key="sulu_page.search.event_subscriber.structure.class">Sulu\Bundle\PageBundle\Search\EventSubscriber\StructureSubscriber</parameter>
-        <parameter key="sulu_search.event_listener.hit.class">Sulu\Bundle\PageBundle\Search\EventListener\HitListener</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu_page.search.metadata.provider.structure" class="%sulu_page.search.metadata.provider.structure.class%">
+        <service id="sulu_page.search.metadata.provider.structure" class="Sulu\Bundle\PageBundle\Search\Metadata\StructureProvider">
             <argument type="service" id="massive_search.factory" />
             <argument type="service" id="sulu_document_manager.metadata_factory" />
             <argument type="service" id="sulu_page.structure.factory" />
@@ -21,7 +14,7 @@
         </service>
 
         <!-- Blame and Timestamp subscriber -->
-        <service id="sulu_page.search.event_subscriber.blame_timestamp" class="%sulu_page.search.event_subscriber.blame_timestamp.class%">
+        <service id="sulu_page.search.event_subscriber.blame_timestamp" class="Sulu\Bundle\PageBundle\Search\EventSubscriber\BlameTimestampSubscriber">
             <argument type="service" id="massive_search.factory" />
             <argument type="service" id="doctrine.orm.entity_manager" />
             <tag name="kernel.event_subscriber" />
@@ -36,12 +29,12 @@
             <tag name="massive_search.reindex.provider" id="sulu_structure"/>
         </service>
 
-        <service id="sulu_page.search.event_subscriber.structure" class="%sulu_page.search.event_subscriber.structure.class%">
+        <service id="sulu_page.search.event_subscriber.structure" class="Sulu\Bundle\PageBundle\Search\EventSubscriber\StructureSubscriber">
             <argument type="service" id="massive_search.search_manager" />
             <tag name="sulu_document_manager.event_subscriber" />
         </service>
 
-        <service id="sulu_search.event_listener.hit" class="%sulu_search.event_listener.hit.class%">
+        <service id="sulu_search.event_listener.hit" class="Sulu\Bundle\PageBundle\Search\EventListener\HitListener">
             <argument type="service" id="sulu_core.webspace.request_analyzer" />
             <tag name="kernel.event_listener" event="massive_search.hit" method="onHit" />
             <tag name="sulu.context" context="website"/>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/services.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="sulu_page.admin.class">Sulu\Bundle\PageBundle\Admin\PageAdmin</parameter>
-        <parameter key="sulu_page.node_repository.class">Sulu\Bundle\PageBundle\Repository\NodeRepository</parameter>
-        <parameter key="sulu_page.rl_repository.class">Sulu\Bundle\PageBundle\Repository\ResourceLocatorRepository</parameter>
-        <parameter key="sulu_page.extension.seo.class">Sulu\Bundle\PageBundle\Content\Structure\SeoStructureExtension</parameter>
-        <parameter key="sulu_page.extension.excerpt.class">Sulu\Bundle\PageBundle\Content\Structure\ExcerptStructureExtension</parameter>
-    </parameters>
     <services>
         <!-- admin class -->
-        <service id="sulu_page.admin" class="%sulu_page.admin.class%">
+        <service id="sulu_page.admin" class="Sulu\Bundle\PageBundle\Admin\PageAdmin">
             <tag name="sulu.admin"/>
             <tag name="sulu.context" context="admin"/>
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
@@ -45,7 +38,7 @@
         </service>
 
         <!-- nodes -->
-        <service id="sulu_page.node_repository" class="%sulu_page.node_repository.class%" public="true">
+        <service id="sulu_page.node_repository" class="Sulu\Bundle\PageBundle\Repository\NodeRepository" public="true">
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_security.user_manager"/>
@@ -57,7 +50,7 @@
         </service>
 
         <!-- resource locator -->
-        <service id="sulu_page.rl_repository" class="%sulu_page.rl_repository.class%" public="true">
+        <service id="sulu_page.rl_repository" class="Sulu\Bundle\PageBundle\Repository\ResourceLocatorRepository" public="true">
             <argument type="service" id="sulu.content.resource_locator.strategy_pool"/>
             <argument type="service" id="sulu.content.structure_manager"/>
         </service>
@@ -125,12 +118,12 @@
         </service>
 
         <!-- structure extension -->
-        <service id="sulu_page.extension.seo" class="%sulu_page.extension.seo.class%">
+        <service id="sulu_page.extension.seo" class="Sulu\Bundle\PageBundle\Content\Structure\SeoStructureExtension">
             <tag name="sulu.structure.extension"/>
         </service>
 
         <!-- structure extension -->
-        <service id="sulu_page.extension.excerpt" class="%sulu_page.extension.excerpt.class%">
+        <service id="sulu_page.extension.excerpt" class="Sulu\Bundle\PageBundle\Content\Structure\ExcerptStructureExtension">
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu.content.type_manager"/>
             <argument type="service" id="sulu_page.export.manager" />

--- a/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/smart_content.xml
@@ -1,37 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <!-- data provider -->
-        <parameter key="sulu_page.smart_content.data_provider_pool.class">Sulu\Component\SmartContent\DataProviderPool</parameter>
-
-        <!-- content provider -->
-        <parameter key="sulu_page.smart_content.data_provider.content.query_builder.class">Sulu\Component\Content\SmartContent\QueryBuilder</parameter>
-        <parameter key="sulu_page.smart_content.data_provider.page.class">Sulu\Component\Content\SmartContent\PageDataProvider</parameter>
-        <parameter key="sulu_page.smart_content.data_provider.content.proxy_factory.class">ProxyManager\Factory\LazyLoadingValueHolderFactory</parameter>
-
-        <!-- content type -->
-        <parameter key="sulu_page.smart_content.content_type.class">Sulu\Component\SmartContent\ContentType</parameter>
-    </parameters>
     <services>
         <!-- data provider -->
         <service id="sulu_page.smart_content.data_provider_pool"
-                 class="%sulu_page.smart_content.data_provider_pool.class%" public="true"/>
+                 class="Sulu\Component\SmartContent\DataProviderPool" public="true"/>
 
         <!-- content provider -->
         <service id="sulu_page.smart_content.data_provider.content.proxy_factory"
-                 class="%sulu_page.smart_content.data_provider.content.proxy_factory.class%">
+                 class="ProxyManager\Factory\LazyLoadingValueHolderFactory">
             <argument type="service" id="sulu_core.proxy_manager.configuration"/>
         </service>
         <service id="sulu_page.smart_content.data_provider.content.query_builder"
-                 class="%sulu_page.smart_content.data_provider.content.query_builder.class%" public="false">
+                 class="Sulu\Component\Content\SmartContent\QueryBuilder" public="false">
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_page.extension.manager"/>
             <argument type="service" id="sulu.phpcr.session"/>
             <argument>%sulu.content.language.namespace%</argument>
         </service>
         <service id="sulu_page.smart_content.data_provider.content"
-                 class="%sulu_page.smart_content.data_provider.page.class%">
+                 class="Sulu\Component\Content\SmartContent\PageDataProvider">
             <argument type="service" id="sulu_page.smart_content.data_provider.content.query_builder"/>
             <argument type="service" id="sulu.content.query_executor"/>
             <argument type="service" id="sulu_document_manager.document_manager"/>
@@ -48,7 +36,7 @@
         </service>
 
         <!-- content type -->
-        <service id="sulu_page.smart_content.content_type" class="%sulu_page.smart_content.content_type.class%">
+        <service id="sulu_page.smart_content.content_type" class="Sulu\Component\SmartContent\ContentType">
             <argument type="service" id="sulu_page.smart_content.data_provider_pool"/>
             <argument type="service" id="sulu_tag.tag_manager"/>
             <argument type="service" id="request_stack"/>

--- a/src/Sulu/Bundle/PersistenceBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Resources/config/services.xml
@@ -2,21 +2,14 @@
 <container xmlns="http://symfony.com/schema/dic/services"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu.persistence.event_subscriber.orm.timestampable.class">Sulu\Component\Persistence\EventSubscriber\ORM\TimestampableSubscriber</parameter>
-        <parameter key="sulu.persistence.event_subscriber.orm.user_blame.class">Sulu\Component\Persistence\EventSubscriber\ORM\UserBlameSubscriber</parameter>
-        <parameter key="sulu.persistence.event_subscriber.orm.metadata.class">Sulu\Component\Persistence\EventSubscriber\ORM\MetadataSubscriber</parameter>
-    </parameters>
-
     <services>
-        <service id="sulu.persistence.event_subscriber.orm.timestampable" class="%sulu.persistence.event_subscriber.orm.timestampable.class%">
+        <service id="sulu.persistence.event_subscriber.orm.timestampable" class="Sulu\Component\Persistence\EventSubscriber\ORM\TimestampableSubscriber">
             <tag name="doctrine.event_listener" event="loadClassMetadata"/>
             <tag name="doctrine.event_listener" event="preUpdate"/>
             <tag name="doctrine.event_listener" event="prePersist"/>
         </service>
 
-        <service id="sulu.persistence.event_subscriber.orm.user_blame" class="%sulu.persistence.event_subscriber.orm.user_blame.class%">
+        <service id="sulu.persistence.event_subscriber.orm.user_blame" class="Sulu\Component\Persistence\EventSubscriber\ORM\UserBlameSubscriber">
             <argument type="service" id="security.token_storage" on-invalid="null"/>
 
             <!-- Priority 50 as the MetadataLoader need to be before the ResolveTargetEntityListener of Doctrine -->
@@ -24,7 +17,7 @@
             <tag name="doctrine.event_listener" event="onFlush" priority="50"/>
         </service>
 
-        <service id="sulu.persistence.event_subscriber.orm.metadata" class="%sulu.persistence.event_subscriber.orm.metadata.class%">
+        <service id="sulu.persistence.event_subscriber.orm.metadata" class="Sulu\Component\Persistence\EventSubscriber\ORM\MetadataSubscriber">
             <argument>%sulu.persistence.objects%</argument>
             <!-- Priority 8000 as the MetadataLoader need to be before all other Doctrine listeners -->
             <tag name="doctrine.event_listener" event="loadClassMetadata" priority="8000" />

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/build.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/build.xml
@@ -2,18 +2,12 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_search.build.index.class">Sulu\Bundle\SearchBundle\Build\IndexBuilder</parameter>
-        <parameter key="sulu_search.build.init.class">Sulu\Bundle\SearchBundle\Build\InitBuilder</parameter>
-    </parameters>
-
     <services>
         <!-- build command -->
-        <service id="sulu_search.build.index" class="%sulu_search.build.index.class%">
+        <service id="sulu_search.build.index" class="Sulu\Bundle\SearchBundle\Build\IndexBuilder">
             <tag name="massive_build.builder"/>
         </service>
-        <service id="sulu_search.build.init" class="%sulu_search.build.init.class%">
+        <service id="sulu_search.build.init" class="Sulu\Bundle\SearchBundle\Build\InitBuilder">
             <tag name="massive_build.builder"/>
         </service>
     </services>

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/metadata.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/metadata.xml
@@ -2,19 +2,12 @@
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_search.metadata.driver.structure.class">Sulu\Bundle\SearchBundle\Search\Metadata\StructureDriver</parameter>
-    </parameters>
-
     <services>
-
-        <service id="sulu_search.metadata.driver.structure" class="%sulu_search.metadata.driver.structure.class%">
+        <service id="sulu_search.metadata.driver.structure" class="Sulu\Bundle\SearchBundle\Search\Metadata\StructureDriver">
             <argument type="service" id="massive_search.factory" />
             <argument type="service" id="sulu_document_manager.metadata_factory" />
             <argument type="service" id="sulu_page.structure.factory" />
             <tag name="massive_search.metadata.driver" />
         </service>
-
     </services>
 </container>

--- a/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
+++ b/src/Sulu/Bundle/SearchBundle/Resources/config/search.xml
@@ -2,15 +2,9 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_search.controller.search.class">Sulu\Bundle\SearchBundle\Controller\SearchController</parameter>
-        <parameter key="sulu_search.search.factory.class">Sulu\Bundle\SearchBundle\Search\Factory</parameter>
-    </parameters>
-
     <services>
         <!-- Controller -->
-        <service id="sulu_search.controller.search" class="%sulu_search.controller.search.class%" public="true">
+        <service id="sulu_search.controller.search" class="Sulu\Bundle\SearchBundle\Controller\SearchController" public="true">
             <argument type="service" id="massive_search.search_manager"/>
             <argument type="service" id="massive_search.metadata.provider.chain"/>
             <argument type="service" id="sulu_security.security_checker"/>
@@ -39,7 +33,7 @@
         </service>
 
         <!-- Custom factory -->
-        <service id="sulu_search.search.factory" class="%sulu_search.search.factory.class%"/>
+        <service id="sulu_search.search.factory" class="Sulu\Bundle\SearchBundle\Search\Factory"/>
 
         <service id="Sulu\Bundle\SearchBundle\Search\Converter\StructureConverter">
             <argument type="service" id="sulu_document_manager.document_manager"/>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -14,26 +14,7 @@
             <parameter key="security">1</parameter>
         </parameter>
 
-        <parameter key="permissions">%sulu_security.permissions%</parameter><!-- TODO deprecated -->
-
-        <parameter key="sulu_security.admin.class">Sulu\Bundle\SecurityBundle\Admin\SecurityAdmin</parameter>
-        <parameter key="sulu_security.authentication_entry_point.class">Sulu\Bundle\SecurityBundle\Security\AuthenticationEntryPoint</parameter>
-        <parameter key="sulu_security.authentication_handler.class">Sulu\Bundle\SecurityBundle\Security\AuthenticationHandler</parameter>
-        <parameter key="sulu_security.mask_converter.class">Sulu\Component\Security\Authorization\MaskConverter</parameter>
-        <parameter key="sulu_security.salt_generator.class">Sulu\Component\Security\Authentication\SaltGenerator</parameter>
-        <parameter key="sulu_security.token_generator.class">Sulu\Bundle\SecurityBundle\Util\TokenGenerator</parameter>
-        <parameter key="sulu_security.security_context_voter.class">Sulu\Component\Security\Authorization\SecurityContextVoter</parameter>
-        <parameter key="sulu_security.access_control_manager.class">Sulu\Component\Security\Authorization\AccessControl\AccessControlManager</parameter>
-        <parameter key="sulu_security.phpcr_access_control_provider.class">Sulu\Component\Security\Authorization\AccessControl\PhpcrAccessControlProvider</parameter>
-        <parameter key="sulu_security.doctrine_access_control_provider.class">Sulu\Component\Security\Authorization\AccessControl\DoctrineAccessControlProvider</parameter>
-        <parameter key="sulu_security.permission_controller.class">Sulu\Bundle\SecurityBundle\Controller\PermissionController</parameter>
-        <parameter key="sulu_security.user_repository.class">Sulu\Bundle\SecurityBundle\Entity\UserRepository</parameter>
-        <parameter key="sulu_security.user_setting_repository.class">Sulu\Bundle\SecurityBundle\Entity\UserSettingRepository</parameter>
-        <parameter key="sulu_security.user_repository_factory.class">Sulu\Component\Security\Authentication\UserRepositoryFactory</parameter>
-        <parameter key="sulu_security.build.user.class">Sulu\Bundle\SecurityBundle\Build\UserBuilder</parameter>
-        <parameter key="sulu_security.entity.role">Sulu\Bundle\SecurityBundle\Entity\Role</parameter>
         <parameter key="sulu_security.entity.user_setting">Sulu\Bundle\SecurityBundle\Entity\UserSetting</parameter>
-        <parameter key="sulu_security.profile_controller.class">Sulu\Bundle\SecurityBundle\Controller\ProfileController</parameter>
     </parameters>
 
     <services>
@@ -64,7 +45,7 @@
 
             <tag name="sulu.context" context="admin"/>
         </service>
-        <service id="sulu_security.admin" class="%sulu_security.admin.class%">
+        <service id="sulu_security.admin" class="Sulu\Bundle\SecurityBundle\Admin\SecurityAdmin">
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="translator"/>
@@ -87,32 +68,32 @@
 
         <service
             id="sulu_security.authentication_entry_point"
-            class="%sulu_security.authentication_entry_point.class%"
+            class="Sulu\Bundle\SecurityBundle\Security\AuthenticationEntryPoint"
         />
 
-        <service id="sulu_security.authentication_handler" class="%sulu_security.authentication_handler.class%">
+        <service id="sulu_security.authentication_handler" class="Sulu\Bundle\SecurityBundle\Security\AuthenticationHandler">
             <argument type="service" id="router"/>
             <argument>%sulu_security.two_factor_methods%</argument>
         </service>
 
-        <service id="sulu_security.mask_converter" class="%sulu_security.mask_converter.class%" public="true">
-            <argument>%permissions%</argument>
+        <service id="sulu_security.mask_converter" class="Sulu\Component\Security\Authorization\MaskConverter" public="true">
+            <argument>%sulu_security.permissions%</argument>
         </service>
 
-        <service id="sulu_security.salt_generator" class="%sulu_security.salt_generator.class%" public="true">
+        <service id="sulu_security.salt_generator" class="Sulu\Component\Security\Authentication\SaltGenerator" public="true">
         </service>
-        <service id="%sulu_security.salt_generator.class%" alias="sulu_security.salt_generator"/>
+        <service id="Sulu\Component\Security\Authentication\SaltGenerator" alias="sulu_security.salt_generator"/>
 
-        <service id="sulu_security.token_generator" class="%sulu_security.token_generator.class%" public="true">
+        <service id="sulu_security.token_generator" class="Sulu\Bundle\SecurityBundle\Util\TokenGenerator" public="true">
         </service>
 
-        <service id="sulu_security.security_context_voter" class="%sulu_security.security_context_voter.class%" public="false">
+        <service id="sulu_security.security_context_voter" class="Sulu\Component\Security\Authorization\SecurityContextVoter" public="false">
             <argument type="service" id="sulu_security.access_control_manager"/>
-            <argument>%permissions%</argument>
+            <argument>%sulu_security.permissions%</argument>
             <tag name="security.voter"/>
         </service>
 
-        <service id="sulu_security.access_control_manager" class="%sulu_security.access_control_manager.class%">
+        <service id="sulu_security.access_control_manager" class="Sulu\Component\Security\Authorization\AccessControl\AccessControlManager">
             <argument type="service" id="sulu_security.mask_converter"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="sulu_security.system_store"/>
@@ -130,14 +111,14 @@
 
         <service id="Sulu\Bundle\SecurityBundle\System\SystemStoreInterface" alias="sulu_security.system_store"/>
 
-        <service id="sulu_security.phpcr_access_control_provider" class="%sulu_security.phpcr_access_control_provider.class%">
+        <service id="sulu_security.phpcr_access_control_provider" class="Sulu\Component\Security\Authorization\AccessControl\PhpcrAccessControlProvider">
             <argument type="service" id="sulu_document_manager.document_manager"/>
             <argument type="service" id="sulu.repository.role"/>
-            <argument>%permissions%</argument>
+            <argument>%sulu_security.permissions%</argument>
             <tag name="sulu.access_control"/>
         </service>
 
-        <service id="sulu_security.doctrine_access_control_provider" class="%sulu_security.doctrine_access_control_provider.class%">
+        <service id="sulu_security.doctrine_access_control_provider" class="Sulu\Component\Security\Authorization\AccessControl\DoctrineAccessControlProvider">
             <argument type="service" id="doctrine.orm.default_entity_manager"/>
             <argument type="service" id="sulu.repository.role"/>
             <argument type="service" id="sulu.repository.access_control"/>
@@ -145,7 +126,7 @@
             <tag name="sulu.access_control"/>
         </service>
 
-        <service id="sulu_security.permission_controller" class="%sulu_security.permission_controller.class%" public="true">
+        <service id="sulu_security.permission_controller" class="Sulu\Bundle\SecurityBundle\Controller\PermissionController" public="true">
             <argument type="service" id="sulu_security.access_control_manager"/>
             <argument type="service" id="sulu_security.security_checker"/>
             <argument type="service" id="sulu.repository.role"/>
@@ -154,7 +135,7 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
-        <service id="sulu_security.profile_controller" class="%sulu_security.profile_controller.class%" public="true">
+        <service id="sulu_security.profile_controller" class="Sulu\Bundle\SecurityBundle\Controller\ProfileController" public="true">
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="doctrine.orm.default_entity_manager"/>
             <argument type="service" id="fos_rest.view_handler"/>
@@ -210,13 +191,13 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
-        <service id="sulu_security.user_setting_repository" class="%sulu_security.user_setting_repository.class%" public="true">
+        <service id="sulu_security.user_setting_repository" class="Sulu\Bundle\SecurityBundle\Entity\UserSettingRepository" public="true">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>
 
             <argument>%sulu_security.entity.user_setting%</argument>
         </service>
 
-        <service id="sulu_security.user_repository" class="%sulu_security.user_repository.class%" public="true">
+        <service id="sulu_security.user_repository" class="Sulu\Bundle\SecurityBundle\Entity\UserRepository" public="true">
             <factory service="doctrine.orm.entity_manager" method="getRepository"/>
 
             <argument>%sulu.model.user.class%</argument>
@@ -228,7 +209,7 @@
             <argument type="service" id="doctrine.orm.entity_manager"/>
         </service>
 
-        <service id="sulu_security.build.user" class="%sulu_security.build.user.class%">
+        <service id="sulu_security.build.user" class="Sulu\Bundle\SecurityBundle\Build\UserBuilder">
             <tag name="massive_build.builder" />
         </service>
 

--- a/src/Sulu/Bundle/TestBundle/Resources/config/test_user_provider.xml
+++ b/src/Sulu/Bundle/TestBundle/Resources/config/test_user_provider.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="sulu.test_user_provider.class">Sulu\Bundle\TestBundle\Testing\TestUserProvider</parameter>
-        <parameter key="sulu.test_voter.class">Sulu\Bundle\TestBundle\Testing\TestVoter</parameter>
-        <parameter key="sulu_test.test_user_repository.class">Sulu\Bundle\TestBundle\Entity\TestUserRepository</parameter>
-    </parameters>
     <services>
-        <service id="test_user_provider" class="%sulu.test_user_provider.class%" public="true">
+        <service id="test_user_provider" class="Sulu\Bundle\TestBundle\Testing\TestUserProvider" public="true">
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="sulu.repository.contact"/>
             <argument type="service" id="sulu.repository.user"/>
@@ -14,7 +9,7 @@
             <argument type="service" id="sulu_security.user_provider"/>
             <tag name="kernel.reset" method="reset"/>
         </service>
-        <service id="test_voter" class="%sulu.test_voter.class%" public="false">
+        <service id="test_voter" class="Sulu\Bundle\TestBundle\Testing\TestVoter" public="false">
             <tag name="security.voter"/>
         </service>
     </services>

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.xml
@@ -2,28 +2,6 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_website.admin.class">Sulu\Bundle\WebsiteBundle\Admin\WebsiteAdmin</parameter>
-        <parameter key="sulu_website.navigation_mapper.class">Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapper</parameter>
-        <parameter key="sulu_website.sitemap.class">Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGenerator</parameter>
-        <parameter key="sulu_website.twig.content_path.class">Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathTwigExtension</parameter>
-        <parameter key="sulu_website.twig.navigation.class">Sulu\Bundle\WebsiteBundle\Twig\Navigation\NavigationTwigExtension</parameter>
-        <parameter key="sulu_website.twig.navigation.memoized.class">Sulu\Bundle\WebsiteBundle\Twig\Navigation\MemoizedNavigationTwigExtension</parameter>
-        <parameter key="sulu_website.twig.sitemap.class">Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtension</parameter>
-        <parameter key="sulu_website.twig.sitemap.memoized.class">Sulu\Bundle\WebsiteBundle\Twig\Sitemap\MemoizedSitemapTwigExtension</parameter>
-        <parameter key="sulu_website.twig.content.class">Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension</parameter>
-        <parameter key="sulu_website.twig.content.memoized.class">Sulu\Bundle\WebsiteBundle\Twig\Content\MemoizedContentTwigExtension</parameter>
-        <parameter key="sulu_website.twig.util.class">Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension</parameter>
-        <parameter key="sulu_website.routing.portal_loader.class">Sulu\Bundle\WebsiteBundle\Routing\PortalLoader</parameter>
-        <parameter key="sulu_website.resolver.request_analyzer.class">Sulu\Bundle\WebsiteBundle\Resolver\RequestAnalyzerResolver</parameter>
-        <parameter key="sulu_website.resolver.structure.class">Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver</parameter>
-        <parameter key="sulu_website.resolver.parameter.class">Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolver</parameter>
-
-        <parameter key="sulu_website.navigation_mapper.query_builder.class">Sulu\Bundle\WebsiteBundle\Navigation\NavigationQueryBuilder</parameter>
-        <parameter key="sulu_website.sitemap.query_builder.class">Sulu\Bundle\WebsiteBundle\Sitemap\SitemapContentQueryBuilder</parameter>
-    </parameters>
-
     <services>
         <!-- controllers -->
         <service id="sulu_website.redirect_controller"
@@ -70,7 +48,7 @@
         </service>
 
         <!-- website admin -->
-        <service id="sulu_website.admin" class="%sulu_website.admin.class%">
+        <service id="sulu_website.admin" class="Sulu\Bundle\WebsiteBundle\Admin\WebsiteAdmin">
             <argument type="service" id="Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument type="service" id="sulu_security.security_checker" />
@@ -81,12 +59,12 @@
         </service>
 
         <!-- navigation mapper -->
-        <service id="sulu_website.navigation_mapper.query_builder" class="%sulu_website.navigation_mapper.query_builder.class%" public="false">
+        <service id="sulu_website.navigation_mapper.query_builder" class="Sulu\Bundle\WebsiteBundle\Navigation\NavigationQueryBuilder" public="false">
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_page.extension.manager"/>
             <argument>%sulu.content.language.namespace%</argument>
         </service>
-        <service id="sulu_website.navigation_mapper" class="%sulu_website.navigation_mapper.class%">
+        <service id="sulu_website.navigation_mapper" class="Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapper">
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu.content.query_executor"/>
             <argument type="service" id="sulu_website.navigation_mapper.query_builder"/>
@@ -96,12 +74,12 @@
         </service>
 
         <!-- sitemap generator -->
-        <service id="sulu_website.sitemap.query_builder" class="%sulu_website.sitemap.query_builder.class%" public="false">
+        <service id="sulu_website.sitemap.query_builder" class="Sulu\Bundle\WebsiteBundle\Sitemap\SitemapContentQueryBuilder" public="false">
             <argument type="service" id="sulu.content.structure_manager"/>
             <argument type="service" id="sulu_page.extension.manager"/>
             <argument>%sulu.content.language.namespace%</argument>
         </service>
-        <service id="sulu_website.sitemap" class="%sulu_website.sitemap.class%">
+        <service id="sulu_website.sitemap" class="Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGenerator">
             <argument type="service" id="sulu.content.query_executor"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_website.sitemap.query_builder"/>
@@ -109,7 +87,7 @@
         </service>
 
         <!-- twig extension: content path -->
-        <service id="sulu_website.twig.content_path" class="%sulu_website.twig.content_path.class%">
+        <service id="sulu_website.twig.content_path" class="Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathTwigExtension">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument>%kernel.environment%</argument>
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>
@@ -118,12 +96,12 @@
         </service>
 
         <!-- twig extension: navigation -->
-        <service id="sulu_website.twig.navigation" class="%sulu_website.twig.navigation.class%">
+        <service id="sulu_website.twig.navigation" class="Sulu\Bundle\WebsiteBundle\Twig\Navigation\NavigationTwigExtension">
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu_website.navigation_mapper"/>
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="null"/>
         </service>
-        <service id="sulu_website.twig.navigation.memoized" class="%sulu_website.twig.navigation.memoized.class%">
+        <service id="sulu_website.twig.navigation.memoized" class="Sulu\Bundle\WebsiteBundle\Twig\Navigation\MemoizedNavigationTwigExtension">
             <argument type="service" id="sulu_website.twig.navigation"/>
             <argument type="service" id="sulu_core.cache.memoize"/>
             <argument type="string">%sulu_website.navigation.cache.lifetime%</argument>
@@ -132,13 +110,13 @@
         </service>
 
         <!-- twig extension: sitemap -->
-        <service id="sulu_website.twig.sitemap" class="%sulu_website.twig.sitemap.class%">
+        <service id="sulu_website.twig.sitemap" class="Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtension">
             <argument type="service" id="sulu_website.sitemap"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument>%kernel.environment%</argument>
             <argument type="service" id="sulu_core.webspace.request_analyzer" on-invalid="ignore"/>
         </service>
-        <service id="sulu_website.twig.sitemap.memoized" class="%sulu_website.twig.sitemap.memoized.class%">
+        <service id="sulu_website.twig.sitemap.memoized" class="Sulu\Bundle\WebsiteBundle\Twig\Sitemap\MemoizedSitemapTwigExtension">
             <argument type="service" id="sulu_website.twig.sitemap"/>
             <argument type="service" id="sulu_core.cache.memoize"/>
             <argument type="string">%sulu_website.sitemap.cache.lifetime%</argument>
@@ -147,7 +125,7 @@
         </service>
 
         <!-- twig extension: content -->
-        <service id="sulu_website.twig.content" class="%sulu_website.twig.content.class%">
+        <service id="sulu_website.twig.content" class="Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension">
             <argument type="service" id="sulu.content.mapper"/>
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu.phpcr.session"/>
@@ -157,7 +135,7 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="request_stack"/>
         </service>
-        <service id="sulu_website.twig.content.memoized" class="%sulu_website.twig.content.memoized.class%">
+        <service id="sulu_website.twig.content.memoized" class="Sulu\Bundle\WebsiteBundle\Twig\Content\MemoizedContentTwigExtension">
             <argument type="service" id="sulu_website.twig.content"/>
             <argument type="service" id="sulu_core.cache.memoize"/>
             <argument type="string">%sulu_website.content.cache.lifetime%</argument>
@@ -166,24 +144,24 @@
         </service>
 
         <!-- twig extension: util -->
-        <service id="sulu_website.twig.util" class="%sulu_website.twig.util.class%">
+        <service id="sulu_website.twig.util" class="Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension">
             <tag name="twig.extension"/>
         </service>
 
         <!-- portal loader -->
-        <service id="sulu_website.routing.portal_loader" class="%sulu_website.routing.portal_loader.class%">
+        <service id="sulu_website.routing.portal_loader" class="Sulu\Bundle\WebsiteBundle\Routing\PortalLoader">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="file_locator"/>
 
             <tag name="routing.loader"/>
         </service>
 
-        <service id="sulu_website.resolver.structure" class="%sulu_website.resolver.structure.class%" public="true">
+        <service id="sulu_website.resolver.structure" class="Sulu\Bundle\WebsiteBundle\Resolver\StructureResolver" public="true">
             <argument type="service" id="sulu.content.type_manager" />
             <argument type="service" id="sulu_page.extension.manager"/>
         </service>
 
-        <service id="sulu_website.resolver.request_analyzer" class="%sulu_website.resolver.request_analyzer.class%">
+        <service id="sulu_website.resolver.request_analyzer" class="Sulu\Bundle\WebsiteBundle\Resolver\RequestAnalyzerResolver">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument>%kernel.environment%</argument>
         </service>
@@ -202,7 +180,7 @@
         <service id="Sulu\Bundle\WebsiteBundle\Resolver\TemplateAttributeResolverInterface"
                  alias="sulu_website.resolver.template_attribute"/>
 
-        <service id="sulu_website.resolver.parameter" class="%sulu_website.resolver.parameter.class%" public="true">
+        <service id="sulu_website.resolver.parameter" class="Sulu\Bundle\WebsiteBundle\Resolver\ParameterResolver" public="true">
             <argument type="service" id="sulu_website.resolver.structure"/>
             <argument type="service" id="sulu_website.resolver.request_analyzer"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager" />

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/website.xml
@@ -2,14 +2,9 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-
-    <parameters>
-        <parameter key="sulu_website.data_collector.sulu_collector.class">Sulu\Bundle\WebsiteBundle\DataCollector\SuluCollector</parameter>
-    </parameters>
-
     <services>
         <!-- request analyzer data collector -->
-        <service id="sulu_website.data_collector.sulu_collector" class="%sulu_website.data_collector.sulu_collector.class%">
+        <service id="sulu_website.data_collector.sulu_collector" class="Sulu\Bundle\WebsiteBundle\DataCollector\SuluCollector">
             <argument>%kernel.environment%</argument>
             <tag name="data_collector" template="@SuluWebsite/Profiler/layout.html.twig" id="sulu"/>
             <tag name="sulu.context" context="website"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7989, https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove sulu class class kernel parameters.

#### Why?

Class parameters are since long time not best practices for bundles because they make the build container bigger. Instead we replace all parameters and inline value.

https://symfony.com/doc/current/bundles/best_practices.html

This refactoring also helps us with moving forward removing old services and classes.