### PR TITLE
Add debug 404 image for image converter errors

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -25,6 +25,7 @@ use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\InvalidMimeTypeForPreviewException;
 use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\ImageConverterInterface;
+use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -156,7 +157,7 @@ class FormatManager implements FormatManagerInterface
                     $formatKey
                 );
             }
-        } catch (ImageProxyException $e) {
+        } catch (IOException|ImageProxyException $e) {
             $this->logger->debug($e->getMessage(), ['exception' => $e]);
             $responseContent = null;
             $status = 404;
@@ -360,20 +361,20 @@ class FormatManager implements FormatManagerInterface
             }
         }
 
-        return \sprintf(
-            '<?xml version="1.0" encoding="utf-8"?>'
-            . '<svg xmlns="http://www.w3.org/2000/svg" width="%s" height="%s">' . \PHP_EOL
-            . '    <rect height="100%%" width="100%%" fill="silver"/>' . \PHP_EOL
-            . '    <text x="%s" y="%s" fill="white" text-anchor="middle" font-family="Monospace" font-size="%s" alignment-baseline="central">' . \PHP_EOL
-            . '        ERROR CODE: %s' . \PHP_EOL
-            . '    </text>' . \PHP_EOL
-            . '</svg>',
-            $x,
-            $y,
-            \ceil($x / 2),
-            \ceil($y / 2),
-            $x / 20,
-            $e->getCode()
-        );
+        $fontSize = $x / 20;
+        $textX = \ceil($x / 2);
+        $textY = \ceil($y / 2);
+        $textY2 = \ceil($textX + $fontSize * 1.5);
+        $errorCode = $e->getCode();
+
+        return <<<XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="$x" height="$y">
+                <rect height="100%" width="100%" fill="silver"/>
+                <text x="$textX" y="$textY" fill="white" text-anchor="middle" font-family="Monospace" font-size="$fontSize" alignment-baseline="central">
+                    ERROR CODE: $errorCode
+                </text>
+            </svg>
+            XML;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -61,7 +61,8 @@ class FormatManager implements FormatManagerInterface
         $saveImage,
         private $responseHeaders,
         private $formats,
-        ?LoggerInterface $logger = null
+        ?LoggerInterface $logger = null,
+        private bool $debug = false
     ) {
         $this->saveImage = 'true' == $saveImage ? true : false;
         $this->fileSystem = new Filesystem();
@@ -160,6 +161,11 @@ class FormatManager implements FormatManagerInterface
             $responseContent = null;
             $status = 404;
             $mimeType = null;
+
+            if ($this->debug) {
+                $mimeType = 'image/svg+xml';
+                $responseContent = $this->getNotFoundImage($formatKey, $e);
+            }
         }
 
         // Set header.
@@ -329,5 +335,45 @@ class FormatManager implements FormatManagerInterface
         }
 
         throw new ImageProxyMediaNotFoundException('Media file version was not found');
+    }
+
+    /**
+     * Get not found image.
+     */
+    private function getNotFoundImage(string $formatKey, \Exception $e): string
+    {
+        $x = 600;
+        $y = 350;
+
+        if (isset($this->formats[$formatKey])) {
+            $format = $this->formats[$formatKey];
+            $x = $format['scale']['x'];
+            $y = $format['scale']['y'];
+
+            // Render square image when only height or only width is given.
+            $x = $x ?: $y; // if x is empty use y as x
+            $y = $y ?: $x; // if y is empty use x as y
+
+            if ($format['scale']['retina']) {
+                $x = $x * 2;
+                $y = $y * 2;
+            }
+        }
+
+        return \sprintf(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            . '<svg xmlns="http://www.w3.org/2000/svg" width="%s" height="%s">' . \PHP_EOL
+            . '    <rect height="100%%" width="100%%" fill="silver"/>' . \PHP_EOL
+            . '    <text x="%s" y="%s" fill="white" text-anchor="middle" font-family="Monospace" font-size="%s" alignment-baseline="central">' . \PHP_EOL
+            . '        ERROR CODE: %s' . \PHP_EOL
+            . '    </text>' . \PHP_EOL
+            . '</svg>',
+            $x,
+            $y,
+            \ceil($x / 2),
+            \ceil($y / 2),
+            $x / 20,
+            $e->getCode()
+        );
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.php
@@ -385,6 +385,7 @@ return static function(ContainerConfigurator $container) {
             '%sulu_media.format_manager.response_headers%',
             '%sulu_media.image.formats%',
             new Reference('logger', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+            '%kernel.debug%',
         ]);
 
     $services->set('sulu_media.type.collection_selection', CollectionSelection::class)

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaStreamControllerTest.php
@@ -152,7 +152,7 @@ class MediaStreamControllerTest extends WebsiteTestCase
 
         $this->client->request('GET', $media->getFormats()['small-inset']);
 
-        $this->assertHttpStatusCode(500, $this->client->getResponse());
+        $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
 
     public function testGetImageAction(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | replaces #3706
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding an error image in debug with the error code.

#### Why?
Makes it clear to the user that the image is missing but still retains the aspect ratio of the image that should be there.