### PR TITLE
Use property types for the `DomainEvent`

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Domain/Event/DomainEvent.php
+++ b/src/Sulu/Bundle/ActivityBundle/Domain/Event/DomainEvent.php
@@ -15,20 +15,11 @@ use Sulu\Component\Security\Authentication\UserInterface;
 
 abstract class DomainEvent
 {
-    /**
-     * @var \DateTimeImmutable
-     */
-    private $eventDateTime;
+    private \DateTimeImmutable $eventDateTime;
 
-    /**
-     * @var string|null
-     */
-    private $eventBatch;
+    private ?string $eventBatch = null;
 
-    /**
-     * @var UserInterface|null
-     */
-    private $user;
+    private ?UserInterface $user = null;
 
     public function __construct()
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Using property types as the properties are private and the getter and setters are strictly typed.

#### Why?
* For a strictly typed Sulu future
* Phpstan will complain if the types of the getters/setter not match the property types.
* Giving explicit default values (good that we have tests that caught that)
