### PR TITLE
Fix and ignore some errors with strictness of optionsmetadata values

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1879,9 +1879,15 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadata.php
 
 		-
+			message: '#^Argument of an invalid type array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+
+		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
@@ -1891,9 +1897,15 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
+			message: '#^Cannot access offset ''name'' on Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+
+		-
 			message: '#^Cannot access offset ''name'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
@@ -1903,19 +1915,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
+			message: '#^Cannot access offset ''value'' on Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapChildren\(\) has parameter \$children with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapOption\(\) has parameter \$parameter with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -1977,7 +1983,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setName\(\) expects float\|int\|string\|null, mixed given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
@@ -1987,7 +1993,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$object of function get_class expects object, array given\.$#'
+			message: '#^Parameter \#1 \$object of function get_class expects object, array\<string, array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -1999,13 +2005,13 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$parameter of method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapOption\(\) expects array, mixed given\.$#'
+			message: '#^Parameter \#1 \$parameter of method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapOption\(\) expects array\{name\: string, type\: string, value\: array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null\}, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
 
 		-
-			message: '#^Parameter \#1 \$parameterValue of method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapOptionMeta\(\) expects array, mixed given\.$#'
+			message: '#^Parameter \#1 \$parameterValue of method Sulu\\Bundle\\AdminBundle\\FormMetadata\\FormMetadataMapper\:\:mapOptionMeta\(\) expects array, Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -2045,6 +2051,18 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+
+		-
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setValue\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+
+		-
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setValue\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ExpressionFormMetadataVisitor.php
 
 		-
 			message: '#^Property Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\FieldMetadata\:\:\$onInvalid \(string\) does not accept string\|null\.$#'
@@ -3212,6 +3230,12 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+
+		-
+			message: '#^Parameter \#1 \$value of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\:\:setValue\(\) expects array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -5023,7 +5047,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
+			message: '#^Cannot access offset 0 on array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 6
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -5041,7 +5065,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getInfoText\(\) on mixed\.$#'
+			message: '#^Cannot call method getInfoText\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -5049,11 +5073,17 @@ parameters:
 		-
 			message: '#^Cannot call method getName\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getPlaceholder\(\) on mixed\.$#'
+			message: '#^Cannot call method getName\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
+
+		-
+			message: '#^Cannot call method getPlaceholder\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -5065,19 +5095,19 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getTitle\(\) on mixed\.$#'
+			message: '#^Cannot call method getTitle\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getType\(\) on mixed\.$#'
+			message: '#^Cannot call method getType\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
 
 		-
-			message: '#^Cannot call method getValue\(\) on mixed\.$#'
+			message: '#^Cannot call method getValue\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/FormMetadata/FormMetadataMapperTest.php
@@ -5257,25 +5287,25 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/FormXmlLoaderTest.php
 
 		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
+			message: '#^Cannot access offset 0 on array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
 
 		-
-			message: '#^Cannot access offset 1 on mixed\.$#'
+			message: '#^Cannot access offset 1 on array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
 
 		-
-			message: '#^Cannot call method getValue\(\) on mixed\.$#'
+			message: '#^Cannot call method getValue\(\) on string\|Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\.$#'
 			identifier: method.nonObject
 			count: 4
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
 
 		-
-			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
+			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, array\<Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\OptionMetadata\>\|bool\|int\|string\|null given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
@@ -32833,288 +32863,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/FileVersionMetaRepositoryTest.php
 
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Call to an undefined method Doctrine\\ORM\\EntityRepository\<Sulu\\Bundle\\TagBundle\\Tag\\TagInterface\>\:\:createNew\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Call to an undefined method object\:\:findByFilters\(\)\.$#'
-			identifier: method.notFound
-			count: 6
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Call to function array_key_exists\(\) with ''dataSource'' and array\{dataSource\: mixed, tags\?\: array\<int\>, tagOperator\?\: string, websiteTags\?\: array\<int\>, websiteTagsOperator\?\: string, sortBy\?\: string, sortMethod\?\: string, includeSubFolders\?\: bool\|string\} will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Cannot access offset 1 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Cannot access offset int\<0, max\> on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Cannot call method getTags\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Cannot call method getTitle\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Cannot call method setName\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createAccessControl\(\) has parameter \$entityClass with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createAccessControl\(\) has parameter \$id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createAccessControl\(\) has parameter \$permissions with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createCollection\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createCollection\(\) has parameter \$parent with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createMedia\(\) has parameter \$collection with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createMedia\(\) has parameter \$mimeType with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createMedia\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createMedia\(\) has parameter \$targetGroups with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createMedia\(\) has parameter \$title with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createMedia\(\) has parameter \$type with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createRole\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createRole\(\) has parameter \$system with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createTag\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createTag\(\) should return Sulu\\Bundle\\TagBundle\\Tag\\TagInterface but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:createType\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(mixed\)\: mixed\)\|null, Closure\(Sulu\\Bundle\\MediaBundle\\Api\\Media\)\: int given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$collection of method Sulu\\Bundle\\MediaBundle\\Entity\\Media\:\:setCollection\(\) expects Sulu\\Bundle\\MediaBundle\\Entity\\CollectionInterface, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$entity of method Doctrine\\ORM\\EntityManager\:\:persist\(\) expects object, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$entityId of method Sulu\\Bundle\\SecurityBundle\\Entity\\AccessControl\:\:setEntityId\(\) expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$mimeType of method Sulu\\Bundle\\MediaBundle\\Entity\\FileVersion\:\:setMimeType\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType\:\:setName\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\MediaBundle\\Entity\\FileVersion\:\:setName\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\MediaBundle\\Entity\\MediaType\:\:setName\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\SecurityBundle\\Entity\\Role\:\:setName\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$parent of method Sulu\\Bundle\\MediaBundle\\Entity\\Collection\:\:setParent\(\) expects Sulu\\Bundle\\MediaBundle\\Entity\\CollectionInterface\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$permissions of method Sulu\\Bundle\\SecurityBundle\\Entity\\AccessControl\:\:setPermissions\(\) expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$system of method Sulu\\Bundle\\SecurityBundle\\Entity\\Role\:\:setSystem\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$targetGroup of method Sulu\\Bundle\\MediaBundle\\Entity\\FileVersion\:\:addTargetGroup\(\) expects Sulu\\Bundle\\AudienceTargetingBundle\\Entity\\TargetGroupInterface, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#1 \$title of method Sulu\\Bundle\\MediaBundle\\Entity\\FileVersionMeta\:\:setTitle\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertContains\(\) expects iterable, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
-			identifier: argument.type
-			count: 5
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Parameter \#3 \$message of method PHPUnit\\Framework\\Assert\:\:assertEquals\(\) expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:\$em \(Doctrine\\ORM\\EntityManager\) does not accept Doctrine\\ORM\\EntityManagerInterface\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Entity\\MediaDataProviderRepositoryTest\:\:\$medias is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
-
-		-
 			message: '#^Binary operation "\." between literal\-string&non\-falsy\-string and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
@@ -37133,12 +36881,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/ContentExportCompilerPass.php
-
-		-
-			message: '#^Cannot access offset ''alias'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/DependencyInjection/Compiler/SmartContentDataProviderCompilerPass.php
 
 		-
 			message: '#^Cannot access offset ''template'' on mixed\.$#'

--- a/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/FormMetadata/FormMetadataMapper.php
@@ -130,6 +130,13 @@ class FormMetadataMapper
         return $field;
     }
 
+    /**
+     * @param array{
+     *     name: string,
+     *     type: string,
+     *     value: bool|int|string|null|OptionMetadata[],
+     * } $parameter
+     */
     private function mapOption(array $parameter): OptionMetadata
     {
         $option = new OptionMetadata();

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ExpressionFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/ExpressionFormMetadataVisitor.php
@@ -74,7 +74,7 @@ class ExpressionFormMetadataVisitor implements FormMetadataVisitorInterface, Typ
                     if (OptionMetadata::TYPE_EXPRESSION === $option->getType()) {
                         /** @var string $value */
                         $value = $option->getValue();
-                        $option->setValue($this->expressionLanguage->evaluate($value, $context));
+                        $option->setValue($this->expressionLanguage->evaluate($value, $context)); // TODO validate that it is `bool|int|string|OptionMetadata[]|null`
                     }
                 }
             }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/OptionMetadata.php
@@ -102,7 +102,7 @@ class OptionMetadata
             $this->value = [];
         }
 
-        $this->value[] = $option;
+        $this->value[] = $option; // @phpstan-ignore assign.propertyType
     }
 
     public function getTitle(string $locale): ?string

--- a/src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Types/NumberTest.php
@@ -161,7 +161,7 @@ class NumberTest extends TestCase
         $fieldMetadata = new FieldMetadata('property-name');
         $multipleOfOption = new OptionMetadata();
         $multipleOfOption->setName('multiple_of');
-        $multipleOfOption->setValue(0.5);
+        $multipleOfOption->setValue('0.5'); // float values are by the XmlParserTrait always strings
         $fieldMetadata->addOption($multipleOfOption);
 
         $jsonSchema = $this->number->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
@@ -344,10 +344,10 @@ class NumberTest extends TestCase
         $fieldMetadata = new FieldMetadata('property-name');
         $minOption = new OptionMetadata();
         $minOption->setName('min');
-        $minOption->setValue(1.2);
+        $minOption->setValue('1.2'); // float values are by the XmlParserTrait always strings
         $maxOption = new OptionMetadata();
         $maxOption->setName('max');
-        $maxOption->setValue(3.4);
+        $maxOption->setValue('3.4'); // float values are by the XmlParserTrait always strings
         $fieldMetadata->addOption($minOption);
         $fieldMetadata->addOption($maxOption);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix and ignore some errors with strictness of optionsmetadata values.

#### Why?

We added some new return types. This return types make some old tests fail, we ignore them. On a few classes we removed it.
