### PR TITLE
Add timestamp support to DateTimeFieldTransformer

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/DateTimeFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/DateTimeFieldTransformer.js
@@ -16,10 +16,19 @@ export default class DateTimeFieldTransformer implements FieldTransformer {
             return null;
         }
 
-        const momentObject = moment(value, moment.ISO_8601);
+        let momentObject;
+
+        if (typeof value === 'number' || (typeof value === 'string' && /^\d+$/.test(value))) {
+            const timestamp = Number(value);
+            // If timestamp is in seconds (less than 10 digits), convert to milliseconds
+            const timestampMs = timestamp < 10000000000 ? timestamp * 1000 : timestamp;
+            momentObject = moment(timestampMs);
+        } else {
+            momentObject = moment(value, moment.ISO_8601);
+        }
 
         if (!momentObject.isValid()) {
-            log.error('Invalid date given: "' + value + '". Format needs to be in "ISO 8601"');
+            log.error('Invalid date given: "' + value + '". Format needs to be in "ISO 8601" or a valid timestamp.');
 
             return null;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/DateTimeFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/DateTimeFieldTransformer.test.js
@@ -25,7 +25,9 @@ test('Test undefined', () => {
 
 test('Test invalid format', () => {
     expect(dateTimeFieldTransformer.transform('xxx', {})).toBe(null);
-    expect(log.error).toBeCalledWith('Invalid date given: "xxx". Format needs to be in "ISO 8601"');
+    expect(log.error).toBeCalledWith(
+        'Invalid date given: "xxx". Format needs to be in "ISO 8601" or a valid timestamp.'
+    );
 });
 
 test('Test valid example', () => {
@@ -77,4 +79,106 @@ test('Test relative format lastWeek example', () => {
     // $FlowFixMe
     expect(dateTime.props.children).toContain(momentObject.format('LLL'));
     expect(translate).toHaveBeenCalledWith('sulu_admin.lastDay');
+});
+
+test('Test timestamp in seconds', () => {
+    // March 10, 2018 1:09:04 PM UTC (timestamp: 1520690944)
+    const timestamp = 1520690944;
+    const result = dateTimeFieldTransformer.transform(timestamp, {});
+
+    // Check that it's a valid React element
+    expect(React.isValidElement(result)).toBe(true);
+    // $FlowFixMe
+    expect(result.type).toBe('span');
+    // $FlowFixMe
+    expect(result.props.className).toBe('default');
+    // $FlowFixMe
+    expect(result.props.children).toContain('March 10, 2018');
+});
+
+test('Test timestamp in milliseconds', () => {
+    // March 10, 2018 1:09:04 PM UTC (timestamp: 1520690944000)
+    const timestamp = 1520690944000;
+    const result = dateTimeFieldTransformer.transform(timestamp, {});
+
+    expect(React.isValidElement(result)).toBe(true);
+    // $FlowFixMe
+    expect(result.type).toBe('span');
+    // $FlowFixMe
+    expect(result.props.className).toBe('default');
+    // $FlowFixMe
+    expect(result.props.children).toContain('March 10, 2018');
+});
+
+test('Test timestamp as string (seconds)', () => {
+    // March 10, 2018 1:09:04 PM UTC (timestamp: "1520690944")
+    const timestamp = '1520690944';
+    const result = dateTimeFieldTransformer.transform(timestamp, {});
+
+    expect(React.isValidElement(result)).toBe(true);
+    // $FlowFixMe
+    expect(result.type).toBe('span');
+    // $FlowFixMe
+    expect(result.props.className).toBe('default');
+    // $FlowFixMe
+    expect(result.props.children).toContain('March 10, 2018');
+});
+
+test('Test timestamp as string (milliseconds)', () => {
+    // March 10, 2018 1:09:04 PM UTC (timestamp: "1520690944000")
+    const timestamp = '1520690944000';
+    const result = dateTimeFieldTransformer.transform(timestamp, {});
+
+    expect(React.isValidElement(result)).toBe(true);
+    // $FlowFixMe
+    expect(result.type).toBe('span');
+    // $FlowFixMe
+    expect(result.props.className).toBe('default');
+    // $FlowFixMe
+    expect(result.props.children).toContain('March 10, 2018');
+});
+
+test('Test timestamp with light skin', () => {
+    const timestamp = 1520690944;
+    const result = dateTimeFieldTransformer.transform(timestamp, {'skin': 'light'});
+
+    expect(React.isValidElement(result)).toBe(true);
+    // $FlowFixMe
+    expect(result.type).toBe('span');
+    // $FlowFixMe
+    expect(result.props.className).toBe('light');
+    // $FlowFixMe
+    expect(result.props.children).toContain('March 10, 2018');
+});
+
+test('Test timestamp with relative format - current timestamp', () => {
+    const currentTimestamp = Math.floor(Date.now() / 1000);
+    const dateTime = dateTimeFieldTransformer.transform(currentTimestamp, {format: 'relative'});
+
+    // $FlowFixMe
+    expect(dateTime.props.children).toContain('sulu_admin.sameDay');
+    expect(translate).toHaveBeenCalledWith('sulu_admin.sameDay');
+});
+
+test('Test invalid timestamp (non-numeric string)', () => {
+    expect(dateTimeFieldTransformer.transform('not-a-timestamp', {})).toBe(null);
+    expect(log.error).toBeCalledWith(
+        'Invalid date given: "not-a-timestamp". Format needs to be in "ISO 8601" or a valid timestamp.'
+    );
+});
+
+test('Test negative timestamp', () => {
+    // December 31, 1969 23:59:59 UTC (timestamp: -1)
+    const timestamp = -1;
+    const result = dateTimeFieldTransformer.transform(timestamp, {});
+
+    expect(React.isValidElement(result)).toBe(true);
+    // $FlowFixMe
+    expect(result.type).toBe('span');
+    // $FlowFixMe
+    expect(result.props.className).toBe('default');
+    // Check for December 31, 1969 or January 1, 1970 depending on timezone
+    // $FlowFixMe
+    const dateString = result.props.children;
+    expect(dateString).toMatch(/December 31, 1969|January 1, 1970/);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds support for timestamps in the DateTimeTransformer.

#### Why?

Timestamps do not need to be converted in the backend and we need it for the new versioning :)