### PR TITLE
Deprecate `AddAdminPass` compiler pass

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -11,6 +11,7 @@ Deprecated compiler passes:
 * `Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\AddRulesPass` -> (`sulu.audience_target_rule`) `tagged_iterator`
 * `Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass` -> `tagged_iterator`
 * `Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProvidersPass` (`sulu.localization_provider`) `tagged_iterator`
+* `Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass` (`sulu.admin`) `tagged_iterator`
 
 ## 2.6.11
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
@@ -25,8 +25,6 @@ abstract class Admin implements ViewProviderInterface, NavigationProviderInterfa
 
     public const SETTINGS_NAVIGATION_ITEM = 'sulu_admin.settings';
 
-    public const SERVICE_TAG = 'sulu.admin';
-
     public static function getPriority(): int
     {
         return 0;

--- a/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Admin.php
@@ -25,6 +25,8 @@ abstract class Admin implements ViewProviderInterface, NavigationProviderInterfa
 
     public const SETTINGS_NAVIGATION_ITEM = 'sulu_admin.settings';
 
+    public const SERVICE_TAG = 'sulu.admin';
+
     public static function getPriority(): int
     {
         return 0;

--- a/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
@@ -24,6 +24,14 @@ class AdminPool
     private $pool = [];
 
     /**
+     * @param iterable<Admin> $admins
+     */
+    public function __construct(iterable $admins = [])
+    {
+        $this->pool = [...$admins];
+    }
+
+    /**
      * Adds a new admin.
      *
      * @param Admin $admin

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
@@ -16,10 +16,14 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Add all admin-services with the tag "sulu.admin" to the AdminPool-Service.
+ *
+ * @deprecated since 2.6 use Symfony tagged_iterator instead.
  */
 class AddAdminPass implements CompilerPassInterface
 {
     public const ADMIN_POOL_DEFINITION_ID = 'sulu_admin.admin_pool';
+
+    /** @deprecated use Admin::TAG instead */
     public const ADMIN_TAG = 'sulu.admin';
 
     public function process(ContainerBuilder $container)

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddAdminPass.php
@@ -22,8 +22,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class AddAdminPass implements CompilerPassInterface
 {
     public const ADMIN_POOL_DEFINITION_ID = 'sulu_admin.admin_pool';
-
-    /** @deprecated use Admin::TAG instead */
     public const ADMIN_TAG = 'sulu.admin';
 
     public function process(ContainerBuilder $container)


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | -
| Related issues/PRs | #7402 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Adding a warning that the `AddAdminPass` will be replaced with a tagged iterator in 3.0

#### Why?
We don't need to implement a feature that is already in Symfony.
