### PR TITLE
Fix deprecation in Route Bundle build method by add return type

### DIFF
--- a/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
+++ b/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
@@ -51,7 +51,7 @@ final class SuluRouteBundle extends AbstractBundle
         $this->extensionAlias = 'sulu_next_route'; // TODO also change route table from `ro_next_routes` to `ro_routes`
     }
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RouteDefaultsOptionsCompilerPass());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add return type to route bundle build method.

#### Why?

Fix deprecation in Route Bundle build method by add return type thrown in tests.