### PR TITLE
Ignore keys in FOSJSRoutingControllerTest

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/FOSJSRoutingControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/FOSJSRoutingControllerTest.php
@@ -39,10 +39,15 @@ class FOSJSRoutingControllerTest extends SuluTestCase
         $this->assertIsArray($json);
         $this->assertArrayHasKey('routes', $json);
 
-        $routes = \array_keys($json['routes']);
-        \sort($routes);
+        $routes = [];
+        foreach (\array_keys($json['routes']) as $route) {
+            $routes[$route] = $route;
+        }
+        \ksort($routes);
 
-        $this->assertSame([
+        $expectedRoutes = [];
+
+        foreach ([
             'sulu_activity.get_activities',
             'sulu_admin.metadata',
             'sulu_admin.put_collaborations',
@@ -122,6 +127,10 @@ class FOSJSRoutingControllerTest extends SuluTestCase
             'sulu_trash.get_trash-items',
             'sulu_website.cget_webspace_analytics',
             'sulu_website.get_webspace_analytics',
-        ], $routes);
+        ] as $routeName) {
+            $expectedRoutes[$routeName] = $routeName;
+        }
+
+        $this->assertSame($expectedRoutes, $routes);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Ignore keys in FOSJSRoutingControllerTest.

#### Why?

This test was kind of hard to debug if something was missing.

Before:

![Bildschirmfoto 2025-06-10 um 13 52 31](https://github.com/user-attachments/assets/c76961d2-bd02-4691-88fe-230f252f7f13)


After:

<img width="973" alt="Bildschirmfoto 2025-06-10 um 13 50 49" src="https://github.com/user-attachments/assets/f509bb25-a57a-44be-a003-78433d320a7d" />

