### PR TITLE
Deprecate the `findAllTags` function in `TagManager`

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -2,6 +2,11 @@
 
 ## 2.6.10
 
+### Deprecate functions as preparation for 3.0
+
+* Sulu\Bundle\TagBundle\Entity\TagRepository::findAllTags -> Sulu\Bundle\TagBundle\Entity\TagRepository::findAll
+* Sulu\Bundle\TagBundle\Tag\TagManager::findAll -> Sulu\Bundle\TagBundle\Entity\TagRepository::findAll
+
 ### Deprecate usage of fos rest routing
 
 We are no longer considering the [fos rest routing](https://github.com/handcraftedinthealps/RestRoutingBundle) as a best practice.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -59533,12 +59533,6 @@ parameters:
 			path: src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\TagBundle\\Entity\\TagRepository\:\:findAllTags\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/TagBundle/Entity/TagRepository.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\TagBundle\\Entity\\TagRepository\:\:findTagById\(\) should return Sulu\\Bundle\\TagBundle\\Tag\\TagInterface\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
@@ -59589,12 +59583,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\TagBundle\\Tag\\TagManager\:\:delete\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/TagBundle/Tag/TagManager.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\TagBundle\\Tag\\TagManager\:\:findAll\(\) should return array\<Sulu\\Bundle\\TagBundle\\Tag\\TagInterface\> but returns array\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/TagBundle/Tag/TagManager.php
 
@@ -59771,12 +59759,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\TagBundle\\Tag\\TagRepositoryInterface\:\:findAllTags\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/TagBundle/Tag/TagRepositoryInterface.php
 
 		-
 			message: '#^Cannot access property \$form on mixed\.$#'

--- a/src/Sulu/Bundle/TagBundle/Entity/TagRepository.php
+++ b/src/Sulu/Bundle/TagBundle/Entity/TagRepository.php
@@ -51,6 +51,9 @@ class TagRepository extends EntityRepository implements TagRepositoryInterface
         }
     }
 
+    /**
+     * @deprecated use the Repository findAll method
+     */
     public function findAllTags()
     {
         return $this->findAll();

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
@@ -43,6 +43,8 @@ class TagManager implements TagManagerInterface
     /**
      * Loads all the tags managed in this system.
      *
+     * @deprecated use the Repository findAll method
+     *
      * @return TagInterface[]
      */
     public function findAll()

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
@@ -20,6 +20,8 @@ interface TagManagerInterface
     /**
      * Loads all the tags managed in this system.
      *
+     * @deprecated use the Repository findAll method
+     *
      * @return TagInterface[]
      */
     public function findAll();

--- a/src/Sulu/Bundle/TagBundle/Tag/TagRepositoryInterface.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagRepositoryInterface.php
@@ -41,7 +41,9 @@ interface TagRepositoryInterface extends RepositoryInterface
     /**
      * Searches for all tags.
      *
-     * @return array
+     * @deprecated use the Repository findAll method
+     *
+     * @return array<TagInterface>
      */
     public function findAllTags();
 }

--- a/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
@@ -21,6 +21,9 @@ use Twig\TwigFunction;
 
 class TagTwigExtension extends AbstractExtension
 {
+    /**
+     * @deprecated Requiring the TagManagerInterface instead of the TagRepository
+     */
     public function __construct(
         private TagManagerInterface $tagManager,
         private TagRequestHandlerInterface $tagRequestHandler,
@@ -29,6 +32,9 @@ class TagTwigExtension extends AbstractExtension
     ) {
     }
 
+    /**
+     * @return array<TwigFunction>
+     */
     public function getFunctions()
     {
         return [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
* Deprecating the `findAllTags` in favour of `findAll` default repository tag.
* Deprecate `findAll` on the TagManager

#### Why?
* Less methods to maintain and phpstan if taken seriously will tell you what kind of object the `findAll` returns.
* Don't proxy method calls through a big objects, it's not good for performance.

#### Context
Maybe having a twig method that returns all tags sounds like a bad performance hole waiting to happen. (People will most likely filter them in twig then, which is pretty inefficient.)