### PR TITLE
Deprecate the LocalizationProviderCompilerPass

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -10,6 +10,7 @@ Deprecated compiler passes:
 * `Sulu\Bundle\MediaBundle\DependencyInjection\FormatCacheClearerCompilerPass` (`sulu_media.format_cache`)
 * `Sulu\Bundle\AudienceTargetingBundle\DependencyInjection\Compiler\AddRulesPass` -> (`sulu.audience_target_rule`) `tagged_iterator`
 * `Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass` -> `tagged_iterator`
+* `Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProvidersPass` (`sulu.localization_provider`) `tagged_iterator`
 
 ## 2.6.11
 

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
@@ -16,9 +16,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Adds tagged services to the LocalizationManager.
+ *
+ * @deprecated since 2.6 use tagged_iterators instead
  */
 class RegisterLocalizationProvidersPass implements CompilerPassInterface
 {
+    /** @deprecated since 2.6 use Sulu\Component\Localization\Provider\LocalizationProviderInterface::SERVICE_TAG */
     public const LOCALIZATION_PROVIDER_TAG = 'sulu.localization_provider';
 
     public function process(ContainerBuilder $container)

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Compiler/RegisterLocalizationProvidersPass.php
@@ -21,7 +21,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class RegisterLocalizationProvidersPass implements CompilerPassInterface
 {
-    /** @deprecated since 2.6 use Sulu\Component\Localization\Provider\LocalizationProviderInterface::SERVICE_TAG */
     public const LOCALIZATION_PROVIDER_TAG = 'sulu.localization_provider';
 
     public function process(ContainerBuilder $container)

--- a/src/Sulu/Component/Localization/Manager/LocalizationManager.php
+++ b/src/Sulu/Component/Localization/Manager/LocalizationManager.php
@@ -26,6 +26,14 @@ class LocalizationManager implements LocalizationManagerInterface
      */
     private $localizationProviders = [];
 
+    /**
+     * @param array<LocalizationProviderInterface> $localizationProviders
+     */
+    public function __construct(iterable $localizationProviders = [])
+    {
+        $this->localizationProviders = [...$localizationProviders];
+    }
+
     public function getLocalizations(): array
     {
         $localizations = [];
@@ -51,6 +59,9 @@ class LocalizationManager implements LocalizationManagerInterface
         );
     }
 
+    /**
+     * @deprecated Use the constructor instead
+     */
     public function addLocalizationProvider(LocalizationProviderInterface $localizationProvider)
     {
         $this->localizationProviders[] = $localizationProvider;

--- a/src/Sulu/Component/Localization/Manager/LocalizationManagerInterface.php
+++ b/src/Sulu/Component/Localization/Manager/LocalizationManagerInterface.php
@@ -30,5 +30,8 @@ interface LocalizationManagerInterface
      */
     public function getLocales(): array;
 
+    /**
+     * @deprecated since Use the constructor instead
+     */
     public function addLocalizationProvider(LocalizationProviderInterface $localizationProvider);
 }

--- a/src/Sulu/Component/Localization/Provider/LocalizationProviderInterface.php
+++ b/src/Sulu/Component/Localization/Provider/LocalizationProviderInterface.php
@@ -18,6 +18,8 @@ use Sulu\Component\Localization\Localization;
  */
 interface LocalizationProviderInterface
 {
+    public const SERVICE_TAG = 'sulu.localization_provider';
+
     /**
      * @return Localization[]
      */

--- a/src/Sulu/Component/Localization/Provider/LocalizationProviderInterface.php
+++ b/src/Sulu/Component/Localization/Provider/LocalizationProviderInterface.php
@@ -18,7 +18,6 @@ use Sulu\Component\Localization\Localization;
  */
 interface LocalizationProviderInterface
 {
-
     /**
      * @return Localization[]
      */

--- a/src/Sulu/Component/Localization/Provider/LocalizationProviderInterface.php
+++ b/src/Sulu/Component/Localization/Provider/LocalizationProviderInterface.php
@@ -18,7 +18,6 @@ use Sulu\Component\Localization\Localization;
  */
 interface LocalizationProviderInterface
 {
-    public const SERVICE_TAG = 'sulu.localization_provider';
 
     /**
      * @return Localization[]


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | -
| Related issues/PRs | #7402 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Deprecating the `RegisterLocalizationProvidersPass` so that we can remove it in 3.0

#### Why?
Symfony already implements this behaviour which is much more convenient.

#### Example Usage
```xml
<service id="sulu.core.localization_manager" 
    class="Sulu\Component\Localization\Manager\LocalizationManager" 
    public="true"
>
    <argument type="tagged_iterator" tag="sulu.localization_provider" />
</service>
```