### PR TITLE
Using a clearer error message when asserting response codes

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
@@ -53,7 +53,7 @@ trait AssertHttpStatusCodeTrait
                 $message = \implode(\PHP_EOL, \array_slice($message, 0, $debugLength));
 
                 $message = \sprintf(
-                    'HTTP status code %s is not expected %s!' . \PHP_EOL
+                    'Got status code %s (Expected: %s)' . \PHP_EOL
                     . 'Exception: %s' . \PHP_EOL
                     . 'Exception-File: %s' . \PHP_EOL
                     . 'Showing %s lines of the response body:' . \PHP_EOL

--- a/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/AssertHttpStatusCodeTrait.php
@@ -53,7 +53,7 @@ trait AssertHttpStatusCodeTrait
                 $message = \implode(\PHP_EOL, \array_slice($message, 0, $debugLength));
 
                 $message = \sprintf(
-                    'Got status code %s (Expected: %s)' . \PHP_EOL
+                    'Got HTTP status code %s, but expected %s!' . \PHP_EOL
                     . 'Exception: %s' . \PHP_EOL
                     . 'Exception-File: %s' . \PHP_EOL
                     . 'Showing %s lines of the response body:' . \PHP_EOL


### PR DESCRIPTION
Before:
`HTTP status code 200 is not expected 400!`

After:
`Got status code 200 (Expected: 400)`

This way it's clearer what code we got and what we expected.