### PR TITLE
Resolve nested content / view blocks

### DIFF
--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -14,6 +14,7 @@
             <argument type="service" id="sulu_content.resource_loader_provider"/>
             <argument type="service" id="sulu_content.content_aggregator"/>
             <argument type="service" id="sulu_content.smart_resolver_provider"/>
+            <argument type="service" id="property_accessor"/>
         </service>
         <service id="Sulu\Content\Application\ContentResolver\ContentResolverInterface" alias="sulu_content.content_resolver"/>
 

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -336,9 +336,12 @@ class ContentResolver implements ContentResolverInterface
                 $result['content'][$name][$key] = $entry;
                 if (isset($view[$key])) {
                     $result['view'][$name][$key] = $view[$key];
-                } else {
-                    $result['view'][$name][$key] = $view;
                 }
+            }
+
+            // If the view is not set for this name, we can use the root view
+            if (($result['view'][$name] ?? null) === null) {
+                $result['view'][$name] = $view;
             }
 
             $result['resolvableResources'] = $resolvableResources;

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -24,6 +24,7 @@ use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
 use Sulu\Content\Application\SmartResolver\SmartResolverProviderInterface;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -42,6 +43,7 @@ class ContentResolver implements ContentResolverInterface
         private ResourceLoaderProvider $resourceLoaderProvider,
         private ContentAggregatorInterface $contentAggregator,
         private SmartResolverProviderInterface $smartResolverProvider,
+        private PropertyAccessorInterface $propertyAccessor
     ) {
     }
 
@@ -95,10 +97,10 @@ class ContentResolver implements ContentResolverInterface
                         ]);
 
                         // Resolve this entity
-                        $result = $this->resolveInternal($resourceDimension, $depth, $priorityQueue);
+                        $normalizedContentData = $this->resolveInternal($resourceDimension, $depth, $priorityQueue);
                         $resolvedValue = $this->normalizeContentData(
-                            $result['content'],
-                            $result['view'],
+                            $normalizedContentData['content'],
+                            $normalizedContentData['view'],
                             $resource,
                         );
                     } elseif ($resource instanceof ContentView) {
@@ -106,17 +108,18 @@ class ContentResolver implements ContentResolverInterface
                          *     content: array{'0': array<string, mixed>},
                          *     view: array{'0': array<string, mixed>},
                          *     resolvableResources: array<int, array<string, array<int, array<int|string, ResolvableInterface>>>>
-                         * } $result */
-                        $result = $this->resolveContentView($resource, '0', $depth);
+                         * } $normalizedContentData
+                         */
+                        $normalizedContentData = $this->resolveContentView($resource, '0', $depth);
                         $resolvedValue = [
-                            'content' => $result['content']['0'],
+                            'content' => $normalizedContentData['content']['0'],
                             // All resolved resources have the same view structure, so we can just take the first one
-                            'view' => \reset($result['view']['0']) ?? $result['view']['0'],
+                            'view' => \reset($normalizedContentData['view']['0']) ?? $normalizedContentData['view']['0'],
                         ];
 
                         // Add resolvable resources to priority queue
                         $priorityQueue = $this->mergeResolvableResources(
-                            $result['resolvableResources'],
+                            $normalizedContentData['resolvableResources'],
                             $priorityQueue,
                         );
                     } else {
@@ -136,11 +139,62 @@ class ContentResolver implements ContentResolverInterface
             1, // Start at depth 1 since the initial resolution was at depth 0
         );
 
-        return $this->normalizeContentData(
+        $normalizedContentData = $this->normalizeContentData(
             $finalContent,
             $resolvedContent['view'],
             $dimensionContent->getResource(),
         );
+
+        $this->replaceNestedContentViews($normalizedContentData, '[content]');
+
+        return $normalizedContentData;
+    }
+
+    /**
+     * @param array{
+     *     resource: object,
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     extension: array<string, array<string, mixed>>
+     * } $normalizedContentData
+     */
+    private function replaceNestedContentViews(array &$normalizedContentData, string $path): void
+    {
+        $pathValues = [];
+        $iterable = $this->propertyAccessor->getValue($normalizedContentData, $path) ?? [];
+        if (!\is_array($iterable)) {
+            return;
+        }
+
+        /** @var string $key */
+        foreach ($iterable as $key => $entry) {
+            if (\is_array($entry)) {
+                if ([] !== $entry) {
+                    $this->replaceNestedContentViews($normalizedContentData, $path . '[' . $key . ']');
+                }
+                if ('view' === $key) {
+                    $value = $this->propertyAccessor->getValue($normalizedContentData, $path . '[' . $key . ']');
+                    // Replace 'content' with 'view' in the path
+                    $viewPath = \substr_replace($path, '[view]', 0, 9);
+
+                    // If there are more [content] positions, we need to remove them, only keep the first one from the root property resolver
+                    $viewPath = (($nextContentPosition = \strpos($viewPath, '[content]')) !== false) ? \substr($viewPath, 0, $nextContentPosition) : $viewPath;
+
+                    // Only override empty view paths
+                    if (($this->propertyAccessor->getValue($normalizedContentData, $viewPath) ?? []) === []) {
+                        $pathValues[$viewPath] = $value;
+                    }
+                }
+                if ('content' === $key) {
+                    $value = $this->propertyAccessor->getValue($normalizedContentData, $path . '[' . $key . ']');
+                    $pathValues[$path] = $value;
+                }
+            }
+        }
+
+        foreach ($pathValues as $path => $value) {
+            $this->propertyAccessor->setValue($normalizedContentData, $path, $value); // @phpstan-ignore-line
+        }
     }
 
     /**

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -139,8 +139,6 @@ class ContentResolverTest extends SuluTestCase
 
     public function testResolveMedias(): void
     {
-        self::markTestSkipped('This test is skipped because it somehow fails in the CI.');
-
         // @phpstan-ignore-next-line
         $collection1 = self::createCollection(['title' => 'collection-1', 'locale' => 'en']);
         $mediaType = self::createMediaType(['name' => 'Image', 'description' => 'This is an image']);
@@ -204,20 +202,18 @@ class ContentResolverTest extends SuluTestCase
         self::assertSame($media1->getId(), $contentMedia1->getId());
 
         /** @var mixed[] $excerpt */
-        $excerpt = $content['excerpt'];
-        $contentMedia1 = $excerpt['excerptIcon'];
+        $excerpt = $result['extension']['excerpt'];
+        $contentMedia1 = $excerpt['icon'];
         self::assertInstanceOf(Media::class, $contentMedia1);
         self::assertSame($media1->getId(), $contentMedia1->getId());
 
-        $contentMedia2 = $excerpt['excerptImage'];
+        $contentMedia2 = $excerpt['image'];
         self::assertInstanceOf(Media::class, $contentMedia2);
         self::assertSame($media2->getId(), $contentMedia2->getId());
     }
 
     public function testResolveCollections(): void
     {
-        self::markTestSkipped('This test is skipped because it somehow fails in the CI.');
-
         // @phpstan-ignore-next-line
         $collection1 = self::createCollection(['title' => 'collection-1', 'locale' => 'en']);
         $collection2 = self::createCollection([
@@ -270,8 +266,6 @@ class ContentResolverTest extends SuluTestCase
 
     public function testResolveCategories(): void
     {
-        self::markTestSkipped('This test is skipped because it somehow fails in the CI.');
-
         // @phpstan-ignore-next-line
         $category1 = self::createCategory(['key' => 'category-1']);
         $category2 = self::createCategory(['key' => 'category-2']);
@@ -305,9 +299,12 @@ class ContentResolverTest extends SuluTestCase
         $categorySelection = $content['category_selection'];
         self::assertIsArray($categorySelection);
         self::assertCount(2, $categorySelection);
+
         $contentCategory1 = $categorySelection[0];
+        self::assertInstanceOf(Category::class, $contentCategory1);
         self::assertSame($category1->getId(), $contentCategory1->getId());
         $contentCategory2 = $categorySelection[1];
+        self::assertInstanceOf(Category::class, $contentCategory2);
         self::assertSame($category2->getId(), $contentCategory2->getId());
 
         $singleCategorySelection = $content['single_category_selection'];
@@ -315,14 +312,15 @@ class ContentResolverTest extends SuluTestCase
         self::assertSame($category1->getId(), $singleCategorySelection->getId());
 
         /** @var mixed[] $excerpt */
-        $excerpt = $content['excerpt'];
-
-        $excerptCategories = $excerpt['excerptCategories'];
+        $excerpt = $result['extension']['excerpt'];
+        $excerptCategories = $excerpt['categories'];
         self::assertIsArray($excerptCategories);
         self::assertCount(2, $excerptCategories);
         $excerptCategory1 = $excerptCategories[0];
+        self::assertInstanceOf(Category::class, $excerptCategory1);
         self::assertSame($category1->getId(), $excerptCategory1->getId());
         $excerptCategory2 = $excerptCategories[1];
+        self::assertInstanceOf(Category::class, $excerptCategory2);
         self::assertSame($category2->getId(), $excerptCategory2->getId());
     }
 
@@ -370,8 +368,6 @@ class ContentResolverTest extends SuluTestCase
 
     public function testResolveContentBlocks(): void
     {
-        self::markTestSkipped('This test is skipped because it somehow fails in the CI.');
-
         // @phpstan-ignore-next-line
         $collection1 = self::createCollection(['title' => 'collection-1', 'locale' => 'en']);
         $mediaType = self::createMediaType(['name' => 'Image', 'description' => 'This is an image']);
@@ -425,39 +421,50 @@ class ContentResolverTest extends SuluTestCase
         static::getEntityManager()->flush();
 
         $dimensionContent = $this->contentAggregator->aggregate($example1, ['locale' => 'en', 'stage' => 'live']);
-        /** @var mixed[] $result */
+        /** @var array{content: array{title: string, url: string, blocks: array<int, mixed>}} $result */
         $result = $this->contentResolver->resolve($dimensionContent);
 
-        /** @var mixed[] $content */
+        /** @var array{title: string, url: string, blocks: array<int, mixed>} $content */
         $content = $result['content'];
 
         self::assertSame('Lorem Ipsum', $content['title']);
         self::assertSame('/lorem-ipsum', $content['url']);
 
         // block 0
-        self::assertSame('editor', $content['blocks'][0]['type']);
-        self::assertSame('<p>Block Level 0: Lorem Ipsum dolor sit amet</p>', $content['blocks'][0]['text_editor']);
+        /** @var array{type: string, text_editor: string} $block0 */
+        $block0 = $content['blocks'][0];
+        self::assertSame('editor', $block0['type']);
+        self::assertSame('<p>Block Level 0: Lorem Ipsum dolor sit amet</p>', $block0['text_editor']);
 
         // block 1
-        self::assertSame('media', $content['blocks'][1]['type']);
-        $mediaSelection = $content['blocks'][1]['media_selection'];
+        /** @var array{type: string, media_selection: mixed[]} $block1 */
+        $block1 = $content['blocks'][1];
+        self::assertSame('media', $block1['type']);
+        $mediaSelection = $block1['media_selection'];
         self::assertCount(1, $mediaSelection);
         $mediaApi1 = $mediaSelection[0];
         self::assertInstanceOf(Media::class, $mediaApi1);
         self::assertSame($media1->getId(), $mediaApi1->getId());
 
         // block 2
-        self::assertSame('block', $content['blocks'][2]['type']);
-        self::assertSame('<p>Block Level 1: Lorem Ipsum dolor sit amet</p>', $content['blocks'][2]['blocks'][0]['text_editor']);
-        self::assertSame('editor', $content['blocks'][2]['blocks'][0]['type']);
+        /** @var array{type: string, blocks: array<int, mixed>} $block2 */
+        $block2 = $content['blocks'][2];
+        self::assertSame('block', $block2['type']);
 
-        self::assertSame('media', $content['blocks'][2]['blocks'][1]['type']);
-        $mediaSelection = $content['blocks'][2]['blocks'][1]['media_selection'];
+        /** @var array{type: string, text_editor: string} $block2_0 */
+        $block2_0 = $block2['blocks'][0];
+        self::assertSame('<p>Block Level 1: Lorem Ipsum dolor sit amet</p>', $block2_0['text_editor']);
+        self::assertSame('editor', $block2_0['type']);
+
+        /** @var array{type: string, media_selection: mixed[]} $block2_1 */
+        $block2_1 = $block2['blocks'][1];
+        self::assertSame('media', $block2_1['type']);
+        $mediaSelection = $block2_1['media_selection'];
         self::assertCount(2, $mediaSelection);
-        $mediaApi1 = $content['blocks'][2]['blocks'][1]['media_selection'][0];
+        $mediaApi1 = $block2_1['media_selection'][0];
         self::assertInstanceOf(Media::class, $mediaApi1);
         self::assertSame($media1->getId(), $mediaApi1->getId());
-        $mediaApi2 = $content['blocks'][2]['blocks'][1]['media_selection'][1];
+        $mediaApi2 = $block2_1['media_selection'][1];
         self::assertInstanceOf(Media::class, $mediaApi2);
         self::assertSame($media2->getId(), $mediaApi2->getId());
     }

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -421,20 +421,29 @@ class ContentResolverTest extends SuluTestCase
         static::getEntityManager()->flush();
 
         $dimensionContent = $this->contentAggregator->aggregate($example1, ['locale' => 'en', 'stage' => 'live']);
-        /** @var array{content: array{title: string, url: string, blocks: array<int, mixed>}} $result */
+        /** @var array{content: array{title: string, url: string, blocks: array<int, mixed>}, view: array{blocks: array<int, mixed>}} $result */
         $result = $this->contentResolver->resolve($dimensionContent);
 
         /** @var array{title: string, url: string, blocks: array<int, mixed>} $content */
         $content = $result['content'];
-
         self::assertSame('Lorem Ipsum', $content['title']);
         self::assertSame('/lorem-ipsum', $content['url']);
+
+        /** @var array{blocks: array<int, mixed>} $view */
+        $view = $result['view'];
+        /** @var array<int, mixed> $viewBlocks */
+        $viewBlocks = $view['blocks'];
+        self::assertCount(3, $viewBlocks);
 
         // block 0
         /** @var array{type: string, text_editor: string} $block0 */
         $block0 = $content['blocks'][0];
         self::assertSame('editor', $block0['type']);
         self::assertSame('<p>Block Level 0: Lorem Ipsum dolor sit amet</p>', $block0['text_editor']);
+
+        /** @var array{text_editor: mixed} $viewBlock0 */
+        $viewBlock0 = $viewBlocks[0];
+        self::assertSame([], $viewBlock0['text_editor']);
 
         // block 1
         /** @var array{type: string, media_selection: mixed[]} $block1 */
@@ -446,15 +455,28 @@ class ContentResolverTest extends SuluTestCase
         self::assertInstanceOf(Media::class, $mediaApi1);
         self::assertSame($media1->getId(), $mediaApi1->getId());
 
+        /** @var array{media_selection: array{ids: mixed[], displayOption: mixed}} $viewBlock1 */
+        $viewBlock1 = $viewBlocks[1];
+        $mediaSelectionView = $viewBlock1['media_selection'];
+        self::assertSame([$media1->getId()], $mediaSelectionView['ids']);
+        self::assertNull($mediaSelectionView['displayOption']);
+
         // block 2
         /** @var array{type: string, blocks: array<int, mixed>} $block2 */
         $block2 = $content['blocks'][2];
         self::assertSame('block', $block2['type']);
+        /** @var array{blocks: array<int, mixed>} $viewBlock2 */
+        $viewBlock2 = $viewBlocks[2];
+        /** @var array<int, mixed> $viewBlocks2 */
+        $viewBlocks2 = $viewBlock2['blocks'];
 
         /** @var array{type: string, text_editor: string} $block2_0 */
         $block2_0 = $block2['blocks'][0];
         self::assertSame('<p>Block Level 1: Lorem Ipsum dolor sit amet</p>', $block2_0['text_editor']);
         self::assertSame('editor', $block2_0['type']);
+        /** @var array{text_editor: mixed} $viewBlock2_0 */
+        $viewBlock2_0 = $viewBlocks2[0];
+        self::assertSame([], $viewBlock2_0['text_editor']);
 
         /** @var array{type: string, media_selection: mixed[]} $block2_1 */
         $block2_1 = $block2['blocks'][1];
@@ -467,5 +489,11 @@ class ContentResolverTest extends SuluTestCase
         $mediaApi2 = $block2_1['media_selection'][1];
         self::assertInstanceOf(Media::class, $mediaApi2);
         self::assertSame($media2->getId(), $mediaApi2->getId());
+
+        /** @var array{media_selection: array{ids: mixed[], displayOption: mixed}} $viewBlock2_1 */
+        $viewBlock2_1 = $viewBlocks2[1];
+        $mediaSelectionView = $viewBlock2_1['media_selection'];
+        self::assertSame([$media1->getId(), $media2->getId()], $mediaSelectionView['ids']);
+        self::assertNull($mediaSelectionView['displayOption']);
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -34,6 +34,7 @@ use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionPropertyResolver;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class ContentResolverTest extends TestCase
 {
@@ -102,6 +103,7 @@ class ContentResolverTest extends TestCase
             $this->resourceLoaderProvider,
             $this->contentAggregator->reveal(),
             new SmartResolverProvider($serviceLocator),
+            new PropertyAccessor()
         );
     }
 
@@ -156,17 +158,10 @@ class ContentResolverTest extends TestCase
          *     article: string|null,
          *     pages: array{
          *       array{
-         *         resource: Page,
-         *         content: array{
-         *           title: string,
-         *           url: string,
-         *           article: string|null
-         *         },
-         *         view: array{
-         *           title: mixed[],
-         *           url: mixed[],
-         *           article: mixed[]
-         *         }
+         *         title: string,
+         *         url: string,
+         *         article: string|null,
+         *         pages?: array<mixed>|null
          *       }
          *     }
          *   },
@@ -174,7 +169,9 @@ class ContentResolverTest extends TestCase
          *     title: mixed[],
          *     url: mixed[],
          *     article: mixed[],
-         *     pages: array{0: array{ids: array<string>}}
+         *     pages: array{
+         *       array{ids: array<string>}
+         *     }
          *   }
          * } $result
          */
@@ -194,16 +191,10 @@ class ContentResolverTest extends TestCase
         self::assertSame(['111-111-222'], $view['pages'][0]['ids']);
 
         // SubEntity
-        self::assertSame($content['pages'][0]['resource'], $page2);
-        $innerContent = $content['pages'][0]['content'];
+        $innerContent = $content['pages'][0];
         self::assertSame('Page 2', $innerContent['title']);
         self::assertSame('/page-2', $innerContent['url']);
         self::assertSame('<p>Page 2 article</p>', $innerContent['article']);
-
-        $innerView = $content['pages'][0]['view'];
-        self::assertSame([], $innerView['title']);
-        self::assertSame([], $innerView['url']);
-        self::assertSame([], $innerView['article']);
     }
 
     public function testResolveCircularLoopPages(): void
@@ -265,79 +256,75 @@ class ContentResolverTest extends TestCase
         $expectedData = [
             // Level 0 - page1
             [
-                'resource' => $page1,
                 'title' => 'Sulu',
                 'url' => '/page',
                 'article' => null,
-                'nextId' => '111-111-222',
             ],
             // Level 1 - page2
             [
-                'resource' => $page2,
                 'title' => 'Page 2',
                 'url' => '/page-2',
                 'article' => '<p>Page 2 article</p>',
-                'nextId' => '111-111-111',
             ],
             // Levels 2, 4 - page1 (repeats)
             [
-                'resource' => $page1,
                 'title' => 'Sulu',
                 'url' => '/page',
                 'article' => null,
-                'nextId' => '111-111-222',
             ],
             // Levels 3, 5 - page2 (repeats)
             [
-                'resource' => $page2,
                 'title' => 'Page 2',
                 'url' => '/page-2',
                 'article' => '<p>Page 2 article</p>',
-                'nextId' => '111-111-111',
             ],
             // Back to page1 for level 4
             [
-                'resource' => $page1,
                 'title' => 'Sulu',
                 'url' => '/page',
                 'article' => null,
-                'nextId' => '111-111-222',
             ],
             // Back to page2 for level 5
             [
-                'resource' => $page2,
                 'title' => 'Page 2',
                 'url' => '/page-2',
                 'article' => '<p>Page 2 article</p>',
-                'nextId' => '111-111-111',
             ],
         ];
 
-        $contentPointer = $result;
+        $contentPointer = $result['content'];
+
+        /**
+         * @var array{
+         *     title: mixed[],
+         *     url: mixed[],
+         *     article: mixed[],
+         *     pages: array<int, array{ids: array<string>}>
+         * } $view
+         */
+        $view = $result['view'];
+        self::assertSame([], $view['title']);
+        self::assertSame([], $view['url']);
+        self::assertSame([], $view['article']);
+        self::assertSame(['111-111-222'], $view['pages'][0]['ids']);
+
         // Loop through expected levels and verify the content
         for ($level = 0; $level < 6; ++$level) {
             $expectedLevel = $expectedData[$level % \count($expectedData)];
 
             // Test based on the level index
-            self::assertSame($expectedLevel['resource'], $contentPointer['resource'], "Level $level resource incorrect"); //@phpstan-ignore-line
-            self::assertSame($expectedLevel['title'], $contentPointer['content']['title'], "Level $level title incorrect"); //@phpstan-ignore-line
-            self::assertSame($expectedLevel['url'], $contentPointer['content']['url'], "Level $level url incorrect"); //@phpstan-ignore-line
-            self::assertSame($expectedLevel['article'], $contentPointer['content']['article'], "Level $level article incorrect"); //@phpstan-ignore-line
-
-            // Check view data for the current level
-            self::assertSame([], $contentPointer['view']['title'], "Level $level view title incorrect"); //@phpstan-ignore-line
-            self::assertSame([], $contentPointer['view']['url'], "Level $level view url incorrect"); //@phpstan-ignore-line
-            self::assertSame([], $contentPointer['view']['article'], "Level $level view article incorrect"); //@phpstan-ignore-line
-            self::assertSame([$expectedLevel['nextId']], $contentPointer['view']['pages'][0]['ids'], "Level $level view page ids incorrect"); //@phpstan-ignore-line
+            self::assertSame($expectedLevel['title'], $contentPointer['title'], "Level $level title incorrect"); //@phpstan-ignore-line
+            self::assertSame($expectedLevel['url'], $contentPointer['url'], "Level $level url incorrect"); //@phpstan-ignore-line
+            self::assertSame($expectedLevel['article'], $contentPointer['article'], "Level $level article incorrect"); //@phpstan-ignore-line
 
             // Level 5 is where we expect it to break the circular reference
             if (5 === $level) {
-                self::assertNull($contentPointer['content']['pages'][0], 'Circular reference should break after level 5'); //@phpstan-ignore-line
+                self::assertNull($contentPointer['pages'][0], 'Circular reference should break after level 5'); //@phpstan-ignore-line
                 break;
             }
 
             // Move the pointer to the next page in the reference chain
-            $contentPointer = $contentPointer['content']['pages'][0]; //@phpstan-ignore-line
+            $contentPointer = $contentPointer['pages'][0]; //@phpstan-ignore-line
         }
     }
 

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -151,27 +151,18 @@ class ContentResolverTest extends TestCase
 
         /**
          * @var array{
-         *   resource: Page,
+         *   resource: mixed,
          *   content: array{
          *     title: string,
          *     url: string,
-         *     article: string|null,
-         *     pages: array{
-         *       array{
-         *         title: string,
-         *         url: string,
-         *         article: string|null,
-         *         pages?: array<mixed>|null
-         *       }
-         *     }
+         *     article: mixed,
+         *     pages: array<int, mixed>
          *   },
          *   view: array{
          *     title: mixed[],
          *     url: mixed[],
          *     article: mixed[],
-         *     pages: array{
-         *       array{ids: array<string>}
-         *     }
+         *     pages: array{ids: array<string>}
          *   }
          * } $result
          */
@@ -184,13 +175,15 @@ class ContentResolverTest extends TestCase
         self::assertSame('/page', $content['url']);
         self::assertNull($content['article']);
 
+        /** @var array{title: mixed[], url: mixed[], article: mixed[], pages: array{ids: array<string>}} $view */
         $view = $result['view'];
         self::assertSame([], $view['title']);
         self::assertSame([], $view['url']);
         self::assertSame([], $view['article']);
-        self::assertSame(['111-111-222'], $view['pages'][0]['ids']);
+        self::assertSame(['111-111-222'], $view['pages']['ids']);
 
         // SubEntity
+        /** @var array{title: string, url: string, article: string} $innerContent */
         $innerContent = $content['pages'][0];
         self::assertSame('Page 2', $innerContent['title']);
         self::assertSame('/page-2', $innerContent['url']);
@@ -299,14 +292,14 @@ class ContentResolverTest extends TestCase
          *     title: mixed[],
          *     url: mixed[],
          *     article: mixed[],
-         *     pages: array<int, array{ids: array<string>}>
+         *     pages: array{ids: array<string>}
          * } $view
          */
         $view = $result['view'];
         self::assertSame([], $view['title']);
         self::assertSame([], $view['url']);
         self::assertSame([], $view['article']);
-        self::assertSame(['111-111-222'], $view['pages'][0]['ids']);
+        self::assertSame(['111-111-222'], $view['pages']['ids']);
 
         // Loop through expected levels and verify the content
         for ($level = 0; $level < 6; ++$level) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Resolves the nested content / view blocks of sub content rich entities.

#### Why?

Only the root level should have a `content` and `view` array.