### PR TITLE
Migrate rest routings to default symfony routing files of AudienceTargetingBundle

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -96,6 +96,5 @@ sulu_trash_api:
 
 # additional bundles
 sulu_audience_targeting_api:
-    type: rest
-    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_api.yml"
+    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -92,8 +92,7 @@ sulu_search:
     prefix: /admin/search
 
 sulu_audience_targeting_api:
-    type: rest
-    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_api.yml"
+    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
 
 sulu_activity_api:

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/routing_api.yaml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/routing_api.yaml
@@ -1,0 +1,47 @@
+sulu_audience_targeting.get_target-groups:
+    path: '/target-groups.{_format}'
+    methods: GET
+    controller: 'sulu_audience_targeting.target_group_controller::cgetAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_audience_targeting.get_target-group:
+    path: '/target-groups/{id}.{_format}'
+    methods: GET
+    controller: 'sulu_audience_targeting.target_group_controller::getAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_audience_targeting.post_target-group:
+    path: '/target-groups.{_format}'
+    methods: POST
+    controller: 'sulu_audience_targeting.target_group_controller::postAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_audience_targeting.put_target-group:
+    path: '/target-groups/{id}.{_format}'
+    methods: PUT
+    controller: 'sulu_audience_targeting.target_group_controller::putAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_audience_targeting.delete_target-group:
+    path: '/target-groups/{id}.{_format}'
+    methods: DELETE
+    controller: 'sulu_audience_targeting.target_group_controller::deleteAction'
+    format: json
+    requirements:
+        _format: json|csv
+
+sulu_audience_targeting.delete_target-groups:
+    path: '/target-groups.{_format}'
+    methods: DELETE
+    controller: 'sulu_audience_targeting.target_group_controller::cdeleteAction'
+    format: json
+    requirements:
+        _format: json|csv

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/routing_website.yaml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/routing_website.yaml
@@ -1,0 +1,7 @@
+sulu_audience_targeting.target_group:
+    path: "%sulu_audience_targeting.url%"
+    controller: sulu_audience_targeting.target_group_evaluation_controller::targetGroupAction
+
+sulu_audience_targeting.target_group_hit:
+    path: "%sulu_audience_targeting.hit.url%"
+    controller: sulu_audience_targeting.target_group_evaluation_controller::targetGroupHitAction

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_admin.yml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_admin.yml
@@ -3,8 +3,7 @@ sulu_admin:
     prefix: /admin
 
 sulu_category_api:
-    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_api.yml"
-    type: rest
+    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_api.yaml"
     prefix: /api
 
 # The following route are necessary to get AdminController::configAction work.

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_website.yml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_website.yml
@@ -9,4 +9,4 @@ caching_test_homepage:
         reverseProxyTtl: 60
 
 sulu_audience_targeting:
-    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_website.yml"
+    resource: "@SuluAudienceTargetingBundle/Resources/config/routing_website.yaml"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7434
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Migrate rest routings to default symfony routing files of AudienceTargetingBundle.

#### Why?

See https://github.com/sulu/sulu/issues/7434