### PR TITLE
Fix `SuluCollector` for profiler tab with new content structure

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49357,48 +49357,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
 
 		-
-			message: '#^Call to an undefined method Sulu\\Component\\Content\\Compat\\StructureInterface\:\:getContentLocales\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
-			message: '#^Call to an undefined method Sulu\\Component\\Content\\Compat\\StructureInterface\:\:getInternal\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
-			message: '#^Call to an undefined method Sulu\\Component\\Content\\Compat\\StructureInterface\:\:getIsShadow\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
-			message: '#^Call to an undefined method Sulu\\Component\\Content\\Compat\\StructureInterface\:\:getNavContexts\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
-			message: '#^Call to an undefined method Sulu\\Component\\Content\\Compat\\StructureInterface\:\:getOriginTemplate\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
-			message: '#^Call to an undefined method Sulu\\Component\\Content\\Compat\\StructureInterface\:\:getShadowBaseLanguage\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
-			message: '#^Call to an undefined method Sulu\\Component\\Content\\Compat\\StructureInterface\:\:getShadowLocales\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
 			message: '#^Cannot access offset ''environments'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 3
@@ -49411,26 +49369,8 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
 
 		-
-			message: '#^Cannot access offset ''structure'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
 			message: '#^Cannot call method toArray\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\DataCollector\\SuluCollector\:\:data\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\DataCollector\\SuluCollector\:\:data\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
 

--- a/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
@@ -11,10 +11,10 @@
 
 namespace Sulu\Bundle\WebsiteBundle\DataCollector;
 
-use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Webspace;
+use Sulu\Page\Domain\Model\PageDimensionContent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
@@ -26,12 +26,12 @@ class SuluCollector extends DataCollector
     ) {
     }
 
-    public function data($key)
+    public function data(string|int $key): mixed
     {
         return $this->data[$key] ?? null;
     }
 
-    public function collect(Request $request, Response $response, ?\Throwable $exception = null)
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
         if (!$request->attributes->has('_sulu')) {
             return;
@@ -76,33 +76,25 @@ class SuluCollector extends DataCollector
         $this->data['resource_locator_prefix'] = $requestAttributes->getAttribute('resourceLocatorPrefix');
 
         $structure = null;
-        if ($request->attributes->has('_route_params')) {
-            $params = $request->attributes->get('_route_params');
-            if (isset($params['structure'])) {
-                /** @var StructureInterface $structureObject */
-                $structureObject = $params['structure'];
+        if ($request->attributes->has('object')) {
+            $object = $request->attributes->get('object');
+            if ($object instanceof PageDimensionContent) {
+                $page = $object->getResource();
 
                 $structure = [
-                    'id' => $structureObject->getUuid(),
-                    'objectClass' => $structureObject::class,
-                    'path' => $structureObject->getPath(),
-                    'nodeType' => $structureObject->getNodeType(),
-                    'internal' => $structureObject->getInternal(),
-                    'nodeState' => $structureObject->getNodeState(),
-                    'published' => $structureObject->getPublished(),
-                    'publishedState' => $structureObject->getPublishedState(),
-                    'navContexts' => $structureObject->getNavContexts(),
-                    'shadowLocales' => $structureObject->getShadowLocales(),
-                    'contentLocales' => $structureObject->getContentLocales(),
-                    'shadowOn' => $structureObject->getIsShadow(),
-                    'shadowBaseLanguage' => $structureObject->getShadowBaseLanguage(),
-                    'template' => $structureObject->getKey(),
-                    'originTemplate' => $structureObject->getOriginTemplate(),
-                    'hasSub' => $structureObject->getHasChildren(),
-                    'creator' => $structureObject->getCreator(),
-                    'changer' => $structureObject->getChanger(),
-                    'created' => $structureObject->getCreated(),
-                    'changed' => $structureObject->getChanged(),
+                    'id' => $page->getUuid(),
+                    'class' => $page::class,
+                    'dimensionClass' => $object::class,
+                    'nodeState' => $object->getStage(),
+                    'locale' => $object->getLocale(),
+                    'navContexts' => $object->getNavigationContexts(),
+                    'published' => $object->getWorkflowPublished(),
+                    'ghostLocale' => $object->getGhostLocale(),
+                    'template' => $object->getTemplateKey(),
+                    'creator' => $page->getCreator(),
+                    'changer' => $page->getChanger(),
+                    'created' => $page->getCreated(),
+                    'changed' => $page->getChanged(),
                 ];
             }
         }
@@ -122,12 +114,12 @@ class SuluCollector extends DataCollector
         }
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'sulu';
     }
 
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }

--- a/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
@@ -11,10 +11,16 @@
 
 namespace Sulu\Bundle\WebsiteBundle\DataCollector;
 
+use Sulu\Component\Persistence\Model\AuditableInterface;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\Webspace;
-use Sulu\Page\Domain\Model\PageDimensionContent;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\ShadowInterface;
+use Sulu\Content\Domain\Model\TemplateInterface;
+use Sulu\Content\Domain\Model\WorkflowInterface;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
@@ -78,27 +84,52 @@ class SuluCollector extends DataCollector
         $structure = null;
         if ($request->attributes->has('object')) {
             $object = $request->attributes->get('object');
-            if ($object instanceof PageDimensionContent) {
-                $page = $object->getResource();
 
-                $structure = [
-                    'id' => $page->getUuid(),
-                    'class' => $page::class,
-                    'dimensionClass' => $object::class,
-                    'nodeState' => $object->getStage(),
-                    'locale' => $object->getLocale(),
-                    'navContexts' => $object->getNavigationContexts(),
-                    'published' => $object->getWorkflowPublished(),
-                    'ghostLocale' => $object->getGhostLocale(),
-                    'template' => $object->getTemplateKey(),
-                    'creator' => $page->getCreator(),
-                    'changer' => $page->getChanger(),
-                    'created' => $page->getCreated(),
-                    'changed' => $page->getChanged(),
-                ];
+            $structure = [];
+            if ($object instanceof DimensionContentInterface) {
+                $resource = $object->getResource();
+
+                $structure['id'] = $resource->getId();
+                $structure['class'] = $resource::class;
+                $structure['dimensionClass'] = $object::class;
+                $structure['nodeState'] = $object->getStage();
+                $structure['locale'] = $object->getLocale();
+                $structure['availableLocales'] = $object->getAvailableLocales();
+                $structure['ghostLocale'] = $object->getGhostLocale();
+
+                if ($resource instanceof AuditableInterface) {
+                    $structure['created'] = $this->renderUserAndTimeStamp($resource->getCreator(), $resource->getCreated());
+                    $structure['changed'] = $this->renderUserAndTimeStamp($resource->getChanger(), $resource->getChanged());
+                }
+            }
+
+            if ($object instanceof TemplateInterface) {
+                $structure['template'] = $object->getTemplateKey();
+            }
+
+            if ($object instanceof WorkflowInterface) {
+                $structure['published'] = $object->getWorkflowPublished();
+            }
+
+            if ($object instanceof PageDimensionContentInterface) {
+                $structure['navContexts'] = $object->getNavigationContexts();
+            }
+
+            if ($object instanceof ShadowInterface) {
+                $structure['shadowLocales'] = $object->getShadowLocales();
             }
         }
         $this->data['structure'] = $structure;
+    }
+
+    private function renderUserAndTimeStamp(?UserInterface $user, \DateTimeInterface $timestamp): string
+    {
+        $userName = '(unknown user)';
+        if (null !== $user) {
+            $userName = $user->getFullName();
+        }
+
+        return $userName . ' @ ' . $timestamp->format('Y-m-d H:i:s');
     }
 
     /**

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
@@ -96,19 +96,11 @@
     {% if collector.data('structure') %}
     <table>
         <tbody>
-            {{ self.table_row('id', collector.data('structure').id) }}
-            {{ self.table_row('class', collector.data('structure').class) }}
-            {{ self.table_row('dimensionClass', collector.data('structure').dimensionClass) }}
-            {{ self.table_row('nodeState', collector.data('structure').nodeState) }}
-            {{ self.table_row('locale', collector.data('structure').locale) }}
-            {{ self.table_row('published', collector.data('structure').published.format('Y-m-d H:i:s')) }}
-            {{ self.table_row('navContexts', collector.data('structure').navContexts) }}
-            {{ self.table_row('ghostLoacle', collector.data('structure').ghostLocale) }}
-            {{ self.table_row('template', collector.data('structure').template) }}
-            {{ self.table_row('creator', collector.data('structure').creator) }}
-            {{ self.table_row('changer', collector.data('structure').changer) }}
-            {{ self.table_row('created', collector.data('structure').created.format('Y-m-d H:i:s')) }}
-            {{ self.table_row('changed', collector.data('structure').changed.format('Y-m-d H:i:s')) }}
+            {% set structure = collector.data('structure') %}
+
+            {% for name, value in structure %}
+                {{ self.table_row(name, value) }}
+            {% endfor %}
         </tbody>
     </table>
     {% else %}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
@@ -4,7 +4,7 @@
     <?xml version="1.0" encoding="UTF-8"?>
     <svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <!-- Generator: Sketch 42 (36781) - http://www.bohemiancoding.com/sketch -->
-        <title>Artboard</title>
+        <title>Sulu</title>
         <desc>Created with Sketch.</desc>
         <defs></defs>
         <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -36,17 +36,15 @@
             <span>{{ collector.data('structure').template }}</span>
         </div>
         <div class="sf-toolbar-info-piece">
-            <b>Structure class</b>
-            <span>{{ collector.data('structure').objectClass }}</span>
+            <b>Class</b>
+            <span>{{ collector.data('structure').class }}</span>
         </div>
         {% endif %}
         <div class="sf-toolbar-info-piece">
             <b>Localization</b>
             <span>
                 {{ collector.data('localization') }}
-                {% if collector.data('structure') %}
-                ({{ collector.data('structure').shadowOn ? collector.data('structure').shadowBaseLanguage : 'no shadow' }})
-                {% endif %}
+                {% if collector.data('structure') %} ({{ collector.data('structure').locale }}) {% endif %}
             </span>
         </div>
     {% endset %}
@@ -94,6 +92,29 @@
         </div>
     </div>
 
+    <h2>Structure</h2>
+    {% if collector.data('structure') %}
+    <table>
+        <tbody>
+            {{ self.table_row('id', collector.data('structure').id) }}
+            {{ self.table_row('class', collector.data('structure').class) }}
+            {{ self.table_row('dimensionClass', collector.data('structure').dimensionClass) }}
+            {{ self.table_row('nodeState', collector.data('structure').nodeState) }}
+            {{ self.table_row('locale', collector.data('structure').locale) }}
+            {{ self.table_row('published', collector.data('structure').published.format('Y-m-d H:i:s')) }}
+            {{ self.table_row('navContexts', collector.data('structure').navContexts) }}
+            {{ self.table_row('ghostLoacle', collector.data('structure').ghostLocale) }}
+            {{ self.table_row('template', collector.data('structure').template) }}
+            {{ self.table_row('creator', collector.data('structure').creator) }}
+            {{ self.table_row('changer', collector.data('structure').changer) }}
+            {{ self.table_row('created', collector.data('structure').created.format('Y-m-d H:i:s')) }}
+            {{ self.table_row('changed', collector.data('structure').changed.format('Y-m-d H:i:s')) }}
+        </tbody>
+    </table>
+    {% else %}
+        No structure was found.
+    {% endif %}
+
     <h2>Webspace</h2>
     <table>
         <tbody>
@@ -110,34 +131,6 @@
             {% endfor %}
         </tbody>
     </table>
-    <h2>Structure</h2>
-    {% if collector.data('structure') %}
-    <table>
-        <tbody>
-            {{ self.table_row('id', collector.data('structure').id) }}
-            {{ self.table_row('class', collector.data('structure').objectClass) }}
-            {{ self.table_row('path', collector.data('structure').path) }}
-            {{ self.table_row('nodeType', collector.data('structure').nodeType) }}
-            {{ self.table_row('internal', collector.data('structure').internal ? 'yes' : 'no') }}
-            {{ self.table_row('nodeState', collector.data('structure').nodeState) }}
-            {{ self.table_row('published', collector.data('structure').published.format('Y-m-d H:i:s')) }}
-            {{ self.table_row('nodeState', collector.data('structure').nodeState) }}
-            {{ self.table_row('navContexts', collector.data('structure').navContexts) }}
-            {{ self.table_row('shadowLocales', collector.data('structure').shadowLocales) }}
-            {{ self.table_row('contentLocales', collector.data('structure').contentLocales) }}
-            {{ self.table_row('shadowOn', collector.data('structure').shadowOn ? 'yes' : 'no') }}
-            {{ self.table_row('shadowBaseLanguage', collector.data('structure').shadowBaseLanguage) }}
-            {{ self.table_row('template', collector.data('structure').template) }}
-            {{ self.table_row('has children', collector.data('structure').hasSub ? 'yes' : 'no') }}
-            {{ self.table_row('creator', collector.data('structure').creator) }}
-            {{ self.table_row('changer', collector.data('structure').changer) }}
-            {{ self.table_row('created', collector.data('structure').created.format('Y-m-d H:i:s')) }}
-            {{ self.table_row('changed', collector.data('structure').changed.format('Y-m-d H:i:s')) }}
-        </tbody>
-    </table>
-    {% else %}
-        No structure was found.
-    {% endif %}
 {% endblock %}
 
 {% macro table_row(field, value) %}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/DataCollector/SuluCollectorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/DataCollector/SuluCollectorTest.php
@@ -91,6 +91,7 @@ class SuluCollectorTest extends TestCase
 
         $this->attributes->has('_route_params')->willReturn(true)->shouldBeCalled();
         $this->attributes->get('_route_params')->willReturn(['structure' => $structure->reveal()])->shouldBeCalled();
+        $this->attributes->has('object')->willReturn(false);
 
         $webspace->toArray()->shouldBeCalled();
         $portal->toArray()->shouldBeCalled();

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/DataCollector/SuluCollectorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/DataCollector/SuluCollectorTest.php
@@ -89,8 +89,6 @@ class SuluCollectorTest extends TestCase
             ]
         ))->shouldBeCalled();
 
-        $this->attributes->has('_route_params')->willReturn(true)->shouldBeCalled();
-        $this->attributes->get('_route_params')->willReturn(['structure' => $structure->reveal()])->shouldBeCalled();
         $this->attributes->has('object')->willReturn(false);
 
         $webspace->toArray()->shouldBeCalled();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Updating collector in the Symfony profiler bar to use the new content entity.

#### Why?
Otherwise the profiler bar will just be empty.