### PR TITLE
Remove duplicated pagination

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -164,16 +164,11 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         );
         $this->addInternalFilters($queryBuilder, $filters, $alias);
 
-        if (($page = $filters['page']) && ($limit = $filters['limit'])) {
-            $this->dimensionContentQueryEnhancer->addPagination($queryBuilder, $page, $limit);
-        }
-
         // TODO refactor this part to not use distinct
         // we need the distinct here, because joins due to tags/categories can lead to duplicate results
         $queryBuilder->select('DISTINCT ' . $alias . '.uuid as id');
         $queryBuilder->addSelect('filterDimensionContent.title');
         $this->smartContentQueryEnhancer->addOrderBySelects($queryBuilder);
-
         $this->smartContentQueryEnhancer->addPagination($queryBuilder, $filters['page'], $filters['limit'], $filters['maxPerPage']);
 
         /** @var array{id: string, title: string}[] $result */

--- a/packages/content/src/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
+++ b/packages/content/src/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
@@ -215,12 +215,6 @@ class DimensionContentQueryEnhancer
         }
     }
 
-    public function addPagination(QueryBuilder $queryBuilder, int $page, int $limit): void
-    {
-        $queryBuilder->setMaxResults($limit);
-        $queryBuilder->setFirstResult(($page - 1) * $limit);
-    }
-
     /**
      * TODO it should be possible to add custom select for all contents here example when the
      *     excerpt tab and entity get extended with additional relation.

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -180,7 +180,6 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         $queryBuilder->addSelect('page.webspaceKey as webspace');
         $queryBuilder->addSelect('filterDimensionContent.title');
         $this->smartContentQueryEnhancer->addOrderBySelects($queryBuilder);
-
         $this->smartContentQueryEnhancer->addPagination($queryBuilder, $filters['page'], $filters['limit'], $filters['maxPerPage']);
 
         /** @var array{id: string, title: string, webspace: string}[] $queryResult */

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
@@ -153,15 +153,12 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         );
         $this->addInternalFilters($queryBuilder, $filters, $alias);
 
-        if (($page = $filters['page']) && ($limit = $filters['limit'])) {
-            $this->dimensionContentQueryEnhancer->addPagination($queryBuilder, $page, $limit);
-        }
-
         // TODO refactor this to not use distinct
         // We need the distinct here, because joins due to tags/categories can lead to duplicate results
         $queryBuilder->select('DISTINCT snippet.uuid as id');
         $queryBuilder->addSelect('filterDimensionContent.title');
         $this->smartContentQueryEnhancer->addOrderBySelects($queryBuilder);
+
         $this->smartContentQueryEnhancer->addPagination($queryBuilder, $filters['page'], $filters['limit'], $filters['maxPerPage']);
 
         /** @var array{id: string, title: string, changed?: string, authored?: string}[] $queryResult */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Removes duplicated pagination config on the query builder in the SmartContentProviders

#### Why?

Pagination should only be set once 😄 
