### PR TITLE
Move navigation content based service to Sulu Content Infrastructure integration

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Content/DataMapper/NavigationContextDataMapper.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/DataMapper/NavigationContextDataMapper.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Page\Application\DataMapper;
+namespace Sulu\Page\Infrastructure\Sulu\Content\DataMapper;
 
 use Sulu\Content\Application\ContentDataMapper\DataMapper\DataMapperInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;

--- a/packages/page/src/Infrastructure/Sulu/Content/Merger/NavigationContextMerger.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/Merger/NavigationContextMerger.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Page\Application\Merger;
+namespace Sulu\Page\Infrastructure\Sulu\Content\Merger;
 
 use Sulu\Content\Application\ContentMerger\Merger\MergerInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;

--- a/packages/page/src/Infrastructure/Sulu/Content/Normalizer/PageNormalizer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/Normalizer/PageNormalizer.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Page\Application\Normalizer;
+namespace Sulu\Page\Infrastructure\Sulu\Content\Normalizer;
 
 use Sulu\Content\Application\ContentNormalizer\Normalizer\NormalizerInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -18,10 +18,8 @@ use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore;
 use Sulu\Content\Infrastructure\Sulu\Preview\ContentObjectProvider;
-use Sulu\Page\Application\DataMapper\NavigationContextDataMapper;
 use Sulu\Page\Application\Mapper\PageContentMapper;
 use Sulu\Page\Application\Mapper\PageMapperInterface;
-use Sulu\Page\Application\Merger\NavigationContextMerger;
 use Sulu\Page\Application\MessageHandler\ApplyWorkflowTransitionPageMessageHandler;
 use Sulu\Page\Application\MessageHandler\CopyLocalePageMessageHandler;
 use Sulu\Page\Application\MessageHandler\CopyPageMessageHandler;
@@ -39,6 +37,9 @@ use Sulu\Page\Infrastructure\Doctrine\Repository\NavigationRepository;
 use Sulu\Page\Infrastructure\Doctrine\Repository\PageRepository;
 use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Sulu\Page\Infrastructure\Sulu\Build\HomepageBuilder;
+use Sulu\Page\Infrastructure\Sulu\Content\DataMapper\NavigationContextDataMapper;
+use Sulu\Page\Infrastructure\Sulu\Content\Merger\NavigationContextMerger;
+use Sulu\Page\Infrastructure\Sulu\Content\Normalizer\PageNormalizer;
 use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Sulu\Page\Infrastructure\Sulu\Content\PageSmartContentProvider;
 use Sulu\Page\Infrastructure\Sulu\Content\PageTeaserProvider;
@@ -203,7 +204,7 @@ final class SuluPageBundle extends AbstractBundle
 
         // Normalizer service
         $services->set('sulu_page.page_normalizer')
-            ->class('Sulu\Page\Application\Normalizer\PageNormalizer')
+            ->class(PageNormalizer::class)
             ->tag('sulu_content.normalizer');
 
         // Property Resolver services

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/DataMapper/NavigationContextDataMapperTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/DataMapper/NavigationContextDataMapperTest.php
@@ -9,13 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\Page\Tests\Unit\Application\Merger\DataMapper;
+namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\DataMapper;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Sulu\Page\Application\DataMapper\NavigationContextDataMapper;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
+use Sulu\Page\Infrastructure\Sulu\Content\DataMapper\NavigationContextDataMapper;
 
 class NavigationContextDataMapperTest extends TestCase
 {

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/Merger/NavigationContextMergerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/Merger/NavigationContextMergerTest.php
@@ -9,17 +9,17 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\Page\Tests\Unit\Application\Merger\NavigationContextMerger;
+namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\Merger;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Content\Application\ContentMerger\Merger\MergerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Page\Application\Merger\NavigationContextMerger;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\Merger\NavigationContextMerger;
 
 class NavigationContextMergerTest extends TestCase
 {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Move navigation content based service to Sulu Content Infrastructure integration.

#### Why?

They are not part of the page domain / application. They integrate the page navigation context into the content resolving, mapping, normalization. Services implementing `Sulu\Content` services should live in the ../Infrastructure/Sulu/Content namespace.