### PR TITLE
Fix ExampleControllerTest to use the correct RouteRepository

### DIFF
--- a/packages/content/tests/Functional/Integration/ExampleControllerTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerTest.php
@@ -15,6 +15,7 @@ namespace Sulu\Content\Tests\Functional\Integration;
 
 use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
@@ -142,8 +143,8 @@ class ExampleControllerTest extends SuluTestCase
 
         $this->assertResponseSnapshot('example_post.json', $response, 201);
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(1, $routeRepository->findBy([]));
 
         /** @var int $id */
         $id = \json_decode((string) $response->getContent(), true)['id'] ?? null; // @phpstan-ignore-line
@@ -224,8 +225,8 @@ class ExampleControllerTest extends SuluTestCase
 
         $response = $this->client->getResponse();
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(3, $routeRepository->findBy([]));
 
         $this->assertResponseSnapshot('example_put.json', $response, 200);
     }
@@ -248,8 +249,8 @@ class ExampleControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(204, $response);
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(3, $routeRepository->findBy([])); // TODO we need tackle this
     }
 
     protected function getSnapshotFolder(): string


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | 
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Update test to use the correct route repo.

#### Why?

As part of https://github.com/sulu/sulu/pull/7995 stumbled over that the tests still uses the old repo instead of the new to test the routes.