### PR TITLE
Disconnect admin controller from page bundle service

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -62,7 +62,7 @@ class AdminController
         private NavigationRegistry $navigationRegistry,
         private FieldTypeOptionRegistryInterface $fieldTypeOptionRegistry,
         private ContactManagerInterface $contactManager,
-        private DataProviderPoolInterface $dataProviderPool,
+        private ?DataProviderPoolInterface $dataProviderPool,
         private LinkProviderPoolInterface $linkProviderPool,
         private LocalizationManagerInterface $localizationManager,
         private string $environment,
@@ -142,7 +142,7 @@ class AdminController
                 'resources' => $this->resources,
                 'smartContent' => \array_map(function(DataProviderInterface $dataProvider) {
                     return $dataProvider->getConfiguration();
-                }, $this->dataProviderPool->getAll()),
+                }, $this->dataProviderPool?->getAll() ?? []),
                 'user' => $user,
                 'contact' => $contact,
                 'collaborationEnabled' => $this->collaborationEnabled,

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -14,7 +14,7 @@
             <argument type="service" id="sulu_admin.navigation_registry"/>
             <argument type="service" id="sulu_admin.field_type_option_registry"/>
             <argument type="service" id="sulu_contact.contact_manager" />
-            <argument type="service" id="sulu_page.smart_content.data_provider_pool" />
+            <argument type="service" id="sulu_page.smart_content.data_provider_pool" on-invalid="null" />
             <argument type="service" id="sulu_markup.link_tag.provider_pool"/>
             <argument type="service" id="sulu.core.localization_manager" />
             <argument>%kernel.environment%</argument>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs |  https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Disconnect admin controller from page bundle service.

#### Why?

The admin bundle should not relate on the page bundle services. For moving forward faster I did make it optional as @Prokyonn already work on the new smart content implementation.