### PR TITLE
Deprecate the sulu.context kernel parameter

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -4,9 +4,9 @@
 
 ### Deprecate usage of `sulu.context` parameter
 
-The `sulu.context` parameter is deprecated and services should not longer depend on it.
+The `sulu.context` parameter is deprecated and services should no longer depend on it.
 
-If some services behave differently between an `admin` or a `website` request you should depend on
+If some services behave differently between an `admin` or a `website` request, you should depend on
 [Symfony Firewall Config](https://symfony.com/doc/7.4/security.html#fetching-the-firewall-configuration-for-a-request)
 instead.
 
@@ -14,8 +14,8 @@ instead.
 $suluContext = $this->security?->getFirewallConfig($request)?->getName() === 'admin' ? 'admin' : 'website';
 ```
 
-Still best practices is that your services do not depend on such states, instead of controllers or commands
-should be based on the request or command arguments give other parameters to your service to control its behavior.
+Still, best practices is that your services do not depend on such states. Instead controllers or commands
+should be based on the request or command arguments, giving other parameters to your service to control its behavior.
 
 ## 2.6.10
 

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,5 +1,22 @@
 # Upgrade
 
+## 2.6.11
+
+### Deprecate usage of `sulu.context` parameter
+
+The `sulu.context` parameter is deprecated and services should not longer depend on it.
+
+If some services behave differently between an `admin` or a `website` request you should depend on
+[Symfony Firewall Config](https://symfony.com/doc/7.4/security.html#fetching-the-firewall-configuration-for-a-request)
+instead.
+
+```php
+$suluContext = $this->security?->getFirewallConfig($request)?->getName() === 'admin' ? 'admin' : 'website';
+```
+
+Still best practices is that your services do not depend on such states, instead of controllers or commands
+should be based on the request or command arguments give other parameters to your service to control its behavior.
+
 ## 2.6.10
 
 ### Deprecate usage of fos rest routing

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -237,6 +237,9 @@ abstract class SuluKernel extends Kernel
      *
      * The context indicates to the runtime code which
      * front controller has been accessed (e.g. website or admin)
+     *
+     * @internal Only for internal use, do not use in your code, might be removed in the future.
+     *           Check for the current Symfony firewall name instead: https://symfony.com/doc/7.4/security.html#fetching-the-firewall-configuration-for-a-request
      */
     protected function getContext(): string
     {
@@ -247,6 +250,8 @@ abstract class SuluKernel extends Kernel
      * Set context.
      *
      * @return $this
+     *
+     * @internal Only for internal use, do not use in your code, might be removed in the future.
      */
     protected function setContext(string $context)
     {

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -26,8 +26,14 @@ abstract class SuluKernel extends Kernel
 {
     use MicroKernelTrait;
 
+    /**
+     * @internal Only for internal use, do not use in your code, might be removed in the future.
+     */
     public const CONTEXT_ADMIN = 'admin';
 
+    /**
+     * @internal Only for internal use, do not use in your code, might be removed in the future.
+     */
     public const CONTEXT_WEBSITE = 'website';
 
     /**

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -27,12 +27,12 @@ abstract class SuluKernel extends Kernel
     use MicroKernelTrait;
 
     /**
-     * @internal Only for internal use, do not use in your code, might be removed in the future.
+     * @internal only for internal use, do not use in your code, might be removed in the future
      */
     public const CONTEXT_ADMIN = 'admin';
 
     /**
-     * @internal Only for internal use, do not use in your code, might be removed in the future.
+     * @internal only for internal use, do not use in your code, might be removed in the future
      */
     public const CONTEXT_WEBSITE = 'website';
 
@@ -257,7 +257,7 @@ abstract class SuluKernel extends Kernel
      *
      * @return $this
      *
-     * @internal Only for internal use, do not use in your code, might be removed in the future.
+     * @internal only for internal use, do not use in your code, might be removed in the future
      */
     protected function setContext(string $context)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Deprecate the `sulu.context` kernel parameter.

#### Why?

Why we did try to remove in the past more and more sulu.context based behaviour and it was a inofficial a long communicated that its service should not depend on it. Its time for official deprecate the parameter now. So we are save at time of 3.0 to remove it. Currently marking it at internal as we not yet completely removed it from internal usage, but this way we are free to remove it on 3.0 at any time.