### PR TITLE
Feature: List item action title added

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/ButtonCell.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/ButtonCell.js
@@ -10,6 +10,7 @@ type Props = {|
     onClick: ?(rowId: string | number, rowIndex: number) => void,
     rowId: string | number,
     rowIndex: number,
+    title?: string,
 |};
 
 export default class ButtonCell extends React.PureComponent<Props> {
@@ -29,11 +30,12 @@ export default class ButtonCell extends React.PureComponent<Props> {
         const {
             disabled,
             icon,
+            title,
         } = this.props;
 
         return (
             <Cell className={tableStyles.buttonCell}>
-                <button disabled={disabled} onClick={this.handleClick} type="button">
+                <button disabled={disabled} onClick={this.handleClick} type="button" title={title}>
                     <Icon name={icon} />
                 </button>
             </Cell>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/Row.js
@@ -197,7 +197,7 @@ export default class Row extends React.PureComponent<Props> {
 
         return buttons.map((button: ButtonConfig, index) => {
             const key = `control-${rowIndex}-${index}`;
-            const {disabled, icon, onClick} = button;
+            const {disabled, icon, onClick, title} = button;
 
             return (
                 <ButtonCell
@@ -207,6 +207,7 @@ export default class Row extends React.PureComponent<Props> {
                     onClick={onClick}
                     rowId={this.getIdentifier()}
                     rowIndex={rowIndex}
+                    title={title}
                 />
             );
         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Table/types.js
@@ -7,6 +7,7 @@ export type ButtonConfig = {|
     disabled?: boolean,
     icon: string,
     onClick: ?(rowId: string | number, index: number) => void,
+    title?: string,
 |};
 
 export type Skin = 'dark' | 'light' | 'flat';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/types.js
@@ -40,6 +40,7 @@ export type ItemActionConfig = {|
     disabled?: boolean,
     icon: string,
     onClick: ?(rowId: string | number, index: number) => void,
+    title?: string,
 |};
 
 export type ItemActionsProvider = (item: ?Object) => Array<ItemActionConfig>;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
List item action title added.

#### Why?
To display of list item action title when mouse hover.

#### Example Usage

getItemActionConfig(key, parameters) {
    const {disable_for_empty_selection: disableForEmptySelection = false} = this.options;
    const keyObject = key;

    return {
      type: 'button',
      label: translate('sulu_admin.order.generate_xml'),
      icon: 'su-document',
      title: translate('sulu_admin.order.generate_xml'),
      onClick: () => this.handleClick(keyObject),
    };
  }

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md

<!--

Dear Contributors,

Thank you for contributing to the Sulu ecosystem!

We appreciate your effort to improve our project.  
If you need assistance or have questions about your pull request, our team is here to help.  
Please join our Slack channel for support: https://sulu.io/services/support#chat.

Best Regards, 
The Sulu Core Team

-->
