### PR TITLE
Add link provider capabilities to WebspaceCopyCommand

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17676,6 +17676,11 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
 
 		-
+			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Command\\\\WebspaceCopyCommand\\:\\:updateLinkSelection\\(\\) has parameter \\$structureArray with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+
+		-
 			message: "#^Method Sulu\\\\Bundle\\\\PageBundle\\\\Command\\\\WebspaceCopyCommand\\:\\:updatePageSelection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -17757,6 +17762,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$property of method Sulu\\\\Bundle\\\\PageBundle\\\\Command\\\\WebspaceCopyCommand\\:\\:updateHtmlSuluLinks\\(\\) expects Sulu\\\\Component\\\\Content\\\\Metadata\\\\PropertyMetadata, Sulu\\\\Component\\\\Content\\\\Metadata\\\\ItemMetadata given\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$property of method Sulu\\\\Bundle\\\\PageBundle\\\\Command\\\\WebspaceCopyCommand\\:\\:updateLinkSelection\\(\\) expects Sulu\\\\Component\\\\Content\\\\Metadata\\\\PropertyMetadata, Sulu\\\\Component\\\\Content\\\\Metadata\\\\ItemMetadata given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
 

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -581,11 +581,11 @@ class WebspaceCopyCommand extends Command
             return;
         }
 
-        if($structureArray[$property->getName()]['provider'] !== 'page') {
+        if ('page' !== $structureArray[$property->getName()]['provider']) {
             return;
         }
 
-        if(empty($structureArray[$property->getName()]['href'])) {
+        if (empty($structureArray[$property->getName()]['href'])) {
             return;
         }
 

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -571,6 +571,7 @@ class WebspaceCopyCommand extends Command
      *
      * @param string $localeSource
      * @param string $localeDestination
+     *
      * @return void
      */
     protected function updateLinkSelection(

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -446,6 +446,14 @@ class WebspaceCopyCommand extends Command
                     $localeDestination
                 );
                 break;
+            case 'link':
+                $this->updateLinkSelection(
+                    $structureArray,
+                    $property,
+                    $localeSource,
+                    $localeDestination
+                );
+                break;
         }
     }
 
@@ -555,6 +563,43 @@ class WebspaceCopyCommand extends Command
 
             $structureArray[$property->getName()]['items'][$key]['id'] = $targetDocumentDestination->getUuid();
         }
+    }
+
+    /**
+     * Updates references in structure for content type `link`.
+     *
+     * @param string $localeSource
+     * @param string $localeDestination
+     */
+    protected function updateLinkSelection(
+        array &$structureArray,
+        PropertyMetadata $property,
+        $localeSource,
+        $localeDestination
+    ) {
+        if (!isset($structureArray[$property->getName()]['provider'])) {
+            return;
+        }
+
+        if($structureArray[$property->getName()]['provider'] !== 'page') {
+            return;
+        }
+
+        if(empty($structureArray[$property->getName()]['href'])) {
+            return;
+        }
+
+        $targetDocumentDestination = $this->getTargetDocumentDestination(
+            $structureArray[$property->getName()]['href'],
+            $localeSource,
+            $localeDestination
+        );
+
+        if (!$targetDocumentDestination) {
+            return;
+        }
+
+        $structureArray[$property->getName()]['href'] = $targetDocumentDestination->getUuid();
     }
 
     /**

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\PageBundle\Command;
 
 use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor;
+use Sulu\Bundle\MarkupBundle\Markup\LinkTag;
 use Sulu\Bundle\MarkupBundle\Markup\TagMatchGroup;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Document\HomeDocument;
@@ -570,6 +571,7 @@ class WebspaceCopyCommand extends Command
      *
      * @param string $localeSource
      * @param string $localeDestination
+     * @return void
      */
     protected function updateLinkSelection(
         array &$structureArray,
@@ -577,11 +579,11 @@ class WebspaceCopyCommand extends Command
         $localeSource,
         $localeDestination
     ) {
-        if (!isset($structureArray[$property->getName()]['provider'])) {
+        if (!\is_array($structureArray[$property->getName()])) {
             return;
         }
-
-        if ('page' !== $structureArray[$property->getName()]['provider']) {
+        $linkProvider = $structureArray[$property->getName()]['provider'] ?? LinkTag::DEFAULT_PROVIDER;
+        if ('page' !== $linkProvider) {
             return;
         }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/link.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/link.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>internallinks</key>
+
+    <view>default</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line"/>
+        <property name="url" type="resource_locator">
+            <tag name="sulu.rlp"/>
+        </property>
+        <property name="link_to_page" type="link"/>
+        <property name="external_link" type="link"/>
+    </properties>
+</template>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/link.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/link.xml
@@ -15,6 +15,7 @@
             <tag name="sulu.rlp"/>
         </property>
         <property name="link_to_page" type="link"/>
+        <property name="link_to_other_page" type="link"/>
         <property name="external_link" type="link"/>
     </properties>
 </template>

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
@@ -459,7 +459,7 @@ class WebspaceCopyCommandTest extends SuluTestCase
                     'href' => $page5->getUuid(),
                     'title' => null,
                     'rel' => null,
-                    'locale' => 'de'
+                    'locale' => 'de',
                 ],
                 'external_link' => [
                     'provider' => 'external',
@@ -469,7 +469,7 @@ class WebspaceCopyCommandTest extends SuluTestCase
                     'href' => 'https://sulu.io',
                     'title' => null,
                     'rel' => null,
-                    'locale' => 'de'
+                    'locale' => 'de',
                 ],
             ]
         );

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
@@ -201,13 +201,20 @@ class WebspaceCopyCommandTest extends SuluTestCase
         $this->assertStringContainsString($targetDocument->getUuid(), $page4->getStructure()->toArray()['article'][0]['text']);
     }
 
+    /**
+     * @return void
+     * @throws \Sulu\Component\DocumentManager\Exception\DocumentManagerException
+     */
     protected function checkLinkContentType()
     {
         /** @var PageDocument $targetDocument */
         $targetDocument = $this->documentManager->find('/cmf/destination_io/contents/node5', 'de');
+        /** @var PageDocument $targetDocumentMagicProvider */
+        $targetDocumentMagicProvider = $this->documentManager->find('/cmf/destination_io/contents/node4', 'de');
         /** @var PageDocument $page6 */
         $page6 = $this->documentManager->find('/cmf/destination_io/contents/node6', 'de');
         $this->assertSame($targetDocument->getUuid(), $page6->getStructure()->toArray()['link_to_page']['href']);
+        $this->assertSame($targetDocumentMagicProvider->getUuid(), $page6->getStructure()->toArray()['link_to_other_page']['href']);
         $this->assertSame('https://sulu.io', $page6->getStructure()->toArray()['external_link']['href']);
     }
 
@@ -445,6 +452,9 @@ class WebspaceCopyCommandTest extends SuluTestCase
             ]
         );
 
+        /** @var PageDocument $page4 */
+        /** @var PageDocument $page5 */
+        /** @var PageDocument $page6 */
         $page6 = $this->documentManager->create('page');
         $page6->setStructureType('link');
         $page6->setTitle('Node6');
@@ -457,6 +467,16 @@ class WebspaceCopyCommandTest extends SuluTestCase
                     'anchor' => null,
                     'query' => null,
                     'href' => $page5->getUuid(),
+                    'title' => null,
+                    'rel' => null,
+                    'locale' => 'de',
+                ],
+                'link_to_other_page' => [
+                    'provider' => null,
+                    'target' => '_self',
+                    'anchor' => null,
+                    'query' => null,
+                    'href' => $page4->getUuid(),
                     'title' => null,
                     'rel' => null,
                     'locale' => 'de',

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
@@ -109,7 +109,7 @@ class WebspaceCopyCommandTest extends SuluTestCase
 
         /** @var HomeDocument $baseDocument */
         $homeDocumentDestination = $this->documentManager->find('/cmf/destination_io/contents');
-        $this->assertCount(5, $homeDocumentDestination->getChildren());
+        $this->assertCount(6, $homeDocumentDestination->getChildren());
 
         $this->checkRedirectInternal();
         $this->checkSmartContentReference();
@@ -118,6 +118,7 @@ class WebspaceCopyCommandTest extends SuluTestCase
         $this->checkTeaserSelection();
         $this->checkSingleInternalLink();
         $this->checkTextEditorLinkInBlock();
+        $this->checkLinkContentType();
     }
 
     protected function checkRedirectInternal()
@@ -198,6 +199,16 @@ class WebspaceCopyCommandTest extends SuluTestCase
         /** @var PageDocument $page4 */
         $page4 = $this->documentManager->find('/cmf/destination_io/contents/node4', 'es');
         $this->assertStringContainsString($targetDocument->getUuid(), $page4->getStructure()->toArray()['article'][0]['text']);
+    }
+
+    protected function checkLinkContentType()
+    {
+        /** @var PageDocument $targetDocument */
+        $targetDocument = $this->documentManager->find('/cmf/destination_io/contents/node5', 'de');
+        /** @var PageDocument $page6 */
+        $page6 = $this->documentManager->find('/cmf/destination_io/contents/node6', 'de');
+        $this->assertSame($targetDocument->getUuid(), $page6->getStructure()->toArray()['link_to_page']['href']);
+        $this->assertSame('https://sulu.io', $page6->getStructure()->toArray()['external_link']['href']);
     }
 
     /**
@@ -433,6 +444,43 @@ class WebspaceCopyCommandTest extends SuluTestCase
                 'parent_path' => '/cmf/sulu_io/contents',
             ]
         );
+
+        $page6 = $this->documentManager->create('page');
+        $page6->setStructureType('link');
+        $page6->setTitle('Node6');
+        $page6->getStructure()->bind(
+            [
+                'title' => 'Node6',
+                'link_to_page' => [
+                    'provider' => 'page',
+                    'target' => '_self',
+                    'anchor' => null,
+                    'query' => null,
+                    'href' => $page5->getUuid(),
+                    'title' => null,
+                    'rel' => null,
+                    'locale' => 'de'
+                ],
+                'external_link' => [
+                    'provider' => 'external',
+                    'target' => '_self',
+                    'anchor' => null,
+                    'query' => null,
+                    'href' => 'https://sulu.io',
+                    'title' => null,
+                    'rel' => null,
+                    'locale' => 'de'
+                ],
+            ]
+        );
+        $this->documentManager->persist(
+            $page6,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents',
+            ]
+        );
+
         $this->documentManager->flush();
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
@@ -203,6 +203,7 @@ class WebspaceCopyCommandTest extends SuluTestCase
 
     /**
      * @return void
+     *
      * @throws \Sulu\Component\DocumentManager\Exception\DocumentManagerException
      */
     protected function checkLinkContentType()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8082
| Related issues/PRs | #8082
| License | MIT

#### What's in this PR?

Adds functionality to update link content type references during webspace copy command

#### Why?

Because it was not implemented, yet. :-)

Because I messed up #8083, here is the PR for the Sulu 2.5 branch.
