### PR TITLE
Replace $request->request with $request->getPayload()

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -450,7 +450,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
 
             $account = $this->doPost($request);
             $this->entityManager->persist($account);
-            $this->domainEventCollector->collect(new AccountCreatedEvent($account, $request->request->all()));
+            $this->domainEventCollector->collect(new AccountCreatedEvent($account, $request->getPayload()->all()));
             $this->entityManager->flush();
 
             $locale = $this->getUser()->getLocale();
@@ -503,7 +503,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
         $account->setChanger($this->getUser());
 
         // Add urls, phones, emails, tags, bankAccounts, notes, addresses,..
-        $this->accountManager->addNewContactRelations($account, $request->request->all());
+        $this->accountManager->addNewContactRelations($account, $request->getPayload()->all());
 
         return $account;
     }
@@ -527,7 +527,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
             } else {
                 $this->doPut($account, $request, $this->entityManager);
 
-                $this->domainEventCollector->collect(new AccountModifiedEvent($account, $request->request->all()));
+                $this->domainEventCollector->collect(new AccountModifiedEvent($account, $request->getPayload()->all()));
                 $this->entityManager->flush();
 
                 // get api entity
@@ -704,7 +704,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
         $account->setMainContact($mainContact);
 
         if ($accountModified) {
-            $this->domainEventCollector->collect(new AccountModifiedEvent($account, $request->request->all()));
+            $this->domainEventCollector->collect(new AccountModifiedEvent($account, $request->getPayload()->all()));
         }
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactController.php
@@ -352,7 +352,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
         try {
             $this->checkArguments($request);
             $contact = $this->contactManager->save(
-                $request->request->all()
+                $request->getPayload()->all()
             );
             $apiContact = $this->contactManager->getContact(
                 $contact,
@@ -381,7 +381,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
     public function putAction($id, Request $request)
     {
         try {
-            $contact = $this->contactManager->save($request->request->all(), $id);
+            $contact = $this->contactManager->save($request->getPayload()->all(), $id);
 
             $apiContact = $this->contactManager->getContact($contact, $this->getUser()->getLocale());
             $view = $this->view($apiContact, 200);
@@ -408,7 +408,7 @@ class ContactController extends AbstractRestController implements ClassResourceI
     {
         try {
             $contact = $this->contactManager->save(
-                $request->request->all(),
+                $request->getPayload()->all(),
                 $id,
                 true
             );

--- a/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
@@ -112,7 +112,7 @@ class ContactTitleController extends AbstractRestController implements ClassReso
             $this->entityManager->persist($title);
 
             $this->domainEventCollector->collect(
-                new ContactTitleCreatedEvent($title, $request->request->all())
+                new ContactTitleCreatedEvent($title, $request->getPayload()->all())
             );
 
             $this->entityManager->flush();
@@ -151,7 +151,7 @@ class ContactTitleController extends AbstractRestController implements ClassReso
                     $title->setTitle($name);
 
                     $this->domainEventCollector->collect(
-                        new ContactTitleModifiedEvent($title, $request->request->all())
+                        new ContactTitleModifiedEvent($title, $request->getPayload()->all())
                     );
 
                     $this->entityManager->flush();

--- a/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/PositionController.php
@@ -119,7 +119,7 @@ class PositionController extends AbstractRestController implements ClassResource
             $this->entityManager->persist($position);
 
             $this->domainEventCollector->collect(
-                new ContactPositionCreatedEvent($position, $request->request->all())
+                new ContactPositionCreatedEvent($position, $request->getPayload()->all())
             );
 
             $this->entityManager->flush();
@@ -158,7 +158,7 @@ class PositionController extends AbstractRestController implements ClassResource
                     $position->setPosition($name);
 
                     $this->domainEventCollector->collect(
-                        new ContactPositionModifiedEvent($position, $request->request->all())
+                        new ContactPositionModifiedEvent($position, $request->getPayload()->all())
                     );
 
                     $this->entityManager->flush();

--- a/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
@@ -101,7 +101,7 @@ class CustomUrlController extends AbstractRestController implements SecuredContr
 
         $document = $this->customUrlManager->create(
             $webspace,
-            $request->request->all()
+            $request->getPayload()->all()
         );
         $this->documentManager->flush();
 
@@ -123,7 +123,7 @@ class CustomUrlController extends AbstractRestController implements SecuredContr
     {
         $manager = $this->customUrlManager;
 
-        $document = $manager->save($id, $request->request->all());
+        $document = $manager->save($id, $request->getPayload()->all());
         $this->documentManager->flush();
 
         $context = new Context();

--- a/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
@@ -27,7 +27,7 @@ abstract class AbstractMediaController extends AbstractRestController
      */
     protected function getData(Request $request, $fallback = true)
     {
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
         $data['locale'] = $request->get('locale', $fallback ? $this->getLocale($request) : null);
         $data['collection'] = $request->get('collection');
         $data['contentLanguages'] = $request->get('contentLanguages', []);

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
@@ -60,7 +60,7 @@ class MediaFormatController extends AbstractRestController implements ClassResou
      */
     public function putAction($id, $key, Request $request)
     {
-        $options = $request->request->all();
+        $options = $request->getPayload()->all();
 
         if (empty($options)) {
             $this->formatOptionsManager->delete($id, $key);
@@ -81,7 +81,7 @@ class MediaFormatController extends AbstractRestController implements ClassResou
      */
     public function cpatchAction($id, Request $request)
     {
-        $formatOptions = $request->request->all();
+        $formatOptions = $request->getPayload()->all();
         foreach ($formatOptions as $formatKey => $formatOption) {
             if (empty($formatOption)) {
                 $this->formatOptionsManager->delete($id, $formatKey);

--- a/src/Sulu/Bundle/PageBundle/Controller/PageController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/PageController.php
@@ -512,7 +512,7 @@ class PageController extends AbstractRestController implements ClassResourceInte
 
     private function persistDocument(Request $request, $formType, $document, $locale): void
     {
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
 
         if ($request->query->has('parentId')) {
             $data['parent'] = $request->query->get('parentId');

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -92,7 +92,7 @@ class PreviewRenderer implements PreviewRendererInterface
         $currentRequest = $this->requestStack->getCurrentRequest();
         if (null !== $currentRequest) {
             $query = $currentRequest->query->all();
-            $request = $currentRequest->request->all();
+            $request = $currentRequest->getPayload()->all();
         }
 
         $attributes = $this->routeDefaultsProvider->getByEntity(\get_class($object), $id, $locale, $object);

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
@@ -80,12 +80,12 @@ class ProfileController implements ClassResourceInterface
         $user = $this->tokenStorage->getToken()->getUser();
         $this->userManager->save($this->getData($request), $request->get('locale'), $user->getId(), true);
 
-        $user->setFirstName($request->request->get('firstName'));
-        $user->setLastName($request->request->get('lastName'));
+        $user->setFirstName($request->getPayload()->get('firstName'));
+        $user->setLastName($request->getPayload()->get('lastName'));
 
         if ($user instanceof TwoFactorInterface) {
             /** @var array{method?: string|null} $twoFactorData */
-            $twoFactorData = $request->request->all('twoFactor');
+            $twoFactorData = $request->getPayload()->all('twoFactor');
             $twoFactorMethod = $twoFactorData['method'] ?? null;
 
             if ($twoFactorMethod) {
@@ -124,7 +124,7 @@ class ProfileController implements ClassResourceInterface
      */
     public function patchSettingsAction(Request $request)
     {
-        $settings = $request->request->all();
+        $settings = $request->getPayload()->all();
 
         try {
             /** @var User $user */
@@ -223,7 +223,7 @@ class ProfileController implements ClassResourceInterface
     {
         $data = [];
 
-        foreach ($request->request->all() as $key => $value) {
+        foreach ($request->getPayload()->all() as $key => $value) {
             if (\in_array($key, ['firstName', 'lastName', 'username', 'email', 'password', 'locale'], true)) {
                 $data[$key] = $value;
             }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleController.php
@@ -161,9 +161,9 @@ class RoleController extends AbstractRestController implements ClassResourceInte
      */
     public function postAction(Request $request)
     {
-        $name = $request->request->get('name');
-        $key = $request->request->get('key');
-        $system = $request->request->get('system');
+        $name = $request->getPayload()->get('name');
+        $key = $request->getPayload()->get('key');
+        $system = $request->getPayload()->get('system');
 
         try {
             if (null === $name) {
@@ -179,7 +179,7 @@ class RoleController extends AbstractRestController implements ClassResourceInte
             $role->setKey($key);
             $role->setSystem($system);
 
-            $permissions = $request->request->all('permissions');
+            $permissions = $request->getPayload()->all('permissions');
 
             if (!empty($permissions)) {
                 foreach ($permissions as $permissionData) {
@@ -187,14 +187,14 @@ class RoleController extends AbstractRestController implements ClassResourceInte
                 }
             }
 
-            $securityTypeData = $request->request->all('securityType');
+            $securityTypeData = $request->getPayload()->all('securityType');
             if ($this->checkSecurityTypeData($securityTypeData)) {
                 $this->setSecurityType($role, $securityTypeData);
             }
 
             try {
                 $this->entityManager->persist($role);
-                $this->eventCollector->collect(new RoleCreatedEvent($role, $request->request->all()));
+                $this->eventCollector->collect(new RoleCreatedEvent($role, $request->getPayload()->all()));
                 $this->entityManager->flush();
 
                 $view = $this->view($this->convertRole($role), 200);
@@ -221,9 +221,9 @@ class RoleController extends AbstractRestController implements ClassResourceInte
     {
         /** @var RoleInterface $role */
         $role = $this->roleRepository->findRoleById($id);
-        $name = $request->request->get('name');
-        $key = $request->request->get('key');
-        $system = $request->request->get('system');
+        $name = $request->getPayload()->get('name');
+        $key = $request->getPayload()->get('key');
+        $system = $request->getPayload()->get('system');
 
         try {
             if (!$role) {
@@ -233,18 +233,18 @@ class RoleController extends AbstractRestController implements ClassResourceInte
                 $role->setKey($key);
                 $role->setSystem($system);
 
-                if (!$this->processPermissions($role, $request->request->all('permissions'))) {
+                if (!$this->processPermissions($role, $request->getPayload()->all('permissions'))) {
                     throw new RestException('Could not update dependencies!');
                 }
 
-                $securityTypeData = $request->request->all('securityType');
+                $securityTypeData = $request->getPayload()->all('securityType');
                 if ($this->checkSecurityTypeData($securityTypeData)) {
                     $this->setSecurityType($role, $securityTypeData);
                 } else {
                     $role->setSecurityType(null);
                 }
 
-                $this->eventCollector->collect(new RoleModifiedEvent($role, $request->request->all()));
+                $this->eventCollector->collect(new RoleModifiedEvent($role, $request->getPayload()->all()));
                 $this->entityManager->flush();
                 $view = $this->view($this->convertRole($role), 200);
             }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -132,7 +132,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
         try {
             $this->checkArguments($request);
             $locale = $this->getRequestParameter($request, 'locale', true);
-            $data = $request->request->all();
+            $data = $request->getPayload()->all();
             $data['contactId'] = $request->query->get('contactId');
             $user = $this->userManager->save($data, $locale);
             $view = $this->view($user, 200);
@@ -187,7 +187,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
         try {
             $this->checkArguments($request);
             $locale = $this->getRequestParameter($request, 'locale', true);
-            $user = $this->userManager->save($request->request->all(), $locale, $id);
+            $user = $this->userManager->save($request->getPayload()->all(), $locale, $id);
             $view = $this->view($user, 200);
         } catch (EntityNotFoundException $exc) {
             $view = $this->view($exc->toArray(), 404);
@@ -211,7 +211,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
     {
         try {
             $locale = $this->getRequestParameter($request, 'locale');
-            $user = $this->userManager->save($request->request->all(), $locale, $id, true);
+            $user = $this->userManager->save($request->getPayload()->all(), $locale, $id, true);
             $view = $this->view($user, 200);
         } catch (EntityNotFoundException $exc) {
             $view = $this->view($exc->toArray(), 404);

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/SingleSignOnLoginRequestSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/SingleSignOnLoginRequestSubscriber.php
@@ -62,8 +62,8 @@ class SingleSignOnLoginRequestSubscriber implements EventSubscriberInterface
         }
 
         $isResetPassword = 'sulu_security.reset_password.email' === $route;
-        $identifier = $request->request->get('username') ?? $request->request->get('user');
-        $password = $request->request->get('password');
+        $identifier = $request->getPayload()->get('username') ?? $request->getPayload()->get('user');
+        $password = $request->getPassword()->get('password');
 
         if (!$identifier || !\is_string($identifier)) {
             return;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginRequestSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginRequestSubscriberTest.php
@@ -115,7 +115,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_admin.login_check');
-        $request->request->set('username', 'martin');
+        $request->getPayload()->set('username', 'martin');
         $event = $this->createRequestEvent($request);
 
         $this->subscriber->onKernelRequest($event);
@@ -127,8 +127,8 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_admin.login_check');
-        $request->request->set('username', 'martin');
-        $request->request->set('password', '123');
+        $request->getPayload()->set('username', 'martin');
+        $request->getPayload()->set('password', '123');
         $event = $this->createRequestEvent($request);
 
         $this->subscriber->onKernelRequest($event);
@@ -140,7 +140,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
-        $request->request->set('username', 'martin');
+        $request->getPayload()->set('username', 'martin');
         $event = $this->createRequestEvent($request);
 
         $this->subscriber->onKernelRequest($event);
@@ -152,7 +152,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
-        $request->request->set('username', 'hello@sulu.io');
+        $request->getPayload()->set('username', 'hello@sulu.io');
         $event = $this->createRequestEvent($request);
 
         $this->subscriber->onKernelRequest($event);
@@ -164,7 +164,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
-        $request->request->set('username', 'admin');
+        $request->getPayload()->set('username', 'admin');
         $event = $this->createRequestEvent($request);
         $user = new User();
         $user->setEmail('admin@sulu.io');
@@ -178,7 +178,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
-        $request->request->set('username', 'admin');
+        $request->getPayload()->set('username', 'admin');
         $event = $this->createRequestEvent($request);
         $user = new User();
         $user->setEmail('admin@sulu.io');
@@ -193,8 +193,8 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
     {
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
-        $request->request->set('username', 'admin');
-        $request->request->set('password', 'admin');
+        $request->getPayload()->set('username', 'admin');
+        $request->getPayload()->set('password', 'admin');
         $event = $this->createRequestEvent($request);
         $user = new User();
         $user->setEmail('admin@sulu.io');
@@ -210,7 +210,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
         $redirectUrl = 'https://example.com/authorize';
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_admin.login_check');
-        $request->request->set('username', 'martin@sulu.io');
+        $request->getPayload()->set('username', 'martin@sulu.io');
         $event = $this->createRequestEvent($request);
         $openIdAdapter = $this->prophesize(OpenIdSingleSignOnAdapter::class);
         $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)
@@ -229,7 +229,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
         $redirectUrl = 'https://example.com/authorize';
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
-        $request->request->set('username', 'martin@sulu.io');
+        $request->getPayload()->set('username', 'martin@sulu.io');
         $event = $this->createRequestEvent($request);
         $openIdAdapter = $this->prophesize(OpenIdSingleSignOnAdapter::class);
         $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)
@@ -248,7 +248,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
         $redirectUrl = 'https://example.com/authorize';
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_admin.login_check');
-        $request->request->set('username', 'admin');
+        $request->getPayload()->set('username', 'admin');
         $event = $this->createRequestEvent($request);
         $openIdAdapter = $this->prophesize(OpenIdSingleSignOnAdapter::class);
         $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)
@@ -270,7 +270,7 @@ class SingleSignOnLoginRequestSubscriberTest extends TestCase
         $redirectUrl = 'https://example.com/authorize';
         $request = Request::create('/admin/login', Request::METHOD_POST);
         $request->attributes->set('_route', 'sulu_security.reset_password.email');
-        $request->request->set('username', 'admin');
+        $request->getPayload()->set('username', 'admin');
         $event = $this->createRequestEvent($request);
         $openIdAdapter = $this->prophesize(OpenIdSingleSignOnAdapter::class);
         $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)

--- a/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
+++ b/src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
@@ -423,7 +423,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     private function processForm(Request $request, $document)
     {
         $locale = $this->getLocale($request);
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
         $data['workflowStage'] = $request->get('state', WorkflowStage::PUBLISHED);
 
         /** @var class-string<FormTypeInterface> $formType */
@@ -461,7 +461,7 @@ class SnippetController implements SecuredControllerInterface, ClassResourceInte
     private function checkAreaSnippet(Request $request, SnippetDocument $document)
     {
         $force = $request->headers->get('SuluForcePut', false);
-        $structureType = $request->request->get('template');
+        $structureType = $request->getPayload()->get('template');
 
         return $force
             || $structureType === $document->getStructureType()

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -292,6 +292,6 @@ class TagController extends AbstractRestController implements ClassResourceInter
      */
     protected function getData(Request $request)
     {
-        return $request->request->all();
+        return $request->getPayload()->all();
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
+++ b/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
@@ -203,7 +203,7 @@ class TrashItemController extends AbstractRestController implements ClassResourc
 
         try {
             return match ($action) {
-                'restore' => $this->restoreTrashItem($id, $request->request->all()),
+                'restore' => $this->restoreTrashItem($id, $request->getPayload()->all()),
                 default => throw new RestException(\sprintf('Unrecognized action: "%s"', $action)),
             };
         } catch (RestException $ex) {

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -110,7 +110,7 @@ class AnalyticsController extends AbstractRestController implements ClassResourc
      */
     public function postAction(Request $request, $webspace)
     {
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
         $data['content'] = $this->buildContent($data);
 
         $entity = $this->analyticsManager->create($webspace, $data);
@@ -130,7 +130,7 @@ class AnalyticsController extends AbstractRestController implements ClassResourc
      */
     public function putAction(Request $request, $webspace, $id)
     {
-        $data = $request->request->all();
+        $data = $request->getPayload()->all();
         $data['content'] = $this->buildContent($data);
 
         $entity = $this->analyticsManager->update($id, $data);

--- a/src/Sulu/Component/Hash/RequestHashChecker.php
+++ b/src/Sulu/Component/Hash/RequestHashChecker.php
@@ -28,9 +28,9 @@ class RequestHashChecker implements RequestHashCheckerInterface
 
     public function checkHash(Request $request, $object, $identifier)
     {
-        if (!$request->request->has($this->hashParameter)
+        if (!$request->getPayload()->has($this->hashParameter)
             || 'true' === $request->query->get($this->forceParameter, false)
-            || $request->request->get($this->hashParameter) == $this->hasher->hash($object)
+            || $request->getPayload()->get($this->hashParameter) == $this->hasher->hash($object)
         ) {
             return true;
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7811
| Related issues/PRs | #7811
| License | MIT
| Documentation PR | sulu/sulu-docs

#### What's in this PR?

Replacing $request->request with $request->getPayload()

#### Why?

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->
Addresses #7811 

#### Example Usage

```
$request->request->get('foo');
becomes
$request->getPayload()->get('foo');
```
<!--
```php
// If you added new features, show examples of how to use them here

$foo = new Foo();

// Now we can do
$foo->doSomething();
```
-->

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md

<!--

Dear Contributors,

Thank you for contributing to the Sulu ecosystem!

We appreciate your effort to improve our project.  
If you need assistance or have questions about your pull request, our team is here to help.  
Please join our Slack channel for support: https://sulu.io/services/support#chat.

Best Regards, 
The Sulu Core Team

-->
