### PR TITLE
Deprecate the `AddMetadataProviderPass`

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -12,7 +12,7 @@ Deprecated compiler passes:
 * `Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass` -> `tagged_iterator`
 * `Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProvidersPass` (`sulu.localization_provider`) `tagged_iterator`
 * `Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass` (`sulu.admin`) `tagged_iterator`
-* `Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry` (`sulu_admin.property_metadata_mapper`) `tagged_locator`
+* `Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddMetadataProvider` (`sulu_admin.property_metadata_mapper`) `tagged_locator`
 
 ## 2.6.11
 

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -12,6 +12,7 @@ Deprecated compiler passes:
 * `Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass` -> `tagged_iterator`
 * `Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProvidersPass` (`sulu.localization_provider`) `tagged_iterator`
 * `Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass` (`sulu.admin`) `tagged_iterator`
+* `Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry` (`sulu_admin.property_metadata_mapper`) `tagged_locator`
 
 ## 2.6.11
 

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddMetadataProviderPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/AddMetadataProviderPass.php
@@ -15,8 +15,13 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * @deprecated use tagged_locator instead:
+ * <argument type="tagged_locator" tag="sulu_admin.metadata_provider" index-by="type" />
+ */
 class AddMetadataProviderPass implements CompilerPassInterface
 {
+    /** @deprecated use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface::SERVICE_TAG instead */
     public const TAG = 'sulu_admin.metadata_provider';
 
     public function process(ContainerBuilder $container)

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
@@ -13,7 +13,5 @@ namespace Sulu\Bundle\AdminBundle\Metadata;
 
 interface MetadataProviderInterface
 {
-    public const SERVICE_TAG = 'sulu_admin.metadata_provider';
-
     public function getMetadata(string $key, string $locale, array $metadataOptions): MetadataInterface;
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderInterface.php
@@ -13,5 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Metadata;
 
 interface MetadataProviderInterface
 {
+    public const SERVICE_TAG = 'sulu_admin.metadata_provider';
+
     public function getMetadata(string $key, string $locale, array $metadataOptions): MetadataInterface;
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderRegistry.php
@@ -11,14 +11,31 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata;
 
+use Psr\Container\ContainerInterface;
 use Sulu\Bundle\AdminBundle\Exception\MetadataProviderNotFoundException;
 
 class MetadataProviderRegistry
 {
     private $metadataProviders = [];
 
+    public function __construct(
+        private ?ContainerInterface $container = null,
+    ) {
+        if (null === $container) {
+            trigger_deprecation('sulu/sulu', '2.6', 'Not using the tagged_locator to pass MetadataProviders is deprecated');
+        }
+    }
+
     public function getMetadataProvider(string $type): MetadataProviderInterface
     {
+        if (null !== $this->container) {
+            if (!$this->container->has($type)) {
+                throw new MetadataProviderNotFoundException($type);
+            }
+
+            return $this->container->get($type);
+        }
+
         if (!\array_key_exists($type, $this->metadataProviders)) {
             throw new MetadataProviderNotFoundException($type);
         }
@@ -26,8 +43,13 @@ class MetadataProviderRegistry
         return $this->metadataProviders[$type];
     }
 
+    /**
+     * @deprecated since Sulu 2.6 use the constructor instead
+     */
     public function addMetadataProvider(string $type, MetadataProviderInterface $metadataProvider)
     {
+        trigger_deprecation('sulu/sulu', '2.6', 'Do not add metadata Providers manually. Use the constructor');
+
         $this->metadataProviders[$type] = $metadataProvider;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderRegistry.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata;
 
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Sulu\Bundle\AdminBundle\Exception\MetadataProviderNotFoundException;
 
@@ -23,6 +24,10 @@ class MetadataProviderRegistry
     ) {
     }
 
+    /**
+     * @throws MetadataProviderNotFoundException
+     * @throws ContainerExceptionInterface
+     */
     public function getMetadataProvider(string $type): MetadataProviderInterface
     {
         if (null !== $this->container) {
@@ -30,7 +35,10 @@ class MetadataProviderRegistry
                 throw new MetadataProviderNotFoundException($type);
             }
 
-            return $this->container->get($type);
+            /** @var MetadataProviderInterface $metadataProvider */
+            $metadataProvider = $this->container->get($type);
+
+            return $metadataProvider;
         }
 
         if (!\array_key_exists($type, $this->metadataProviders)) {

--- a/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderRegistry.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/MetadataProviderRegistry.php
@@ -21,9 +21,6 @@ class MetadataProviderRegistry
     public function __construct(
         private ?ContainerInterface $container = null,
     ) {
-        if (null === $container) {
-            trigger_deprecation('sulu/sulu', '2.6', 'Not using the tagged_locator to pass MetadataProviders is deprecated');
-        }
     }
 
     public function getMetadataProvider(string $type): MetadataProviderInterface
@@ -48,8 +45,6 @@ class MetadataProviderRegistry
      */
     public function addMetadataProvider(string $type, MetadataProviderInterface $metadataProvider)
     {
-        trigger_deprecation('sulu/sulu', '2.6', 'Do not add metadata Providers manually. Use the constructor');
-
         $this->metadataProviders[$type] = $metadataProvider;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -45,7 +45,9 @@
         <service
             id="sulu_admin.metadata_provider_registry"
             class="Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry"
-        />
+        >
+            <argument type="tagged_locator" tag="sulu_admin.metadata_provider" index-by="type" />
+         </service>
 
         <service
             id="sulu_admin.form_metadata_provider"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | #7402 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Deprecating `AddMetadataProviderPass` and suggesting the tagged_locator instead.

#### Why?
- Symfony already has this feature.
- As far as I know the locator also only loads the services when they're actually used, so maybe also a performance thing?

#### Example Usage
```xml
<service id="Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry">
    <argument type="tagged_locator" tag="sulu_admin.metadata_provider" index-by="type" />
</service>
```