### PR TITLE
Migrate rest routings to default symfony routing files of RouteBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -67,8 +67,7 @@ sulu_custom_urls_api:
     prefix: /admin/api
 
 sulu_route_api:
-    type: rest
-    resource: "@SuluRouteBundle/Resources/config/routing_api.yml"
+    resource: "@SuluRouteBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview:

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -72,8 +72,7 @@ sulu_custom_urls_api:
     prefix: /admin/api
 
 sulu_route_api:
-    type: rest
-    resource: "@SuluRouteBundle/Resources/config/routing_api.yml"
+    resource: "@SuluRouteBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_preview:

--- a/src/Sulu/Bundle/RouteBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/RouteBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,23 @@
+sulu_routes.post_route:
+    path: '/routes.{_format}'
+    methods: POST
+    controller: 'sulu_route.route_controller::postAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_routes.get_routes:
+    path: '/routes.{_format}'
+    methods: GET
+    controller: 'sulu_route.route_controller::cgetAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_routes.delete_routes:
+    path: '/routes.{_format}'
+    methods: DELETE
+    controller: 'sulu_route.route_controller::cdeleteAction'
+    format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/RouteBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Application/config/routing.yml
@@ -1,4 +1,3 @@
 sulu_route_api:
-    resource: "@SuluRouteBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluRouteBundle/Resources/config/routing_api.yaml"
     prefix: /api


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7434
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Migrate rest routings to default symfony routing files of RouteBundle.

#### Why?

See https://github.com/sulu/sulu/issues/7434