### PR TITLE
Adding admin url in profiler bar

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\WebsiteBundle\DataCollector;
 
+use Sulu\Component\Content\Compat\Structure\PageBridge;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Portal;
@@ -22,8 +23,10 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 class SuluCollector extends DataCollector
 {
     public function __construct(
-        private string $kernelEnvironment = 'dev'
+        private string $kernelEnvironment = 'dev',
+        private string $adminUrl = '/admin',
     ) {
+        $this->adminUrl = \rtrim('//', $this->adminUrl);
     }
 
     public function data($key)
@@ -110,6 +113,8 @@ class SuluCollector extends DataCollector
             }
         }
         $this->data['structure'] = $structure;
+
+        $this->data['adminUrl'] = $this->getAdminUrlForRequest($request);
     }
 
     /**
@@ -123,6 +128,23 @@ class SuluCollector extends DataCollector
         foreach ($localizations as &$localization) {
             $localization = (string) $localization['language'] . ($localization['default'] ? ' (default)' : '');
         }
+    }
+
+    protected function getAdminUrlForRequest(Request $request): ?string
+    {
+        $locale = $request->getLocale();
+
+        /** @var RequestAttributes $requestAttributes */
+        $requestAttributes = $request->attributes->get('_sulu');
+        /** @var Webspace $webspace */
+        $webspace = $requestAttributes->getAttribute('webspace');
+
+        $object = $request->attributes->get('structure');
+        if (!$object instanceof PageBridge) {
+            return null;
+        }
+
+        return $this->adminUrl . '/#/webspaces/' . $webspace->getKey() . '/pages/' . $locale . '/' . $object->getUuid() . '/details';
     }
 
     public function getName()

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/views/Profiler/layout.html.twig
@@ -49,6 +49,14 @@
                 {% endif %}
             </span>
         </div>
+        {% if collector.data('adminUrl') is not null %}
+            <div class="sf-toolbar-info-piece">
+                <b>Admin Url</b>
+                <span>
+                    <a href="{{ collector.data('adminUrl') }}">Go to admin view</a>
+                </span>
+            </div>
+        {% endif %}
     {% endset %}
     {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/DependencyInjection/SuluWebsiteExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/DependencyInjection/SuluWebsiteExtensionTest.php
@@ -31,7 +31,7 @@ class SuluWebsiteExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderNotHasService('sulu_website.data_collector.sulu_collector');
     }
 
-    public function testLoadWithContextWebsite(): void
+    public function testLoadWithContextWebsiteWithDebugEnabled(): void
     {
         $this->container->setParameter('sulu.context', 'website');
         $this->container->setParameter('kernel.bundles', []);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #8041 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

### What's in this PR?
A way to generate a link to the admin panel for a given site.

### Why?
For debugging purposes it's nice to get the admin url for the current page to make it easier to find where to configured.

### Problems
* There is no way to generate the admin base url (I think that might be because of the different kernels admin/website)
* Support more formats out of the box? (like article bundle etc)
* Is the admin format configurable somewhere then we need a different approach.
* Only register the service in dev. Currently the only way I see is either with attributes + autowiring or php in the service container so no way in the xml.