### PR TITLE
Remove show drafts variable from ContentTeaserProvider

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
@@ -40,9 +40,8 @@ class ArticleTeaserProvider extends ContentTeaserProvider
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
-        bool $showDrafts,
     ) {
-        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, ArticleInterface::class, $showDrafts);
+        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, ArticleInterface::class);
 
         $this->translator = $translator;
     }

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -225,7 +225,6 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_content.content_metadata_inspector'),
                 new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('translator'),
-                '%sulu_document_manager.show_drafts%',
             ])
             ->tag('sulu.teaser.provider', ['alias' => ArticleInterface::RESOURCE_KEY]);
 

--- a/packages/content/src/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
+++ b/packages/content/src/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
@@ -65,13 +65,7 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
     protected $contentRichEntityClass;
 
     /**
-     * @var bool
-     */
-    protected $showDrafts;
-
-    /**
      * @param class-string<T> $contentRichEntityClass
-     * @param bool $showDrafts Inject parameter "sulu_document_manager.show_drafts" here
      */
     public function __construct(
         ContentManagerInterface $contentManager,
@@ -79,14 +73,12 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         string $contentRichEntityClass,
-        bool $showDrafts
     ) {
         $this->contentManager = $contentManager;
         $this->entityManager = $entityManager;
         $this->contentMetadataInspector = $contentMetadataInspector;
         $this->metadataProviderRegistry = $metadataProviderRegistry;
         $this->contentRichEntityClass = $contentRichEntityClass;
-        $this->showDrafts = $showDrafts;
     }
 
     /**

--- a/packages/content/tests/Application/ExampleTestBundle/Resources/config/services.yaml
+++ b/packages/content/tests/Application/ExampleTestBundle/Resources/config/services.yaml
@@ -40,7 +40,6 @@ services:
             - '@sulu_content.content_metadata_inspector'
             - '@sulu_admin.metadata_provider_registry'
             - '@translator'
-            - '%sulu_document_manager.show_drafts%'
         tags:
             - { name: sulu.teaser.provider, alias: examples }
 

--- a/packages/content/tests/Application/ExampleTestBundle/Teaser/ExampleTeaserProvider.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Teaser/ExampleTeaserProvider.php
@@ -40,9 +40,8 @@ class ExampleTeaserProvider extends ContentTeaserProvider
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
-        bool $showDrafts
     ) {
-        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, Example::class, $showDrafts);
+        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, Example::class);
 
         $this->translator = $translator;
     }

--- a/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
@@ -40,9 +40,8 @@ class PageTeaserProvider extends ContentTeaserProvider
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
-        bool $showDrafts,
     ) {
-        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, PageInterface::class, $showDrafts);
+        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, PageInterface::class);
 
         $this->translator = $translator;
     }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -319,7 +319,6 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_content.content_metadata_inspector'),
                 new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('translator'),
-                '%sulu_document_manager.show_drafts%',
             ])
             ->tag('sulu.teaser.provider', ['alias' => PageInterface::RESOURCE_KEY]);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove show drafts variable from ContentTeaserProvider.

#### Why?

As part of: https://github.com/sulu/sulu/pull/7995