### PR TITLE
Remove sortable in versioning table

### DIFF
--- a/packages/article/config/lists/articles_versions.xml
+++ b/packages/article/config/lists/articles_versions.xml
@@ -29,7 +29,7 @@
             <entity-name>Sulu\Article\Domain\Model\ArticleInterface</entity-name>
         </property>
 
-        <property name="title" translation="sulu_admin.title" visibility="always" searchability="yes">
+        <property name="title" translation="sulu_admin.title" visibility="always" sortable="false">
             <field-name>title</field-name>
             <entity-name>dimensionContent</entity-name>
 
@@ -38,14 +38,14 @@
             <transformer type="title"/>
         </property>
 
-        <property name="version" translation="sulu_admin.published" visibility="yes">
+        <property name="version" translation="sulu_admin.published" visibility="always" sortable="false">
             <field-name>version</field-name>
             <entity-name>dimensionContent</entity-name>
 
             <transformer type="datetime"/>
         </property>
 
-        <concatenation-property name="changer" glue=" " translation="sulu_admin.changer" sortable="false" visibility="yes">
+        <concatenation-property name="changer" glue=" " translation="sulu_admin.changer" visibility="always" sortable="false">
             <field>
                 <field-name>firstName</field-name>
                 <entity-name>%sulu.model.contact.class%</entity-name>
@@ -59,11 +59,5 @@
                 <joins ref="changer"/>
             </field>
         </concatenation-property>
-
-        <property name="changed" translation="sulu_admin.changed">
-            <field-name>changed</field-name>
-            <entity-name>Sulu\Article\Domain\Model\ArticleInterface</entity-name>
-            <transformer type="datetime"/>
-        </property>
     </properties>
 </list>

--- a/packages/page/config/lists/pages_versions.xml
+++ b/packages/page/config/lists/pages_versions.xml
@@ -29,7 +29,7 @@
             <entity-name>Sulu\Page\Domain\Model\PageInterface</entity-name>
         </property>
 
-        <property name="title" translation="sulu_admin.title" visibility="always" searchability="yes">
+        <property name="title" translation="sulu_admin.title" visibility="always" sortable="false">
             <field-name>title</field-name>
             <entity-name>dimensionContent</entity-name>
 
@@ -38,14 +38,14 @@
             <transformer type="title"/>
         </property>
 
-        <property name="version" translation="sulu_admin.published" visibility="always">
+        <property name="version" translation="sulu_admin.published" visibility="always" sortable="false">
             <field-name>version</field-name>
             <entity-name>dimensionContent</entity-name>
 
             <transformer type="datetime"/>
         </property>
 
-        <concatenation-property name="changer" glue=" " translation="sulu_admin.changer" sortable="false" visibility="yes">
+        <concatenation-property name="changer" glue=" " translation="sulu_admin.changer" visibility="always" sortable="false" >
             <field>
                 <field-name>firstName</field-name>
                 <entity-name>%sulu.model.contact.class%</entity-name>
@@ -59,11 +59,5 @@
                 <joins ref="changer"/>
             </field>
         </concatenation-property>
-
-        <property name="changed" translation="sulu_admin.changed">
-            <field-name>changed</field-name>
-            <entity-name>Sulu\Page\Domain\Model\PageInterface</entity-name>
-            <transformer type="datetime"/>
-        </property>
     </properties>
 </list>

--- a/packages/snippet/config/lists/snippets_versions.xml
+++ b/packages/snippet/config/lists/snippets_versions.xml
@@ -29,7 +29,7 @@
             <entity-name>Sulu\Snippet\Domain\Model\SnippetInterface</entity-name>
         </property>
 
-        <property name="title" translation="sulu_admin.title" visibility="always" searchability="yes">
+        <property name="title" translation="sulu_admin.title" visibility="always" sortable="false">
             <field-name>title</field-name>
             <entity-name>dimensionContent</entity-name>
 
@@ -38,14 +38,14 @@
             <transformer type="title"/>
         </property>
 
-        <property name="version" translation="sulu_admin.published" visibility="yes">
+        <property name="version" translation="sulu_admin.published" visibility="always" sortable="false">
             <field-name>version</field-name>
             <entity-name>dimensionContent</entity-name>
 
             <transformer type="datetime"/>
         </property>
 
-        <concatenation-property name="changer" glue=" " translation="sulu_admin.changer" sortable="false" visibility="yes">
+        <concatenation-property name="changer" glue=" " translation="sulu_admin.changer" visibility="always" sortable="false">
             <field>
                 <field-name>firstName</field-name>
                 <entity-name>%sulu.model.contact.class%</entity-name>
@@ -59,11 +59,5 @@
                 <joins ref="changer"/>
             </field>
         </concatenation-property>
-
-        <property name="changed" translation="sulu_admin.changed">
-            <field-name>changed</field-name>
-            <entity-name>Sulu\Snippet\Domain\Model\SnippetInterface</entity-name>
-            <transformer type="datetime"/>
-        </property>
     </properties>
 </list>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #8054 
| License | MIT

#### What's in this PR?

Removes the sortable column on the versioning table.

#### Why?

Sorting does not make sense for versions, the newest version should always be on the top. Additionally buttons in the header row breaks the current table design (different padding for header row)