### PR TITLE
Fix AuditableInterface for ArticleBundle

### DIFF
--- a/packages/article/src/Domain/Model/ArticleDimensionContent.php
+++ b/packages/article/src/Domain/Model/ArticleDimensionContent.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Domain\Model;
 
-use Sulu\Content\Domain\Model\AuditableInterface;
 use Sulu\Content\Domain\Model\AuditableTrait;
 use Sulu\Content\Domain\Model\AuthorTrait;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
@@ -29,7 +28,7 @@ use Sulu\Content\Domain\Model\WorkflowTrait;
 /**
  * @experimental
  */
-class ArticleDimensionContent implements ArticleDimensionContentInterface, AuditableInterface
+class ArticleDimensionContent implements ArticleDimensionContentInterface
 {
     use AuditableTrait;
     use AuthorTrait;

--- a/packages/article/src/Domain/Model/ArticleDimensionContentInterface.php
+++ b/packages/article/src/Domain/Model/ArticleDimensionContentInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Article\Domain\Model;
 
+use Sulu\Content\Domain\Model\AuditableInterface;
 use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\ExcerptInterface;
@@ -26,7 +27,7 @@ use Sulu\Content\Domain\Model\WorkflowInterface;
  *
  * @extends DimensionContentInterface<ArticleInterface>
  */
-interface ArticleDimensionContentInterface extends DimensionContentInterface, ExcerptInterface, SeoInterface, TemplateInterface, RoutableInterface, WorkflowInterface, ShadowInterface, WebspaceInterface, AuthorInterface
+interface ArticleDimensionContentInterface extends DimensionContentInterface, ExcerptInterface, SeoInterface, TemplateInterface, RoutableInterface, WorkflowInterface, ShadowInterface, WebspaceInterface, AuthorInterface, AuditableInterface
 {
     public function getTitle(): ?string;
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Sets the AuditableInterface properly on the ArticleDimensionContentInterface

#### Why?

We should always extend the main interface instead of the class.
