### PR TITLE
Add yaml routing files for all existing yml routes

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -47,11 +47,11 @@ sulu_snippet_api:
     prefix: /admin/api
 
 sulu_location:
-    resource: "@SuluLocationBundle/Resources/config/routing.yml"
+    resource: "@SuluLocationBundle/Resources/config/routing.yaml"
     prefix: /admin/location
 
 sulu_website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /admin/website
 
 sulu_website_api:

--- a/config/routes/sulu_website.yaml
+++ b/config/routes/sulu_website.yaml
@@ -6,9 +6,9 @@ sulu_search:
     resource: "@SuluSearchBundle/Resources/config/routing_website.yaml"
 
 sulu_website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing_website.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing_website.yaml"
 
 when@dev:
     _portal_errors:
-        resource: "@SuluWebsiteBundle/Resources/config/routing_error.yml"
+        resource: "@SuluWebsiteBundle/Resources/config/routing_error.yaml"
         type: portal

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -52,11 +52,11 @@ sulu_snippet_api:
     prefix: /admin/api
 
 sulu_location:
-    resource: "@SuluLocationBundle/Resources/config/routing.yml"
+    resource: "@SuluLocationBundle/Resources/config/routing.yaml"
     prefix: /admin/location
 
 sulu_website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /admin/website
 
 sulu_website_api:

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_admin.yml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/routing_admin.yml
@@ -25,7 +25,7 @@ sulu_security_api:
     prefix: /admin/api
 
 sulu_website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /admin
 
 sulu_preview_api:

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/routing.yml
@@ -15,7 +15,7 @@ sulu_security_api:
 
 sulu_website:
     type: rest
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /admin
 
 sulu_preview:

--- a/src/Sulu/Bundle/LocationBundle/Resources/config/routing.yaml
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/routing.yaml
@@ -1,0 +1,3 @@
+sulu_location.geolocator_query:
+    path: /geolocator
+    controller: sulu_location.controller.geolocator::queryAction

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing_admin.yml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/routing_admin.yml
@@ -30,7 +30,7 @@ sulu_security_api:
 
 sulu_website:
     type: rest
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /admin
 
 sulu_preview:

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/routing.yml
@@ -36,5 +36,5 @@ sulu_preview_public:
 
 sulu_website:
     type: rest
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /admin

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/routing.yml
@@ -23,7 +23,7 @@ sulu_preview_public:
     prefix: /admin/p
 
 sulu_website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /admin
 
 sulu_media:

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing.yaml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing.yaml
@@ -1,0 +1,4 @@
+sulu_website.cache.remove:
+    path: /cache
+    controller: sulu_website.cache_controller::clearAction
+    methods: DELETE

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yaml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yaml
@@ -1,0 +1,3 @@
+_errors:
+    resource: "@FrameworkBundle/Resources/config/routing/errors.xml"
+    prefix:   /_error

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_website.yaml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_website.yaml
@@ -1,0 +1,16 @@
+sulu_website.sitemap_index:
+    path: /sitemap.xml
+    controller: sulu_website.sitemap_controller::indexAction
+
+sulu_website.paginated_sitemap:
+    path: /sitemaps/{alias}-{page}.xml
+    controller: sulu_website.sitemap_controller::sitemapPaginatedAction
+    requirements: {page: \d+}
+
+sulu_website.sitemap:
+    path: /sitemaps/{alias}.xml
+    controller: sulu_website.sitemap_controller::sitemapAction
+
+sulu_website.segment_switch:
+    path: '%sulu_website.segment_switch_url%'
+    controller: sulu_website.segment_controller::switchAction

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_admin.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_admin.yml
@@ -1,5 +1,5 @@
 sulu_website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /sulu_website
 
 sulu_page_api:
@@ -11,7 +11,7 @@ sulu_website_api:
     prefix: /api
 
 sulu_website.website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing_website.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing_website.yaml"
 
 sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yaml"

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_website.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/routing_website.yml
@@ -1,13 +1,13 @@
 sulu_website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing.yaml"
     prefix: /sulu_website
 
 _portal_errors:
-    resource: "@SuluWebsiteBundle/Resources/config/routing_error.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing_error.yaml"
     type: portal
 
 sulu_website.website:
-    resource: "@SuluWebsiteBundle/Resources/config/routing_website.yml"
+    resource: "@SuluWebsiteBundle/Resources/config/routing_website.yaml"
 
 sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yaml"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/7434
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add yaml routing files for all existing yml routes.

#### Why?

Symfony uses .yaml and the upgrade for https://github.com/sulu/sulu/issues/7434 is a lot easier as it search and replace `.yaml` and remove `type: rest`