### PR TITLE
Remove old metadata usage in webspace manager service

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -400,7 +400,7 @@ now the primary means of interacting with the bundle.
 ### Metadata now locale independent
 
 The Sulu Metadata classes `ItemMetadata`, `SectionMetadata`, `FieldMetadata`, `OptionMetadata` and `FormMetadata` are
-now independent from the locale and contain all metadata for all locales this means setter and getter changed.
+now independent of the locale and contain all metadata for all locales this means setter and getter changed.
 
 ```diff
 // getter
@@ -504,6 +504,13 @@ DROP INDEX UNIQ_5CEC3EEAE25D857EC242628A1FA6DDA ON se_permissions;
 ALTER TABLE se_permissions DROP module;
 CREATE UNIQUE INDEX UNIQ_5CEC3EEAE25D857EA1FA6DDA ON se_permissions (context, idRoles);
 ```
+
+### The StructureMetadataFactory service removed
+
+The StructureMetadataFactory service was removed and replaced by the MetadataProviderRegistry.
+So a few constructor of specific classes has been changed:
+
+- `Sulu\Component\Webspace\Manager\WebspaceManager` 
 
 ### Removed deprecations for 3.0
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -43,7 +43,7 @@
             <argument>%kernel.environment%</argument>
             <argument>%router.request_context.host%</argument>
             <argument>%router.request_context.scheme%</argument>
-            <argument type="service" id="sulu_page.structure.factory" />
+            <argument type="service" id="sulu_admin.metadata_provider_registry" />
 
             <tag name="sulu.localization_provider"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? |  yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove old metadata usage in webspace manager service.

#### Why?

The old metadata where still used in the webspace manager here we need replace it also with the new metadata.