### PR TITLE
Migrate rest routings to default symfony routing files of CoreBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -59,8 +59,7 @@ sulu_website_api:
     prefix: /admin/api
 
 sulu_core:
-    type: rest
-    resource: "@SuluCoreBundle/Resources/config/routing_api.yml"
+    resource: "@SuluCoreBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_custom_urls_api:

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -64,8 +64,7 @@ sulu_website_api:
     prefix: /admin/api
 
 sulu_core:
-    type: rest
-    resource: "@SuluCoreBundle/Resources/config/routing_api.yml"
+    resource: "@SuluCoreBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_custom_urls_api:

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,7 @@
+sulu_core.get_localizations:
+    path: '/localizations.{_format}'
+    methods: GET
+    controller: 'sulu_core.localization_controller::cgetAction'
+    format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/CoreBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Application/config/routing.yml
@@ -1,4 +1,3 @@
 sulu_core:
-    type: rest
-    resource: "@SuluCoreBundle/Resources/config/routing_api.yml"
+    resource: "@SuluCoreBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7434
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Migrate rest routings to default symfony routing files of CoreBundle.

#### Why?

See https://github.com/sulu/sulu/issues/7434