### PR TITLE
Remove usage of old route repository in page and article controller tests

### DIFF
--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -15,6 +15,7 @@ namespace Sulu\Article\Tests\Functional\Integration;
 
 use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
@@ -143,8 +144,8 @@ class ArticleControllerTest extends SuluTestCase
 
         $this->assertResponseSnapshot('article_post.json', $response, 201);
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(1, $routeRepository->findBy([]));
 
         /** @var string $id */
         $id = \json_decode((string) $response->getContent(), true)['id'] ?? null; // @phpstan-ignore-line
@@ -223,8 +224,8 @@ class ArticleControllerTest extends SuluTestCase
 
         $response = $this->client->getResponse();
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(3, $routeRepository->findBy([]));
 
         $this->assertResponseSnapshot('article_put.json', $response, 200);
     }
@@ -247,8 +248,8 @@ class ArticleControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(204, $response);
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(3, $routeRepository->findBy([])); // TODO we need tackle this
     }
 
     protected function getSnapshotFolder(): string

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -377,7 +377,7 @@ class PageControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(3, $routeRepository->findBy([]));
+        $this->assertCount(4, $routeRepository->findBy([]));
 
         $this->assertResponseSnapshot('page_put.json', $response, 200);
     }
@@ -416,6 +416,10 @@ class PageControllerTest extends SuluTestCase
         $this->client->request('GET', '/admin/api/pages?locale=en&webspace=sulu-io&expandedIds=' . $id);
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('page_post_before_order_list.json', $response, 200);
+
+        // test if the routes count still correct
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(7, $routeRepository->findBy([]));
 
         return $id;
     }
@@ -504,6 +508,9 @@ class PageControllerTest extends SuluTestCase
         /** @var string $copiedPageId */
         $copiedPageId = $content['_embedded']['pages'][0]['_embedded']['pages'][1]['_embedded']['pages'][0]['id']; // @phpstan-ignore-line
 
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(10, $routeRepository->findBy([]));
+
         return $copiedPageId;
     }
 
@@ -529,7 +536,7 @@ class PageControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(204, $response);
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(3, $routeRepository->findBy([])); // TODO we need tackle this
+        $this->assertCount(10, $routeRepository->findBy([])); // TODO we need tackle this
     }
 
     protected function getSnapshotFolder(): string

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -23,6 +23,7 @@ use Sulu\Page\Application\MessageHandler\CreatePageMessageHandler;
 use Sulu\Page\Application\MessageHandler\ModifyPageMessageHandler;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
@@ -234,8 +235,8 @@ class PageControllerTest extends SuluTestCase
 
         $this->assertResponseSnapshot('page_post.json', $response, 201);
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(1, $routeRepository->findBy([]));
 
         /** @var string $id */
         $id = \json_decode((string) $response->getContent(), true)['id'] ?? null; // @phpstan-ignore-line
@@ -375,8 +376,8 @@ class PageControllerTest extends SuluTestCase
 
         $response = $this->client->getResponse();
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(3, $routeRepository->findBy([]));
 
         $this->assertResponseSnapshot('page_put.json', $response, 200);
     }
@@ -527,8 +528,8 @@ class PageControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(204, $response);
 
-        $routeRepository = $this->getContainer()->get('sulu.repository.route');
-        $this->assertCount(0, $routeRepository->findAll());
+        $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+        $this->assertCount(3, $routeRepository->findBy([])); // TODO we need tackle this
     }
 
     protected function getSnapshotFolder(): string


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | yes 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | see https://github.com/sulu/sulu/pull/8065, https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use correct new route repository.

#### Why?

See https://github.com/sulu/sulu/pull/8065