### PR TITLE
Deprecate FormatCacheClearerCompilerPass

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -7,6 +7,7 @@
 Deprecated compiler passes:
 
 * `Sulu\Bundle\SecurityBundle\DependencyInjection\Compiler\AccessControlProviderPass` -> `tagged_iterator`
+* `Sulu\Bundle\MediaBundle\DependencyInjection\FormatCacheClearerCompilerPass` (sulu_media.format_cache)
 
 ## 2.6.11
 

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/FormatCacheClearerCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/FormatCacheClearerCompilerPass.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Registers the format cache clearers.
+ *
+ * @deprecated since 2.6 use the tagged_iterator instead
  */
 class FormatCacheClearerCompilerPass implements CompilerPassInterface
 {

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Exception\FormatOptionsMissingParameterException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaException;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
+use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearerInterface;
 use Sulu\Bundle\MediaBundle\Media\PropertiesProvider\MediaPropertiesProviderInterface;
 use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
@@ -408,6 +409,9 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
 
         $container->registerForAutoconfiguration(MediaPropertiesProviderInterface::class)
             ->addTag('sulu_media.media_properties_provider');
+
+        $container->registerForAutoconfiguration(FormatCacheClearerInterface::class)
+            ->addTag('sulu_media.format_cache');
     }
 
     private function configureStorage(array $config, ContainerBuilder $container, LoaderInterface $loader)

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheClearer.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatCache/FormatCacheClearer.php
@@ -19,9 +19,17 @@ use Sulu\Bundle\MediaBundle\Media\Exception\CacheNotFoundException;
 class FormatCacheClearer implements FormatCacheClearerInterface
 {
     /**
-     * @var FormatCacheInterface[]
+     * @var array<string, FormatCacheInterface>
      */
     private $caches = [];
+
+    /**
+     * @param iterable<string, FormatCacheInterface> $caches
+     */
+    public function __construct(iterable $caches = [])
+    {
+        $this->caches = [...$caches];
+    }
 
     /**
      * Clear all or the given cache.
@@ -47,6 +55,8 @@ class FormatCacheClearer implements FormatCacheClearerInterface
 
     /**
      * Adds a cache to the aggregate.
+     *
+     * @deprecated use the constructor instead
      *
      * @param FormatCacheInterface $cache The cache
      * @param string $alias The cache alias


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | #7402 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Deprecating the `FormatCacheClearerCompilerPass` and auto registering all classes that implement the `CacheClearCompilerPass` interface.

#### Why?
Symfony already implements this feature. Why not use it?

#### Example Usage
```xml
<service id="sulu_media.format_cache_clearer" class="Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheClearer">
    <argument type="tagged_iterator" tag="sulu_media.format_cache" index-by="alias" />
</service>
```