### PR TITLE
Make link targets configurable

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkPlugin.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/ExternalLinkPlugin/ExternalLinkPlugin.js
@@ -7,6 +7,7 @@ import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 import ContextualBalloon from '@ckeditor/ckeditor5-ui/src/panel/balloon/contextualballoon';
 import ClickObserver from '@ckeditor/ckeditor5-engine/src/view/observer/clickobserver';
 import {render, unmountComponentAtNode} from 'react-dom';
+import linkTypeRegistry from '../../../Link/registries/linkTypeRegistry';
 import {translate} from '../../../../utils';
 import {addLinkConversion, findModelItemInSelection, findViewLinkItemInSelection} from '../../utils';
 import LinkBalloonView from '../../LinkBalloonView';
@@ -79,7 +80,7 @@ export default class ExternalLinkPlugin extends Plugin {
                             onTargetChange={this.handleTargetChange}
                             onTitleChange={this.handleTitleChange}
                             open={this.open}
-                            options={undefined}
+                            options={linkTypeRegistry.getOptions('external')}
                             rel={this.rel}
                             target={this.target}
                             title={this.title}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/InternalLinkPlugin.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/plugins/InternalLinkPlugin/InternalLinkPlugin.js
@@ -47,7 +47,7 @@ export default class InternalLinkPlugin extends Plugin {
     balloon: typeof ContextualBalloon;
 
     @computed get internalLinkTypes(): Array<string> {
-        return linkTypeRegistry.getKeys().filter((type) => type !== 'external');
+        return linkTypeRegistry.getKeys();
     }
 
     @computed get href(): ?string | number {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/index.js
@@ -2,5 +2,6 @@
 import LinkTypeOverlay from './overlays/LinkTypeOverlay';
 import ExternalLinkTypeOverlay from './overlays/ExternalLinkTypeOverlay';
 import linkTypeRegistry from './registries/linkTypeRegistry';
+import linkOverlayRegistry from './registries/linkOverlayRegistry';
 
-export {LinkTypeOverlay, ExternalLinkTypeOverlay, linkTypeRegistry};
+export {LinkTypeOverlay, ExternalLinkTypeOverlay, linkTypeRegistry, linkOverlayRegistry};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/ExternalLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/ExternalLinkTypeOverlay.js
@@ -170,7 +170,21 @@ class ExternalLinkTypeOverlay extends React.Component<LinkTypeOverlayProps> {
             target,
             title,
             href,
+            options,
         } = this.props;
+
+        if (!options || !options.targets) {
+            throw new Error('The ExternalLinkTypeOverlay needs atleast targets as options in order to work!');
+        }
+
+        const {
+            targets = {
+                '_blank': 'sulu_admin.link_target_blank',
+                '_self': 'sulu_admin.link_target_self',
+                '_parent': 'sulu_admin.link_target_parent',
+                '_top': 'sulu_admin.link_target_top',
+            },
+        } = options;
 
         return (
             <Dialog
@@ -197,10 +211,11 @@ class ExternalLinkTypeOverlay extends React.Component<LinkTypeOverlayProps> {
                     {this.protocol && this.protocol !== 'mailto:' && onTargetChange
                         && <Form.Field label={translate('sulu_admin.link_target')} required={true}>
                             <SingleSelect onChange={onTargetChange} value={target}>
-                                <SingleSelect.Option value="_blank">_blank</SingleSelect.Option>
-                                <SingleSelect.Option value="_self">_self</SingleSelect.Option>
-                                <SingleSelect.Option value="_parent">_parent</SingleSelect.Option>
-                                <SingleSelect.Option value="_top">_top</SingleSelect.Option>
+                                {Object.keys(targets).map((targetValue) => (
+                                    <SingleSelect.Option key={targetValue} value={targetValue}>
+                                        {translate(targets[targetValue])}
+                                    </SingleSelect.Option>
+                                ))}
                             </SingleSelect>
                         </Form.Field>
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/ExternalLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/ExternalLinkTypeOverlay.js
@@ -173,18 +173,7 @@ class ExternalLinkTypeOverlay extends React.Component<LinkTypeOverlayProps> {
             options,
         } = this.props;
 
-        if (!options || !options.targets) {
-            throw new Error('The ExternalLinkTypeOverlay needs atleast targets as options in order to work!');
-        }
-
-        const {
-            targets = {
-                '_blank': 'sulu_admin.link_target_blank',
-                '_self': 'sulu_admin.link_target_self',
-                '_parent': 'sulu_admin.link_target_parent',
-                '_top': 'sulu_admin.link_target_top',
-            },
-        } = options;
+        const targets = options?.targets || ['_blank', '_self', '_parent', '_top'];
 
         return (
             <Dialog
@@ -211,9 +200,9 @@ class ExternalLinkTypeOverlay extends React.Component<LinkTypeOverlayProps> {
                     {this.protocol && this.protocol !== 'mailto:' && onTargetChange
                         && <Form.Field label={translate('sulu_admin.link_target')} required={true}>
                             <SingleSelect onChange={onTargetChange} value={target}>
-                                {Object.keys(targets).map((targetValue) => (
+                                {targets.map((targetValue) => (
                                     <SingleSelect.Option key={targetValue} value={targetValue}>
-                                        {translate(targets[targetValue])}
+                                        {translate(`sulu_admin.link${targetValue}`)}
                                     </SingleSelect.Option>
                                 ))}
                             </SingleSelect>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/LinkTypeOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/LinkTypeOverlay.js
@@ -39,7 +39,7 @@ export default class LinkTypeOverlay extends React.Component<LinkTypeOverlayProp
             listAdapter = '',
             overlayTitle = '',
             resourceKey,
-            targets,
+            targets = ['_blank', '_self', '_parent', '_top'],
         } = options;
 
         return (
@@ -82,9 +82,9 @@ export default class LinkTypeOverlay extends React.Component<LinkTypeOverlayProp
                     {onTargetChange &&
                         <Form.Field label={translate('sulu_admin.link_target')} required={true}>
                             <SingleSelect onChange={onTargetChange} value={target}>
-                                {Object.keys(targets).map((targetValue) => (
+                                {targets.map((targetValue) => (
                                     <SingleSelect.Option key={targetValue} value={targetValue}>
-                                        {translate(targets[targetValue])}
+                                        {translate(`sulu_admin.link${targetValue}`)}
                                     </SingleSelect.Option>
                                 ))}
                             </SingleSelect>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/LinkTypeOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/overlays/LinkTypeOverlay.js
@@ -28,7 +28,7 @@ export default class LinkTypeOverlay extends React.Component<LinkTypeOverlayProp
             title,
         } = this.props;
 
-        if (!options) {
+        if (!options || !options.targets) {
             throw new Error('The LinkTypeOverlay needs some options in order to work!');
         }
 
@@ -39,6 +39,7 @@ export default class LinkTypeOverlay extends React.Component<LinkTypeOverlayProp
             listAdapter = '',
             overlayTitle = '',
             resourceKey,
+            targets,
         } = options;
 
         return (
@@ -81,10 +82,11 @@ export default class LinkTypeOverlay extends React.Component<LinkTypeOverlayProp
                     {onTargetChange &&
                         <Form.Field label={translate('sulu_admin.link_target')} required={true}>
                             <SingleSelect onChange={onTargetChange} value={target}>
-                                <SingleSelect.Option value="_blank">_blank</SingleSelect.Option>
-                                <SingleSelect.Option value="_self">_self</SingleSelect.Option>
-                                <SingleSelect.Option value="_parent">_parent</SingleSelect.Option>
-                                <SingleSelect.Option value="_top">_top</SingleSelect.Option>
+                                {Object.keys(targets).map((targetValue) => (
+                                    <SingleSelect.Option key={targetValue} value={targetValue}>
+                                        {translate(targets[targetValue])}
+                                    </SingleSelect.Option>
+                                ))}
                             </SingleSelect>
                         </Form.Field>
                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/registries/linkOverlayRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/registries/linkOverlayRegistry.js
@@ -1,0 +1,46 @@
+// @flow
+import type {ComponentType} from 'react';
+import type {
+    LinkTypeOverlayProps,
+} from '../types';
+
+class linkOverlayRegistry {
+    overlays: {[string]: ComponentType<LinkTypeOverlayProps>};
+
+    constructor() {
+        this.clear();
+    }
+
+    clear() {
+        this.overlays = {};
+    }
+
+    setDefaultOverlay(overlay: ComponentType<LinkTypeOverlayProps>) {
+        this.overlays['default'] = overlay;
+    }
+
+    add(
+        type: string,
+        overlay: ComponentType<LinkTypeOverlayProps>
+    ) {
+        this.overlays[type] = overlay;
+    }
+
+    getOverlay(type: string): ComponentType<LinkTypeOverlayProps> {
+        if (this.overlays[type]) {
+            return this.overlays[type];
+        }
+
+        if (this.overlays['default']) {
+            return this.overlays['default'];
+        }
+
+        throw new Error(
+            'There is no overlay for an link type with the key "' + type +
+            '" registered and no default overlay is set.' +
+            '\n\nRegistered keys: ' + Object.keys(this.overlays).sort().join(', ')
+        );
+    }
+}
+
+export default new linkOverlayRegistry();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/ExternalLinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/ExternalLinkTypeOverlay.test.js
@@ -22,7 +22,6 @@ test('Render overlay with an undefined URL', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: ['_blank', '_self', '_parent', '_top'],
                 }
             }
             rel={undefined}
@@ -32,19 +31,6 @@ test('Render overlay with an undefined URL', () => {
     );
 
     expect(externalLinkOverlay.find('Form').render()).toMatchSnapshot();
-});
-
-test('Render overlay without options', () => {
-    expect(() => shallow(
-        <ExternalLinkTypeOverlay
-            href={undefined}
-            onCancel={jest.fn()}
-            onConfirm={jest.fn()}
-            onHrefChange={jest.fn()}
-            open={true}
-            options={undefined}
-        />
-    )).toThrow('The ExternalLinkTypeOverlay needs atleast targets as options in order to work!');
 });
 
 test('Render overlay with mailto URL', () => {
@@ -62,12 +48,6 @@ test('Render overlay with mailto URL', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel={undefined}
@@ -94,12 +74,6 @@ test('Render overlay with a URL', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel={undefined}
@@ -129,12 +103,6 @@ test('Pass correct props to Dialog', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel={undefined}
@@ -165,12 +133,6 @@ test('Display given URL with query parameters in href input', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             target="_blank"
@@ -199,12 +161,6 @@ test('Do not call onHrefChange handler if input did not loose focus', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel={undefined}
@@ -235,12 +191,6 @@ test('Fields should change immediately after protocol was changed', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel={undefined}
@@ -279,12 +229,6 @@ test('Call onHrefChange with URL that includes mail subject and mail body for ma
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel={undefined}
@@ -329,12 +273,6 @@ test('Should not include mail subject and body in URL after switching to another
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             target="_blank"
@@ -367,12 +305,6 @@ test('Reset target to self when a mailto link is entered', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel={undefined}
@@ -405,12 +337,6 @@ test('Should not reset target to self when a non-mail URL is entered', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel={undefined}
@@ -443,12 +369,6 @@ test('Rel value should be transformed correctly', () => {
                 {
                     displayProperties: [],
                     resourceKey: '',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
                 }
             }
             rel="noopener  noreferrer "

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/ExternalLinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/ExternalLinkTypeOverlay.test.js
@@ -18,6 +18,13 @@ test('Render overlay with an undefined URL', () => {
             onTargetChange={jest.fn()}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: ['_blank', '_self', '_parent', '_top'],
+                }
+            }
             rel={undefined}
             target={undefined}
             title={undefined}
@@ -25,6 +32,19 @@ test('Render overlay with an undefined URL', () => {
     );
 
     expect(externalLinkOverlay.find('Form').render()).toMatchSnapshot();
+});
+
+test('Render overlay without options', () => {
+    expect(() => shallow(
+        <ExternalLinkTypeOverlay
+            href={undefined}
+            onCancel={jest.fn()}
+            onConfirm={jest.fn()}
+            onHrefChange={jest.fn()}
+            open={true}
+            options={undefined}
+        />
+    )).toThrow('The ExternalLinkTypeOverlay needs atleast targets as options in order to work!');
 });
 
 test('Render overlay with mailto URL', () => {
@@ -38,6 +58,18 @@ test('Render overlay with mailto URL', () => {
             onTargetChange={jest.fn()}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel={undefined}
             target={undefined}
             title={undefined}
@@ -58,6 +90,18 @@ test('Render overlay with a URL', () => {
             onTargetChange={jest.fn()}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel={undefined}
             target={undefined}
             title={undefined}
@@ -81,6 +125,18 @@ test('Pass correct props to Dialog', () => {
             onTargetChange={jest.fn()}
             onTitleChange={jest.fn()}
             open={false}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel={undefined}
             target={undefined}
             title={undefined}
@@ -105,6 +161,18 @@ test('Display given URL with query parameters in href input', () => {
             onTargetChange={targetChangeSpy}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             target="_blank"
             title={undefined}
         />
@@ -127,6 +195,18 @@ test('Do not call onHrefChange handler if input did not loose focus', () => {
             onTargetChange={targetChangeSpy}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel={undefined}
             target="_blank"
             title={undefined}
@@ -151,6 +231,18 @@ test('Fields should change immediately after protocol was changed', () => {
             onTargetChange={targetChangeSpy}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel={undefined}
             target="_blank"
             title={undefined}
@@ -183,6 +275,18 @@ test('Call onHrefChange with URL that includes mail subject and mail body for ma
             onTargetChange={targetChangeSpy}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel={undefined}
             target="_blank"
             title={undefined}
@@ -221,6 +325,18 @@ test('Should not include mail subject and body in URL after switching to another
             onTargetChange={jest.fn()}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             target="_blank"
             title={undefined}
         />
@@ -247,6 +363,18 @@ test('Reset target to self when a mailto link is entered', () => {
             onTargetChange={targetChangeSpy}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel={undefined}
             target="_blank"
             title={undefined}
@@ -273,6 +401,18 @@ test('Should not reset target to self when a non-mail URL is entered', () => {
             onTargetChange={targetChangeSpy}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel={undefined}
             target="_blank"
             title={undefined}
@@ -299,6 +439,18 @@ test('Rel value should be transformed correctly', () => {
             onTargetChange={jest.fn()}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    displayProperties: [],
+                    resourceKey: '',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
+                }
+            }
             rel="noopener  noreferrer "
             target={undefined}
             title={undefined}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js
@@ -27,6 +27,12 @@ test('Render overlay with minimal config', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
                 }
             }
         />
@@ -65,6 +71,12 @@ test('Render overlay with query enabled', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
                 }
             }
         />
@@ -90,6 +102,12 @@ test('Render overlay with anchor enabled', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
                 }
             }
         />
@@ -115,6 +133,12 @@ test('Render overlay with target enabled', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
                 }
             }
         />
@@ -140,6 +164,12 @@ test('Render overlay with title enabled', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
+                    targets: {
+                        '_blank': 'sulu_admin.link_blank',
+                        '_self': 'sulu_admin.link_self',
+                        '_parent': 'sulu_admin.link_parent',
+                        '_top': 'sulu_admin.link_top',
+                    },
                 }
             }
         />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js
@@ -27,12 +27,7 @@ test('Render overlay with minimal config', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
+                    targets: ['_blank', '_self', '_parent', '_top'],
                 }
             }
         />
@@ -71,12 +66,7 @@ test('Render overlay with query enabled', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
+                    targets: ['_blank', '_self', '_parent', '_top'],
                 }
             }
         />
@@ -102,12 +92,7 @@ test('Render overlay with anchor enabled', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
+                    targets: ['_blank', '_self', '_parent', '_top'],
                 }
             }
         />
@@ -133,12 +118,7 @@ test('Render overlay with target enabled', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
+                    targets: ['_blank', '_self', '_parent', '_top'],
                 }
             }
         />
@@ -164,12 +144,7 @@ test('Render overlay with title enabled', () => {
                     listAdapter: 'column_list',
                     overlayTitle: 'Choose page',
                     resourceKey: 'pages',
-                    targets: {
-                        '_blank': 'sulu_admin.link_blank',
-                        '_self': 'sulu_admin.link_self',
-                        '_parent': 'sulu_admin.link_parent',
-                        '_top': 'sulu_admin.link_top',
-                    },
+                    targets: ['_blank', '_self', '_parent', '_top'],
                 }
             }
         />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/registries/LinkOverlayRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/registries/LinkOverlayRegistry.test.js
@@ -1,0 +1,92 @@
+// @flow
+import React from 'react';
+import linkOverlayRegistry from '../../registries/linkOverlayRegistry';
+
+beforeEach(() => {
+    linkOverlayRegistry.clear();
+});
+
+test('Clear all information from linkOverlayRegistry', () => {
+    const Component = () => (<div />);
+    const DefaultComponent = () => (<div>Default</div>);
+
+    linkOverlayRegistry.setDefaultOverlay(DefaultComponent);
+    linkOverlayRegistry.add('test1', Component);
+    expect(Object.keys(linkOverlayRegistry.overlays)).toHaveLength(2);
+
+    linkOverlayRegistry.clear();
+    expect(Object.keys(linkOverlayRegistry.overlays)).toHaveLength(0);
+});
+
+test('Set default overlay in linkOverlayRegistry', () => {
+    const DefaultComponent = () => (<div>Default</div>);
+
+    linkOverlayRegistry.setDefaultOverlay(DefaultComponent);
+    expect(linkOverlayRegistry.overlays['default']).toBe(DefaultComponent);
+});
+
+test('Add overlay to linkOverlayRegistry', () => {
+    const Component = () => (<div />);
+    const AnotherComponent = () => (<div>Another</div>);
+
+    linkOverlayRegistry.add('test1', Component);
+    linkOverlayRegistry.add('test2', AnotherComponent);
+
+    expect(linkOverlayRegistry.overlays['test1']).toBe(Component);
+    expect(linkOverlayRegistry.overlays['test2']).toBe(AnotherComponent);
+    expect(Object.keys(linkOverlayRegistry.overlays)).toHaveLength(2);
+});
+
+test('Get overlay returns specific overlay when type exists', () => {
+    const Component = () => (<div />);
+    const DefaultComponent = () => (<div>Default</div>);
+
+    linkOverlayRegistry.setDefaultOverlay(DefaultComponent);
+    linkOverlayRegistry.add('test1', Component);
+
+    expect(linkOverlayRegistry.getOverlay('test1')).toBe(Component);
+});
+
+test('Get overlay returns default overlay when type does not exist', () => {
+    const DefaultComponent = () => (<div>Default</div>);
+
+    linkOverlayRegistry.setDefaultOverlay(DefaultComponent);
+
+    expect(linkOverlayRegistry.getOverlay('nonexistent')).toBe(DefaultComponent);
+});
+
+test('Get overlay throws error when no overlays are registered', () => {
+    expect(() => linkOverlayRegistry.getOverlay('test')).toThrow(
+        /There is no overlay for an link type with the key "test" registered and no default overlay is set/
+    );
+});
+
+test('Get overlay throws error with registered keys in message', () => {
+    const Component = () => (<div />);
+    linkOverlayRegistry.add('test1', Component);
+    linkOverlayRegistry.add('test2', Component);
+
+    expect(() => linkOverlayRegistry.getOverlay('nonexistent')).toThrow(/test1, test2/);
+});
+
+test('Add overlay can override existing overlay', () => {
+    const Component1 = () => (<div>Component1</div>);
+    const Component2 = () => (<div>Component2</div>);
+
+    linkOverlayRegistry.add('test1', Component1);
+    expect(linkOverlayRegistry.getOverlay('test1')).toBe(Component1);
+
+    linkOverlayRegistry.add('test1', Component2);
+    expect(linkOverlayRegistry.getOverlay('test1')).toBe(Component2);
+});
+
+test('Default overlay can be overridden', () => {
+    const DefaultComponent1 = () => (<div>Default1</div>);
+    const DefaultComponent2 = () => (<div>Default2</div>);
+
+    linkOverlayRegistry.setDefaultOverlay(DefaultComponent1);
+    expect(linkOverlayRegistry.getOverlay('nonexistent')).toBe(DefaultComponent1);
+
+    linkOverlayRegistry.setDefaultOverlay(DefaultComponent2);
+    expect(linkOverlayRegistry.getOverlay('nonexistent')).toBe(DefaultComponent2);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/registries/LinkTypeRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/registries/LinkTypeRegistry.test.js
@@ -30,6 +30,12 @@ test('Add internal link type to LinkTypeRegistry', () => {
         listAdapter: 'listAdapter',
         overlayTitle: 'overlayTitle',
         resourceKey: 'resourceKey',
+        targets: {
+            '_blank': 'sulu_admin.link_blank',
+            '_self': 'sulu_admin.link_self',
+            '_parent': 'sulu_admin.link_parent',
+            '_top': 'sulu_admin.link_top',
+        },
     };
 
     linkTypeRegistry.add('test1', Component, 'Test1', options);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/registries/LinkTypeRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/registries/LinkTypeRegistry.test.js
@@ -30,12 +30,7 @@ test('Add internal link type to LinkTypeRegistry', () => {
         listAdapter: 'listAdapter',
         overlayTitle: 'overlayTitle',
         resourceKey: 'resourceKey',
-        targets: {
-            '_blank': 'sulu_admin.link_blank',
-            '_self': 'sulu_admin.link_self',
-            '_parent': 'sulu_admin.link_parent',
-            '_top': 'sulu_admin.link_top',
-        },
+        targets: ['_blank', '_self', '_parent', '_top'],
     };
 
     linkTypeRegistry.add('test1', Component, 'Test1', options);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/types.js
@@ -28,6 +28,7 @@ export type LinkTypeOptions = {|
     listAdapter?: string,
     overlayTitle?: string,
     resourceKey: string,
+    targets?: string[],
 |};
 
 export type LinkValue = {|

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -123,7 +123,7 @@ import {smartContentConfigStore} from './containers/SmartContent';
 import PreviewForm from './views/PreviewForm';
 import FormOverlayList from './views/FormOverlayList';
 import {initializeJexl} from './utils/jexl';
-import {ExternalLinkTypeOverlay, LinkTypeOverlay} from './containers/Link';
+import {ExternalLinkTypeOverlay, linkOverlayRegistry, LinkTypeOverlay} from './containers/Link';
 import linkTypeRegistry from './containers/Link/registries/linkTypeRegistry';
 import AiApplication from './containers/AiApplication';
 
@@ -172,6 +172,7 @@ initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: bool
         registerListItemActions();
         registerFieldTypes(config.fieldTypeOptions);
         registerTextEditors();
+        registerLinkOverlays();
         registerInternalLinkTypes(config.internalLinkTypes);
         registerFormToolbarActions();
         registerListToolbarActions();
@@ -302,11 +303,15 @@ function registerTextEditors() {
     textEditorRegistry.add('ckeditor5', CKEditor5);
 }
 
+function registerLinkOverlays() {
+    linkOverlayRegistry.setDefaultOverlay(LinkTypeOverlay);
+    linkOverlayRegistry.add('external', ExternalLinkTypeOverlay);
+}
+
 function registerInternalLinkTypes(internalLinkTypes) {
     for (const internalLinkTypeKey in internalLinkTypes) {
         const internalLinkType = internalLinkTypes[internalLinkTypeKey];
-        // Todo: This should not be necessary anymore, when the overlay registry is implemented.
-        const overlay = internalLinkTypeKey === 'external' ? ExternalLinkTypeOverlay : LinkTypeOverlay;
+        const overlay = linkOverlayRegistry.getOverlay(internalLinkTypeKey);
 
         linkTypeRegistry.add(
             internalLinkTypeKey,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -18,7 +18,6 @@ import userStore, {
 } from './stores/userStore';
 import {Config, resourceRouteRegistry} from './services';
 import initializer from './services/initializer';
-import {translate} from './utils';
 import ResourceTabs from './views/ResourceTabs';
 import List, {
     listItemActionRegistry,
@@ -306,9 +305,12 @@ function registerTextEditors() {
 function registerInternalLinkTypes(internalLinkTypes) {
     for (const internalLinkTypeKey in internalLinkTypes) {
         const internalLinkType = internalLinkTypes[internalLinkTypeKey];
+        // Todo: This should not be necessary anymore, when the overlay registry is implemented.
+        const overlay = internalLinkTypeKey === 'external' ? ExternalLinkTypeOverlay : LinkTypeOverlay;
+
         linkTypeRegistry.add(
             internalLinkTypeKey,
-            LinkTypeOverlay,
+            overlay,
             internalLinkType.title,
             {
                 displayProperties: internalLinkType.displayProperties,
@@ -317,17 +319,10 @@ function registerInternalLinkTypes(internalLinkTypes) {
                 listAdapter: internalLinkType.listAdapter,
                 overlayTitle: internalLinkType.overlayTitle,
                 resourceKey: internalLinkType.resourceKey,
+                targets: internalLinkType.targets,
             }
         );
     }
-
-    // Add external LinkType
-    linkTypeRegistry.add(
-        'external',
-        ExternalLinkTypeOverlay,
-        translate('sulu_admin.external_link'),
-        undefined
-    );
 }
 
 function registerFormToolbarActions() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -251,5 +251,9 @@
     "sulu_admin.translator_error": "Fehler beim Übersetzen",
     "sulu_admin.send_feedback": "Feedback senden",
     "sulu_admin.feedback": "Feedback",
-    "sulu_admin.send": "Senden"
+    "sulu_admin.send": "Senden",
+    "sulu_admin.link_target_blank":  "_blank",
+    "sulu_admin.link_target_self": "_self",
+    "sulu_admin.link_target_parent": "_parent",
+    "sulu_admin.link_target_top": "_top"
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/ExternalLinkProvider.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/ExternalLinkProvider.php
@@ -11,10 +11,6 @@
 
 namespace Sulu\Bundle\MarkupBundle\Markup\Link;
 
-use Ramsey\Uuid\Uuid;
-use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
-use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
-use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/ExternalLinkProvider.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/ExternalLinkProvider.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\PageBundle\Markup\Link;
+namespace Sulu\Bundle\MarkupBundle\Markup\Link;
 
 use Ramsey\Uuid\Uuid;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfiguration.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfiguration.php
@@ -69,7 +69,7 @@ class LinkConfiguration
     ];
 
     /**
-     * @param array<string, string>|null $targets
+     * @param array<string>|null $targets
      */
     public function __construct(
         string $title,

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfiguration.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfiguration.php
@@ -57,6 +57,20 @@ class LinkConfiguration
     #[Groups(['frontend'])]
     private $icon;
 
+    /**
+     * @var string[]
+     */
+    #[Groups(['frontend'])]
+    private $targets = [
+        '_blank',
+        '_self',
+        '_parent',
+        '_top',
+    ];
+
+    /**
+     * @param array<string, string>|null $targets
+     */
     public function __construct(
         string $title,
         string $resourceKey,
@@ -64,7 +78,8 @@ class LinkConfiguration
         array $displayProperties,
         string $overlayTitle,
         string $emptyText,
-        string $icon
+        string $icon,
+        ?array $targets = null
     ) {
         $this->title = $title;
         $this->resourceKey = $resourceKey;
@@ -73,5 +88,6 @@ class LinkConfiguration
         $this->overlayTitle = $overlayTitle;
         $this->emptyText = $emptyText;
         $this->icon = $icon;
+        $this->targets = $targets ?? $this->targets;
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfigurationBuilder.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfigurationBuilder.php
@@ -53,6 +53,9 @@ class LinkConfigurationBuilder
      */
     private $targets = null;
 
+    /**
+     * @return LinkConfigurationBuilder
+     */
     public static function create()
     {
         return new self();

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfigurationBuilder.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfigurationBuilder.php
@@ -48,6 +48,11 @@ class LinkConfigurationBuilder
      */
     private $icon;
 
+    /**
+     * @var ?array<string, string>
+     */
+    private $targets = null;
+
     public static function create()
     {
         return new self();
@@ -105,6 +110,16 @@ class LinkConfigurationBuilder
         return $this;
     }
 
+    /**
+     * @param array<string, string> $targets
+     */
+    public function setTargets(array $targets): self
+    {
+        $this->targets = $targets;
+
+        return $this;
+    }
+
     public function getLinkConfiguration(): LinkConfiguration
     {
         return new LinkConfiguration(
@@ -114,7 +129,8 @@ class LinkConfigurationBuilder
             $this->displayProperties,
             $this->overlayTitle,
             $this->emptyText,
-            $this->icon
+            $this->icon,
+            $this->targets,
         );
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderInterface.php
@@ -19,7 +19,7 @@ interface LinkProviderInterface
     /**
      * Return configuration for content-type.
      *
-     * @return ?LinkConfiguration
+     * @return LinkConfiguration|LinkConfigurationBuilder|null
      */
     public function getConfiguration();
 

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
@@ -51,7 +51,11 @@ class LinkProviderPool implements LinkProviderPoolInterface
             $providerConfiguration = $provider->getConfiguration();
 
             if ($providerConfiguration instanceof LinkConfiguration) {
-                @trigger_deprecation('sulu/sulu', '2.6', 'The LinkProvider should return a LinkConfigurationBuilder and not a LinkConfiguration. The LinkConfigurationBuilder will not be supported in 3.0.');
+                @trigger_deprecation(
+                    'sulu/sulu',
+                    '2.6',
+                    'The LinkProvider should return a LinkConfigurationBuilder and not a LinkConfiguration. The LinkConfiguration will not be supported in 3.0.'
+                );
             }
 
             $configuration[$name] = $providerConfiguration instanceof LinkConfigurationBuilder ? $providerConfiguration->getLinkConfiguration() : $providerConfiguration;

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
@@ -47,7 +47,14 @@ class LinkProviderPool implements LinkProviderPoolInterface
     {
         $configuration = [];
         foreach ($this->providers as $name => $provider) {
-            $configuration[$name] = $provider->getConfiguration();
+            /** @var LinkConfiguration|LinkConfigurationBuilder|null $providerConfiguration */
+            $providerConfiguration = $provider->getConfiguration();
+
+            if ($providerConfiguration instanceof LinkConfiguration) {
+                @trigger_deprecation('sulu/sulu', '2.6', 'The LinkProvider should return a LinkConfigurationBuilder and not a LinkConfiguration. The LinkConfigurationBuilder will not be supported in 3.0.');
+            }
+
+            $configuration[$name] = $providerConfiguration instanceof LinkConfigurationBuilder ? $providerConfiguration->getLinkConfiguration() : $providerConfiguration;
         }
 
         return \array_filter($configuration);

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.xml
@@ -51,5 +51,12 @@
 
             <tag name="sulu_markup.tag" tag="link" type="html"/>
         </service>
+
+        <service id="sulu_markup.external_link_provider"
+                 class="Sulu\Bundle\MarkupBundle\Markup\Link\ExternalLinkProvider">
+            <argument type="service" id="translator"/>
+
+            <tag name="sulu.link.provider" alias="external"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/ExternalLinkProviderTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/ExternalLinkProviderTest.php
@@ -9,15 +9,15 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\PageBundle\Tests\Unit\Markup\Link;
+namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Markup\Link;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MarkupBundle\Markup\Link\ExternalLinkProvider;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
-use Sulu\Bundle\PageBundle\Markup\Link\ExternalLinkProvider;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ExternalLinkProviderTest extends TestCase
@@ -34,10 +34,7 @@ class ExternalLinkProviderTest extends TestCase
      */
     protected $translator;
 
-    /**
-     * @var ExternalLinkProvider
-     */
-    protected $externalLinkProvider;
+    protected ExternalLinkProvider $externalLinkProvider;
 
     public function setUp(): void
     {
@@ -52,8 +49,8 @@ class ExternalLinkProviderTest extends TestCase
     {
         $this->translator->trans('sulu_admin.external_link', [], 'admin')->willReturn('External Link');
 
-        /** @var LinkConfigurationBuilder $externalLinkProviderConfiguration */
-        $externalLinkProviderConfiguration = $this->externalLinkProvider->getConfiguration();
+        /** @var LinkConfigurationBuilder $configurationBuilder */
+        $configurationBuilder = $this->externalLinkProvider->getConfiguration();
         $this->assertEquals(
             new LinkConfiguration(
                 'External Link',
@@ -63,14 +60,9 @@ class ExternalLinkProviderTest extends TestCase
                 '',
                 '',
                 '',
-                [
-                    '_blank',
-                    '_self',
-                    '_parent',
-                    '_top',
-                ],
+                ['_blank', '_self', '_parent', '_top'],
             ),
-            $externalLinkProviderConfiguration->getLinkConfiguration()
+            $configurationBuilder->getLinkConfiguration()
         );
     }
 
@@ -84,12 +76,12 @@ class ExternalLinkProviderTest extends TestCase
 
         $this->assertCount(2, $result);
 
-        $this->assertEquals($url1, $result[0]->getUrl());
-        $this->assertEquals($url1, $result[0]->getTitle());
+        $this->assertSame($url1, $result[0]->getUrl());
+        $this->assertSame('', $result[0]->getTitle());
         $this->assertTrue($result[0]->isPublished());
 
-        $this->assertEquals($url2, $result[1]->getUrl());
-        $this->assertEquals($url2, $result[1]->getTitle());
+        $this->assertSame($url2, $result[1]->getUrl());
+        $this->assertSame('', $result[1]->getTitle());
         $this->assertTrue($result[1]->isPublished());
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/LinkProviderPoolTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/LinkProviderPoolTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\MarkupBundle\Tests\Unit\Markup\Link;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPool;
@@ -24,9 +25,9 @@ class LinkProviderPoolTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var LinkProviderInterface[]
+     * @var ObjectProphecy<LinkProviderInterface>[]
      */
-    protected $providers = [];
+    protected $providerProphecies = [];
 
     /**
      * @var LinkProviderPoolInterface
@@ -35,7 +36,7 @@ class LinkProviderPoolTest extends TestCase
 
     public function setUp(): void
     {
-        $this->providers = [
+        $this->providerProphecies = [
             'content' => $this->prophesize(LinkProviderInterface::class),
             'media' => $this->prophesize(LinkProviderInterface::class),
             'page' => $this->prophesize(LinkProviderInterface::class),
@@ -46,14 +47,14 @@ class LinkProviderPoolTest extends TestCase
                 function($provider) {
                     return $provider->reveal();
                 },
-                $this->providers
+                $this->providerProphecies
             )
         );
     }
 
     public function testGetProvider(): void
     {
-        $this->assertEquals($this->providers['content']->reveal(), $this->pool->getProvider('content'));
+        $this->assertEquals($this->providerProphecies['content']->reveal(), $this->pool->getProvider('content'));
     }
 
     public function testGetProviderNotFound(): void
@@ -96,9 +97,9 @@ class LinkProviderPoolTest extends TestCase
             ),
         ];
 
-        $this->providers['content']->getConfiguration()->willReturn($configuration['content']);
-        $this->providers['media']->getConfiguration()->willReturn($configuration['media']);
-        $this->providers['page']->getConfiguration()->willReturn(null);
+        $this->providerProphecies['content']->getConfiguration()->willReturn($configuration['content']);
+        $this->providerProphecies['media']->getConfiguration()->willReturn($configuration['media']);
+        $this->providerProphecies['page']->getConfiguration()->willReturn(null);
 
         $this->assertEquals($configuration, $this->pool->getConfiguration());
     }

--- a/src/Sulu/Bundle/MediaBundle/Markup/Link/MediaLinkProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Markup/Link/MediaLinkProvider.php
@@ -29,14 +29,13 @@ class MediaLinkProvider implements LinkProviderInterface
 
     public function getConfiguration()
     {
-        /** @var LinkConfigurationBuilder $linkConfigurationBuilder */
         $linkConfigurationBuilder = LinkConfigurationBuilder::create();
 
         return $linkConfigurationBuilder
             ->setTitle($this->translator->trans('sulu_media.media', [], 'admin'))
             ->setResourceKey('media')
-            ->setListAdapter('')
             ->setDisplayProperties(['title'])
+            ->setListAdapter('')
             ->setOverlayTitle('')
             ->setEmptyText('')
             ->setIcon('');

--- a/src/Sulu/Bundle/MediaBundle/Markup/Link/MediaLinkProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Markup/Link/MediaLinkProvider.php
@@ -11,22 +11,35 @@
 
 namespace Sulu\Bundle\MediaBundle\Markup\Link;
 
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MediaLinkProvider implements LinkProviderInterface
 {
     public function __construct(
         private MediaRepositoryInterface $mediaRepository,
         private MediaManagerInterface $mediaManager,
+        private TranslatorInterface $translator,
     ) {
     }
 
     public function getConfiguration()
     {
-        return null;
+        /** @var LinkConfigurationBuilder $linkConfigurationBuilder */
+        $linkConfigurationBuilder = LinkConfigurationBuilder::create();
+
+        return $linkConfigurationBuilder
+            ->setTitle($this->translator->trans('sulu_media.media', [], 'admin'))
+            ->setResourceKey('media')
+            ->setListAdapter('')
+            ->setDisplayProperties(['title'])
+            ->setOverlayTitle('')
+            ->setEmptyText('')
+            ->setIcon('');
     }
 
     public function preload(array $hrefs, $locale, $published = true)

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -472,6 +472,7 @@
         <service id="sulu_media.media_link_provider" class="Sulu\Bundle\MediaBundle\Markup\Link\MediaLinkProvider">
             <argument type="service" id="sulu.repository.media" />
             <argument type="service" id="sulu_media.media_manager"/>
+            <argument type="service" id="translator"/>
             <tag name="sulu.link.provider" alias="media"/>
         </service>
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
@@ -35,6 +35,10 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
 
         const targets = options?.targets || ['_blank', '_self', '_parent', '_top'];
 
+        if (typeof href === 'string') {
+            throw new Error('The id of a media should always be a number!');
+        }
+
         return (
             <Dialog
                 cancelText={translate('sulu_admin.cancel')}
@@ -49,7 +53,7 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
                         <SingleMediaSelection
                             locale={locale || observable.box(userStore.contentLocale)}
                             onChange={this.handleChange}
-                            value={{displayOption: undefined, id: parseInt(href)}}
+                            value={{displayOption: undefined, id: href}}
                         />
                     </Form.Field>
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
@@ -30,7 +30,21 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
             title,
             target,
             anchor,
+            options,
         } = this.props;
+
+        if (!options || !options.targets) {
+            throw new Error('The MediaLinkTypeOverlay needs atleast targets as options in order to work!');
+        }
+
+        const {
+            targets = {
+                '_blank': 'sulu_admin.link_target_blank',
+                '_self': 'sulu_admin.link_target_self',
+                '_parent': 'sulu_admin.link_target_parent',
+                '_top': 'sulu_admin.link_target_top',
+            },
+        } = options;
 
         if (typeof href === 'string') {
             throw new Error('The id of a media should always be a number!');
@@ -63,10 +77,11 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
                     {!!onTargetChange &&
                         <Form.Field label={translate('sulu_admin.link_target')} required={true}>
                             <SingleSelect onChange={onTargetChange} value={target}>
-                                <SingleSelect.Option value="_blank">_blank</SingleSelect.Option>
-                                <SingleSelect.Option value="_self">_self</SingleSelect.Option>
-                                <SingleSelect.Option value="_parent">_parent</SingleSelect.Option>
-                                <SingleSelect.Option value="_top">_top</SingleSelect.Option>
+                                {Object.keys(targets).map((targetValue) => (
+                                    <SingleSelect.Option key={targetValue} value={targetValue}>
+                                        {translate(targets[targetValue])}
+                                    </SingleSelect.Option>
+                                ))}
                             </SingleSelect>
                         </Form.Field>
                     }

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/overlays/MediaLinkTypeOverlay.js
@@ -33,22 +33,7 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
             options,
         } = this.props;
 
-        if (!options || !options.targets) {
-            throw new Error('The MediaLinkTypeOverlay needs atleast targets as options in order to work!');
-        }
-
-        const {
-            targets = {
-                '_blank': 'sulu_admin.link_target_blank',
-                '_self': 'sulu_admin.link_target_self',
-                '_parent': 'sulu_admin.link_target_parent',
-                '_top': 'sulu_admin.link_target_top',
-            },
-        } = options;
-
-        if (typeof href === 'string') {
-            throw new Error('The id of a media should always be a number!');
-        }
+        const targets = options?.targets || ['_blank', '_self', '_parent', '_top'];
 
         return (
             <Dialog
@@ -64,7 +49,7 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
                         <SingleMediaSelection
                             locale={locale || observable.box(userStore.contentLocale)}
                             onChange={this.handleChange}
-                            value={{displayOption: undefined, id: href}}
+                            value={{displayOption: undefined, id: parseInt(href)}}
                         />
                     </Form.Field>
 
@@ -77,9 +62,9 @@ export default class MediaLinkTypeOverlay extends React.Component<LinkTypeOverla
                     {!!onTargetChange &&
                         <Form.Field label={translate('sulu_admin.link_target')} required={true}>
                             <SingleSelect onChange={onTargetChange} value={target}>
-                                {Object.keys(targets).map((targetValue) => (
+                                {targets.map((targetValue) => (
                                     <SingleSelect.Option key={targetValue} value={targetValue}>
-                                        {translate(targets[targetValue])}
+                                        {translate(`sulu_admin.link${targetValue}`)}
                                     </SingleSelect.Option>
                                 ))}
                             </SingleSelect>

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js
@@ -19,6 +19,12 @@ test('Render overlay with minimal config', () => {
             onConfirm={jest.fn()}
             onHrefChange={jest.fn()}
             open={true}
+            options={
+                {
+                    resourceKey: 'media',
+                    displayProperties: ['title'],
+                }
+            }
         />
     );
 
@@ -33,7 +39,12 @@ test('Render overlay with invalid href type', () => {
             onConfirm={jest.fn()}
             onHrefChange={jest.fn()}
             open={true}
-            options={undefined}
+            options={
+                {
+                    resourceKey: 'media',
+                    displayProperties: ['title'],
+                }
+            }
         />
     )).toThrow('The id of a media should always be a number!');
 });
@@ -47,6 +58,12 @@ test('Render overlay with anchor enabled', () => {
             onConfirm={jest.fn()}
             onHrefChange={jest.fn()}
             open={true}
+            options={
+                {
+                    resourceKey: 'media',
+                    displayProperties: ['title'],
+                }
+            }
         />
     );
 
@@ -62,6 +79,12 @@ test('Render overlay with target enabled', () => {
             onHrefChange={jest.fn()}
             onTargetChange={jest.fn()}
             open={true}
+            options={
+                {
+                    resourceKey: 'media',
+                    displayProperties: ['title'],
+                }
+            }
         />
     );
 
@@ -77,6 +100,12 @@ test('Render overlay with title enabled', () => {
             onHrefChange={jest.fn()}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    resourceKey: 'media',
+                    displayProperties: ['title'],
+                }
+            }
         />
     );
 
@@ -94,6 +123,12 @@ test('Delegate only id to onHrefChange method', () => {
             onHrefChange={hrefChangeSpy}
             onTitleChange={jest.fn()}
             open={true}
+            options={
+                {
+                    resourceKey: 'media',
+                    displayProperties: ['title'],
+                }
+            }
         />
     );
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -64,6 +64,7 @@ initializer.addUpdateConfigHook('sulu_media', (config: Object, initialized: bool
 
     TeaserSelection.Item.mediaUrl = imageFormatUrl + '?locale=en&format=sulu-25x25';
 
+    // Todo: Remove this and add overlay registry.
     when(
         () => !!initializer.initializedTranslationsLocale,
         (): void => {

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/index.js
@@ -1,5 +1,4 @@
 // @flow
-import {when} from 'mobx';
 import {initializer} from 'sulu-admin-bundle/services';
 import {
     blockPreviewTransformerRegistry,
@@ -7,9 +6,8 @@ import {
     fieldRegistry,
     viewRegistry,
 } from 'sulu-admin-bundle/containers';
-import {translate} from 'sulu-admin-bundle/utils';
 import {TeaserSelection} from 'sulu-page-bundle/containers';
-import linkTypeRegistry from 'sulu-admin-bundle/containers/Link/registries/linkTypeRegistry';
+import linkOverlayRegistry from 'sulu-admin-bundle/containers/Link/registries/linkOverlayRegistry';
 import {MediaCardOverviewAdapter, MediaCardSelectionAdapter} from './containers/List';
 import {MediaSelection, MediaVersionUpload, SingleMediaUpload, SingleMediaSelection, ImageMap} from './containers/Form';
 import {
@@ -24,6 +22,8 @@ import {MediaLinkTypeOverlay} from './containers/Link';
 
 const FIELD_TYPE_MEDIA_SELECTION = 'media_selection';
 const FIELD_TYPE_SINGLE_MEDIA_SELECTION = 'single_media_selection';
+
+linkOverlayRegistry.add('media', MediaLinkTypeOverlay);
 
 initializer.addUpdateConfigHook('sulu_media', (config: Object, initialized: boolean) => {
     const {media_permissions: mediaPermissions} = config;
@@ -63,15 +63,4 @@ initializer.addUpdateConfigHook('sulu_media', (config: Object, initialized: bool
     );
 
     TeaserSelection.Item.mediaUrl = imageFormatUrl + '?locale=en&format=sulu-25x25';
-
-    // Todo: Remove this and add overlay registry.
-    when(
-        () => !!initializer.initializedTranslationsLocale,
-        (): void => {
-            linkTypeRegistry.add('media', MediaLinkTypeOverlay, translate('sulu_media.media'), {
-                resourceKey: 'media',
-                displayProperties: ['title'],
-            });
-        }
-    );
 });

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Markup/Link/MediaLinkProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Markup/Link/MediaLinkProviderTest.php
@@ -14,9 +14,12 @@ namespace Sulu\Bundle\MediaBundle\Tests\Unit\Markup\Link;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Markup\Link\MediaLinkProvider;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MediaLinkProviderTest extends TestCase
 {
@@ -37,20 +40,44 @@ class MediaLinkProviderTest extends TestCase
      */
     private $mediaLinkProvider;
 
+    /**
+     * @var ObjectProphecy<TranslatorInterface>
+     */
+    private $translator;
+
     public function setUp(): void
     {
         $this->mediaRepository = $this->prophesize(MediaRepositoryInterface::class);
         $this->mediaManager = $this->prophesize(MediaManagerInterface::class);
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+        $this->translator->trans('sulu_media.media', [], 'admin')
+            ->willReturn('Media');
 
         $this->mediaLinkProvider = new MediaLinkProvider(
             $this->mediaRepository->reveal(),
-            $this->mediaManager->reveal()
+            $this->mediaManager->reveal(),
+            $this->translator->reveal()
         );
     }
 
     public function testGetConfiguration(): void
     {
-        $this->assertNull($this->mediaLinkProvider->getConfiguration());
+        /** @var LinkConfigurationBuilder $configurationBuilder */
+        $configurationBuilder = $this->mediaLinkProvider->getConfiguration();
+
+        $this->assertEquals(
+            new LinkConfiguration(
+                'Media',
+                'media',
+                '',
+                ['title'],
+                '',
+                '',
+                '',
+                ['_blank', '_self', '_parent', '_top'],
+            ),
+            $configurationBuilder->getLinkConfiguration()
+        );
     }
 
     public function testPreload(): void

--- a/src/Sulu/Bundle/PageBundle/Markup/Link/ExternalLinkProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Markup/Link/ExternalLinkProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Markup\Link;
+
+use Ramsey\Uuid\Uuid;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @internal
+ */
+class ExternalLinkProvider implements LinkProviderInterface
+{
+    public function __construct(
+        private TranslatorInterface $translator,
+    ) {
+    }
+
+    public function getConfiguration()
+    {
+        /** @var LinkConfigurationBuilder $linkConfigurationBuilder */
+        $linkConfigurationBuilder = LinkConfigurationBuilder::create();
+
+        return $linkConfigurationBuilder
+            ->setTitle($this->translator->trans('sulu_admin.external_link', [], 'admin'))
+            ->setResourceKey('')
+            ->setListAdapter('')
+            ->setDisplayProperties([])
+            ->setOverlayTitle('')
+            ->setEmptyText('')
+            ->setIcon('');
+    }
+
+    public function preload(array $hrefs, $locale, $published = true)
+    {
+        if (0 === \count($hrefs)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($hrefs as $href) {
+            $result[] = new LinkItem($href, '', $href, true);
+        }
+
+        return $result;
+    }
+}

--- a/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
@@ -40,15 +40,17 @@ class PageLinkProvider implements LinkProviderInterface
 
     public function getConfiguration()
     {
-        return LinkConfigurationBuilder::create()
+        /** @var LinkConfigurationBuilder $configurationBuilder */
+        $configurationBuilder = LinkConfigurationBuilder::create()
             ->setTitle($this->translator->trans('sulu_page.pages', [], 'admin'))
             ->setResourceKey('pages')
             ->setListAdapter('column_list')
             ->setDisplayProperties(['title'])
             ->setOverlayTitle($this->translator->trans('sulu_page.single_selection_overlay_title', [], 'admin'))
             ->setEmptyText($this->translator->trans('sulu_page.no_page_selected', [], 'admin'))
-            ->setIcon('su-document')
-            ->getLinkConfiguration();
+            ->setIcon('su-document');
+
+        return $configurationBuilder;
     }
 
     public function preload(array $hrefs, $locale, $published = true)

--- a/src/Sulu/Bundle/PageBundle/Resources/config/link-tag.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/link-tag.xml
@@ -14,12 +14,5 @@
 
             <tag name="sulu.link.provider" alias="page"/>
         </service>
-
-        <service id="sulu_page.link_tag.external_provider"
-                 class="Sulu\Bundle\PageBundle\Markup\Link\ExternalLinkProvider">
-            <argument type="service" id="translator"/>
-
-            <tag name="sulu.link.provider" alias="external"/>
-        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/PageBundle/Resources/config/link-tag.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/link-tag.xml
@@ -14,5 +14,12 @@
 
             <tag name="sulu.link.provider" alias="page"/>
         </service>
+
+        <service id="sulu_page.link_tag.external_provider"
+                 class="Sulu\Bundle\PageBundle\Markup\Link\ExternalLinkProvider">
+            <argument type="service" id="translator"/>
+
+            <tag name="sulu.link.provider" alias="external"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -89,5 +89,9 @@
     "sulu_activity.description.pages.preview_link_generated": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" erstellt",
     "sulu_activity.description.pages.preview_link_revoked": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" widerrufen",
     "sulu_reference.resource.pages": "Seite",
-    "sulu_reference.resource.snippets": "Schnipsel"
+    "sulu_reference.resource.snippets": "Schnipsel",
+    "sulu_admin.link_target_blank":  "_blank",
+    "sulu_admin.link_target_self": "_self",
+    "sulu_admin.link_target_parent": "_parent",
+    "sulu_admin.link_target_top": "_top"
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.de.json
@@ -89,9 +89,5 @@
     "sulu_activity.description.pages.preview_link_generated": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" erstellt",
     "sulu_activity.description.pages.preview_link_revoked": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" widerrufen",
     "sulu_reference.resource.pages": "Seite",
-    "sulu_reference.resource.snippets": "Schnipsel",
-    "sulu_admin.link_target_blank":  "_blank",
-    "sulu_admin.link_target_self": "_self",
-    "sulu_admin.link_target_parent": "_parent",
-    "sulu_admin.link_target_top": "_top"
+    "sulu_reference.resource.snippets": "Schnipsel"
 }

--- a/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/PageBundle/Resources/translations/admin.en.json
@@ -89,5 +89,9 @@
     "sulu_activity.description.pages.preview_link_generated": "{userFullName} has generated a public preview link \"{resourceTitle}\"",
     "sulu_activity.description.pages.preview_link_revoked": "{userFullName} has revoked the public preview link \"{resourceTitle}\"",
     "sulu_reference.resource.pages": "Page",
-    "sulu_reference.resource.snippets": "Snippet"
+    "sulu_reference.resource.snippets": "Snippet",
+    "sulu_admin.link_target_blank":  "_blank",
+    "sulu_admin.link_target_self": "_self",
+    "sulu_admin.link_target_parent": "_parent",
+    "sulu_admin.link_target_top": "_top"
 }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/ExternalLinkProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/ExternalLinkProviderTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Markup\Link;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
+use Sulu\Bundle\PageBundle\Markup\Link\ExternalLinkProvider;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ExternalLinkProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var string
+     */
+    protected $locale = 'en';
+
+    /**
+     * @var ObjectProphecy<TranslatorInterface>
+     */
+    protected $translator;
+
+    /**
+     * @var ExternalLinkProvider
+     */
+    protected $externalLinkProvider;
+
+    public function setUp(): void
+    {
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+
+        $this->externalLinkProvider = new ExternalLinkProvider(
+            $this->translator->reveal(),
+        );
+    }
+
+    public function testGetConfiguration(): void
+    {
+        $this->translator->trans('sulu_admin.external_link', [], 'admin')->willReturn('External Link');
+
+        /** @var LinkConfigurationBuilder $externalLinkProviderConfiguration */
+        $externalLinkProviderConfiguration = $this->externalLinkProvider->getConfiguration();
+        $this->assertEquals(
+            new LinkConfiguration(
+                'External Link',
+                '',
+                '',
+                [],
+                '',
+                '',
+                '',
+                [
+                    '_blank',
+                    '_self',
+                    '_parent',
+                    '_top',
+                ],
+            ),
+            $externalLinkProviderConfiguration->getLinkConfiguration()
+        );
+    }
+
+    public function testPreload(): void
+    {
+        $url1 = 'https://sulu.io/';
+        $url2 = 'https://sulu.rocks/en';
+
+        /** @var LinkItem[] $result */
+        $result = $this->externalLinkProvider->preload([$url1, $url2], $this->locale);
+
+        $this->assertCount(2, $result);
+
+        $this->assertEquals($url1, $result[0]->getUrl());
+        $this->assertEquals($url1, $result[0]->getTitle());
+        $this->assertTrue($result[0]->isPublished());
+
+        $this->assertEquals($url2, $result[1]->getUrl());
+        $this->assertEquals($url2, $result[1]->getTitle());
+        $this->assertTrue($result[1]->isPublished());
+    }
+}

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
@@ -127,8 +127,8 @@ class PageLinkProviderTest extends TestCase
         $this->translator->trans('sulu_page.single_selection_overlay_title', [], 'admin')->willReturn('Choose page');
         $this->translator->trans('sulu_page.no_page_selected', [], 'admin')->willReturn('No page selected');
 
-        /** @var LinkConfigurationBuilder $pageProviderConfiguration */
-        $pageProviderConfiguration = $this->pageLinkProvider->getConfiguration();
+        /** @var LinkConfigurationBuilder $configurationBuilder */
+        $configurationBuilder = $this->pageLinkProvider->getConfiguration();
         $this->assertEquals(
             new LinkConfiguration(
                 'Pages',
@@ -138,14 +138,9 @@ class PageLinkProviderTest extends TestCase
                 'Choose page',
                 'No page selected',
                 'su-document',
-                [
-                    '_blank' => 'sulu_admin.link_blank',
-                    '_self' => 'sulu_admin.link_self',
-                    '_parent' => 'sulu_admin.link_parent',
-                    '_top' => 'sulu_admin.link_top',
-                ],
+                ['_blank', '_self', '_parent', '_top'],
             ),
-            $pageProviderConfiguration->getLinkConfiguration()
+            $configurationBuilder->getLinkConfiguration()
         );
     }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
@@ -16,6 +16,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\PageBundle\Markup\Link\PageLinkProvider;
 use Sulu\Bundle\SecurityBundle\Entity\User;
@@ -126,6 +127,8 @@ class PageLinkProviderTest extends TestCase
         $this->translator->trans('sulu_page.single_selection_overlay_title', [], 'admin')->willReturn('Choose page');
         $this->translator->trans('sulu_page.no_page_selected', [], 'admin')->willReturn('No page selected');
 
+        /** @var LinkConfigurationBuilder $pageProviderConfiguration */
+        $pageProviderConfiguration = $this->pageLinkProvider->getConfiguration();
         $this->assertEquals(
             new LinkConfiguration(
                 'Pages',
@@ -134,9 +137,15 @@ class PageLinkProviderTest extends TestCase
                 ['title'],
                 'Choose page',
                 'No page selected',
-                'su-document'
+                'su-document',
+                [
+                    '_blank' => 'sulu_admin.link_blank',
+                    '_self' => 'sulu_admin.link_self',
+                    '_parent' => 'sulu_admin.link_parent',
+                    '_top' => 'sulu_admin.link_top',
+                ],
             ),
-            $this->pageLinkProvider->getConfiguration()
+            $pageProviderConfiguration->getLinkConfiguration()
         );
     }
 

--- a/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/LinkTest.php
@@ -313,6 +313,19 @@ class LinkTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($this->structure->reveal());
 
+        $this->providerPool->getProvider(Argument::type('string'))
+            ->shouldBeCalled()
+            ->willReturn($this->provider->reveal());
+
+        $linkItem = $this->prophesize(LinkItem::class);
+        $linkItem->getUrl()
+            ->shouldBeCalled()
+            ->willReturn('/test/test2');
+
+        $this->provider->preload(['/test/test2'], 'de', true)
+            ->shouldBeCalled()
+            ->willReturn([$linkItem]);
+
         $result = $this->link->getContentData($this->property->reveal());
 
         $this->assertSame('/test/test2', $result);

--- a/src/Sulu/Component/Content/Types/Link.php
+++ b/src/Sulu/Component/Content/Types/Link.php
@@ -23,6 +23,9 @@ use Sulu\Component\Content\SimpleContentType;
  */
 class Link extends SimpleContentType
 {
+    /**
+     * @deprecated
+     */
     public const LINK_TYPE_EXTERNAL = 'external';
 
     public function __construct(private LinkProviderPoolInterface $providerPool)
@@ -92,10 +95,6 @@ class Link extends SimpleContentType
 
         if (!$value || !isset($value['provider'])) {
             return null;
-        }
-
-        if (self::LINK_TYPE_EXTERNAL === $value['provider']) {
-            return $value['href'];
         }
 
         $provider = $this->providerPool->getProvider($value['provider']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Create an ExternLinkProvider and add targets with translations to the LinkConfiguration.

#### Why?

So the translations of the link targets can be overridden and also can be changed.

#### Example Usage

Inside the LinkProvider
```php
return LinkConfigurationBuilder::create()
            ->setTargets(['_blank' => 'sulu_admin.link_blank'])
            ...
```

