### PR TITLE
Fix null issue when structure type is not found

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Reference/Provider/AbstractDocumentReferenceProvider.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Reference/Provider/AbstractDocumentReferenceProvider.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\DocumentManagerBundle\Reference\Provider;
 use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollector;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
 use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
+use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;
 use Sulu\Component\Content\Document\Behavior\ExtensionBehavior;
@@ -84,6 +85,9 @@ abstract class AbstractDocumentReferenceProvider implements DocumentReferencePro
         }
 
         $templateStructure = $this->structureManager->getStructure($document->getStructureType(), $this->getStructureType());
+        if (!$templateStructure instanceof StructureInterface) {
+            return;
+        }
 
         foreach ($templateStructure->getProperties(true) as $property) {
             $contentType = $this->contentTypeManager->get($property->getContentTypeName());

--- a/src/Sulu/Component/Content/Compat/StructureManagerInterface.php
+++ b/src/Sulu/Component/Content/Compat/StructureManagerInterface.php
@@ -24,7 +24,7 @@ interface StructureManagerInterface
      * @param string $key
      * @param string $type
      *
-     * @return StructureInterface
+     * @return StructureInterface|null
      */
     public function getStructure($key, $type = Structure::TYPE_PAGE);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| License | MIT

#### What's in this PR?

While upgrading one of our Sulu projects to 2.6, I ran into an issue executing the `sulu:reference:refresh` command:
```
12:23:40 CRITICAL  [console] Error thrown while running command "sulu:reference:refresh". Message: "Call to a member function getProperties() on null" ["exception" => Error { …},"command" => "sulu:reference:refresh","message" => "Call to a member function getProperties() on null"]
```

To fix this, I added an explicit type check to the logic in `AbstractDocumentReferenceProvider::updateReferences()`.

Also, I updated the doc clock comment of the `\Sulu\Component\Content\Compat\StructureManagerInterface::getStructure()` method to indicate that null can also be returned, as the logic in the `\Sulu\Component\Content\Compat\StructureManager` class does it when an exception happens. I don't feel this counts as a BC break, but your mileage may vary.
