### PR TITLE
Migrate rest routings to default symfony routing files of CategoryBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -39,8 +39,7 @@ sulu_media_api:
     prefix: /admin/api
 
 sulu_category_api:
-    type: rest
-    resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
+    resource: "@SuluCategoryBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_snippet_api:

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -44,8 +44,7 @@ sulu_media_api:
     prefix: /admin/api
 
 sulu_category_api:
-    type: rest
-    resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
+    resource: "@SuluCategoryBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_snippet_api:

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,105 @@
+# Category
+sulu_category.get_category:
+    path: '/categories/{id}.{_format}'
+    methods: GET
+    controller: 'sulu_category.category_controller::getAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.get_categories:
+    path: '/categories.{_format}'
+    methods: GET
+    controller: 'sulu_category.category_controller::cgetAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.post_category:
+    path: '/categories.{_format}'
+    methods: POST
+    controller: 'sulu_category.category_controller::postAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.put_category:
+    path: '/categories/{id}.{_format}'
+    methods: PUT
+    controller: 'sulu_category.category_controller::putAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.patch_category:
+    path: '/categories/{id}.{_format}'
+    methods: PATCH
+    controller: 'sulu_category.category_controller::patchAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.delete_category:
+    path: '/categories/{id}.{_format}'
+    methods: DELETE
+    controller: 'sulu_category.category_controller::deleteAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.post_category_trigger:
+    path: '/categories/{id}.{_format}'
+    methods: POST
+    controller: 'sulu_category.category_controller::postTriggerAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+# Keyword
+sulu_category.get_category_keywords:
+    path: '/categories/{categoryId}/keywords.{_format}'
+    methods: GET
+    controller: 'sulu_category.keyword_controller::cgetAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.post_category_keyword:
+    path: '/categories/{categoryId}/keywords.{_format}'
+    methods: POST
+    controller: 'sulu_category.keyword_controller::postAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.get_category_keyword:
+    path: '/categories/{categoryId}/keywords/{id}.{_format}'
+    methods: GET
+    controller: 'sulu_category.keyword_controller::getAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.put_category_keyword:
+    path: '/categories/{categoryId}/keywords/{id}.{_format}'
+    methods: PUT
+    controller: 'sulu_category.keyword_controller::putAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.delete_category_keyword:
+    path: '/categories/{categoryId}/keywords/{id}.{_format}'
+    methods: DELETE
+    controller: 'sulu_category.keyword_controller::deleteAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_category.delete_category_keywords:
+    path: '/categories/{categoryId}/keywords.{_format}'
+    methods: DELETE
+    controller: 'sulu_category.keyword_controller::cdeleteAction'
+    format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/routing.yml
@@ -3,6 +3,5 @@ sulu_admin:
     prefix: /admin
 
 sulu_category_api:
-    resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluCategoryBundle/Resources/config/routing_api.yaml"
     prefix: /api


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7434
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Migrate rest routings to default symfony routing files of CategoryBundle

#### Why?

See https://github.com/sulu/sulu/issues/7434