### PR TITLE
Fix the usage of Symfony's pseudo_localization feature

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -24911,11 +24911,6 @@ parameters:
 			path: src/Sulu/Bundle/RouteBundle/Model/RoutableInterface.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\RouteBundle\\\\Model\\\\RoutableInterface\\:\\:setRoute\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/Model/RoutableInterface.php
-
-		-
 			message: "#^Method Sulu\\\\Bundle\\\\RouteBundle\\\\PageTree\\\\NullPageTreeUpdater\\:\\:update\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/RouteBundle/PageTree/NullPageTreeUpdater.php
@@ -25134,26 +25129,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\RouteBundle\\\\Tests\\\\Unit\\\\Generator\\\\ChainRouteGeneratorTest\\:\\:\\$mappings type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/ChainRouteGeneratorTest.php
-
-		-
-			message: "#^Access to an undefined property Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Sulu\\\\Bundle\\\\RouteBundle\\\\Model\\\\RoutableInterface\\>\\:\\:\\$getLocale\\.$#"
-			count: 3
-			path: src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
-
-		-
-			message: "#^Access to an undefined property Prophecy\\\\Prophecy\\\\ObjectProphecy\\<Sulu\\\\Bundle\\\\RouteBundle\\\\Model\\\\RoutableInterface\\>\\:\\:\\$name\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/Tests/Unit/Generator/SymfonyExpressionTokenProviderTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\RouteBundle\\\\Tests\\\\Unit\\\\Manager\\\\TestRoutable\\:\\:getId\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/Tests/Unit/Manager/RouteManagerTest.php
-
-		-
-			message: "#^Method Sulu\\\\Bundle\\\\RouteBundle\\\\Tests\\\\Unit\\\\Manager\\\\TestRoutable\\:\\:getRoute\\(\\) should return Sulu\\\\Bundle\\\\RouteBundle\\\\Model\\\\RouteInterface but returns Sulu\\\\Bundle\\\\RouteBundle\\\\Model\\\\RouteInterface\\|null\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/RouteBundle/Tests/Unit/Manager/RouteManagerTest.php
 
 		-
 			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with array will always evaluate to false\\.$#"
@@ -43747,7 +43722,7 @@ parameters:
 
 		-
 			message: "#^Method Sulu\\\\Component\\\\Import\\\\Format\\\\Xliff12\\:\\:utf8ToCharset\\(\\) should return string but returns string\\|false\\.$#"
-			count: 2
+			count: 1
 			path: src/Sulu/Component/Import/Format/Xliff12.php
 
 		-

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\RouteBundle\Generator;
 
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -22,7 +21,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class SymfonyExpressionTokenProvider implements TokenProviderInterface
 {
     /**
-     * @var TranslatorInterface&LocaleAwareInterface
+     * @var TranslatorInterface
      */
     private $translator;
 
@@ -33,15 +32,6 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
 
     public function __construct(TranslatorInterface $translator)
     {
-        if (!$translator instanceof LocaleAwareInterface) {
-            throw new \LogicException(\sprintf(
-                'Expected "translator" in "%s" to be instance of "%s" but "%s" given.',
-                __CLASS__,
-                LocaleAwareInterface::class,
-                \get_class($translator)
-            ));
-        }
-
         $this->translator = $translator;
 
         $this->expressionLanguage = new ExpressionLanguage();
@@ -80,7 +70,7 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
             }
 
             if ($entityLocale) {
-                $this->translator->setLocale($entityLocale);
+                $this->setLocale($entityLocale);
             }
 
             $result = $this->expressionLanguage->evaluate($name, [
@@ -93,6 +83,13 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
         } catch (\Exception $e) {
             throw new CannotEvaluateTokenException($name, $entity, $e);
         } finally {
+            $this->setLocale($locale);
+        }
+    }
+
+    private function setLocale(string $locale): void
+    {
+        if (\method_exists($this->translator, 'setLocale')) {
             $this->translator->setLocale($locale);
         }
     }

--- a/src/Sulu/Bundle/RouteBundle/Generator/TranslatorWrapper.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/TranslatorWrapper.php
@@ -19,9 +19,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class TranslatorWrapper implements TranslatorInterface, LocaleAwareInterface
 {
-    /**
-     * @param TranslatorInterface&LocaleAwareInterface $translator
-     */
     public function __construct(private TranslatorInterface $translator)
     {
     }

--- a/src/Sulu/Bundle/RouteBundle/Model/RoutableInterface.php
+++ b/src/Sulu/Bundle/RouteBundle/Model/RoutableInterface.php
@@ -30,6 +30,8 @@ interface RoutableInterface
 
     /**
      * Set route.
+     *
+     * @return void
      */
     public function setRoute(RouteInterface $route);
 

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/Manager/RouteManagerTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/Manager/RouteManagerTest.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\RouteBundle\Manager\RouteManager;
 use Sulu\Bundle\RouteBundle\Manager\RouteNotCreatedException;
 use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
 use Sulu\Bundle\RouteBundle\Model\RouteInterface;
+use Sulu\Bundle\RouteBundle\Tests\Unit\TestRoutable;
 
 class RouteManagerTest extends TestCase
 {
@@ -589,33 +590,6 @@ class RouteManagerTest extends TestCase
         $result = $this->manager->createOrUpdateByAttributes($entityClass, $entityId, $locale, $path, true);
 
         $this->assertEquals($resolvedRoute->reveal(), $result);
-    }
-}
-
-class TestRoutable implements RoutableInterface
-{
-    public function __construct(private ?RouteInterface $route = null)
-    {
-    }
-
-    public function getId()
-    {
-        return 1;
-    }
-
-    public function getRoute()
-    {
-        return $this->route;
-    }
-
-    public function setRoute(RouteInterface $route): void
-    {
-        $this->route = $route;
-    }
-
-    public function getLocale()
-    {
-        return 'de';
     }
 }
 

--- a/src/Sulu/Bundle/RouteBundle/Tests/Unit/TestRoutable.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Unit/TestRoutable.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RouteBundle\Tests\Unit;
+
+use Sulu\Bundle\RouteBundle\Model\RoutableInterface;
+use Sulu\Bundle\RouteBundle\Model\RouteInterface;
+
+class TestRoutable implements RoutableInterface
+{
+    public ?string $name = null;
+
+    public function __construct(
+        private ?RouteInterface $route = null,
+        private int $id = 1,
+        private string $locale = 'de',
+    ) {
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getRoute(): ?RouteInterface
+    {
+        return $this->route;
+    }
+
+    public function setRoute(RouteInterface $route): void
+    {
+        $this->route = $route;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/TranslatorListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/TranslatorListener.php
@@ -45,6 +45,10 @@ class TranslatorListener implements EventSubscriberInterface
             return;
         }
 
+        if (!\method_exists($this->translator, 'setLocale')) {
+            return;
+        }
+
         $this->translator->setLocale($localization->getLocale(Localization::LCID));
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/TranslatorListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/TranslatorListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class TranslatorListenerTest extends TestCase
 {
@@ -52,6 +53,25 @@ class TranslatorListenerTest extends TestCase
 
         $translator->setLocale('de_AT')->shouldBeCalled();
 
+        $eventListener->onKernelRequest($event);
+    }
+
+    public function testOnKernelRequestWithPseudolocalization(): void
+    {
+        // Asserting that this test should not crash (default behaviour)
+        $this->expectNotToPerformAssertions();
+
+        $translator = $this->prophesize(TranslatorInterface::class);
+        $request = new Request();
+        $localization = new Localization('de', 'at');
+        $requestAttributes = new RequestAttributes([
+            'localization' => $localization,
+        ]);
+        $request->attributes->set('_sulu', $requestAttributes);
+
+        $event = $this->createRequestEvent($request);
+
+        $eventListener = new TranslatorListener($translator->reveal());
         $eventListener->onKernelRequest($event);
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #8025 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Only calling the `setLocale` function on the translator if it does exist.

#### Why?
Otherwise it will crash.

## Context
This is just a stopgap solution for older versions. I will make another pull request to the 3.0 to use the `LocaleSwitcher` introduced into 6.1.