### PR TITLE
Migrate rest routings to default symfony routing files of SnippetBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -43,8 +43,7 @@ sulu_category_api:
     prefix: /admin/api
 
 sulu_snippet_api:
-    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluSnippetBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_location:

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -48,8 +48,7 @@ sulu_category_api:
     prefix: /admin/api
 
 sulu_snippet_api:
-    resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluSnippetBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_location:

--- a/src/Sulu/Bundle/SnippetBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,81 @@
+# Snippet
+sulu_snippet.get_snippets:
+    path: '/snippets.{_format}'
+    methods: GET
+    controller: 'sulu_snippet.controller.snippet::cgetAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_snippet.get_snippet:
+    path: '/snippets/{id}.{_format}'
+    methods: GET
+    controller: 'sulu_snippet.controller.snippet::getAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_snippet.post_snippet:
+    path: '/snippets.{_format}'
+    methods: POST
+    controller: 'sulu_snippet.controller.snippet::postAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_snippet.put_snippet:
+    path: '/snippets/{id}.{_format}'
+    methods: PUT
+    controller: 'sulu_snippet.controller.snippet::putAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_snippet.delete_snippet:
+    path: '/snippets/{id}.{_format}'
+    methods: DELETE
+    controller: 'sulu_snippet.controller.snippet::deleteAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_snippet.post_snippet_trigger:
+    path: '/snippets/{id}.{_format}'
+    methods: POST
+    controller: 'sulu_snippet.controller.snippet::postTriggerAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+# Snippet Areas
+sulu_snippet.get_snippet-areas:
+    path: '/snippet-areas.{_format}'
+    methods: GET
+    controller: 'sulu_snippet.snippet_area_controller::cgetAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_snippet.put_snippet-area:
+    path: '/snippet-areas/{key}.{_format}'
+    methods: PUT
+    controller: 'sulu_snippet.snippet_area_controller::putAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_snippet.delete_snippet-area:
+    path: '/snippet-areas/{key}.{_format}'
+    methods: DELETE
+    controller: 'sulu_snippet.snippet_area_controller::deleteAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_snippet.get_languages:
+    path: '/languages.{_format}'
+    methods: GET
+    controller: 'sulu_snippet.language_controller::cgetAction'
+    format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Application/config/routing.yml
@@ -1,7 +1,6 @@
 sulu_snippet:
-    type: rest
     prefix: /api
-    resource: '@SuluSnippetBundle/Resources/config/routing_api.yml'
+    resource: '@SuluSnippetBundle/Resources/config/routing_api.yaml'
 
 sulu_media_website:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yaml"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7434
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Migrate rest routings to default symfony routing files of SnippetBundle

#### Why?

See https://github.com/sulu/sulu/issues/7434