### PR TITLE
Remove not longer require search init and search index builders

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -241,13 +241,11 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                             'phpcr_migrations' => [],
                             'system_collections' => [],
                             'security' => [],
-                            'search_init' => [],
                         ],
                     ],
                     'maintain' => [
                         'dependencies' => [
                             'node_order' => [],
-                            'search_index' => [],
                             'phpcr_migrations' => [],
                         ],
                     ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | database-1  | 2025-07-30T17
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove not longer require search init and search index builders.

#### Why?

Actually sulu:build was not longer working.