### PR TITLE
Add support for mapping properties to resolve only specific data

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
@@ -12,6 +12,8 @@
 namespace Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
@@ -22,6 +24,12 @@ use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface
  */
 class ArticleSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param array{
+     *     resourceLoader?: string,
+     *     metadata?: FieldMetadata|null,
+     * } $params
+     */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
         if (
@@ -50,8 +58,30 @@ class ArticleSelectionPropertyResolver implements PropertyResolverInterface
                 'ids' => $identifiers,
                 ...$params,
             ],
-            priority: 100
+            priority: 100,
+            metadata: [
+                'properties' => $this->getProperties($params['metadata'] ?? null),
+            ]
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getProperties(?FieldMetadata $metadata): ?array
+    {
+        $properties = null;
+        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
+            $properties = [];
+
+            /** @var OptionMetadata[] $optionsMetadataArray */
+            $optionsMetadataArray = $propertiesMetadata->getValue();
+            foreach ($optionsMetadataArray as $optionMetadata) {
+                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
+            }
+        }
+
+        return $properties;
     }
 
     public static function getType(): string

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
@@ -12,8 +12,6 @@
 namespace Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
@@ -27,7 +25,7 @@ class ArticleSelectionPropertyResolver implements PropertyResolverInterface
     /**
      * @param array{
      *     resourceLoader?: string,
-     *     metadata?: FieldMetadata|null,
+     *     properties?: array<string, mixed>|null,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
@@ -60,28 +58,9 @@ class ArticleSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 100,
             metadata: [
-                'properties' => $this->getProperties($params['metadata'] ?? null),
+                'properties' => $params['properties'] ?? null,
             ]
         );
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function getProperties(?FieldMetadata $metadata): ?array
-    {
-        $properties = null;
-        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
-            $properties = [];
-
-            /** @var OptionMetadata[] $optionsMetadataArray */
-            $optionsMetadataArray = $propertiesMetadata->getValue();
-            foreach ($optionsMetadataArray as $optionMetadata) {
-                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
-            }
-        }
-
-        return $properties;
     }
 
     public static function getType(): string

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
@@ -12,8 +12,6 @@
 namespace Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
@@ -27,7 +25,7 @@ class SingleArticleSelectionPropertyResolver implements PropertyResolverInterfac
     /**
      * @param array{
      *     resourceLoader?: string,
-     *     metadata?: FieldMetadata|null,
+     *     properties?: array<string, mixed>|null,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
@@ -48,28 +46,9 @@ class SingleArticleSelectionPropertyResolver implements PropertyResolverInterfac
             ],
             priority: 100,
             metadata: [
-                'properties' => $this->getProperties($params['metadata'] ?? null),
+                'properties' => $params['properties'] ?? null,
             ]
         );
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function getProperties(?FieldMetadata $metadata): ?array
-    {
-        $properties = null;
-        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
-            $properties = [];
-
-            /** @var OptionMetadata[] $optionsMetadataArray */
-            $optionsMetadataArray = $propertiesMetadata->getValue();
-            foreach ($optionsMetadataArray as $optionMetadata) {
-                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
-            }
-        }
-
-        return $properties;
     }
 
     public static function getType(): string

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
@@ -12,6 +12,8 @@
 namespace Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
@@ -22,6 +24,12 @@ use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface
  */
 class SingleArticleSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param array{
+     *     resourceLoader?: string,
+     *     metadata?: FieldMetadata|null,
+     * } $params
+     */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
         if (!\is_string($data)) {
@@ -38,8 +46,30 @@ class SingleArticleSelectionPropertyResolver implements PropertyResolverInterfac
                 'id' => $data,
                 ...$params,
             ],
-            priority: 100
+            priority: 100,
+            metadata: [
+                'properties' => $this->getProperties($params['metadata'] ?? null),
+            ]
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getProperties(?FieldMetadata $metadata): ?array
+    {
+        $properties = null;
+        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
+            $properties = [];
+
+            /** @var OptionMetadata[] $optionsMetadataArray */
+            $optionsMetadataArray = $propertiesMetadata->getValue();
+            foreach ($optionsMetadataArray as $optionMetadata) {
+                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
+            }
+        }
+
+        return $properties;
     }
 
     public static function getType(): string

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver\ArticleSelectionPropertyResolver;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 
 #[CoversClass(ArticleSelectionPropertyResolver::class)]
@@ -119,5 +121,64 @@ class ArticleSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content[0]);
         $this->assertSame('1', $content[0]->getId());
         $this->assertSame('custom_article', $content[0]->getResourceLoaderKey());
+    }
+
+    public function testResolveWithMetadata(): void
+    {
+        $propertyOption1 = new OptionMetadata();
+        $propertyOption1->setName('property1');
+        $propertyOption1->setValue('value1');
+
+        $propertyOption2 = new OptionMetadata();
+        $propertyOption2->setName('property2');
+        $propertyOption2->setValue('value2');
+
+        $propertiesOption = new OptionMetadata();
+        $propertiesOption->setName('properties');
+        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
+
+        $metadata = new FieldMetadata('test_field');
+        $metadata->addOption($propertiesOption);
+
+        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ], $content[0]->getMetadata());
+    }
+
+    public function testResolveWithoutMetadata(): void
+    {
+        $contentView = $this->resolver->resolve(['1'], 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content[0]->getMetadata());
+    }
+
+    public function testResolveWithEmptyMetadata(): void
+    {
+        $metadata = new FieldMetadata('test_field');
+
+        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content[0]->getMetadata());
     }
 }

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
@@ -18,7 +18,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver\ArticleSelectionPropertyResolver;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 
 #[CoversClass(ArticleSelectionPropertyResolver::class)]
@@ -125,22 +124,12 @@ class ArticleSelectionPropertyResolverTest extends TestCase
 
     public function testResolveWithMetadata(): void
     {
-        $propertyOption1 = new OptionMetadata();
-        $propertyOption1->setName('property1');
-        $propertyOption1->setValue('value1');
-
-        $propertyOption2 = new OptionMetadata();
-        $propertyOption2->setName('property2');
-        $propertyOption2->setValue('value2');
-
-        $propertiesOption = new OptionMetadata();
-        $propertiesOption->setName('properties');
-        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
-
-        $metadata = new FieldMetadata('test_field');
-        $metadata->addOption($propertiesOption);
-
-        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+        $contentView = $this->resolver->resolve(['1'], 'en', [
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ]);
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolverTest.php
@@ -18,7 +18,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver\SingleArticleSelectionPropertyResolver;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 
 #[CoversClass(SingleArticleSelectionPropertyResolver::class)]
@@ -107,22 +106,12 @@ class SingleArticleSelectionPropertyResolverTest extends TestCase
 
     public function testResolveWithMetadata(): void
     {
-        $propertyOption1 = new OptionMetadata();
-        $propertyOption1->setName('property1');
-        $propertyOption1->setValue('value1');
-
-        $propertyOption2 = new OptionMetadata();
-        $propertyOption2->setName('property2');
-        $propertyOption2->setValue('value2');
-
-        $propertiesOption = new OptionMetadata();
-        $propertiesOption->setName('properties');
-        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
-
-        $metadata = new FieldMetadata('test_field');
-        $metadata->addOption($propertiesOption);
-
-        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+        $contentView = $this->resolver->resolve('1', 'en', [
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ]);
 
         $content = $contentView->getContent();
         $this->assertInstanceOf(ResolvableResource::class, $content);

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolverTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver\SingleArticleSelectionPropertyResolver;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 
 #[CoversClass(SingleArticleSelectionPropertyResolver::class)]
@@ -101,5 +103,61 @@ class SingleArticleSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content);
         $this->assertSame('1', $content->getId());
         $this->assertSame('custom_article', $content->getResourceLoaderKey());
+    }
+
+    public function testResolveWithMetadata(): void
+    {
+        $propertyOption1 = new OptionMetadata();
+        $propertyOption1->setName('property1');
+        $propertyOption1->setValue('value1');
+
+        $propertyOption2 = new OptionMetadata();
+        $propertyOption2->setName('property2');
+        $propertyOption2->setValue('value2');
+
+        $propertiesOption = new OptionMetadata();
+        $propertiesOption->setName('properties');
+        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
+
+        $metadata = new FieldMetadata('test_field');
+        $metadata->addOption($propertiesOption);
+
+        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ], $content->getMetadata());
+    }
+
+    public function testResolveWithoutMetadata(): void
+    {
+        $contentView = $this->resolver->resolve('1', 'en');
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content->getMetadata());
+    }
+
+    public function testResolveWithEmptyMetadata(): void
+    {
+        $metadata = new FieldMetadata('test_field');
+
+        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content->getMetadata());
     }
 }

--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -54,6 +54,14 @@
             <tag name="sulu_content.content_resolver" type="seo"/>
         </service>
 
+        <!-- DimensionContent Resolver -->
+        <service id="sulu_content.dimension_content_resolver"
+                 class="Sulu\Content\Application\ContentResolver\Resolver\DimensionContentResolver">
+            <argument type="service" id="property_accessor"/>
+
+            <tag name="sulu_content.content_resolver" type="object"/>
+        </service>
+
         <!-- Metadata Resolver -->
         <service id="sulu_content.metadata_resolver"
                  class="Sulu\Content\Application\MetadataResolver\MetadataResolver">

--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -3,18 +3,37 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <!-- main Content Resolver -->
-        <service id="sulu_content.content_resolver"
-                 class="Sulu\Content\Application\ContentResolver\ContentResolver">
+        <!-- main Content Resolver services -->
+        <service id="sulu_content.resolvable_resource_loader" class="Sulu\Content\Application\ContentResolver\ResolvableResourceLoader\ResolvableResourceLoader">
+            <argument type="service" id="sulu_content.resource_loader_provider" />
+            <argument type="service" id="sulu_content.smart_resolver_provider" />
+        </service>
+
+        <service id="sulu_content.resolvable_resource_queue_processor" class="Sulu\Content\Application\ContentResolver\ResolvableResourceQueue\ResolvableResourceQueueProcessor" />
+        <service id="sulu_content.resolvable_resource_replacer" class="Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\ResolvableResourceReplacer"/>
+
+        <service id="sulu_content.content_view_resolver" class="Sulu\Content\Application\ContentResolver\ContentViewResolver\ContentViewResolver">
+            <argument type="service" id="sulu_content.resolvable_resource_queue_processor" />
             <argument
                 type="tagged_iterator"
                 tag="sulu_content.content_resolver"
                 index-by="type"
             />
-            <argument type="service" id="sulu_content.resource_loader_provider"/>
-            <argument type="service" id="sulu_content.content_aggregator"/>
-            <argument type="service" id="sulu_content.smart_resolver_provider"/>
-            <argument type="service" id="property_accessor"/>
+        </service>
+
+        <service id="sulu_content.content_view_data_normalizer" class="Sulu\Content\Application\ContentResolver\DataNormalizer\ContentViewDataNormalizer">
+            <argument type="service" id="property_accessor" />
+        </service>
+
+        <service id="sulu_content.content_resolver" class="Sulu\Content\Application\ContentResolver\ContentResolver" public="true">
+            <argument type="service" id="sulu_content.content_view_resolver" />
+            <argument type="service" id="sulu_content.resolvable_resource_loader" />
+            <argument type="service" id="sulu_content.resolvable_resource_queue_processor" />
+            <argument type="service" id="sulu_content.resolvable_resource_replacer" />
+            <argument type="service" id="sulu_content.content_view_data_normalizer" />
+            <argument type="service" id="sulu_content.content_aggregator" />
+            <!--  TODO          <argument>%sulu_content.resource_resolver.max_depth%</argument>-->
+            <argument>5</argument>
         </service>
         <service id="Sulu\Content\Application\ContentResolver\ContentResolverInterface" alias="sulu_content.content_resolver"/>
 

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -14,36 +14,27 @@ declare(strict_types=1);
 namespace Sulu\Content\Application\ContentResolver;
 
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
-use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
-use Sulu\Content\Application\ContentResolver\Resolver\SettingsResolver;
+use Sulu\Content\Application\ContentResolver\ContentViewResolver\ContentViewResolverInterface;
+use Sulu\Content\Application\ContentResolver\DataNormalizer\ContentViewDataNormalizerInterface;
+use Sulu\Content\Application\ContentResolver\ResolvableResourceLoader\ResolvableResourceLoaderInterface;
+use Sulu\Content\Application\ContentResolver\ResolvableResourceQueue\ResolvableResourceQueueProcessorInterface;
+use Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\ResolvableResourceReplacerInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
-use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
-use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
-use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
-use Sulu\Content\Application\SmartResolver\SmartResolverProviderInterface;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Webmozart\Assert\Assert;
 
-/**
- * @phpstan-import-type SettingsData from SettingsResolver
- */
-class ContentResolver implements ContentResolverInterface
+readonly class ContentResolver implements ContentResolverInterface
 {
-    // TODO add configurable parameter for max depth
-    private const MAX_DEPTH = 5;
-
-    /**
-     * @param iterable<ResolverInterface> $contentResolvers
-     */
     public function __construct(
-        private iterable $contentResolvers,
-        private ResourceLoaderProvider $resourceLoaderProvider,
+        private ContentViewResolverInterface $contentViewResolver,
+        private ResolvableResourceLoaderInterface $resolvableResourceLoader,
+        private ResolvableResourceQueueProcessorInterface $resolvableResourceQueueProcessor,
+        private ResolvableResourceReplacerInterface $resolvableResourceReplacer,
+        private ContentViewDataNormalizerInterface $contentViewDataNormalizer,
         private ContentAggregatorInterface $contentAggregator,
-        private SmartResolverProviderInterface $smartResolverProvider,
-        private PropertyAccessorInterface $propertyAccessor
+        private int $maxDepth
     ) {
     }
 
@@ -54,148 +45,116 @@ class ContentResolver implements ContentResolverInterface
         $stage = $dimensionContent->getStage();
 
         // Initial resolution to gather ResolvableResources
-        /** @var array<int, array<string, array<int, array<int|string, ResolvableInterface>>>> $priorityQueue */
+        /** @var array<int, array<string, array<int, array<int|string, array<string, ResolvableInterface>>>>> $priorityQueue */
         $priorityQueue = [];
         $resolvedResources = [];
 
         $resolvedContent = $this->resolveInternal($dimensionContent, 0, $priorityQueue, $properties);
+
         // Process the priority queue until it's empty
         while (!empty($priorityQueue)) {
-            // Get the highest priority resources (first key due to krsort in mergeResolvableResources)
-            $highestPriorityKey = \array_key_first($priorityQueue);
-            $resourcesAtPriority = $priorityQueue[$highestPriorityKey];
-            unset($priorityQueue[$highestPriorityKey]);
+            // Extract highest priority resources from the queue
+            $extractedResources = $this->resolvableResourceQueueProcessor->extractHighestPriorityResources(
+                $priorityQueue,
+                $this->maxDepth
+            );
 
-            $loaderIdDepths = [];
-            $resourcesToLoad = [];
-            // filter resources with depth too high
-            foreach ($resourcesAtPriority as $loaderKey => $resourcePerDepth) {
-                foreach ($resourcePerDepth as $depth => $resources) {
-                    if ($depth > self::MAX_DEPTH) {
-                        continue;
-                    }
-                    foreach ($resources as $id => $resource) {
-                        $resourcesToLoad[$loaderKey][$id] = $resource;
-                        $loaderIdDepths[$loaderKey][$id] = $depth;
-                    }
-                }
-            }
+            $resourcesToLoad = $extractedResources['resourcesToLoad'];
+            $loaderIdDepths = $extractedResources['loaderIdDepths'];
 
             // Load resources at this priority level
-            /** @var array<string, array<string, ResolvableResource>> $resourcesToLoad */
-            $loadedResources = $this->loadResources($resourcesToLoad, $locale);
+            $loadedResources = $this->resolvableResourceLoader->loadResources($resourcesToLoad, $locale);
 
             // Process loaded resources
             foreach ($loadedResources as $loaderKey => $resources) {
-                foreach ($resources as $id => $resource) {
+                foreach ($resources as $id => $resourcePerMetadataIdentifier) {
                     $depth = $loaderIdDepths[$loaderKey][$id];
-                    if ($resource instanceof ContentRichEntityInterface) {
-                        // Get the dimension content for this entity
-                        $resourceDimension = $this->contentAggregator->aggregate($resource, [
-                            'locale' => $locale,
-                            'stage' => $stage,
-                        ]);
+                    foreach ($resourcePerMetadataIdentifier as $metadataIdentifier => $resource) {
+                        if ($resource instanceof ContentRichEntityInterface) {
+                            // For content-rich entities, get the dimension content and resolve it
+                            $childContent = $this->contentAggregator->aggregate($resource, [
+                                'locale' => $locale,
+                                'stage' => $stage,
+                            ]);
 
-                        // Resolve this entity
-                        $normalizedContentData = $this->resolveInternal($resourceDimension, $depth, $priorityQueue);
-                        $resolvedValue = $this->normalizeContentData(
-                            $normalizedContentData['content'],
-                            $normalizedContentData['view'],
-                            $resource,
-                        );
-                    } elseif ($resource instanceof ContentView) {
-                        /** @var array{
-                         *     content: array{'0': array<string, mixed>},
-                         *     view: array{'0': array<string, mixed>},
-                         *     resolvableResources: array<int, array<string, array<int, array<int|string, ResolvableInterface>>>>
-                         * } $normalizedContentData
-                         */
-                        $normalizedContentData = $this->resolveContentView($resource, '0', $depth);
-                        $resolvedValue = [
-                            'content' => $normalizedContentData['content']['0'],
-                            // All resolved resources have the same view structure, so we can just take the first one
-                            'view' => \reset($normalizedContentData['view']['0']) ?? $normalizedContentData['view']['0'],
-                        ];
+                            /** @var ResolvableInterface $resolvableResource */
+                            $resolvableResource = $resourcesToLoad[$loaderKey][$id][$metadataIdentifier];
+                            $metadata = $resolvableResource->getMetadata();
+                            /** @var array<string, string>|null $internalProperties */
+                            $internalProperties = $metadata['properties'] ?? null;
 
-                        // Add resolvable resources to priority queue
-                        $priorityQueue = $this->mergeResolvableResources(
-                            $normalizedContentData['resolvableResources'],
-                            $priorityQueue,
-                        );
-                    } else {
-                        // For non-entity resources, just store the resource directly
-                        $resolvedValue = $resource;
+                            $normalizedContentData = $this->resolveInternal($childContent, $depth + 1, $priorityQueue, $internalProperties);
+
+                            $resolvedValue = $this->contentViewDataNormalizer->normalizeContentViewData(
+                                $normalizedContentData['content'],
+                                $normalizedContentData['view'],
+                                $resource,
+                            );
+
+                            if (null !== $internalProperties && [] !== $internalProperties) {
+                                $this->contentViewDataNormalizer->recursivelyMapProperties(
+                                    data: $resolvedValue,
+                                    properties: $internalProperties,
+                                    isRoot: false
+                                );
+                            }
+                        } elseif ($resource instanceof ContentView) {
+                            /** @var array{
+                             *     content: array{'0': array<string, mixed>},
+                             *     view: array{'0': array<string, mixed>},
+                             *     resolvableResources: array<int, array<string, array<int, array<int|string, array<string, ResolvableInterface>>>>>
+                             * } $normalizedContentData
+                             */
+                            $normalizedContentData = $this->contentViewResolver->resolveContentView($resource, '0', $depth, $priorityQueue);
+                            $resolvedValue = [
+                                'content' => $normalizedContentData['content']['0'],
+                                // All resolved resources have the same view structure, so we can just take the first one
+                                'view' => \reset($normalizedContentData['view']['0']) ?? $normalizedContentData['view']['0'],
+                            ];
+
+                            // Add resolvable resources to priority queue
+                            $priorityQueue = $this->resolvableResourceQueueProcessor->mergeResolvableResources(
+                                $normalizedContentData['resolvableResources'],
+                                $priorityQueue,
+                            );
+                        } else {
+                            // For non-entity resources, just store the resource directly
+                            $resolvedValue = $resource;
+                        }
+
+                        $resolvedResources[$loaderKey][$id][$metadataIdentifier] = $resolvedValue;
                     }
-
-                    $resolvedResources[$loaderKey][$id] = $resolvedValue;
                 }
             }
         }
 
         // Replace all ResolvableResource references with their actual resolved values
-        $finalContent = $this->replaceResolvableResourcesWithResolvedValues(
+        $finalContent = $this->resolvableResourceReplacer->replaceResolvableResourcesWithResolvedValues(
             $resolvedContent['content'],
             $resolvedResources,
             1, // Start at depth 1 since the initial resolution was at depth 0
+            $this->maxDepth,
         );
 
-        $normalizedContentData = $this->normalizeContentData(
+        $normalizedContentData = $this->contentViewDataNormalizer->normalizeContentViewData(
             $finalContent,
             $resolvedContent['view'],
             $dimensionContent->getResource(),
-            $properties
         );
 
-        $this->replaceNestedContentViews($normalizedContentData, '[content]');
+        $this->contentViewDataNormalizer->replaceNestedContentViews(
+            $normalizedContentData,
+            '[content]'
+        );
+
+        if (null !== $properties && [] !== $properties) {
+            $this->contentViewDataNormalizer->recursivelyMapProperties(
+                data: $normalizedContentData,
+                properties: $properties,
+            );
+        }
 
         return $normalizedContentData;
-    }
-
-    /**
-     * @param array{
-     *     resource: object,
-     *     content: array<string, mixed>,
-     *     view: array<string, mixed>,
-     *     extension: array<string, array<string, mixed>>
-     * } $normalizedContentData
-     */
-    private function replaceNestedContentViews(array &$normalizedContentData, string $path): void
-    {
-        $pathValues = [];
-        $iterable = $this->propertyAccessor->getValue($normalizedContentData, $path) ?? [];
-        if (!\is_array($iterable)) {
-            return;
-        }
-
-        /** @var string $key */
-        foreach ($iterable as $key => $entry) {
-            if (\is_array($entry)) {
-                if ([] !== $entry) {
-                    $this->replaceNestedContentViews($normalizedContentData, $path . '[' . $key . ']');
-                }
-                if ('view' === $key) {
-                    $value = $this->propertyAccessor->getValue($normalizedContentData, $path . '[' . $key . ']');
-                    // Replace 'content' with 'view' in the path
-                    $viewPath = \substr_replace($path, '[view]', 0, 9);
-
-                    // If there are more [content] positions, we need to remove them, only keep the first one from the root property resolver
-                    $viewPath = (($nextContentPosition = \strpos($viewPath, '[content]')) !== false) ? \substr($viewPath, 0, $nextContentPosition) : $viewPath;
-
-                    // Only override empty view paths
-                    if (($this->propertyAccessor->getValue($normalizedContentData, $viewPath) ?? []) === []) {
-                        $pathValues[$viewPath] = $value;
-                    }
-                }
-                if ('content' === $key) {
-                    $value = $this->propertyAccessor->getValue($normalizedContentData, $path . '[' . $key . ']');
-                    $pathValues[$path] = $value;
-                }
-            }
-        }
-
-        foreach ($pathValues as $path => $value) {
-            $this->propertyAccessor->setValue($normalizedContentData, $path, $value); // @phpstan-ignore-line
-        }
     }
 
     /**
@@ -205,13 +164,13 @@ class ContentResolver implements ContentResolverInterface
      *
      * @param DimensionContentInterface<T> $dimensionContent
      * @param int $depth Current depth
-     * @param array<int, array<string, array<int, array<int|string, ResolvableInterface>>>> $priorityQueue Reference to the priority queue
+     * @param array<int, array<string, array<int, array<int|string, array<string, ResolvableInterface>>>>> &$priorityQueue Reference to the priority queue
      * @param array<string, mixed>|null $properties
      *
      * @return array{
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
-     *     resolvableResources: array<int, array<string, array<int, array<string|int, ResolvableInterface>>>>,
+     *     resolvableResources: array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>>,
      * }
      */
     private function resolveInternal(
@@ -220,370 +179,15 @@ class ContentResolver implements ContentResolverInterface
         array &$priorityQueue,
         ?array $properties = null
     ): array {
-        $contentViews = $this->getContentViews($dimensionContent, $properties);
-        $resolvedContent = $this->resolveContentViews($contentViews, $depth);
+        $contentViews = $this->contentViewResolver->getContentViews($dimensionContent, $properties);
+        $resolvedContent = $this->contentViewResolver->resolveContentViews($contentViews, $depth, $priorityQueue);
 
         // Add resolvable resources to priority queue
-        $priorityQueue = $this->mergeResolvableResources(
+        $priorityQueue = $this->resolvableResourceQueueProcessor->mergeResolvableResources(
             $resolvedContent['resolvableResources'],
             $priorityQueue,
         );
 
         return $resolvedContent;
-    }
-
-    /**
-     * @template T of ContentRichEntityInterface
-     *
-     * @param DimensionContentInterface<T> $dimensionContent
-     * @param array<string, mixed>|null $properties
-     *
-     * @return array<string|int, ContentView>
-     */
-    private function getContentViews(DimensionContentInterface $dimensionContent, ?array $properties = null): array
-    {
-        $contentViews = [];
-
-        /**
-         * @var string $resolverKey
-         * @var ResolverInterface $contentResolver
-         */
-        foreach ($this->contentResolvers as $resolverKey => $contentResolver) {
-            $contentView = $contentResolver->resolve($dimensionContent, $properties);
-
-            if (!$contentView instanceof ContentView) {
-                continue;
-            }
-
-            $contentViews[$resolverKey] = $contentView;
-        }
-
-        return $contentViews;
-    }
-
-    /**
-     * @param ContentView[] $contentViews
-     *
-     * @return array{
-     *     content: array<string, mixed>,
-     *     view: array<string, mixed>,
-     *     resolvableResources: array<int, array<string, array<int, array<string|int, ResolvableInterface>>>>,
-     * }
-     */
-    private function resolveContentViews(array $contentViews, int $depth): array
-    {
-        $content = [];
-        $view = [];
-
-        $resolvableResources = [];
-        foreach ($contentViews as $name => $contentView) {
-            $result = $this->resolveContentView($contentView, (string) $name, $depth);
-            $content = \array_merge($content, $result['content']);
-            $view = \array_merge($view, $result['view']);
-            $resolvableResources = $this->mergeResolvableResources($resolvableResources, $result['resolvableResources']);
-        }
-
-        return [
-            'content' => $content,
-            'view' => $view,
-            'resolvableResources' => $resolvableResources,
-            'depth' => $depth,
-        ];
-    }
-
-    /**
-     * @return array{
-     *     content: array<string, mixed>,
-     *     view: array<string, mixed>,
-     *     resolvableResources: array<int, array<string, array<int, array<string|int, ResolvableInterface>>>>
-     * }
-     */
-    private function resolveContentView(ContentView $contentView, string $name, int $depth): array
-    {
-        $content = $contentView->getContent();
-        $view = $contentView->getView();
-
-        $result = [
-            'content' => [],
-            'view' => [],
-            'resolvableResources' => [],
-            'depth' => $depth,
-        ];
-        if (\is_array($content)) {
-            if (\count(\array_filter($content, fn ($entry) => $entry instanceof ContentView)) === \count($content)) {
-                /** @var ContentView[] $content */
-                // resolve array of content views
-                $resolvedContentViews = $this->resolveContentViews($content, $depth + 1);
-                $result['content'][$name] = $resolvedContentViews['content'];
-                $result['view'][$name] = $resolvedContentViews['view'];
-                $result['resolvableResources'] = $this->mergeResolvableResources($result['resolvableResources'], $resolvedContentViews['resolvableResources']);
-
-                return $result;
-            }
-
-            $resolvableResources = [];
-            foreach ($content as $key => $entry) {
-                // resolve array of mixed content
-                if ($entry instanceof ContentView) {
-                    $resolvedContentView = $this->resolveContentView($entry, $key, $depth + 1);
-                    $result['content'][$name] = \array_merge($result['content'][$name] ?? [], $resolvedContentView['content']);
-                    $result['view'][$name] = \array_merge($result['view'][$name] ?? [], $resolvedContentView['view']);
-                    $resolvableResources = $this->mergeResolvableResources($resolvableResources, $resolvedContentView['resolvableResources']);
-
-                    continue;
-                }
-
-                if ($entry instanceof ResolvableInterface) {
-                    $resolvableResources[$entry->getPriority()][$entry->getResourceLoaderKey()][$depth][$entry->getId()] = $entry;
-                }
-
-                $result['content'][$name][$key] = $entry;
-                if (isset($view[$key])) {
-                    $result['view'][$name][$key] = $view[$key];
-                }
-            }
-
-            // If the view is not set for this name, we can use the root view
-            if (($result['view'][$name] ?? null) === null) {
-                $result['view'][$name] = $view;
-            }
-
-            $result['resolvableResources'] = $resolvableResources;
-
-            return $result;
-        }
-
-        if ($content instanceof ResolvableInterface) {
-            // @phpstan-ignore-next-line
-            $result['resolvableResources'][$content->getPriority()][$content->getResourceLoaderKey()][$depth][$content->getId()] = $content;
-        }
-
-        $result['content'][$name] = $content;
-        $result['view'][$name] = $view;
-
-        return $result;
-    }
-
-    /**
-     * @param array<SmartResolvable> $smartResources
-     *
-     * @return array<ContentView>
-     */
-    private function loadSmartResources(array $smartResources, ?string $locale): array
-    {
-        $loadedResources = [];
-
-        foreach ($smartResources as $id => $smartResource) {
-            $resourceLoaderKey = $smartResource->getResourceLoaderKey();
-            $smartResolver = $this->smartResolverProvider->getSmartResolver($resourceLoaderKey);
-
-            $loadedResources[$id] = $smartResolver->resolve(
-                $smartResource,
-                $locale,
-            );
-        }
-
-        return $loadedResources;
-    }
-
-    /**
-     * @param array<ResolvableResource> $resolvableResources
-     *
-     * @return array<string|int, mixed>
-     */
-    private function loadResolvableResources(array $resolvableResources, string $loaderKey, ?string $locale): array
-    {
-        $resourceLoader = $this->resourceLoaderProvider->getResourceLoader($loaderKey);
-        if (!$resourceLoader) {
-            throw new \RuntimeException(\sprintf('ResourceLoader with key "%s" not found', $loaderKey));
-        }
-
-        $resourceIds = \array_map(fn (ResolvableResource $resource) => $resource->getId(), $resolvableResources);
-
-        return $resourceLoader->load(
-            $resourceIds,
-            $locale,
-        );
-    }
-
-    /**
-     * Loads and resolves resources from various resource loaders.
-     *
-     * @param array<string, array<string, ResolvableInterface>> $resourcesPerLoader Resource loaders and their associated resources to load
-     *
-     * @return array<string, mixed[]> Resolved resources organized by resource loader key
-     */
-    private function loadResources(array $resourcesPerLoader, ?string $locale): array
-    {
-        $loadedResources = [];
-        foreach ($resourcesPerLoader as $loaderKey => $resourcesToLoad) {
-            if (!$loaderKey) {
-                throw new \RuntimeException(\sprintf('ResourceLoader key "%s" is invalid', $loaderKey));
-            }
-
-            $smartResolvableResources = [];
-            $resolvableResources = [];
-            foreach ($resourcesToLoad as $id => $resource) {
-                if ($resource instanceof SmartResolvable) {
-                    $smartResolvableResources[$id] = $resource;
-                } elseif ($resource instanceof ResolvableResource) {
-                    $resolvableResources[$id] = $resource;
-                } else {
-                    throw new \RuntimeException(\sprintf('Resource with id "%s" is neither a SmartResolvable nor a ResolvableResource', $id));
-                }
-            }
-
-            if (\count($smartResolvableResources) > 0) {
-                $loadedResources[$loaderKey] = $this->loadSmartResources($smartResolvableResources, $locale);
-            }
-
-            if (\count($resolvableResources) > 0) {
-                $loadedResources[$loaderKey] = $this->loadResolvableResources($resolvableResources, $loaderKey, $locale);
-            }
-        }
-
-        return $loadedResources;
-    }
-
-    /**
-     * @param array<string, mixed> $content
-     * @param array<string, mixed[]> $resolvedResources
-     *
-     * @return array<string, mixed>
-     */
-    private function replaceResolvableResourcesWithResolvedValues(array $content, array $resolvedResources, int $depth): array
-    {
-        if ($depth > self::MAX_DEPTH) {
-            // replace non resolved resources with null
-            \array_walk_recursive($content, function(&$value) {
-                if ($value instanceof ResolvableResource) {
-                    // TODO add callback with exception in dev mode
-                    $value = null;
-                }
-            });
-
-            return $content;
-        }
-
-        if (0 === \count($resolvedResources)) {
-            return $content;
-        }
-
-        $hasReplaced = false;
-        \array_walk_recursive($content, function(&$value) use ($resolvedResources, &$hasReplaced) {
-            if ($value instanceof ResolvableInterface && isset($resolvedResources[$value->getResourceLoaderKey()][$value->getId()])) {
-                $value = $value->executeResourceCallback(
-                    $resolvedResources[$value->getResourceLoaderKey()][$value->getId()],
-                );
-                $hasReplaced = true;
-            }
-        });
-
-        // Recursively replace ResolvableResource instances in nested arrays
-        // if a replacement was made in the previous step.
-        // This is necessary to resolve nested ResolvableResource instances
-        // which might have been added during the first replacement,
-        // e.g., when a ResolvableResource is replaced with an array containing another ResolvableResource.
-        if ($hasReplaced) {
-            $content = $this->replaceResolvableResourcesWithResolvedValues($content, $resolvedResources, $depth + 1);
-        }
-
-        return $content;
-    }
-
-    /**
-     * Merges the given resolvable resources with the existing resolvable resources.
-     * The resolvable resources are ordered by priority and indexed by priority, loader key and object id.
-     *
-     * @param array<int, array<string, array<int, array<string|int, ResolvableInterface>>>> $resolvableResources
-     * @param array<int, array<string, array<int, array<string|int, ResolvableInterface>>>> $existingResolvableResources
-     *
-     * @return array<int, array<string, array<int, array<string|int, ResolvableInterface>>>>
-     */
-    private function mergeResolvableResources(array $resolvableResources, array $existingResolvableResources): array
-    {
-        foreach ($resolvableResources as $priority => $loaderResolvableResources) {
-            foreach ($loaderResolvableResources as $loaderKey => $resolvableResourcesPerLoader) {
-                foreach ($resolvableResourcesPerLoader as $depth => $resolvableResourcePerDepth) {
-                    foreach ($resolvableResourcePerDepth as $resolvableResource) {
-                        $existingResolvableResources[$priority][$loaderKey][$depth][$resolvableResource->getId()] = $resolvableResource;
-                    }
-                }
-            }
-        }
-        \krsort($existingResolvableResources);
-
-        return $existingResolvableResources;
-    }
-
-    /**
-     * @template T of DimensionContentInterface
-     *
-     * @param array<string, mixed> $content
-     * @param array<string, mixed> $view
-     * @param ContentRichEntityInterface<T> $resource
-     *
-     * @return array{
-     *     resource: ContentRichEntityInterface<T>,
-     *     content: array<string, mixed>,
-     *     view: array<string, mixed>,
-     *     extension: array<string, array<string, mixed>>,
-     * }
-     */
-    private function normalizeContentData(array $content, array $view, ContentRichEntityInterface $resource, ?array $properties = null): array
-    {
-        /** @var array<string, mixed> $templateData */
-        $templateData = array_merge($content['object'] ?? [], $content['template'] ?? []);
-        unset($content['template']);
-
-        /** @var array<string, mixed> $templateView */
-        $templateView = array_merge($view['object'], $view['template'] ?? []);
-        unset($view['template']);
-
-        /** @var SettingsData $settingsData */
-        $settingsData = $content['settings'] ?? [];
-        unset($content['settings'], $view['settings']);
-
-        /** @var array<string, array<string, mixed>> $extensionData */
-        $extensionData = $content;
-
-        $result = \array_merge(
-            [
-                'resource' => $resource,
-                'content' => $templateData,
-                'view' => $templateView,
-                'extension' => $extensionData,
-            ],
-            $settingsData,
-        );
-
-        if ($properties !== null && $properties !== []) {
-            $this->recursivelyMapProperties($result, ($properties));
-        }
-
-        return $result;
-    }
-
-    private function recursivelyMapProperties(array &$data, array $properties, string $path = '', int $depth = 0): void
-    {
-        $iterable = $path === '' ? $data : ($this->propertyAccessor->getValue($data, $path) ?? []);
-        foreach ($iterable as $key => $value) {
-            if (
-                ($properties[$key] ?? null) &&
-                $depth === (substr_count($path, '][') + 1)
-            ) {
-                $parent = $this->propertyAccessor->getValue($data, $path);
-                unset($parent[$key]);
-                $this->propertyAccessor->setValue($data, $path, $parent);
-
-                $rootPath = '[' . implode('][', explode('.', $key)) . ']';
-                $this->propertyAccessor->setValue($data, $rootPath, $value);
-            }
-
-            // do not walk into 'view' as views cannot be mapped via properties
-            if (is_array($value) && $key !== 'view') {
-                $this->recursivelyMapProperties($data, $properties, $path . '[' . $key . ']', $depth + 1);
-            }
-        }
     }
 }

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -47,7 +47,7 @@ class ContentResolver implements ContentResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): array
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): array
     {
         $locale = $dimensionContent->getLocale();
         Assert::string($locale, 'Locale must be a string');
@@ -58,7 +58,7 @@ class ContentResolver implements ContentResolverInterface
         $priorityQueue = [];
         $resolvedResources = [];
 
-        $resolvedContent = $this->resolveInternal($dimensionContent, 0, $priorityQueue);
+        $resolvedContent = $this->resolveInternal($dimensionContent, 0, $priorityQueue, $properties);
         // Process the priority queue until it's empty
         while (!empty($priorityQueue)) {
             // Get the highest priority resources (first key due to krsort in mergeResolvableResources)
@@ -143,6 +143,7 @@ class ContentResolver implements ContentResolverInterface
             $finalContent,
             $resolvedContent['view'],
             $dimensionContent->getResource(),
+            $properties
         );
 
         $this->replaceNestedContentViews($normalizedContentData, '[content]');
@@ -205,6 +206,7 @@ class ContentResolver implements ContentResolverInterface
      * @param DimensionContentInterface<T> $dimensionContent
      * @param int $depth Current depth
      * @param array<int, array<string, array<int, array<int|string, ResolvableInterface>>>> $priorityQueue Reference to the priority queue
+     * @param array<string, mixed>|null $properties
      *
      * @return array{
      *     content: array<string, mixed>,
@@ -216,8 +218,9 @@ class ContentResolver implements ContentResolverInterface
         DimensionContentInterface $dimensionContent,
         int $depth,
         array &$priorityQueue,
+        ?array $properties = null
     ): array {
-        $contentViews = $this->getContentViews($dimensionContent);
+        $contentViews = $this->getContentViews($dimensionContent, $properties);
         $resolvedContent = $this->resolveContentViews($contentViews, $depth);
 
         // Add resolvable resources to priority queue
@@ -233,10 +236,11 @@ class ContentResolver implements ContentResolverInterface
      * @template T of ContentRichEntityInterface
      *
      * @param DimensionContentInterface<T> $dimensionContent
+     * @param array<string, mixed>|null $properties
      *
      * @return array<string|int, ContentView>
      */
-    private function getContentViews(DimensionContentInterface $dimensionContent): array
+    private function getContentViews(DimensionContentInterface $dimensionContent, ?array $properties = null): array
     {
         $contentViews = [];
 
@@ -245,7 +249,7 @@ class ContentResolver implements ContentResolverInterface
          * @var ResolverInterface $contentResolver
          */
         foreach ($this->contentResolvers as $resolverKey => $contentResolver) {
-            $contentView = $contentResolver->resolve($dimensionContent);
+            $contentView = $contentResolver->resolve($dimensionContent, $properties);
 
             if (!$contentView instanceof ContentView) {
                 continue;
@@ -526,14 +530,14 @@ class ContentResolver implements ContentResolverInterface
      *     extension: array<string, array<string, mixed>>,
      * }
      */
-    private function normalizeContentData(array $content, array $view, ContentRichEntityInterface $resource): array
+    private function normalizeContentData(array $content, array $view, ContentRichEntityInterface $resource, ?array $properties = null): array
     {
         /** @var array<string, mixed> $templateData */
-        $templateData = $content['template'] ?? [];
+        $templateData = array_merge($content['object'] ?? [], $content['template'] ?? []);
         unset($content['template']);
 
         /** @var array<string, mixed> $templateView */
-        $templateView = $view['template'] ?? [];
+        $templateView = array_merge($view['object'], $view['template'] ?? []);
         unset($view['template']);
 
         /** @var SettingsData $settingsData */
@@ -543,7 +547,7 @@ class ContentResolver implements ContentResolverInterface
         /** @var array<string, array<string, mixed>> $extensionData */
         $extensionData = $content;
 
-        return \array_merge(
+        $result = \array_merge(
             [
                 'resource' => $resource,
                 'content' => $templateData,
@@ -552,5 +556,34 @@ class ContentResolver implements ContentResolverInterface
             ],
             $settingsData,
         );
+
+        if ($properties !== null && $properties !== []) {
+            $this->recursivelyMapProperties($result, ($properties));
+        }
+
+        return $result;
+    }
+
+    private function recursivelyMapProperties(array &$data, array $properties, string $path = '', int $depth = 0): void
+    {
+        $iterable = $path === '' ? $data : ($this->propertyAccessor->getValue($data, $path) ?? []);
+        foreach ($iterable as $key => $value) {
+            if (
+                ($properties[$key] ?? null) &&
+                $depth === (substr_count($path, '][') + 1)
+            ) {
+                $parent = $this->propertyAccessor->getValue($data, $path);
+                unset($parent[$key]);
+                $this->propertyAccessor->setValue($data, $path, $parent);
+
+                $rootPath = '[' . implode('][', explode('.', $key)) . ']';
+                $this->propertyAccessor->setValue($data, $rootPath, $value);
+            }
+
+            // do not walk into 'view' as views cannot be mapped via properties
+            if (is_array($value) && $key !== 'view') {
+                $this->recursivelyMapProperties($data, $properties, $path . '[' . $key . ']', $depth + 1);
+            }
+        }
     }
 }

--- a/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
@@ -22,7 +22,7 @@ interface ContentResolverInterface
      * @template T of ContentRichEntityInterface
      *
      * @param DimensionContentInterface<T> $dimensionContent
-     * @param array<string, mixed>|null $properties
+     * @param array<string, string>|null $properties
      *
      * @return array{
      *     resource: object,

--- a/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
@@ -22,6 +22,7 @@ interface ContentResolverInterface
      * @template T of ContentRichEntityInterface
      *
      * @param DimensionContentInterface<T> $dimensionContent
+     * @param array<string, mixed>|null $properties
      *
      * @return array{
      *     resource: object,
@@ -30,5 +31,5 @@ interface ContentResolverInterface
      *     extension: array<string, array<string, mixed>>,
      * }
      */
-    public function resolve(DimensionContentInterface $dimensionContent): array;
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): array;
 }

--- a/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolver.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\ContentViewResolver;
+
+use Sulu\Content\Application\ContentResolver\ResolvableResourceQueue\ResolvableResourceQueueProcessorInterface;
+use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
+use Sulu\Content\Domain\Model\ContentRichEntityInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+
+/**
+ * @internal This service is intended for internal use only within the package/library.
+ * Modifying or depending on this service may result in unexpected behavior and is not supported.
+ */
+class ContentViewResolver implements ContentViewResolverInterface
+{
+    /**
+     * @param iterable<string, ResolverInterface> $contentResolvers
+     */
+    public function __construct(
+        private ResolvableResourceQueueProcessorInterface $resolvableResourceQueueProcessor,
+        private iterable $contentResolvers
+    ) {
+    }
+
+    /**
+     * @template T of ContentRichEntityInterface
+     *
+     * @param DimensionContentInterface<T> $dimensionContent
+     * @param array<string, string>|null $properties
+     *
+     * @return array<string|int, ContentView>
+     */
+    public function getContentViews(DimensionContentInterface $dimensionContent, ?array $properties = null): array
+    {
+        $contentViews = [];
+
+        /**
+         * @var string $resolverKey
+         * @var ResolverInterface $contentResolver
+         */
+        foreach ($this->contentResolvers as $resolverKey => $contentResolver) {
+            $contentView = $contentResolver->resolve($dimensionContent, $properties);
+
+            if (!$contentView instanceof ContentView) {
+                continue;
+            }
+
+            $contentViews[$resolverKey] = $contentView;
+        }
+
+        return $contentViews;
+    }
+
+    /**
+     * @param ContentView[] $contentViews
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> &$priorityQueue Reference to the priority queue
+     *
+     * @return array{
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     resolvableResources: array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>>,
+     * }
+     */
+    public function resolveContentViews(array $contentViews, int $depth, array &$priorityQueue = []): array
+    {
+        $content = [];
+        $view = [];
+
+        $resolvableResources = [];
+        foreach ($contentViews as $name => $contentView) {
+            $result = $this->resolveContentView($contentView, (string) $name, $depth, $priorityQueue);
+            $content = \array_merge($content, $result['content']);
+            $view = \array_merge($view, $result['view']);
+            $resolvableResources = $this->resolvableResourceQueueProcessor->mergeResolvableResources(
+                $resolvableResources,
+                $result['resolvableResources']
+            );
+        }
+
+        return [
+            'content' => $content,
+            'view' => $view,
+            'resolvableResources' => $resolvableResources,
+            'depth' => $depth,
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> &$priorityQueue Reference to the priority queue
+     *
+     * @return array{
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     resolvableResources: array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>>
+     * }
+     */
+    public function resolveContentView(ContentView $contentView, string $name, int $depth, array &$priorityQueue = []): array
+    {
+        $content = $contentView->getContent();
+        $view = $contentView->getView();
+
+        $result = [
+            'content' => [],
+            'view' => [],
+            'resolvableResources' => [],
+            'depth' => $depth,
+        ];
+
+        if (\is_array($content)) {
+            if (\count(\array_filter($content, fn ($entry) => $entry instanceof ContentView)) === \count($content)) {
+                /** @var ContentView[] $content */
+                // resolve array of content views
+                $resolvedContentViews = $this->resolveContentViews($content, $depth + 1, $priorityQueue);
+                $result['content'][$name] = $resolvedContentViews['content'];
+                $result['view'][$name] = $resolvedContentViews['view'];
+                $result['resolvableResources'] = $this->resolvableResourceQueueProcessor->mergeResolvableResources(
+                    $result['resolvableResources'],
+                    $resolvedContentViews['resolvableResources']
+                );
+
+                return $result;
+            }
+
+            $resolvableResources = [];
+            foreach ($content as $key => $entry) {
+                // resolve array of mixed content
+                if ($entry instanceof ContentView) {
+                    $resolvedContentView = $this->resolveContentView($entry, $key, $depth + 1, $priorityQueue);
+                    $result['content'][$name] = \array_merge($result['content'][$name] ?? [], $resolvedContentView['content']);
+                    $result['view'][$name] = \array_merge($result['view'][$name] ?? [], $resolvedContentView['view']);
+                    $resolvableResources = $this->resolvableResourceQueueProcessor->mergeResolvableResources(
+                        $resolvableResources,
+                        $resolvedContentView['resolvableResources']
+                    );
+
+                    continue;
+                }
+
+                if ($entry instanceof ResolvableInterface) {
+                    $resolvableResources[$entry->getPriority()][$entry->getResourceLoaderKey()][$depth][$entry->getId()][$entry->getMetadataIdentifier()] = $entry;
+                }
+
+                $result['content'][$name][$key] = $entry;
+                if (isset($view[$key])) {
+                    $result['view'][$name][$key] = $view[$key];
+                }
+            }
+
+            // If the view is not set for this name, we can use the root view
+            if (($result['view'][$name] ?? null) === null) {
+                $result['view'][$name] = $view;
+            }
+
+            $result['resolvableResources'] = $resolvableResources;
+
+            return $result;
+        }
+
+        if ($content instanceof ResolvableInterface) {
+            // @phpstan-ignore-next-line
+            $result['resolvableResources'][$content->getPriority()][$content->getResourceLoaderKey()][$depth][$content->getId()][$content->getMetadataIdentifier()] = $content;
+        }
+
+        $result['content'][$name] = $content;
+        $result['view'][$name] = $view;
+
+        return $result;
+    }
+}

--- a/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolverInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\ContentViewResolver;
+
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+
+/**
+ * @internal This interface is intended for internal use only within the package/library.
+ * Modifying or depending on this interface may result in unexpected behavior and is not supported.
+ */
+interface ContentViewResolverInterface
+{
+    /**
+     * @template T of \Sulu\Content\Domain\Model\ContentRichEntityInterface
+     *
+     * @param DimensionContentInterface<T> $dimensionContent
+     * @param array<string, mixed>|null $properties
+     *
+     * @return array<string|int, ContentView>
+     */
+    public function getContentViews(DimensionContentInterface $dimensionContent, ?array $properties = null): array;
+
+    /**
+     * @param ContentView[] $contentViews
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> &$priorityQueue Reference to the priority queue
+     *
+     * @return array{
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     resolvableResources: array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>>,
+     * }
+     */
+    public function resolveContentViews(array $contentViews, int $depth, array &$priorityQueue = []): array;
+
+    /**
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> &$priorityQueue Reference to the priority queue
+     *
+     * @return array{
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     resolvableResources: array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>>
+     * }
+     */
+    public function resolveContentView(ContentView $contentView, string $name, int $depth, array &$priorityQueue = []): array;
+}

--- a/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizer.php
+++ b/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizer.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\DataNormalizer;
+
+use Sulu\Content\Application\ContentResolver\Resolver\SettingsResolver;
+use Sulu\Content\Domain\Model\ContentRichEntityInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+/**
+ * @phpstan-import-type SettingsData from SettingsResolver
+ *
+ * @internal This service is intended for internal use only within the package/library.
+ * Modifying or depending on this service may result in unexpected behavior and is not supported.
+ */
+class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
+{
+    public function __construct(
+        private PropertyAccessorInterface $propertyAccessor
+    ) {
+    }
+
+    /**
+     * @template T of DimensionContentInterface
+     *
+     * @param array<string, mixed> $content
+     * @param array<string, mixed> $view
+     * @param ContentRichEntityInterface<T> $resource
+     *
+     * @return array{
+     *     resource: ContentRichEntityInterface<T>,
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     extension: array<string, array<string, mixed>>,
+     * }
+     */
+    public function normalizeContentViewData(
+        array $content,
+        array $view,
+        ContentRichEntityInterface $resource,
+    ): array {
+        /** @var array<string, mixed> $templateData */
+        $templateData = $content['template'] ?? [];
+        unset($content['template']);
+
+        /** @var array<string, mixed> $templateView */
+        $templateView = $view['template'] ?? [];
+        unset($view['template']);
+
+        /** @var SettingsData $settingsData */
+        $settingsData = $content['settings'] ?? [];
+        unset($content['settings'], $view['settings']);
+
+        /** @var array<string, array<string, mixed>> $extensionData */
+        $extensionData = $content;
+
+        $result = \array_merge(
+            [
+                'resource' => $resource,
+                'content' => $templateData,
+                'view' => $templateView,
+                'extension' => $extensionData,
+            ],
+            $settingsData,
+        );
+
+        return $result;
+    }
+
+    /**
+     * Replaces nested ContentViews in the formatted content data.
+     *
+     * @param array{
+     *     resource: object,
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     extension: array<string, array<string, mixed>>
+     * } $contentData
+     */
+    public function replaceNestedContentViews(array &$contentData, string $path = '[content]'): void
+    {
+        $pathValues = [];
+        $iterable = $this->propertyAccessor->getValue($contentData, $path) ?? [];
+        if (!\is_array($iterable)) {
+            return;
+        }
+
+        /** @var string $key */
+        foreach ($iterable as $key => $entry) {
+            if (\is_array($entry)) {
+                if ([] !== $entry) {
+                    $this->replaceNestedContentViews($contentData, $path . '[' . $key . ']');
+                }
+                if ('view' === $key) {
+                    $value = $this->propertyAccessor->getValue($contentData, $path . '[' . $key . ']');
+                    // Replace 'content' with 'view' in the path
+                    $viewPath = \substr_replace($path, '[view]', 0, 9);
+
+                    // If there are more [content] positions, we need to remove them, only keep the first one from the root property resolver
+                    $viewPath = (($nextContentPosition = \strpos($viewPath, '[content]')) !== false) ? \substr($viewPath, 0, $nextContentPosition) : $viewPath;
+
+                    // Only override empty view paths
+                    if (($this->propertyAccessor->getValue($contentData, $viewPath) ?? []) === []) {
+                        $pathValues[$viewPath] = $value;
+                    }
+                }
+                if ('content' === $key) {
+                    $value = $this->propertyAccessor->getValue($contentData, $path . '[' . $key . ']');
+                    $pathValues[$path] = $value;
+                }
+            }
+        }
+
+        foreach ($pathValues as $path => $value) {
+            $this->propertyAccessor->setValue($contentData, $path, $value); // @phpstan-ignore-line
+        }
+    }
+
+    /**
+     * @param array{
+     *     resource: object,
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     extension: array<string, array<string, mixed>>
+     * } &$data
+     * @param array<string, mixed> $properties
+     */
+    public function recursivelyMapProperties(
+        array &$data,
+        array $properties,
+        string $path = '',
+        int $depth = 0,
+        bool $isRoot = true
+    ): void {
+        $iterable = '' === $path ? $data : ($this->propertyAccessor->getValue($data, $path) ?? []);
+        if (!\is_array($iterable)) {
+            return;
+        }
+
+        foreach ($iterable as $key => $value) {
+            if (
+                ($properties[$key] ?? null)
+                && $depth === (\substr_count($path, '][') + 1)
+            ) {
+                $parent = $this->propertyAccessor->getValue($data, $path);
+                if (!\is_array($parent)) {
+                    continue;
+                }
+                unset($parent[$key]);
+                // @phpstan-ignore-next-line
+                $this->propertyAccessor->setValue($data, $path, $parent);
+
+                if (!\is_string($key)) {
+                    continue;
+                }
+                $rootPath = ($isRoot ? '' : '[content]') . '[' . \implode('][', \explode('.', $key)) . ']';
+                // @phpstan-ignore-next-line
+                $this->propertyAccessor->setValue($data, $rootPath, $value);
+            }
+
+            // do not walk into 'view' as views cannot be mapped via properties
+            if (\is_array($value) && 'view' !== $key) {
+                if (!\is_string($key)) {
+                    continue;
+                }
+                $this->recursivelyMapProperties(
+                    $data, // @phpstan-ignore-line
+                    $properties,
+                    $path . '[' . $key . ']',
+                    $depth + 1,
+                    $isRoot
+                );
+            }
+        }
+    }
+}

--- a/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerInterface.php
+++ b/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\DataNormalizer;
+
+use Sulu\Content\Domain\Model\ContentRichEntityInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+
+/**
+ * @internal This interface is intended for internal use only within the package/library.
+ * Modifying or depending on this interface may result in unexpected behavior and is not supported.
+ */
+interface ContentViewDataNormalizerInterface
+{
+    /**
+     * @template T of DimensionContentInterface
+     *
+     * @param array<string, mixed> $content
+     * @param array<string, mixed> $view
+     * @param ContentRichEntityInterface<T> $resource
+     *
+     * @return array{
+     *     resource: ContentRichEntityInterface<T>,
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     extension: array<string, array<string, mixed>>,
+     * }
+     */
+    public function normalizeContentViewData(
+        array $content,
+        array $view,
+        ContentRichEntityInterface $resource
+    ): array;
+
+    /**
+     * Replaces nested ContentViews in the formatted content data.
+     *
+     * @param array{
+     *     resource: object,
+     *     content: array<string, mixed>,
+     *     view: array<string, mixed>,
+     *     extension: array<string, array<string, mixed>>
+     * } $contentData
+     */
+    public function replaceNestedContentViews(array &$contentData, string $path = '[content]'): void;
+
+    /**
+     * Recursively maps properties in the content data.
+     *
+     * @param array{
+     *      resource: object,
+     *      content: array<string, mixed>,
+     *      view: array<string, mixed>,
+     *      extension: array<string, array<string, mixed>>,
+     *  } $data
+     * @param array<string, string> $properties
+     */
+    public function recursivelyMapProperties(
+        array &$data,
+        array $properties,
+        string $path = '',
+        int $depth = 0,
+        bool $isRoot = true
+    ): void;
+}

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoader.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoader.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\ResolvableResourceLoader;
+
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
+use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
+use Sulu\Content\Application\SmartResolver\SmartResolverProviderInterface;
+
+/**
+ * @internal This service is intended for internal use only within the package/library.
+ * Modifying or depending on this service may result in unexpected behavior and is not supported.
+ */
+class ResolvableResourceLoader implements ResolvableResourceLoaderInterface
+{
+    public function __construct(
+        private ResourceLoaderProvider $resourceLoaderProvider,
+        private SmartResolverProviderInterface $smartResolverProvider
+    ) {
+    }
+
+    public function loadResources(array $resourcesPerLoader, ?string $locale): array
+    {
+        $loadedResources = [];
+        foreach ($resourcesPerLoader as $loaderKey => $resourcesToLoad) {
+            if (!$loaderKey) {
+                throw new \RuntimeException(\sprintf('ResourceLoader key "%s" is invalid', $loaderKey));
+            }
+
+            $smartResolvableResources = [];
+            $resolvableResources = [];
+            $metadataIdentifiersPerResourceId = [];
+            foreach ($resourcesToLoad as $id => $resourcePerMetadataIdentifier) {
+                foreach ($resourcePerMetadataIdentifier as $metadataIdentifier => $resource) {
+                    $metadataIdentifiersPerResourceId[$id][] = $metadataIdentifier;
+                    if ($resource instanceof SmartResolvable) {
+                        $smartResolvableResources[$id] = $resource;
+                    } elseif ($resource instanceof ResolvableResource) {
+                        $resolvableResources[$id] = $resource;
+                    } else {
+                        throw new \RuntimeException(\sprintf('Resource with id "%s" is neither a SmartResolvable nor a ResolvableResource', $id));
+                    }
+                }
+            }
+
+            if (\count($smartResolvableResources) > 0) {
+                $result = $this->loadSmartResolvableResources($smartResolvableResources, $locale);
+                foreach ($result as $id => $loadedResource) {
+                    foreach ($metadataIdentifiersPerResourceId[$id] as $metadataIdentifier) {
+                        $loadedResources[$loaderKey][$id][$metadataIdentifier] = $loadedResource;
+                    }
+                }
+            }
+
+            if (\count($resolvableResources) > 0) {
+                $result = $this->loadResolvableResources($resolvableResources, $loaderKey, $locale);
+                foreach ($result as $id => $loadedResource) {
+                    foreach ($metadataIdentifiersPerResourceId[$id] as $metadataIdentifier) {
+                        $loadedResources[$loaderKey][$id][$metadataIdentifier] = $loadedResource;
+                    }
+                }
+            }
+        }
+
+        return $loadedResources;
+    }
+
+    /**
+     * @param array<SmartResolvable> $smartResources
+     *
+     * @return array<mixed>
+     */
+    private function loadSmartResolvableResources(array $smartResources, ?string $locale): array
+    {
+        $loadedResources = [];
+
+        foreach ($smartResources as $id => $smartResource) {
+            $resourceLoaderKey = $smartResource->getResourceLoaderKey();
+            $smartResolver = $this->smartResolverProvider->getSmartResolver($resourceLoaderKey);
+
+            $loadedResources[$id] = $smartResolver->resolve(
+                $smartResource,
+                $locale,
+            );
+        }
+
+        return $loadedResources;
+    }
+
+    /**
+     * @param array<ResolvableResource> $resolvableResources
+     *
+     * @return array<string|int, mixed>
+     */
+    private function loadResolvableResources(array $resolvableResources, string $loaderKey, ?string $locale): array
+    {
+        $resourceLoader = $this->resourceLoaderProvider->getResourceLoader($loaderKey);
+        if (!$resourceLoader) {
+            throw new \RuntimeException(\sprintf('ResourceLoader with key "%s" not found', $loaderKey));
+        }
+
+        $resourceIds = \array_map(fn (ResolvableResource $resource) => $resource->getId(), $resolvableResources);
+
+        return $resourceLoader->load(
+            $resourceIds,
+            $locale,
+        );
+    }
+}

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoaderInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoaderInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\ResolvableResourceLoader;
+
+use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
+
+/**
+ * @internal This interface is intended for internal use only within the package/library.
+ * Modifying or depending on this interface may result in unexpected behavior and is not supported.
+ */
+interface ResolvableResourceLoaderInterface
+{
+    /**
+     * Loads and resolves resources from various resource loaders.
+     *
+     * @param array<string, array<string|int, array<string, ResolvableInterface>>> $resourcesPerLoader Resource loaders and their associated resources to load
+     *
+     * @return array<string, array<string|int, array<string, mixed>>> Resolved resources organized by resource loader key
+     */
+    public function loadResources(array $resourcesPerLoader, ?string $locale): array;
+}

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceQueue/ResolvableResourceQueueProcessor.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceQueue/ResolvableResourceQueueProcessor.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\ResolvableResourceQueue;
+
+use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
+
+/**
+ * @internal This service is intended for internal use only within the package/library.
+ * Modifying or depending on this service may result in unexpected behavior and is not supported.
+ */
+class ResolvableResourceQueueProcessor implements ResolvableResourceQueueProcessorInterface
+{
+    /**
+     * Merges the given resolvable resources with the existing resolvable resources.
+     * The resolvable resources are ordered by priority and indexed by priority, loader key and object id.
+     *
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> $resolvableResources
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> $existingResolvableResources
+     *
+     * @return array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>>
+     */
+    public function mergeResolvableResources(array $resolvableResources, array $existingResolvableResources): array
+    {
+        foreach ($resolvableResources as $priority => $loaderResolvableResources) {
+            foreach ($loaderResolvableResources as $loaderKey => $resolvableResourcesPerLoader) {
+                foreach ($resolvableResourcesPerLoader as $depth => $resolvableResourcePerDepth) {
+                    foreach ($resolvableResourcePerDepth as $id => $resolvableResourcePerId) {
+                        foreach ($resolvableResourcePerId as $metadataIdentifier => $resolvableResource) {
+                            $existingResolvableResources[$priority][$loaderKey][$depth][$id][$metadataIdentifier] = $resolvableResource;
+                        }
+                    }
+                }
+            }
+        }
+        \krsort($existingResolvableResources);
+
+        return $existingResolvableResources;
+    }
+
+    public function extractHighestPriorityResources(array &$priorityQueue, int $maxDepth): array
+    {
+        if (empty($priorityQueue)) {
+            return [
+                'resourcesToLoad' => [],
+                'loaderIdDepths' => [],
+            ];
+        }
+
+        // Get the highest priority resources (first key due to krsort in mergeResolvableResources)
+        $highestPriorityKey = \array_key_first($priorityQueue);
+        $resourcesAtPriority = $priorityQueue[$highestPriorityKey];
+        unset($priorityQueue[$highestPriorityKey]);
+
+        $loaderIdDepths = [];
+        $resourcesToLoad = [];
+
+        // Filter resources with depth too high
+        foreach ($resourcesAtPriority as $loaderKey => $resourcePerDepth) {
+            foreach ($resourcePerDepth as $depth => $resources) {
+                if ($depth > $maxDepth) {
+                    continue;
+                }
+                foreach ($resources as $id => $resource) {
+                    $resourcesToLoad[$loaderKey][$id] = $resource;
+                    $loaderIdDepths[$loaderKey][$id] = $depth;
+                }
+            }
+        }
+
+        return [
+            'resourcesToLoad' => $resourcesToLoad,
+            'loaderIdDepths' => $loaderIdDepths,
+        ];
+    }
+}

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceQueue/ResolvableResourceQueueProcessorInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceQueue/ResolvableResourceQueueProcessorInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\ResolvableResourceQueue;
+
+use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
+
+/**
+ * @internal This interface is intended for internal use only within the package/library.
+ * Modifying or depending on this interface may result in unexpected behavior and is not supported.
+ */
+interface ResolvableResourceQueueProcessorInterface
+{
+    /**
+     * Merges the given resolvable resources with the existing resolvable resources.
+     * The resolvable resources are ordered by priority and indexed by priority, loader key, object id and metadataIdentifier.
+     *
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> $resolvableResources
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> $existingResolvableResources
+     *
+     * @return array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>>
+     */
+    public function mergeResolvableResources(array $resolvableResources, array $existingResolvableResources): array;
+
+    /**
+     * Gets the highest priority resources from the queue.
+     * Note: This modifies the provided priority queue by removing the processed items.
+     *
+     * @param array<int, array<string, array<int, array<int|string, array<string, ResolvableInterface>>>>> &$priorityQueue Reference to the priority queue
+     * @param int $maxDepth Maximum depth for resource resolution
+     *
+     * @return array{
+     *     resourcesToLoad: array<string, array<int|string, array<string, ResolvableInterface>>>,
+     *     loaderIdDepths: array<string, array<int|string, int>>
+     * }
+     */
+    public function extractHighestPriorityResources(array &$priorityQueue, int $maxDepth): array;
+}

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer;
+
+use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+
+/**
+ * @internal This service is intended for internal use only within the package/library.
+ * Modifying or depending on this service may result in unexpected behavior and is not supported.
+ */
+class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
+{
+    public function replaceResolvableResourcesWithResolvedValues(
+        array $content,
+        array $resolvedResources,
+        int $depth,
+        int $maxDepth
+    ): array {
+        if ($depth > $maxDepth) {
+            // replace non resolved resources with null
+            \array_walk_recursive($content, function(&$value) {
+                if ($value instanceof ResolvableResource) {
+                    // TODO add callback with exception in dev mode
+                    $value = null;
+                }
+            });
+
+            return $content;
+        }
+
+        if (0 === \count($resolvedResources)) {
+            return $content;
+        }
+
+        $hasReplaced = false;
+        \array_walk_recursive($content, function(&$value) use ($resolvedResources, &$hasReplaced) {
+            if (
+                $value instanceof ResolvableInterface
+            ) {
+                $resource = $resolvedResources[$value->getResourceLoaderKey()][$value->getId()][$value->getMetadataIdentifier()] ?? null;
+                $value = $value->executeResourceCallback(
+                    $resource,
+                );
+                $hasReplaced = true;
+            }
+        });
+
+        // Recursively replace ResolvableResource instances in nested arrays
+        // if a replacement was made in the previous step.
+        // This is necessary to resolve nested ResolvableResource instances
+        // which might have been added during the first replacement,
+        // e.g., when a ResolvableResource is replaced with an array containing another ResolvableResource.
+        if ($hasReplaced) {
+            $content = $this->replaceResolvableResourcesWithResolvedValues(
+                $content,
+                $resolvedResources,
+                $depth + 1,
+                $maxDepth
+            );
+        }
+
+        return $content;
+    }
+}

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer;
+
+/**
+ * @internal This interface is intended for internal use only within the package/library.
+ * Modifying or depending on this interface may result in unexpected behavior and is not supported.
+ */
+interface ResolvableResourceReplacerInterface
+{
+    /**
+     * @param array<string, mixed> $content
+     * @param array<string, array<string|int, array<string, mixed>>> $resolvedResources
+     *
+     * @return array<string, mixed>
+     */
+    public function replaceResolvableResourcesWithResolvedValues(
+        array $content,
+        array $resolvedResources,
+        int $depth,
+        int $maxDepth
+    ): array;
+}

--- a/packages/content/src/Application/ContentResolver/Resolver/DimensionContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/DimensionContentResolver.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Content\Application\ContentResolver\Resolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
@@ -8,19 +17,18 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 readonly class DimensionContentResolver implements ResolverInterface
 {
-
     public function __construct(private PropertyAccessorInterface $propertyAccessor)
     {
     }
 
     public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
     {
-        if ($properties === []) {
+        if ([] === $properties) {
             return null;
         }
 
         $properties = $this->filterProperties(
-            array_merge($this->getDefaultProperties(), $properties ?? [])
+            \array_merge($this->getDefaultProperties(), $properties ?? [])
         );
 
         $data = [];
@@ -39,6 +47,9 @@ readonly class DimensionContentResolver implements ResolverInterface
         );
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function getDefaultProperties(): array
     {
         return [
@@ -46,6 +57,11 @@ readonly class DimensionContentResolver implements ResolverInterface
         ];
     }
 
+    /**
+     * @param array<string, string> $properties
+     *
+     * @return array<string, string>
+     */
     private function filterProperties(array $properties): array
     {
         $filteredProperties = [];

--- a/packages/content/src/Application/ContentResolver/Resolver/DimensionContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/DimensionContentResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Sulu\Content\Application\ContentResolver\Resolver;
+
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+readonly class DimensionContentResolver implements ResolverInterface
+{
+
+    public function __construct(private PropertyAccessorInterface $propertyAccessor)
+    {
+    }
+
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
+    {
+        if ($properties === []) {
+            return null;
+        }
+
+        $properties = $this->filterProperties(
+            array_merge($this->getDefaultProperties(), $properties ?? [])
+        );
+
+        $data = [];
+        $resource = $dimensionContent->getResource();
+        foreach ($properties as $key => $path) {
+            if ($this->propertyAccessor->isReadable($dimensionContent, $path)) {
+                $data[$key] = $this->propertyAccessor->getValue($dimensionContent, $path);
+            } elseif ($this->propertyAccessor->isReadable($resource, $path)) {
+                $data[$key] = $this->propertyAccessor->getValue($resource, $path);
+            }
+        }
+
+        return ContentView::create(
+            $data,
+            []
+        );
+    }
+
+    private function getDefaultProperties(): array
+    {
+        return [
+            'id' => self::getPrefix() . 'id',
+        ];
+    }
+
+    private function filterProperties(array $properties): array
+    {
+        $filteredProperties = [];
+        foreach ($properties as $key => $value) {
+            if (\str_starts_with($value, self::getPrefix())) {
+                $filteredProperties[$key] = \str_replace(self::getPrefix(), '', $value);
+            }
+        }
+
+        return $filteredProperties;
+    }
+
+    public static function getPrefix(): string
+    {
+        return 'object.';
+    }
+}

--- a/packages/content/src/Application/ContentResolver/Resolver/DimensionContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/DimensionContentResolver.php
@@ -32,12 +32,9 @@ readonly class DimensionContentResolver implements ResolverInterface
         );
 
         $data = [];
-        $resource = $dimensionContent->getResource();
         foreach ($properties as $key => $path) {
             if ($this->propertyAccessor->isReadable($dimensionContent, $path)) {
                 $data[$key] = $this->propertyAccessor->getValue($dimensionContent, $path);
-            } elseif ($this->propertyAccessor->isReadable($resource, $path)) {
-                $data[$key] = $this->propertyAccessor->getValue($resource, $path);
             }
         }
 

--- a/packages/content/src/Application/ContentResolver/Resolver/ExcerptResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ExcerptResolver.php
@@ -44,7 +44,7 @@ readonly class ExcerptResolver implements ResolverInterface
 
         $formMetadataItems = $formMetadata->getItems();
         $data = $this->getExcerptData($dimensionContent);
-        if ($properties !== null) {
+        if (null !== $properties) {
             $filteredFormMetadataItems = [];
             $filteredTemplateData = [];
             $properties = $this->filterProperties($properties);
@@ -65,12 +65,17 @@ readonly class ExcerptResolver implements ResolverInterface
         return ContentView::create($this->normalizeResolvedItems($resolvedItems, $properties), []);
     }
 
+    /**
+     * @param array<string, string> $properties
+     *
+     * @return array<string, string>
+     */
     private function filterProperties(array $properties): array
     {
         $filteredProperties = [];
         foreach ($properties as $key => $value) {
-            if (\str_starts_with((string)$value, self::getPrefix())) {
-                $normalizedValue = 'excerpt' . \ucfirst(\substr((string)$value, \strlen(self::getPrefix())));
+            if (\str_starts_with((string) $value, self::getPrefix())) {
+                $normalizedValue = 'excerpt' . \ucfirst(\substr((string) $value, \strlen(self::getPrefix())));
                 $filteredProperties[$key] = $normalizedValue;
             }
         }
@@ -80,6 +85,7 @@ readonly class ExcerptResolver implements ResolverInterface
 
     /**
      * @param mixed[] $resolvedItems
+     * @param array<string, string> $properties
      *
      * @return mixed[]
      */
@@ -87,7 +93,7 @@ readonly class ExcerptResolver implements ResolverInterface
     {
         $result = [];
         foreach ($resolvedItems as $key => $item) {
-            if ($properties !== null && \array_key_exists($key, $properties)) {
+            if (null !== $properties && \array_key_exists($key, $properties)) {
                 $normalizedKey = $key;
             } else {
                 $normalizedKey = \str_starts_with((string) $key, 'excerpt') ? \lcfirst(\substr((string) $key, \strlen('excerpt'))) : $key;

--- a/packages/content/src/Application/ContentResolver/Resolver/ExcerptResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ExcerptResolver.php
@@ -30,7 +30,7 @@ readonly class ExcerptResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
     {
         if (!$dimensionContent instanceof ExcerptInterface) {
             return null;
@@ -41,9 +41,41 @@ readonly class ExcerptResolver implements ResolverInterface
 
         /** @var FormMetadata $formMetadata */
         $formMetadata = $this->formMetadataProvider->getMetadata($this->getFormKey(), $locale, []);
-        $resolvedItems = $this->metadataResolver->resolveItems($formMetadata->getItems(), $this->getExcerptData($dimensionContent), $locale);
 
-        return ContentView::create($this->normalizeResolvedItems($resolvedItems), []);
+        $formMetadataItems = $formMetadata->getItems();
+        $data = $this->getExcerptData($dimensionContent);
+        if ($properties !== null) {
+            $filteredFormMetadataItems = [];
+            $filteredTemplateData = [];
+            $properties = $this->filterProperties($properties);
+            foreach ($properties as $key => $value) {
+                if (\array_key_exists($value, $formMetadataItems)) {
+                    $filteredFormMetadataItems[$key] = $formMetadataItems[$value];
+                }
+                if (\array_key_exists($value, $data)) {
+                    $filteredTemplateData[$key] = $data[$value];
+                }
+            }
+            $formMetadataItems = $filteredFormMetadataItems;
+            $data = $filteredTemplateData;
+        }
+
+        $resolvedItems = $this->metadataResolver->resolveItems($formMetadataItems, $data, $locale);
+
+        return ContentView::create($this->normalizeResolvedItems($resolvedItems, $properties), []);
+    }
+
+    private function filterProperties(array $properties): array
+    {
+        $filteredProperties = [];
+        foreach ($properties as $key => $value) {
+            if (\str_starts_with((string)$value, self::getPrefix())) {
+                $normalizedValue = 'excerpt' . \ucfirst(\substr((string)$value, \strlen(self::getPrefix())));
+                $filteredProperties[$key] = $normalizedValue;
+            }
+        }
+
+        return $filteredProperties;
     }
 
     /**
@@ -51,11 +83,16 @@ readonly class ExcerptResolver implements ResolverInterface
      *
      * @return mixed[]
      */
-    protected function normalizeResolvedItems(array $resolvedItems): array
+    protected function normalizeResolvedItems(array $resolvedItems, ?array $properties): array
     {
         $result = [];
         foreach ($resolvedItems as $key => $item) {
-            $normalizedKey = \str_starts_with((string) $key, 'excerpt') ? \lcfirst(\substr((string) $key, \strlen('excerpt'))) : $key;
+            if ($properties !== null && \array_key_exists($key, $properties)) {
+                $normalizedKey = $key;
+            } else {
+                $normalizedKey = \str_starts_with((string) $key, 'excerpt') ? \lcfirst(\substr((string) $key, \strlen('excerpt'))) : $key;
+            }
+
             $result[$normalizedKey] = $item;
         }
 
@@ -94,5 +131,10 @@ readonly class ExcerptResolver implements ResolverInterface
             'excerptIcon' => $dimensionContent->getExcerptIcon(),
             'excerptImage' => $dimensionContent->getExcerptImage(),
         ];
+    }
+
+    public static function getPrefix(): string
+    {
+        return 'excerpt.';
     }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/ResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ResolverInterface.php
@@ -23,7 +23,7 @@ interface ResolverInterface
      * @template T of ContentRichEntityInterface
      *
      * @param DimensionContentInterface<T> $dimensionContent
-     * @param array<string, mixed>|null $properties
+     * @param array<string, string>|null $properties
      */
     public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView;
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/ResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ResolverInterface.php
@@ -23,6 +23,7 @@ interface ResolverInterface
      * @template T of ContentRichEntityInterface
      *
      * @param DimensionContentInterface<T> $dimensionContent
+     * @param array<string, mixed>|null $properties
      */
-    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView;
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView;
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
@@ -28,7 +28,7 @@ readonly class SeoResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
     {
         if (!$dimensionContent instanceof SeoInterface) {
             return null;
@@ -40,12 +40,42 @@ readonly class SeoResolver implements ResolverInterface
         /** @var FormMetadata $formMetadata */
         $formMetadata = $this->formMetadataProvider->getMetadata($this->getFormKey(), $locale, []);
 
-        $items = \array_filter($formMetadata->getItems(), function($item) {
+        $formMetadataItems = \array_filter($formMetadata->getItems(), function ($item) {
             return !\in_array($item->getType(), $this->excludedPropertyTypes(), true);
         });
-        $resolvedItems = $this->metadataResolver->resolveItems($items, $this->getSeoData($dimensionContent), $locale);
+        $data = $this->getSeoData($dimensionContent);
+        if ($properties !== null) {
+            $filteredFormMetadataItems = [];
+            $filteredTemplateData = [];
+            $properties = $this->filterProperties($properties);
+            foreach ($properties as $key => $value) {
+                if (\array_key_exists($value, $formMetadataItems)) {
+                    $filteredFormMetadataItems[$key] = $formMetadataItems[$value];
+                }
+                if (\array_key_exists($value, $data)) {
+                    $filteredTemplateData[$key] = $data[$value];
+                }
+            }
+            $formMetadataItems = $filteredFormMetadataItems;
+            $data = $filteredTemplateData;
+        }
 
-        return ContentView::create($this->normalizeResolvedItems($resolvedItems), []);
+        $resolvedItems = $this->metadataResolver->resolveItems($formMetadataItems, $data, $locale);
+
+        return ContentView::create($this->normalizeResolvedItems($resolvedItems, $properties), []);
+    }
+
+    private function filterProperties(array $properties): array
+    {
+        $filteredProperties = [];
+        foreach ($properties as $key => $value) {
+            if (\str_starts_with((string)$value, self::getPrefix())) {
+                $normalizedValue = 'seo' . \ucfirst(\substr((string)$value, \strlen(self::getPrefix())));
+                $filteredProperties[$key] = $normalizedValue;
+            }
+        }
+
+        return $filteredProperties;
     }
 
     /**
@@ -53,11 +83,16 @@ readonly class SeoResolver implements ResolverInterface
      *
      * @return mixed[]
      */
-    protected function normalizeResolvedItems(array $resolvedItems): array
+    protected function normalizeResolvedItems(array $resolvedItems, ?array $properties): array
     {
         $result = [];
         foreach ($resolvedItems as $key => $item) {
-            $normalizedKey = \lcfirst(\substr((string) $key, \strlen('seo')));
+            if ($properties !== null && \array_key_exists($key, $properties)) {
+                $normalizedKey = $key;
+            } else {
+                $normalizedKey = \str_starts_with((string)$key, 'seo') ? \lcfirst(\substr((string)$key, \strlen('seo'))) : $key;
+            }
+
             $result[$normalizedKey] = $item;
         }
 
@@ -99,5 +134,10 @@ readonly class SeoResolver implements ResolverInterface
             'seoNoFollow' => $dimensionContent->getSeoNoFollow(),
             'seoHideInSitemap' => $dimensionContent->getSeoHideInSitemap(),
         ];
+    }
+
+    public static function getPrefix(): string
+    {
+        return 'seo.';
     }
 }

--- a/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
@@ -40,11 +40,11 @@ readonly class SeoResolver implements ResolverInterface
         /** @var FormMetadata $formMetadata */
         $formMetadata = $this->formMetadataProvider->getMetadata($this->getFormKey(), $locale, []);
 
-        $formMetadataItems = \array_filter($formMetadata->getItems(), function ($item) {
+        $formMetadataItems = \array_filter($formMetadata->getItems(), function($item) {
             return !\in_array($item->getType(), $this->excludedPropertyTypes(), true);
         });
         $data = $this->getSeoData($dimensionContent);
-        if ($properties !== null) {
+        if (null !== $properties) {
             $filteredFormMetadataItems = [];
             $filteredTemplateData = [];
             $properties = $this->filterProperties($properties);
@@ -65,12 +65,17 @@ readonly class SeoResolver implements ResolverInterface
         return ContentView::create($this->normalizeResolvedItems($resolvedItems, $properties), []);
     }
 
+    /**
+     * @param array<string, string> $properties
+     *
+     * @return array<string, string>
+     */
     private function filterProperties(array $properties): array
     {
         $filteredProperties = [];
         foreach ($properties as $key => $value) {
-            if (\str_starts_with((string)$value, self::getPrefix())) {
-                $normalizedValue = 'seo' . \ucfirst(\substr((string)$value, \strlen(self::getPrefix())));
+            if (\str_starts_with((string) $value, self::getPrefix())) {
+                $normalizedValue = 'seo' . \ucfirst(\substr((string) $value, \strlen(self::getPrefix())));
                 $filteredProperties[$key] = $normalizedValue;
             }
         }
@@ -80,6 +85,7 @@ readonly class SeoResolver implements ResolverInterface
 
     /**
      * @param mixed[] $resolvedItems
+     * @param array<string, string> $properties
      *
      * @return mixed[]
      */
@@ -87,10 +93,10 @@ readonly class SeoResolver implements ResolverInterface
     {
         $result = [];
         foreach ($resolvedItems as $key => $item) {
-            if ($properties !== null && \array_key_exists($key, $properties)) {
+            if (null !== $properties && \array_key_exists($key, $properties)) {
                 $normalizedKey = $key;
             } else {
-                $normalizedKey = \str_starts_with((string)$key, 'seo') ? \lcfirst(\substr((string)$key, \strlen('seo'))) : $key;
+                $normalizedKey = \str_starts_with((string) $key, 'seo') ? \lcfirst(\substr((string) $key, \strlen('seo'))) : $key;
             }
 
             $result[$normalizedKey] = $item;

--- a/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
@@ -49,7 +49,7 @@ readonly class SettingsResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
     {
         /** @var SettingsData $result */
         $result = [

--- a/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
@@ -56,6 +56,7 @@ readonly class SettingsResolver implements ResolverInterface
             'availableLocales' => $dimensionContent->getAvailableLocales() ?? [],
         ];
 
+        // TODO handle properties filtering
         if ($dimensionContent instanceof RoutableInterface && $dimensionContent instanceof TemplateInterface) {
             $result = \array_merge($result, $this->getLocalizationsData($dimensionContent));
         }

--- a/packages/content/src/Application/ContentResolver/Resolver/TemplateResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/TemplateResolver.php
@@ -28,7 +28,7 @@ readonly class TemplateResolver implements ResolverInterface
     ) {
     }
 
-    public function resolve(DimensionContentInterface $dimensionContent): ?ContentView
+    public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
     {
         if (!$dimensionContent instanceof TemplateInterface) {
             return null;
@@ -50,8 +50,25 @@ readonly class TemplateResolver implements ResolverInterface
             );
         }
 
+        $formMetadataItems = $formMetadata->getItems();
+        $data = $dimensionContent->getTemplateData();
+        if ($properties !== null) {
+            $filteredFormMetadataItems = [];
+            $filteredTemplateData = [];
+            foreach ($properties as $key => $value) {
+                if (\array_key_exists($key, $formMetadataItems)) {
+                    $filteredFormMetadataItems[$key] = $formMetadataItems[$key];
+                }
+                if (\array_key_exists($key, $data)) {
+                    $filteredTemplateData[$key] = $data[$key];
+                }
+            }
+            $formMetadataItems = $filteredFormMetadataItems;
+            $data = $filteredTemplateData;
+        }
+
         return ContentView::create(
-            $this->metadataResolver->resolveItems($formMetadata->getItems(), $dimensionContent->getTemplateData(), $locale),
+            $this->metadataResolver->resolveItems($formMetadataItems, $data, $locale),
             []
         );
     }

--- a/packages/content/src/Application/ContentResolver/Resolver/TemplateResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/TemplateResolver.php
@@ -52,15 +52,16 @@ readonly class TemplateResolver implements ResolverInterface
 
         $formMetadataItems = $formMetadata->getItems();
         $data = $dimensionContent->getTemplateData();
-        if ($properties !== null) {
+        if (null !== $properties) {
             $filteredFormMetadataItems = [];
             $filteredTemplateData = [];
+            /** @var int|string $value */
             foreach ($properties as $key => $value) {
-                if (\array_key_exists($key, $formMetadataItems)) {
-                    $filteredFormMetadataItems[$key] = $formMetadataItems[$key];
+                if (\array_key_exists($value, $formMetadataItems)) {
+                    $filteredFormMetadataItems[$key] = $formMetadataItems[$value];
                 }
-                if (\array_key_exists($key, $data)) {
-                    $filteredTemplateData[$key] = $data[$key];
+                if (\array_key_exists($value, $data)) {
+                    $filteredTemplateData[$key] = $data[$value];
                 }
             }
             $formMetadataItems = $filteredFormMetadataItems;

--- a/packages/content/src/Application/ContentResolver/Value/ContentView.php
+++ b/packages/content/src/Application/ContentResolver/Value/ContentView.php
@@ -57,15 +57,23 @@ class ContentView
 
     /**
      * @param mixed[] $view
+     * @param array<string, mixed>|null $metadata
      */
-    public static function createResolvable(string|int $id, string $resourceLoaderKey, array $view, int $priority = 0, ?\Closure $closure = null): self
-    {
+    public static function createResolvable(
+        string|int $id,
+        string $resourceLoaderKey,
+        array $view,
+        int $priority = 0,
+        ?\Closure $closure = null,
+        ?array $metadata = null,
+    ): self {
         return new self(
             new ResolvableResource(
                 id: $id,
                 resourceLoaderKey: $resourceLoaderKey,
                 priority: $priority,
                 resourceCallback: $closure,
+                metadata: $metadata,
             ),
             $view,
         );
@@ -74,12 +82,14 @@ class ContentView
     /**
      * @param array<string|int> $ids
      * @param mixed[] $view
+     * @param array<string, mixed>|null $metadata
      */
     public static function createResolvables(
         array $ids,
         string $resourceLoaderKey,
         array $view,
         int $priority = 0,
+        ?array $metadata = null,
     ): self {
         $resolvableResources = [];
 
@@ -88,6 +98,7 @@ class ContentView
                 id: $id,
                 resourceLoaderKey: $resourceLoaderKey,
                 priority: $priority,
+                metadata: $metadata
             );
         }
 

--- a/packages/content/src/Application/ContentResolver/Value/ResolvableInterface.php
+++ b/packages/content/src/Application/ContentResolver/Value/ResolvableInterface.php
@@ -23,4 +23,13 @@ interface ResolvableInterface
     public function getPriority(): int;
 
     public function executeResourceCallback(mixed $resource): mixed;
+
+    /**
+     * Returns the metadata associated with this resolvable resource.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getMetadata(): ?array;
+
+    public function getMetadataIdentifier(): string;
 }

--- a/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
+++ b/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
@@ -20,11 +20,15 @@ class ResolvableResource implements ResolvableInterface
 {
     private \Closure $callback;
 
+    /**
+     * @param array<string, mixed>|null $metadata Optional metadata for additional context
+     */
     public function __construct(
         private string|int $id,
         private string $resourceLoaderKey,
         private int $priority,
         ?\Closure $resourceCallback = null,
+        private ?array $metadata = null,
     ) {
         $this->callback = $resourceCallback ?? (static fn (mixed $resource) => $resource);
     }
@@ -47,5 +51,19 @@ class ResolvableResource implements ResolvableInterface
     public function getPriority(): int
     {
         return $this->priority;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getMetadata(): ?array
+    {
+        return $this->metadata;
+    }
+
+    public function getMetadataIdentifier(): string
+    {
+        // TODO do we need a rekursive key sort?
+        return $this->metadata ? \md5((string) \json_encode($this->metadata)) : '';
     }
 }

--- a/packages/content/src/Application/ContentResolver/Value/SmartResolvable.php
+++ b/packages/content/src/Application/ContentResolver/Value/SmartResolvable.php
@@ -22,12 +22,14 @@ class SmartResolvable implements ResolvableInterface
 
     /**
      * @param mixed[] $data
+     * @param array<string, mixed>|null $metadata Optional metadata for additional context
      */
     public function __construct(
         private array $data,
         private string $resourceLoaderKey,
         private int $priority,
         ?\Closure $resourceCallback = null,
+        private ?array $metadata = null,
     ) {
         $this->callback = $resourceCallback ?? (static fn (mixed $resource) => $resource);
     }
@@ -61,5 +63,19 @@ class SmartResolvable implements ResolvableInterface
     public function getData(): array
     {
         return $this->data;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getMetadata(): ?array
+    {
+        return $this->metadata;
+    }
+
+    public function getMetadataIdentifier(): string
+    {
+        // TODO do we need a rekursive key sort?
+        return $this->metadata ? \md5((string) \json_encode($this->metadata)) : '';
     }
 }

--- a/packages/content/src/Application/MetadataResolver/MetadataResolver.php
+++ b/packages/content/src/Application/MetadataResolver/MetadataResolver.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Application\MetadataResolver;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\PropertyResolverProviderInterface;
@@ -46,7 +48,12 @@ class MetadataResolver
                     $this->resolveItems($item->getItems(), $data, $locale)
                 );
             } else {
-                $contentViews[$name] = $this->resolveProperty($type, $data[$name] ?? null, $locale, ['metadata' => $item]);
+                // TODO remove metadata as soon as we implemented a MetadataAwarePropertyResolverInterface
+                $params = [
+                    'metadata' => $item,
+                    ...($item instanceof FieldMetadata ? $this->serializeFieldMetadataOptions($item) : []),
+                ];
+                $contentViews[$name] = $this->resolveProperty($type, $data[$name] ?? null, $locale, $params);
             }
         }
 
@@ -61,5 +68,49 @@ class MetadataResolver
         $propertyResolver = $this->propertyResolverProvider->getPropertyResolver($type);
 
         return $propertyResolver->resolve($data, $locale, $params);
+    }
+
+    /**
+     * @return array<string, string|int|mixed[]|bool|null>
+     */
+    private function serializeFieldMetadataOptions(ItemMetadata $metadata): array
+    {
+        $parameters = [];
+        if (!$metadata instanceof FieldMetadata) {
+            return [];
+        }
+
+        foreach ($metadata->getOptions() as $option) {
+            $parameters[(string) $option->getName()] = $this->serializeOptionMetadata($option);
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @return array<string|int, mixed>|string|int|bool|null
+     */
+    private function serializeOptionMetadata(OptionMetadata $metadata): string|int|array|bool|null
+    {
+        if (OptionMetadata::TYPE_COLLECTION === $metadata->getType()) {
+            $values = [];
+            /** @var OptionMetadata[]|null $metadataValues */
+            $metadataValues = $metadata->getValue();
+            if (!\is_array($metadataValues)) {
+                throw new \InvalidArgumentException(
+                    \sprintf('The value of option "%s" from type %s, must be an array, %s given.', $metadata->getName(), $metadata->getType(), \gettype($metadataValues)),
+                );
+            }
+            foreach ($metadataValues as $option) {
+                $values[$option->getName()] = $this->serializeOptionMetadata($option);
+            }
+
+            return $values;
+        }
+
+        /** @var string|int|bool|null $result */
+        $result = $metadata->getValue() ?? $metadata->getName();
+
+        return $result;
     }
 }

--- a/packages/content/src/Application/MetadataResolver/MetadataResolver.php
+++ b/packages/content/src/Application/MetadataResolver/MetadataResolver.php
@@ -37,8 +37,8 @@ class MetadataResolver
     public function resolveItems(array $items, array $data, string $locale): array
     {
         $contentViews = [];
-        foreach ($items as $item) {
-            $name = $item->getName();
+        foreach ($items as $key => $item) {
+            $name = $key;
             $type = $item->getType();
             if ($item instanceof SectionMetadata) {
                 $contentViews = \array_merge(

--- a/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
+++ b/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
@@ -106,6 +106,9 @@ class SmartContentSmartResolver implements SmartResolverInterface
             ids: \array_map(static fn (array $item) => $item['id'], $result),
             resourceLoaderKey: $smartContentProvider->getResourceLoaderKey(),
             view: $view,
+            metadata: [
+                'properties' => $params['properties'] ?? null,
+            ]
         );
     }
 

--- a/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
+++ b/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
@@ -19,6 +19,12 @@ use Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader\ExampleResou
 
 class ExampleSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param array{
+     *     resourceLoader?: string,
+     *     metadata?: FieldMetadata|null,
+     * } $params
+     */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
         if (!\is_array($data)
@@ -34,18 +40,6 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
         /** @var string[] $ids */
         $ids = $data;
 
-        $metadata = $params['metadata'] ?? null;
-        $properties = null;
-        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
-            $properties = [];
-
-            /** @var OptionMetadata[] $optionsMetadataArray */
-            $optionsMetadataArray = $propertiesMetadata->getValue();
-            foreach ($optionsMetadataArray as $optionMetadata) {
-                $properties[$optionMetadata->getName()] = $optionMetadata->getValue();
-            }
-        }
-
         return ContentView::createResolvables(
             ids: $ids,
             resourceLoaderKey: $resourceLoaderKey,
@@ -55,9 +49,28 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 150,
             metadata: [
-                'properties' => $properties,
+                'properties' => $this->getProperties($params['metadata'] ?? null),
             ]
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getProperties(?FieldMetadata $metadata): ?array
+    {
+        $properties = null;
+        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
+            $properties = [];
+
+            /** @var OptionMetadata[] $optionsMetadataArray */
+            $optionsMetadataArray = $propertiesMetadata->getValue();
+            foreach ($optionsMetadataArray as $optionMetadata) {
+                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
+            }
+        }
+
+        return $properties;
     }
 
     public static function getType(): string

--- a/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
+++ b/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Content\Tests\Application\ExampleTestBundle\PropertyResolver;
 
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader\ExampleResourceLoader;
@@ -22,7 +20,7 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
     /**
      * @param array{
      *     resourceLoader?: string,
-     *     metadata?: FieldMetadata|null,
+     *     properties?: array<string, mixed>|null,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
@@ -49,28 +47,9 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 150,
             metadata: [
-                'properties' => $this->getProperties($params['metadata'] ?? null),
+                'properties' => $params['properties'] ?? null,
             ]
         );
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function getProperties(?FieldMetadata $metadata): ?array
-    {
-        $properties = null;
-        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
-            $properties = [];
-
-            /** @var OptionMetadata[] $optionsMetadataArray */
-            $optionsMetadataArray = $propertiesMetadata->getValue();
-            foreach ($optionsMetadataArray as $optionMetadata) {
-                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
-            }
-        }
-
-        return $properties;
     }
 
     public static function getType(): string

--- a/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
+++ b/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Sulu\Content\Tests\Application\ExampleTestBundle\PropertyResolver;
+
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader\ExampleResourceLoader;
+
+class ExampleSelectionPropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        if (!\is_array($data)
+            || 0 === \count($data)
+            || !\array_is_list($data)
+        ) {
+            return ContentView::create([], ['ids' => [], ...$params]);
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? ExampleResourceLoader::getKey();
+
+        /** @var string[] $ids */
+        $ids = $data;
+
+        return ContentView::createResolvables(
+            ids: $ids,
+            resourceLoaderKey: $resourceLoaderKey,
+            view: [
+                'ids' => $ids,
+                ...$params,
+            ],
+            priority: 150
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'example_selection';
+    }
+}

--- a/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
+++ b/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
@@ -1,7 +1,18 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Content\Tests\Application\ExampleTestBundle\PropertyResolver;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader\ExampleResourceLoader;
@@ -23,6 +34,18 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
         /** @var string[] $ids */
         $ids = $data;
 
+        $metadata = $params['metadata'] ?? null;
+        $properties = null;
+        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
+            $properties = [];
+
+            /** @var OptionMetadata[] $optionsMetadataArray */
+            $optionsMetadataArray = $propertiesMetadata->getValue();
+            foreach ($optionsMetadataArray as $optionMetadata) {
+                $properties[$optionMetadata->getName()] = $optionMetadata->getValue();
+            }
+        }
+
         return ContentView::createResolvables(
             ids: $ids,
             resourceLoaderKey: $resourceLoaderKey,
@@ -30,7 +53,10 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
                 'ids' => $ids,
                 ...$params,
             ],
-            priority: 150
+            priority: 150,
+            metadata: [
+                'properties' => $properties,
+            ]
         );
     }
 

--- a/packages/content/tests/Application/ExampleTestBundle/ResourceLoader/ExampleResourceLoader.php
+++ b/packages/content/tests/Application/ExampleTestBundle/ResourceLoader/ExampleResourceLoader.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader;
+
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Repository\ExampleRepository;
+
+class ExampleResourceLoader implements ResourceLoaderInterface
+{
+    public const RESOURCE_LOADER_KEY = 'example';
+
+    public function __construct(
+        private ExampleRepository $exampleRepository,
+    ) {
+    }
+
+    /**
+     * @param string[] $ids
+     */
+    public function load(array $ids, ?string $locale, array $params = []): array
+    {
+        $result = $this->exampleRepository->findBy(['ids' => $ids]);
+
+        $mappedResult = [];
+        foreach ($result as $example) {
+            $mappedResult[$example->getId()] = $example;
+        }
+
+        return $mappedResult;
+    }
+
+    public static function getKey(): string
+    {
+        return self::RESOURCE_LOADER_KEY;
+    }
+}

--- a/packages/content/tests/Application/ExampleTestBundle/ResourceLoader/ExampleResourceLoader.php
+++ b/packages/content/tests/Application/ExampleTestBundle/ResourceLoader/ExampleResourceLoader.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader;
 
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
@@ -15,7 +24,7 @@ class ExampleResourceLoader implements ResourceLoaderInterface
     }
 
     /**
-     * @param string[] $ids
+     * @param int[] $ids
      */
     public function load(array $ids, ?string $locale, array $params = []): array
     {

--- a/packages/content/tests/Application/ExampleTestBundle/Resources/config/services.yaml
+++ b/packages/content/tests/Application/ExampleTestBundle/Resources/config/services.yaml
@@ -70,3 +70,15 @@ services:
         tags:
             - { name: 'sulu.context', context: 'admin' }
             - { name: 'sulu_preview.object_provider', provider-key: 'examples' }
+
+    example_test.example_selection_property_resolver:
+        class: Sulu\Content\Tests\Application\ExampleTestBundle\PropertyResolver\ExampleSelectionPropertyResolver
+        tags:
+            - { name: 'sulu_content.property_resolver', alias: 'example_selection' }
+
+    example_test.example_resource_loader:
+        class: Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader\ExampleResourceLoader
+        arguments:
+            - '@example_test.example_repository'
+        tags:
+            - { name: 'sulu_content.resource_loader', alias: 'example' }

--- a/packages/content/tests/Application/config/templates/examples/default-example-selection.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-example-selection.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default-example-selection</key>
+
+    <view>@ExampleTest/examples/default</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Example</title>
+        <title lang="de">Example</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+            <tag name="sulu.search.field" role="title"/>
+        </property>
+
+        <property name="url" type="route">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+            <tag name="sulu.search.field" role="url"/>
+        </property>
+
+        <property name="description" type="text_area">
+            <meta>
+                <title lang="en">Description</title>
+                <title lang="de">Beschreibung</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="description"/>
+        </property>
+
+        <property name="image" type="single_media_selection">
+            <meta>
+                <title lang="en">Image</title>
+                <title lang="de">Bild</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="image"/>
+        </property>
+
+        <property name="examples" type="example_selection">
+            <meta>
+                <title lang="en">Page</title>
+                <title lang="de">Seite</title>
+            </meta>
+        </property>
+
+        <property name="examples_with_properties" type="example_selection">
+            <meta>
+                <title lang="en">Page with properties</title>
+                <title lang="de">Seite mit Properties</title>
+            </meta>
+
+            <params>
+                <param name="properties" type="collection">
+                    <param name="id" value="object.id"/>
+                    <param name="title" value="title"/>
+                    <param name="description" value="description"/>
+                    <param name="excerptTitle" value="excerpt.title"/>
+                    <param name="excerptDescription" value="excerpt.description"/>
+                    <param name="seoTitle" value="seo.title"/>
+                    <param name="seoDescription" value="seo.description"/>
+                </param>
+            </params>
+        </property>
+    </properties>
+</template>

--- a/packages/content/tests/Application/config/templates/examples/default-example-selection.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-example-selection.xml
@@ -72,7 +72,7 @@
 
             <params>
                 <param name="properties" type="collection">
-                    <param name="id" value="object.id"/>
+                    <param name="id" value="object.resource.id"/>
                     <param name="title" value="title"/>
                     <param name="description" value="description"/>
                     <param name="excerptTitle" value="excerpt.title"/>

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -144,9 +144,9 @@ class ContentResolverTest extends SuluTestCase
                 'en' => [
                     'live' => [
                         'template' => 'default-example-selection',
-                        'title' => 'Lorem Ipsum',
-                        'url' => '/lorem-ipsum',
-                        'description' => 'Lorem Ipsum dolor sit amet',
+                        'title' => 'Nested example',
+                        'url' => '/nested-example',
+                        'description' => 'Nested example description',
 
                         'excerptTitle' => 'excerpt-example-title-0',
                         'excerptDescription' => 'excerpt-example-description-0',
@@ -189,49 +189,51 @@ class ContentResolverTest extends SuluTestCase
         $dimensionContent = $this->contentAggregator->aggregate($example1, ['locale' => 'en', 'stage' => 'live']);
         $result = $this->contentResolver->resolve(
             $dimensionContent,
+            [
+                'title' => 'title',
+                'url' => 'url',
+                'examplesWithProperties' => 'examples_with_properties',
+                'examplesWithoutProperties' => 'examples',
+            ]
         );
 
-        $content = $result['content'];
+        self::assertEmpty($result['content']); // content is empty because all fields are extracted to root // TODO is this correct?
 
-        $excerpt = $result['extension']['excerpt'] ?? null;
-        $seo = $result['extension']['seo'] ?? null;
+        // The result contains dynamically mapped properties at the root level
+        // PHPStan doesn't know about these dynamic properties, so we suppress the warnings
+        // @phpstan-ignore-next-line offsetAccess.notFound
+        self::assertSame('Lorem Ipsum', $result['title']);
+        // @phpstan-ignore-next-line offsetAccess.notFound
+        self::assertSame('/lorem-ipsum', $result['url']);
 
-        self::assertIsArray($excerpt);
-        self::assertIsArray($seo);
+        /** @var array<int, mixed> $examplesWithProperties */
+        // @phpstan-ignore-next-line offsetAccess.notFound
+        $examplesWithProperties = $result['examplesWithProperties'];
+        self::assertCount(1, $examplesWithProperties);
 
-        self::assertSame('Lorem Ipsum', $content['title']);
-        self::assertSame('/lorem-ipsum', $content['url']);
-        self::assertSame('<p>Lorem Ipsum dolor sit amet</p>', $content['text_editor']);
-        self::assertSame('Lorem Ipsum dolor sit amet', $content['text_line']);
-        self::assertSame(1337, $content['number']);
-        self::assertSame('+49 123 456 789', $content['phone']);
-        self::assertSame('value-2', $content['single_select']);
-        self::assertSame(['value-2', 'value-3'], $content['select']);
-        self::assertTrue($content['checkbox']);
-        self::assertSame('#ff0000', $content['color']);
-        self::assertSame('13:37', $content['time']);
-        self::assertSame('2020-01-01', $content['date']);
+        /** @var array<int, mixed> $examplesWithoutProperties */
+        // @phpstan-ignore-next-line offsetAccess.notFound
+        $examplesWithoutProperties = $result['examplesWithoutProperties'];
+        self::assertCount(1, $examplesWithoutProperties);
 
-        /** @var \DateTimeInterface|null $dateTime */
-        $dateTime = $content['datetime'];
-        self::assertSame(1577885820 /* 2020-01-01T13:37:00 */, $dateTime?->getTimestamp());
-        self::assertSame('example@sulu.io', $content['email']);
-        self::assertSame('https://sulu.io', $content['external_url']);
-        self::assertSame('Lorem Ipsum dolor sit amet', $content['text_area']);
+        /** @var array<string, mixed> $exampleWithProperties */
+        $exampleWithProperties = $examplesWithProperties[0];
+        self::assertIsInt($exampleWithProperties['id']);
+        self::assertSame('Nested example', $exampleWithProperties['title']);
+        self::assertSame('Nested example description', $exampleWithProperties['description']);
+        self::assertSame('excerpt-example-title-0', $exampleWithProperties['excerptTitle']);
+        self::assertSame('excerpt-example-description-0', $exampleWithProperties['excerptDescription']);
+        self::assertSame('seo-example-title-0', $exampleWithProperties['seoTitle']);
+        self::assertSame('seo-example-description-0', $exampleWithProperties['seoDescription']);
 
-        // Excerpt
-        self::assertSame('excerpt-title-1', $excerpt['title']);
-        self::assertSame('excerpt-more-1', $excerpt['more']);
-        self::assertSame('excerpt-description-1', $excerpt['description']);
-
-        // Seo
-        self::assertSame('seo-title-1', $seo['title']);
-        self::assertSame('seo-description-1', $seo['description']);
-        self::assertSame('seo-keywords-1', $seo['keywords']);
-        self::assertSame('https://sulu.io', $seo['canonicalUrl']);
-        self::assertTrue($seo['noIndex']);
-        self::assertTrue($seo['noFollow']);
-        self::assertTrue($seo['hideInSitemap']);
+        /** @var array<string, mixed> $exampleWithoutProperties */
+        $exampleWithoutProperties = $examplesWithoutProperties[0];
+        self::assertSame('Nested example', $exampleWithoutProperties['title']);
+        self::assertSame('/nested-example', $exampleWithoutProperties['url']);
+        self::assertSame('Nested example description', $exampleWithoutProperties['description']);
+        self::assertNull($exampleWithoutProperties['image']);
+        self::assertEmpty($exampleWithoutProperties['examples']);
+        self::assertEmpty($exampleWithoutProperties['examples_with_properties']);
     }
 
     public function testResolveMedias(): void

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -137,6 +137,103 @@ class ContentResolverTest extends SuluTestCase
         self::assertTrue($seo['hideInSitemap']);
     }
 
+    public function testResolveContentWithProperties(): void
+    {
+        $example0 = static::createExample(
+            [
+                'en' => [
+                    'live' => [
+                        'template' => 'default-example-selection',
+                        'title' => 'Lorem Ipsum',
+                        'url' => '/lorem-ipsum',
+                        'description' => 'Lorem Ipsum dolor sit amet',
+
+                        'excerptTitle' => 'excerpt-example-title-0',
+                        'excerptDescription' => 'excerpt-example-description-0',
+
+                        'seoTitle' => 'seo-example-title-0',
+                        'seoDescription' => 'seo-example-description-0',
+                    ],
+                ],
+            ]
+        );
+        static::getEntityManager()->flush();
+
+        $example1 = static::createExample(
+            [
+                'en' => [
+                    'live' => [
+                        'template' => 'default-example-selection',
+                        'title' => 'Lorem Ipsum',
+                        'url' => '/lorem-ipsum',
+                        'examples' => [$example0->getId()],
+                        'examples_with_properties' => [$example0->getId()],
+                        'excerptTitle' => 'excerpt-title-1',
+                        'excerptMore' => 'excerpt-more-1',
+                        'excerptDescription' => 'excerpt-description-1',
+
+                        'seoTitle' => 'seo-title-1',
+                        'seoDescription' => 'seo-description-1',
+                        'seoKeywords' => 'seo-keywords-1',
+                        'seoCanonicalUrl' => 'https://sulu.io',
+                        'seoNoIndex' => true,
+                        'seoNoFollow' => true,
+                        'seoHideInSitemap' => true,
+                    ],
+                ],
+            ]
+        );
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($example1, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve(
+            $dimensionContent,
+        );
+
+        $content = $result['content'];
+
+        $excerpt = $result['extension']['excerpt'] ?? null;
+        $seo = $result['extension']['seo'] ?? null;
+
+        self::assertIsArray($excerpt);
+        self::assertIsArray($seo);
+
+        self::assertSame('Lorem Ipsum', $content['title']);
+        self::assertSame('/lorem-ipsum', $content['url']);
+        self::assertSame('<p>Lorem Ipsum dolor sit amet</p>', $content['text_editor']);
+        self::assertSame('Lorem Ipsum dolor sit amet', $content['text_line']);
+        self::assertSame(1337, $content['number']);
+        self::assertSame('+49 123 456 789', $content['phone']);
+        self::assertSame('value-2', $content['single_select']);
+        self::assertSame(['value-2', 'value-3'], $content['select']);
+        self::assertTrue($content['checkbox']);
+        self::assertSame('#ff0000', $content['color']);
+        self::assertSame('13:37', $content['time']);
+        self::assertSame('2020-01-01', $content['date']);
+
+        /** @var \DateTimeInterface|null $dateTime */
+        $dateTime = $content['datetime'];
+        self::assertSame(1577885820 /* 2020-01-01T13:37:00 */, $dateTime?->getTimestamp());
+        self::assertSame('example@sulu.io', $content['email']);
+        self::assertSame('https://sulu.io', $content['external_url']);
+        self::assertSame('Lorem Ipsum dolor sit amet', $content['text_area']);
+
+        // Excerpt
+        self::assertSame('excerpt-title-1', $excerpt['title']);
+        self::assertSame('excerpt-more-1', $excerpt['more']);
+        self::assertSame('excerpt-description-1', $excerpt['description']);
+
+        // Seo
+        self::assertSame('seo-title-1', $seo['title']);
+        self::assertSame('seo-description-1', $seo['description']);
+        self::assertSame('seo-keywords-1', $seo['keywords']);
+        self::assertSame('https://sulu.io', $seo['canonicalUrl']);
+        self::assertTrue($seo['noIndex']);
+        self::assertTrue($seo['noFollow']);
+        self::assertTrue($seo['hideInSitemap']);
+    }
+
     public function testResolveMedias(): void
     {
         // @phpstan-ignore-next-line

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentViewResolver/ContentViewResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentViewResolver/ContentViewResolverTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver\ContentViewResolver;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Content\Application\ContentResolver\ContentViewResolver\ContentViewResolver;
+use Sulu\Content\Application\ContentResolver\ResolvableResourceQueue\ResolvableResourceQueueProcessor;
+use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+
+class ContentViewResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ContentViewResolver $contentViewResolver;
+    private ResolvableResourceQueueProcessor $resolvableResourceQueueProcessor;
+
+    /**
+     * @var ObjectProphecy<ResolverInterface>[]
+     */
+    private array $contentResolvers = [];
+
+    protected function setUp(): void
+    {
+        $this->resolvableResourceQueueProcessor = new ResolvableResourceQueueProcessor();
+
+        $templateResolver = $this->prophesize(ResolverInterface::class);
+        $settingsResolver = $this->prophesize(ResolverInterface::class);
+
+        $this->contentResolvers = [
+            'template' => $templateResolver,
+            'settings' => $settingsResolver,
+        ];
+
+        $this->contentViewResolver = new ContentViewResolver(
+            $this->resolvableResourceQueueProcessor,
+            [
+                'template' => $templateResolver->reveal(),
+                'settings' => $settingsResolver->reveal(),
+            ]
+        );
+    }
+
+    public function testGetContentViews(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $example->addDimensionContent($dimensionContent);
+        $dimensionContent->setLocale('en');
+
+        $templateContentView = ContentView::create(['title' => 'Test Title'], ['title' => 'Title Field']);
+        $settingsContentView = ContentView::create(['seo' => 'test'], ['seo' => 'SEO Field']);
+
+        $this->contentResolvers['template']->resolve($dimensionContent, null)
+            ->shouldBeCalled()
+            ->willReturn($templateContentView);
+
+        $this->contentResolvers['settings']->resolve($dimensionContent, null)
+            ->willReturn($settingsContentView)
+            ->shouldBeCalledOnce();
+
+        $result = $this->contentViewResolver->getContentViews($dimensionContent);
+
+        self::assertCount(2, $result);
+        self::assertSame($templateContentView, $result['template']);
+        self::assertSame($settingsContentView, $result['settings']);
+    }
+
+    public function testGetContentViewsWithNullResolver(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $example->addDimensionContent($dimensionContent);
+        $dimensionContent->setLocale('en');
+
+        $templateContentView = ContentView::create(['title' => 'Test Title'], ['title' => 'Title Field']);
+
+        $this->contentResolvers['template']->resolve($dimensionContent, null)
+            ->willReturn($templateContentView)
+            ->shouldBeCalledOnce();
+
+        $this->contentResolvers['settings']->resolve($dimensionContent, null)
+            ->willReturn(null)
+            ->shouldBeCalledOnce();
+
+        $result = $this->contentViewResolver->getContentViews($dimensionContent);
+
+        self::assertCount(1, $result);
+        self::assertSame($templateContentView, $result['template']);
+        self::assertArrayNotHasKey('settings', $result);
+    }
+
+    public function testResolveContentViews(): void
+    {
+        $contentView1 = ContentView::create(['title' => 'Test'], ['title' => 'Title']);
+        $contentView2 = ContentView::create(['description' => 'Desc'], ['description' => 'Description']);
+
+        $contentViews = [
+            'template' => $contentView1,
+            'settings' => $contentView2,
+        ];
+
+        $priorityQueue = [];
+        $result = $this->contentViewResolver->resolveContentViews($contentViews, 0, $priorityQueue);
+
+        // Check the structure of the result
+        self::assertArrayHasKey('template', $result['content']);
+        self::assertArrayHasKey('settings', $result['content']);
+        self::assertSame(['title' => 'Test'], $result['content']['template']);
+        self::assertSame(['description' => 'Desc'], $result['content']['settings']);
+        self::assertSame([], $result['resolvableResources']);
+    }
+
+    public function testResolveContentViewWithResolvableResource(): void
+    {
+        $resolvableResource = new ResolvableResource('123', 'page', 1);
+
+        $contentView = ContentView::create(['page' => $resolvableResource], ['page' => 'Page']);
+
+        $priorityQueue = [];
+        $result = $this->contentViewResolver->resolveContentView($contentView, 'test', 0, $priorityQueue);
+
+        self::assertSame(['page' => $resolvableResource], $result['content']['test']);
+        self::assertSame(['page' => 'Page'], $result['view']['test']);
+
+        // Verify that the resolvable resource was correctly added to the result
+        $expectedPriority = $resolvableResource->getPriority();
+        $expectedLoaderKey = $resolvableResource->getResourceLoaderKey();
+        $expectedId = $resolvableResource->getId();
+        $expectedMetadataId = $resolvableResource->getMetadataIdentifier();
+
+        self::assertArrayHasKey($expectedPriority, $result['resolvableResources']);
+        self::assertArrayHasKey($expectedLoaderKey, $result['resolvableResources'][$expectedPriority]);
+        self::assertArrayHasKey(0, $result['resolvableResources'][$expectedPriority][$expectedLoaderKey]);
+        self::assertArrayHasKey($expectedId, $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][0]);
+        self::assertArrayHasKey($expectedMetadataId, $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][0][$expectedId]);
+        self::assertSame($resolvableResource, $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][0][$expectedId][$expectedMetadataId]);
+    }
+
+    public function testResolveContentViewWithNestedContentViews(): void
+    {
+        $nestedContentView = ContentView::create(['nested' => 'data'], ['nested' => 'view']);
+        $contentView = ContentView::create([$nestedContentView], []);
+
+        $priorityQueue = [];
+        $result = $this->contentViewResolver->resolveContentView($contentView, 'test', 0, $priorityQueue);
+
+        // Verify basic structure
+        self::assertArrayHasKey('test', $result['content']);
+        self::assertArrayHasKey('test', $result['view']);
+
+        // Type-safe access to nested arrays
+        /** @var array<int, array<string, mixed>> $testContent */
+        $testContent = $result['content']['test'];
+        self::assertArrayHasKey(0, $testContent);
+
+        /** @var array<string, mixed> $firstItem */
+        $firstItem = $testContent[0];
+        self::assertArrayHasKey('nested', $firstItem);
+        self::assertSame('data', $firstItem['nested']);
+
+        /** @var array<int, array<string, mixed>> $testView */
+        $testView = $result['view']['test'];
+        self::assertArrayHasKey(0, $testView);
+
+        /** @var array<string, mixed> $firstViewItem */
+        $firstViewItem = $testView[0];
+        self::assertArrayHasKey('nested', $firstViewItem);
+        self::assertSame('view', $firstViewItem['nested']);
+    }
+
+    public function testResolvableResourceQueueProcessorIntegration(): void
+    {
+        $resolvableResource1 = new ResolvableResource('123', 'page', 1, fn ($resource) => $resource);
+        $resolvableResource2 = new ResolvableResource('456', 'article', 2, fn ($resource) => $resource);
+
+        $contentView1 = ContentView::create(['page' => $resolvableResource1], ['page' => 'Page Field']);
+        $contentView2 = ContentView::create(['article' => $resolvableResource2], ['article' => 'Article Field']);
+
+        $contentViews = [
+            'template' => $contentView1,
+            'sidebar' => $contentView2,
+        ];
+
+        $priorityQueue = [];
+        $result = $this->contentViewResolver->resolveContentViews($contentViews, 0, $priorityQueue);
+
+        self::assertNotEmpty($result['resolvableResources']);
+
+        // Resources should be sorted by priority descending (higher priority first)
+        $priorities = \array_keys($result['resolvableResources']);
+        self::assertSame([2, 1], $priorities, 'Resources should be sorted by priority in descending order');
+
+        // Verify priority 2 resource (article)
+        self::assertArrayHasKey('article', $result['resolvableResources'][2]);
+        self::assertSame($resolvableResource2, $result['resolvableResources'][2]['article'][0]['456'][$resolvableResource2->getMetadataIdentifier()]);
+
+        // Verify priority 1 resource (page)
+        self::assertArrayHasKey('page', $result['resolvableResources'][1]);
+        self::assertSame($resolvableResource1, $result['resolvableResources'][1]['page'][0]['123'][$resolvableResource1->getMetadataIdentifier()]);
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver\DataNormalizer;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Application\ContentResolver\DataNormalizer\ContentViewDataNormalizer;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+class ContentViewDataNormalizerTest extends TestCase
+{
+    private ContentViewDataNormalizer $normalizer;
+    private PropertyAccessor $propertyAccessor;
+
+    protected function setUp(): void
+    {
+        $this->propertyAccessor = new PropertyAccessor();
+        $this->normalizer = new ContentViewDataNormalizer($this->propertyAccessor);
+    }
+
+    public function testFormatContentOutput(): void
+    {
+        // Use real Example entity instead of mock
+        $resource = new Example();
+
+        $content = [
+            'template' => ['title' => 'Test Title', 'article' => 'Test Article'],
+            'settings' => ['seo' => ['title' => 'SEO Title']],
+            'extension' => ['data' => 'extension data'],
+        ];
+
+        $view = [
+            'template' => ['title' => 'Title Field', 'article' => 'Article Field'],
+            'settings' => ['seo' => 'SEO Fields'],
+        ];
+
+        $result = $this->normalizer->normalizeContentViewData($content, $view, $resource);
+
+        // Test the actual values without redundant PHPStan assertions
+        self::assertSame($resource, $result['resource']);
+        self::assertSame(['title' => 'Test Title', 'article' => 'Test Article'], $result['content']);
+        self::assertSame(['title' => 'Title Field', 'article' => 'Article Field'], $result['view']);
+        self::assertSame(['extension' => ['data' => 'extension data']], $result['extension']);
+
+        // The 'seo' key is added dynamically through settings merging
+        // PHPStan doesn't know about this dynamic property, so we suppress the warning
+        // @phpstan-ignore-next-line offsetAccess.notFound
+        self::assertSame(['title' => 'SEO Title'], $result['seo']);
+    }
+
+    public function testFormatContentOutputWithProperties(): void
+    {
+        // Use real Example entity instead of mock
+        $resource = new Example();
+
+        $content = [
+            'template' => ['title' => 'Test Title', 'nested' => ['deep' => 'value']],
+        ];
+
+        $view = [
+            'template' => ['title' => 'Title Field'],
+        ];
+
+        $properties = ['nested.deep' => true];
+
+        // The normalizeContentViewData method only takes 3 required parameters
+        $result = $this->normalizer->normalizeContentViewData($content, $view, $resource);
+
+        // Then apply property mapping separately if needed
+        $this->normalizer->recursivelyMapProperties($result, $properties);
+
+        /** @var array<string, mixed> $resultContent */
+        $resultContent = $result['content'];
+        self::assertArrayHasKey('nested', $resultContent);
+
+        /** @var array<string, mixed> $nested */
+        $nested = $resultContent['nested'];
+        self::assertArrayHasKey('deep', $nested);
+        self::assertSame('value', $nested['deep']);
+    }
+
+    public function testReplaceNestedContentViews(): void
+    {
+        $formattedContentData = [
+            'resource' => new \stdClass(),
+            'content' => [
+                'items' => [
+                    'content' => ['nested' => 'data'],
+                    'view' => ['nested' => 'view data'],
+                ],
+            ],
+            'view' => [],
+            'extension' => [],
+        ];
+
+        $this->normalizer->replaceNestedContentViews($formattedContentData);
+
+        self::assertSame(['nested' => 'data'], $formattedContentData['content']['items']);
+        self::assertSame(['nested' => 'view data'], $formattedContentData['view']['items']);
+    }
+
+    public function testFormatContentOutputWithEmptyTemplate(): void
+    {
+        // Use real Example entity instead of mock
+        $resource = new Example();
+
+        $content = ['extension' => ['data' => 'extension data']];
+        $view = [];
+
+        $result = $this->normalizer->normalizeContentViewData($content, $view, $resource);
+
+        // Test actual values without redundant PHPStan assertions
+        self::assertSame([], $result['content']);
+        self::assertSame([], $result['view']);
+        self::assertSame(['extension' => ['data' => 'extension data']], $result['extension']);
+    }
+
+    public function testFormatContentOutputWithNonRootContext(): void
+    {
+        // Use real Example entity instead of mock
+        $resource = new Example();
+
+        $content = [
+            'template' => ['title' => 'Test Title'],
+        ];
+
+        $view = [
+            'template' => ['title' => 'Title Field'],
+        ];
+
+        $properties = ['title' => true];
+
+        // The normalizeContentViewData method only takes 3 required parameters
+        $result = $this->normalizer->normalizeContentViewData($content, $view, $resource);
+
+        // Apply property mapping with non-root context
+        $this->normalizer->recursivelyMapProperties($result, $properties, '', 0, false);
+
+        // When not root, properties should be mapped under [content] path
+        self::assertSame('Test Title', $result['content']['title']);
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoaderTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoaderTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver\ResolvableResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Application\ContentResolver\ResolvableResourceLoader\ResolvableResourceLoader;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
+use Sulu\Content\Application\SmartResolver\Resolver\SmartResolverInterface;
+use Sulu\Content\Application\SmartResolver\SmartResolverProviderInterface;
+
+class ResolvableResourceLoaderTest extends TestCase
+{
+    private ResolvableResourceLoader $resourceLoader;
+    private ResourceLoaderProvider $resourceLoaderProvider;
+    private SmartResolverProviderInterface $smartResolverProvider;
+
+    protected function setUp(): void
+    {
+        $exampleResourceLoader = new class() implements ResourceLoaderInterface {
+            public function load(array $ids, ?string $locale, array $params = []): array
+            {
+                $result = [];
+                foreach ($ids as $id) {
+                    $result[$id] = ['title' => 'Example Resource ' . $id, 'locale' => $locale];
+                }
+
+                return $result;
+            }
+
+            public static function getKey(): string
+            {
+                return 'example';
+            }
+        };
+
+        $smartExampleResolver = new class() implements SmartResolverInterface {
+            public function resolve(SmartResolvable $resolvable, ?string $locale = null): ContentView
+            {
+                return ContentView::create([
+                    'title' => 'Smart Example Resource',
+                    'locale' => $locale,
+                ], []);
+            }
+
+            public static function getType(): string
+            {
+                return 'smart_example';
+            }
+        };
+
+        $this->resourceLoaderProvider = new ResourceLoaderProvider([
+            'example' => $exampleResourceLoader,
+        ]);
+
+        $this->smartResolverProvider = new class($smartExampleResolver) implements SmartResolverProviderInterface {
+            public function __construct(private SmartResolverInterface $smartResolver)
+            {
+            }
+
+            public function getSmartResolver(string $type): SmartResolverInterface
+            {
+                if ('smart_example' === $type) {
+                    return $this->smartResolver;
+                }
+
+                throw new \InvalidArgumentException(\sprintf('Smart resolver for type "%s" not found.', $type));
+            }
+
+            public function hasSmartResolver(string $type): bool
+            {
+                return 'smart_example' === $type;
+            }
+        };
+
+        $this->resourceLoader = new ResolvableResourceLoader(
+            $this->resourceLoaderProvider,
+            $this->smartResolverProvider
+        );
+    }
+
+    public function testLoadResourcesWithResolvableResource(): void
+    {
+        $resolvableResource = new ResolvableResource('123', 'example', 1);
+
+        $resourcesPerLoader = [
+            'example' => [
+                '123' => [$resolvableResource->getMetadataIdentifier() => $resolvableResource],
+            ],
+        ];
+
+        $result = $this->resourceLoader->loadResources($resourcesPerLoader, 'en');
+
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+        self::assertArrayHasKey('example', $result);
+        self::assertArrayHasKey('123', $result['example']);
+        self::assertArrayHasKey($metadataId, $result['example']['123']);
+        self::assertSame([
+            'title' => 'Example Resource 123',
+            'locale' => 'en',
+        ], $result['example']['123'][$metadataId]);
+    }
+
+    public function testLoadResourcesWithSmartResolvable(): void
+    {
+        $smartResolvable = new SmartResolvable(
+            ['id' => '456', 'title' => 'Smart Example Data'],
+            'smart_example',
+            10
+        );
+
+        $resourcesPerLoader = [
+            'smart_example' => [
+                '456' => ['default' => $smartResolvable],
+            ],
+        ];
+
+        $result = $this->resourceLoader->loadResources($resourcesPerLoader, 'en');
+
+        self::assertArrayHasKey('smart_example', $result);
+        self::assertArrayHasKey('456', $result['smart_example']);
+        self::assertArrayHasKey('default', $result['smart_example']['456']);
+        self::assertInstanceOf(ContentView::class, $result['smart_example']['456']['default']);
+
+        $contentView = $result['smart_example']['456']['default'];
+        self::assertSame([
+            'title' => 'Smart Example Resource',
+            'locale' => 'en',
+        ], $contentView->getContent());
+    }
+
+    public function testLoadResourcesWithMixedTypes(): void
+    {
+        $resolvableResource = new ResolvableResource('123', 'example', 1, fn ($resource) => $resource);
+        $smartResolvable = new SmartResolvable(
+            ['id' => '456', 'title' => 'Smart Example Data'],
+            'smart_example',
+            10
+        );
+
+        $resourcesPerLoader = [
+            'example' => [
+                '123' => [$resolvableResource->getMetadataIdentifier() => $resolvableResource],
+            ],
+            'smart_example' => [
+                '456' => ['default' => $smartResolvable],
+            ],
+        ];
+
+        $result = $this->resourceLoader->loadResources($resourcesPerLoader, 'en');
+
+        self::assertArrayHasKey('example', $result);
+        self::assertArrayHasKey('smart_example', $result);
+
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+        self::assertSame([
+            'title' => 'Example Resource 123',
+            'locale' => 'en',
+        ], $result['example']['123'][$metadataId]);
+
+        self::assertInstanceOf(ContentView::class, $result['smart_example']['456']['default']);
+        $contentView = $result['smart_example']['456']['default'];
+        self::assertSame([
+            'title' => 'Smart Example Resource',
+            'locale' => 'en',
+        ], $contentView->getContent());
+    }
+
+    public function testLoadResourcesWithMultipleMetadataIdentifiers(): void
+    {
+        $resolvableResource1 = new ResolvableResource('123', 'example', 1, fn ($resource) => $resource);
+        $resolvableResource2 = new ResolvableResource('123', 'example', 1, fn ($resource) => $resource);
+
+        $metadata1 = $resolvableResource1->getMetadataIdentifier();
+        $metadata2 = $resolvableResource2->getMetadataIdentifier();
+
+        $resourcesPerLoader = [
+            'example' => [
+                '123' => [
+                    $metadata1 => $resolvableResource1,
+                    $metadata2 => $resolvableResource2,
+                ],
+            ],
+        ];
+
+        $result = $this->resourceLoader->loadResources($resourcesPerLoader, 'en');
+
+        self::assertArrayHasKey('example', $result);
+        self::assertArrayHasKey('123', $result['example']);
+        self::assertArrayHasKey($metadata1, $result['example']['123']);
+        self::assertArrayHasKey($metadata2, $result['example']['123']);
+        self::assertSame([
+            'title' => 'Example Resource 123',
+            'locale' => 'en',
+        ], $result['example']['123'][$metadata1]);
+        self::assertSame([
+            'title' => 'Example Resource 123',
+            'locale' => 'en',
+        ], $result['example']['123'][$metadata2]);
+    }
+
+    public function testLoadResourcesWithInvalidLoaderKey(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('ResourceLoader key "" is invalid');
+
+        $resolvableResource = new ResolvableResource('123', '', 1, fn ($resource) => $resource);
+
+        $resourcesPerLoader = [
+            '' => [
+                '123' => ['default' => $resolvableResource],
+            ],
+        ];
+
+        $this->resourceLoader->loadResources($resourcesPerLoader, 'en');
+    }
+
+    public function testLoadResourcesWithMissingResourceLoader(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('ResourceLoader with key "nonexistent" not found');
+
+        $resolvableResource = new ResolvableResource('123', 'nonexistent', 1, fn ($resource) => $resource);
+
+        $resourcesPerLoader = [
+            'nonexistent' => [
+                '123' => ['default' => $resolvableResource],
+            ],
+        ];
+
+        $this->resourceLoader->loadResources($resourcesPerLoader, 'en');
+    }
+
+    public function testLoadResourcesWithInvalidResourceType(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Resource with id "123" is neither a SmartResolvable nor a ResolvableResource');
+
+        $invalidResource = new \stdClass();
+
+        // @phpstan-ignore-next-line
+        $resourcesPerLoader = [
+            'example' => [
+                '123' => [
+                    'default' => $invalidResource,
+                ],
+            ],
+        ];
+
+        $this->resourceLoader->loadResources($resourcesPerLoader, 'en'); // @phpstan-ignore-line
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceQueue/ResolvableResourceQueueProcessorTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceQueue/ResolvableResourceQueueProcessorTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver\ResolvableResourceQueue;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Content\Application\ContentResolver\ResolvableResourceQueue\ResolvableResourceQueueProcessor;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+
+class ResolvableResourceQueueProcessorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ResolvableResourceQueueProcessor $processor;
+
+    protected function setUp(): void
+    {
+        $this->processor = new ResolvableResourceQueueProcessor();
+    }
+
+    public function testMergeResolvableResources(): void
+    {
+        $resource1 = new ResolvableResource('123', 'page', 1, fn ($resource) => $resource);
+        $resource2 = new ResolvableResource('456', 'page', 1, fn ($resource) => $resource);
+        $resource3 = new ResolvableResource('789', 'article', 2, fn ($resource) => $resource);
+
+        $resolvableResources = [
+            1 => [
+                'page' => [
+                    0 => [
+                        '123' => ['default' => $resource1],
+                        '456' => ['default' => $resource2],
+                    ],
+                ],
+            ],
+        ];
+
+        $existingResolvableResources = [
+            2 => [
+                'article' => [
+                    1 => [
+                        '789' => ['default' => $resource3],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->processor->mergeResolvableResources($resolvableResources, $existingResolvableResources);
+
+        // Should be sorted by priority descending (krsort)
+        self::assertCount(2, $result);
+        self::assertArrayHasKey(2, $result);
+        self::assertArrayHasKey(1, $result);
+
+        // Check higher priority comes first
+        $keys = \array_keys($result);
+        self::assertSame(2, $keys[0]);
+        self::assertSame(1, $keys[1]);
+
+        // Verify content
+        self::assertSame($resource3, $result[2]['article'][1]['789']['default']);
+        self::assertSame($resource1, $result[1]['page'][0]['123']['default']);
+        self::assertSame($resource2, $result[1]['page'][0]['456']['default']);
+    }
+
+    public function testMergeResolvableResourcesOverwrite(): void
+    {
+        $resource1 = new ResolvableResource('123', 'page', 1, fn ($resource) => 'first');
+        $resource2 = new ResolvableResource('123', 'page', 1, fn ($resource) => 'second');
+
+        $resolvableResources = [
+            1 => [
+                'page' => [
+                    0 => [
+                        '123' => ['default' => $resource2],
+                    ],
+                ],
+            ],
+        ];
+
+        $existingResolvableResources = [
+            1 => [
+                'page' => [
+                    0 => [
+                        '123' => ['default' => $resource1],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->processor->mergeResolvableResources($resolvableResources, $existingResolvableResources);
+
+        // The newer resource should overwrite the existing one
+        self::assertSame($resource2, $result[1]['page'][0]['123']['default']);
+    }
+
+    public function testExtractHighestPriorityResources(): void
+    {
+        $resource1 = new ResolvableResource('123', 'page', 3, fn ($resource) => $resource);
+        $resource2 = new ResolvableResource('456', 'page', 2, fn ($resource) => $resource);
+        $resource3 = new ResolvableResource('789', 'article', 2, fn ($resource) => $resource);
+
+        $priorityQueue = [
+            3 => [
+                'page' => [
+                    0 => [
+                        '123' => ['default' => $resource1],
+                    ],
+                ],
+            ],
+            2 => [
+                'page' => [
+                    1 => [
+                        '456' => ['default' => $resource2],
+                    ],
+                ],
+                'article' => [
+                    0 => [
+                        '789' => ['default' => $resource3],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->processor->extractHighestPriorityResources($priorityQueue, 5);
+
+        // Should extract highest priority (3) and remove it from queue
+        self::assertCount(1, $priorityQueue);
+        self::assertArrayNotHasKey(3, $priorityQueue);
+        self::assertArrayHasKey(2, $priorityQueue);
+
+        self::assertArrayHasKey('page', $result['resourcesToLoad']);
+        self::assertArrayHasKey('123', $result['resourcesToLoad']['page']);
+        self::assertSame($resource1, $result['resourcesToLoad']['page']['123']['default']);
+
+        self::assertSame(0, $result['loaderIdDepths']['page']['123']);
+    }
+
+    public function testExtractHighestPriorityResourcesWithMaxDepth(): void
+    {
+        $resource1 = new ResolvableResource('123', 'page', 1, fn ($resource) => $resource);
+        $resource2 = new ResolvableResource('456', 'page', 1, fn ($resource) => $resource);
+
+        $priorityQueue = [
+            1 => [
+                'page' => [
+                    2 => [  // depth 2
+                        '123' => ['default' => $resource1],
+                    ],
+                    5 => [  // depth 5 - should be filtered out
+                        '456' => ['default' => $resource2],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->processor->extractHighestPriorityResources($priorityQueue, 3);
+
+        // Should only extract resources with depth <= maxDepth
+        self::assertArrayHasKey('page', $result['resourcesToLoad']);
+        self::assertArrayHasKey('123', $result['resourcesToLoad']['page']);
+        self::assertArrayNotHasKey('456', $result['resourcesToLoad']['page']);
+
+        self::assertSame(2, $result['loaderIdDepths']['page']['123']);
+    }
+
+    public function testExtractHighestPriorityResourcesEmptyQueue(): void
+    {
+        $priorityQueue = [];
+
+        $result = $this->processor->extractHighestPriorityResources($priorityQueue, 5);
+
+        self::assertSame(['resourcesToLoad' => [], 'loaderIdDepths' => []], $result);
+    }
+
+    public function testMergeResolvableResourcesEmpty(): void
+    {
+        $result = $this->processor->mergeResolvableResources([], []);
+
+        self::assertSame([], $result);
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver\ResolvableResourceReplacer;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\ResolvableResourceReplacer;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+
+class ResolvableResourceReplacerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ResolvableResourceReplacer $replacer;
+
+    protected function setUp(): void
+    {
+        $this->replacer = new ResolvableResourceReplacer();
+    }
+
+    public function testReplaceResolvableResourcesWithResolvedValues(): void
+    {
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            function(array $resource) {
+                return $resource['title'] ?? 'Default Title';
+            }
+        );
+
+        $content = [
+            'title' => 'Test',
+            'page' => $resolvableResource,
+            'nested' => [
+                'page' => $resolvableResource,
+            ],
+        ];
+
+        // Use the actual metadata identifier from the resource
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+        $resolvedResources = [
+            'page' => [
+                '123' => [
+                    $metadataId => ['title' => 'Resolved Page Title'],
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertSame('Test', $result['title']);
+        self::assertSame('Resolved Page Title', $result['page']);
+        self::assertIsArray($result['nested']);
+        self::assertArrayHasKey('page', $result['nested']);
+        self::assertSame('Resolved Page Title', $result['nested']['page']);
+    }
+
+    public function testReplaceWithNestedResolvableResources(): void
+    {
+        $firstResource = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            function(array $resource) {
+                return ['nested_page' => $resource['nested_resolvable']];
+            }
+        );
+
+        $nestedResource = new ResolvableResource(
+            '456',
+            'article',
+            1,
+            function(array $resource) {
+                return $resource['title'] ?? 'Default Title';
+            }
+        );
+
+        $content = [
+            'page' => $firstResource,
+        ];
+
+        $firstMetadataId = $firstResource->getMetadataIdentifier();
+        $nestedMetadataId = $nestedResource->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'page' => [
+                '123' => [
+                    $firstMetadataId => ['nested_resolvable' => $nestedResource],
+                ],
+            ],
+            'article' => [
+                '456' => [
+                    $nestedMetadataId => ['title' => 'Article Title'],
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertSame(['nested_page' => 'Article Title'], $result['page']);
+    }
+
+    public function testReplaceWithMaxDepthExceeded(): void
+    {
+        $replacer = new ResolvableResourceReplacer();
+
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            function(mixed $resource) {
+                return $resource;
+            });
+
+        $content = ['page' => $resolvableResource];
+        $resolvedResources = [];
+
+        $result = $replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            3,
+            2
+        );
+
+        // Should replace with null when max depth exceeded
+        self::assertNull($result['page']);
+    }
+
+    public function testReplaceWithEmptyResolvedResources(): void
+    {
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            function(mixed $resource) {
+                return $resource;
+            }
+        );
+
+        $content = ['page' => $resolvableResource];
+        $resolvedResources = [];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        // Should remain unchanged when no resolved resources
+        self::assertSame($resolvableResource, $result['page']);
+    }
+
+    public function testReplaceWithMissingResource(): void
+    {
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            function(mixed $resource) {
+                return $resource ?? 'fallback';
+            });
+
+        $content = ['page' => $resolvableResource];
+
+        $resolvedResources = [
+            'page' => [
+                '456' => ['default' => ['title' => 'Other Page']], // Different ID
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        // Should use callback with null resource
+        self::assertSame('fallback', $result['page']);
+    }
+
+    public function testReplaceWithComplexNestedStructure(): void
+    {
+        $pageResource = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            function(mixed $resource) {
+                return $resource;
+            });
+
+        $articleResource = new ResolvableResource(
+            '456',
+            'article',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            });
+
+        $content = [
+            'items' => [
+                ['type' => 'page', 'resource' => $pageResource],
+                ['type' => 'article', 'resource' => $articleResource],
+            ],
+            'featured' => $pageResource,
+        ];
+
+        $pageMetadataId = $pageResource->getMetadataIdentifier();
+        $articleMetadataId = $articleResource->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'page' => [
+                '123' => [$pageMetadataId => ['title' => 'Page Title', 'content' => 'Page Content']],
+            ],
+            'article' => [
+                '456' => [$articleMetadataId => ['title' => 'Article Title']],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        $expected = [
+            'items' => [
+                ['type' => 'page', 'resource' => ['title' => 'Page Title', 'content' => 'Page Content']],
+                ['type' => 'article', 'resource' => 'Article Title'],
+            ],
+            'featured' => ['title' => 'Page Title', 'content' => 'Page Content'],
+        ];
+
+        self::assertSame($expected, $result);
+    }
+
+    public function testReplaceWithArrayOfResolvableResources(): void
+    {
+        $resource1 = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            });
+
+        $resource2 = new ResolvableResource(
+            '456',
+            'page',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            });
+
+        $content = [
+            'pages' => [$resource1, $resource2],
+        ];
+
+        $metadata1 = $resource1->getMetadataIdentifier();
+        $metadata2 = $resource2->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'page' => [
+                '123' => [$metadata1 => ['title' => 'First Page']],
+                '456' => [$metadata2 => ['title' => 'Second Page']],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertSame(['First Page', 'Second Page'], $result['pages']);
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/TemplateResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/TemplateResolverTest.php
@@ -82,7 +82,7 @@ class TemplateResolverTest extends TestCase
         $defaultFormMetadata = new FormMetadata();
         $fieldMetadata = new FieldMetadata('title');
         $fieldMetadata->setType('text_line');
-        $defaultFormMetadata->setItems([$fieldMetadata]);
+        $defaultFormMetadata->setItems(['title' => $fieldMetadata]);
         $formMetadata->addForm('default', $defaultFormMetadata);
         $formMetadataProvider = $this->prophesize(MetadataProviderInterface::class);
         $formMetadataProvider->getMetadata('example', 'en', [])

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ContentViewTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ContentViewTest.php
@@ -23,8 +23,8 @@ class ContentViewTest extends TestCase
     {
         $contentView = ContentView::create('content', ['view' => 'data']);
 
-        $this->assertSame('content', $contentView->getContent());
-        $this->assertSame(['view' => 'data'], $contentView->getView());
+        self::assertSame('content', $contentView->getContent());
+        self::assertSame(['view' => 'data'], $contentView->getView());
     }
 
     public function testCreateResolvable(): void
@@ -34,9 +34,9 @@ class ContentViewTest extends TestCase
         $content = $contentView->getContent();
         /** @var ResolvableResource $resolvable */
         $resolvable = $content;
-        $this->assertSame(5, $resolvable->getId());
-        $this->assertSame('resourceLoaderKey', $resolvable->getResourceLoaderKey());
-        $this->assertSame(['view' => 'data'], $contentView->getView());
+        self::assertSame(5, $resolvable->getId());
+        self::assertSame('resourceLoaderKey', $resolvable->getResourceLoaderKey());
+        self::assertSame(['view' => 'data'], $contentView->getView());
     }
 
     public function testCreateResolvables(): void
@@ -45,25 +45,25 @@ class ContentViewTest extends TestCase
 
         /** @var ResolvableResource[] $resolvables */
         $resolvables = $contentView->getContent();
-        $this->assertCount(2, $resolvables);
-        $this->assertSame(5, $resolvables[0]->getId());
-        $this->assertSame('resourceLoaderKey', $resolvables[0]->getResourceLoaderKey());
-        $this->assertSame(6, $resolvables[1]->getId());
-        $this->assertSame('resourceLoaderKey', $resolvables[1]->getResourceLoaderKey());
-        $this->assertSame(['view' => 'data'], $contentView->getView());
+        self::assertCount(2, $resolvables);
+        self::assertSame(5, $resolvables[0]->getId());
+        self::assertSame('resourceLoaderKey', $resolvables[0]->getResourceLoaderKey());
+        self::assertSame(6, $resolvables[1]->getId());
+        self::assertSame('resourceLoaderKey', $resolvables[1]->getResourceLoaderKey());
+        self::assertSame(['view' => 'data'], $contentView->getView());
     }
 
     public function testGetContent(): void
     {
         $contentView = ContentView::create('content', ['view' => 'data']);
 
-        $this->assertSame('content', $contentView->getContent());
+        self::assertSame('content', $contentView->getContent());
     }
 
     public function testGetView(): void
     {
         $contentView = ContentView::create('content', ['view' => 'data']);
 
-        $this->assertSame(['view' => 'data'], $contentView->getView());
+        self::assertSame(['view' => 'data'], $contentView->getView());
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ResolvableResourceTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ResolvableResourceTest.php
@@ -22,13 +22,13 @@ class ResolvableResourceTest extends TestCase
     {
         $resolvableResource = new ResolvableResource(5, 'resourceLoaderKey', 0);
 
-        $this->assertSame(5, $resolvableResource->getId());
+        self::assertSame(5, $resolvableResource->getId());
     }
 
     public function testGetResourceLoaderKey(): void
     {
         $resolvableResource = new ResolvableResource(5, 'resourceLoaderKey', 0);
 
-        $this->assertSame('resourceLoaderKey', $resolvableResource->getResourceLoaderKey());
+        self::assertSame('resourceLoaderKey', $resolvableResource->getResourceLoaderKey());
     }
 }

--- a/packages/content/tests/Unit/Content/Application/MetadataResolver/MetadataResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/MetadataResolver/MetadataResolverTest.php
@@ -41,8 +41,8 @@ class MetadataResolverTest extends TestCase
         $fieldMetadata2 = new FieldMetadata('field2');
         $fieldMetadata2->setType('text_line');
         $items = [
-            $sectionMetadata,
-            $fieldMetadata2,
+            'section1' => $sectionMetadata,
+            'field2' => $fieldMetadata2,
         ];
         $data = [
             'field1' => 'value1',

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
@@ -22,6 +24,12 @@ use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
  */
 class PageSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param array{
+     *     resourceLoader?: string,
+     *     metadata?: FieldMetadata|null,
+     * } $params
+     */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
         if (!\is_array($data)
@@ -44,8 +52,30 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
                 'ids' => $ids,
                 ...$params,
             ],
-            priority: 150
+            priority: 150,
+            metadata: [
+                'properties' => $this->getProperties($params['metadata'] ?? null),
+            ]
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getProperties(?FieldMetadata $metadata): ?array
+    {
+        $properties = null;
+        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
+            $properties = [];
+
+            /** @var OptionMetadata[] $optionsMetadataArray */
+            $optionsMetadataArray = $propertiesMetadata->getValue();
+            foreach ($optionsMetadataArray as $optionMetadata) {
+                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
+            }
+        }
+
+        return $properties;
     }
 
     public static function getType(): string

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
@@ -27,7 +25,7 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
     /**
      * @param array{
      *     resourceLoader?: string,
-     *     metadata?: FieldMetadata|null,
+     *     properties?: array<string, mixed>|null,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
@@ -54,28 +52,9 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 150,
             metadata: [
-                'properties' => $this->getProperties($params['metadata'] ?? null),
+                'properties' => $params['properties'] ?? null,
             ]
         );
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function getProperties(?FieldMetadata $metadata): ?array
-    {
-        $properties = null;
-        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
-            $properties = [];
-
-            /** @var OptionMetadata[] $optionsMetadataArray */
-            $optionsMetadataArray = $propertiesMetadata->getValue();
-            foreach ($optionsMetadataArray as $optionMetadata) {
-                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
-            }
-        }
-
-        return $properties;
     }
 
     public static function getType(): string

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
@@ -22,6 +24,12 @@ use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
  */
 class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param array{
+     *     resourceLoader?: string,
+     *     metadata?: FieldMetadata|null,
+     * } $params
+     */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
         if (!\is_string($data)) {
@@ -38,8 +46,30 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
                 'id' => $data,
                 ...$params,
             ],
-            priority: 150
+            priority: 150,
+            metadata: [
+                'properties' => $this->getProperties($params['metadata'] ?? null),
+            ]
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getProperties(?FieldMetadata $metadata): ?array
+    {
+        $properties = null;
+        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
+            $properties = [];
+
+            /** @var OptionMetadata[] $optionsMetadataArray */
+            $optionsMetadataArray = $propertiesMetadata->getValue();
+            foreach ($optionsMetadataArray as $optionMetadata) {
+                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
+            }
+        }
+
+        return $properties;
     }
 
     public static function getType(): string

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
@@ -27,7 +25,7 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
     /**
      * @param array{
      *     resourceLoader?: string,
-     *     metadata?: FieldMetadata|null,
+     *     properties?: array<string, mixed>|null,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
@@ -48,28 +46,9 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 150,
             metadata: [
-                'properties' => $this->getProperties($params['metadata'] ?? null),
+                'properties' => $params['properties'] ?? null,
             ]
         );
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function getProperties(?FieldMetadata $metadata): ?array
-    {
-        $properties = null;
-        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
-            $properties = [];
-
-            /** @var OptionMetadata[] $optionsMetadataArray */
-            $optionsMetadataArray = $propertiesMetadata->getValue();
-            foreach ($optionsMetadataArray as $optionMetadata) {
-                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
-            }
-        }
-
-        return $properties;
     }
 
     public static function getType(): string

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
@@ -14,6 +14,8 @@ namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolv
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionPropertyResolver;
 
@@ -109,5 +111,64 @@ class PageSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $resolvable);
         $this->assertSame(1, $resolvable->getId());
         $this->assertSame('custom_Page', $resolvable->getResourceLoaderKey());
+    }
+
+    public function testResolveWithMetadata(): void
+    {
+        $propertyOption1 = new OptionMetadata();
+        $propertyOption1->setName('property1');
+        $propertyOption1->setValue('value1');
+
+        $propertyOption2 = new OptionMetadata();
+        $propertyOption2->setName('property2');
+        $propertyOption2->setValue('value2');
+
+        $propertiesOption = new OptionMetadata();
+        $propertiesOption->setName('properties');
+        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
+
+        $metadata = new FieldMetadata('test_field');
+        $metadata->addOption($propertiesOption);
+
+        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ], $content[0]->getMetadata());
+    }
+
+    public function testResolveWithoutMetadata(): void
+    {
+        $contentView = $this->resolver->resolve(['1'], 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content[0]->getMetadata());
+    }
+
+    public function testResolveWithEmptyMetadata(): void
+    {
+        $metadata = new FieldMetadata('test_field');
+
+        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content[0]->getMetadata());
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionPropertyResolver;
 
@@ -115,22 +114,12 @@ class PageSelectionPropertyResolverTest extends TestCase
 
     public function testResolveWithMetadata(): void
     {
-        $propertyOption1 = new OptionMetadata();
-        $propertyOption1->setName('property1');
-        $propertyOption1->setValue('value1');
-
-        $propertyOption2 = new OptionMetadata();
-        $propertyOption2->setName('property2');
-        $propertyOption2->setValue('value2');
-
-        $propertiesOption = new OptionMetadata();
-        $propertiesOption->setName('properties');
-        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
-
-        $metadata = new FieldMetadata('test_field');
-        $metadata->addOption($propertiesOption);
-
-        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+        $contentView = $this->resolver->resolve(['1'], 'en', [
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ]);
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\SinglePageSelectionPropertyResolver;
 
@@ -106,22 +105,12 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
 
     public function testResolveWithMetadata(): void
     {
-        $propertyOption1 = new OptionMetadata();
-        $propertyOption1->setName('property1');
-        $propertyOption1->setValue('value1');
-
-        $propertyOption2 = new OptionMetadata();
-        $propertyOption2->setName('property2');
-        $propertyOption2->setValue('value2');
-
-        $propertiesOption = new OptionMetadata();
-        $propertiesOption->setName('properties');
-        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
-
-        $metadata = new FieldMetadata('test_field');
-        $metadata->addOption($propertiesOption);
-
-        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+        $contentView = $this->resolver->resolve('1', 'en', [
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ]);
 
         $content = $contentView->getContent();
         $this->assertInstanceOf(ResolvableResource::class, $content);

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
@@ -14,6 +14,8 @@ namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolv
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\SinglePageSelectionPropertyResolver;
 
@@ -100,5 +102,61 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content);
         $this->assertSame('1', $content->getId());
         $this->assertSame('custom_Page', $content->getResourceLoaderKey());
+    }
+
+    public function testResolveWithMetadata(): void
+    {
+        $propertyOption1 = new OptionMetadata();
+        $propertyOption1->setName('property1');
+        $propertyOption1->setValue('value1');
+
+        $propertyOption2 = new OptionMetadata();
+        $propertyOption2->setName('property2');
+        $propertyOption2->setValue('value2');
+
+        $propertiesOption = new OptionMetadata();
+        $propertiesOption->setName('properties');
+        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
+
+        $metadata = new FieldMetadata('test_field');
+        $metadata->addOption($propertiesOption);
+
+        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ], $content->getMetadata());
+    }
+
+    public function testResolveWithoutMetadata(): void
+    {
+        $contentView = $this->resolver->resolve('1', 'en');
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content->getMetadata());
+    }
+
+    public function testResolveWithEmptyMetadata(): void
+    {
+        $metadata = new FieldMetadata('test_field');
+
+        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content->getMetadata());
     }
 }

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
@@ -27,7 +25,7 @@ class SingleSnippetSelectionPropertyResolver implements PropertyResolverInterfac
     /**
      * @param array{
      *     resourceLoader?: string,
-     *     metadata?: FieldMetadata|null,
+     *     properties?: array<string, mixed>|null,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
@@ -48,28 +46,9 @@ class SingleSnippetSelectionPropertyResolver implements PropertyResolverInterfac
             ],
             priority: 100,
             metadata: [
-                'properties' => $this->getProperties($params['metadata'] ?? null),
+                'properties' => $params['properties'] ?? null,
             ]
         );
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function getProperties(?FieldMetadata $metadata): ?array
-    {
-        $properties = null;
-        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
-            $properties = [];
-
-            /** @var OptionMetadata[] $optionsMetadataArray */
-            $optionsMetadataArray = $propertiesMetadata->getValue();
-            foreach ($optionsMetadataArray as $optionMetadata) {
-                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
-            }
-        }
-
-        return $properties;
     }
 
     public static function getType(): string

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
@@ -22,6 +24,12 @@ use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoade
  */
 class SingleSnippetSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param array{
+     *     resourceLoader?: string,
+     *     metadata?: FieldMetadata|null,
+     * } $params
+     */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
         if (!\is_string($data)) {
@@ -38,8 +46,30 @@ class SingleSnippetSelectionPropertyResolver implements PropertyResolverInterfac
                 'id' => $data,
                 ...$params,
             ],
-            priority: 100
+            priority: 100,
+            metadata: [
+                'properties' => $this->getProperties($params['metadata'] ?? null),
+            ]
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getProperties(?FieldMetadata $metadata): ?array
+    {
+        $properties = null;
+        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
+            $properties = [];
+
+            /** @var OptionMetadata[] $optionsMetadataArray */
+            $optionsMetadataArray = $propertiesMetadata->getValue();
+            foreach ($optionsMetadataArray as $optionMetadata) {
+                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
+            }
+        }
+
+        return $properties;
     }
 
     public static function getType(): string

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
@@ -22,6 +24,12 @@ use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoade
  */
 class SnippetSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param array{
+     *     resourceLoader?: string,
+     *     metadata?: FieldMetadata|null,
+     * } $params
+     */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
         if (
@@ -50,8 +58,30 @@ class SnippetSelectionPropertyResolver implements PropertyResolverInterface
                 'ids' => $identifiers,
                 ...$params,
             ],
-            priority: 100
+            priority: 100,
+            metadata: [
+                'properties' => $this->getProperties($params['metadata'] ?? null),
+            ]
         );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getProperties(?FieldMetadata $metadata): ?array
+    {
+        $properties = null;
+        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
+            $properties = [];
+
+            /** @var OptionMetadata[] $optionsMetadataArray */
+            $optionsMetadataArray = $propertiesMetadata->getValue();
+            foreach ($optionsMetadataArray as $optionMetadata) {
+                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
+            }
+        }
+
+        return $properties;
     }
 
     public static function getType(): string

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
@@ -27,7 +25,7 @@ class SnippetSelectionPropertyResolver implements PropertyResolverInterface
     /**
      * @param array{
      *     resourceLoader?: string,
-     *     metadata?: FieldMetadata|null,
+     *     properties?: array<string, mixed>|null,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
@@ -60,28 +58,9 @@ class SnippetSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 100,
             metadata: [
-                'properties' => $this->getProperties($params['metadata'] ?? null),
+                'properties' => $params['properties'] ?? null,
             ]
         );
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    private function getProperties(?FieldMetadata $metadata): ?array
-    {
-        $properties = null;
-        if ($metadata instanceof FieldMetadata && $propertiesMetadata = $metadata->getOptions()['properties'] ?? null) {
-            $properties = [];
-
-            /** @var OptionMetadata[] $optionsMetadataArray */
-            $optionsMetadataArray = $propertiesMetadata->getValue();
-            foreach ($optionsMetadataArray as $optionMetadata) {
-                $properties[(string) $optionMetadata->getName()] = $optionMetadata->getValue();
-            }
-        }
-
-        return $properties;
     }
 
     public static function getType(): string

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolverTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SingleSnippetSelectionPropertyResolver;
 
@@ -107,22 +106,12 @@ class SingleSnippetSelectionPropertyResolverTest extends TestCase
 
     public function testResolveWithMetadata(): void
     {
-        $propertyOption1 = new OptionMetadata();
-        $propertyOption1->setName('property1');
-        $propertyOption1->setValue('value1');
-
-        $propertyOption2 = new OptionMetadata();
-        $propertyOption2->setName('property2');
-        $propertyOption2->setValue('value2');
-
-        $propertiesOption = new OptionMetadata();
-        $propertiesOption->setName('properties');
-        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
-
-        $metadata = new FieldMetadata('test_field');
-        $metadata->addOption($propertiesOption);
-
-        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+        $contentView = $this->resolver->resolve('1', 'en', [
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ]);
 
         $content = $contentView->getContent();
         $this->assertInstanceOf(ResolvableResource::class, $content);

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolverTest.php
@@ -16,6 +16,8 @@ namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Infrastructure\Sulu\Content\Prope
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SingleSnippetSelectionPropertyResolver;
 
@@ -101,5 +103,61 @@ class SingleSnippetSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content);
         $this->assertSame('1', $content->getId());
         $this->assertSame('custom_snippet', $content->getResourceLoaderKey());
+    }
+
+    public function testResolveWithMetadata(): void
+    {
+        $propertyOption1 = new OptionMetadata();
+        $propertyOption1->setName('property1');
+        $propertyOption1->setValue('value1');
+
+        $propertyOption2 = new OptionMetadata();
+        $propertyOption2->setName('property2');
+        $propertyOption2->setValue('value2');
+
+        $propertiesOption = new OptionMetadata();
+        $propertiesOption->setName('properties');
+        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
+
+        $metadata = new FieldMetadata('test_field');
+        $metadata->addOption($propertiesOption);
+
+        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ], $content->getMetadata());
+    }
+
+    public function testResolveWithoutMetadata(): void
+    {
+        $contentView = $this->resolver->resolve('1', 'en');
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content->getMetadata());
+    }
+
+    public function testResolveWithEmptyMetadata(): void
+    {
+        $metadata = new FieldMetadata('test_field');
+
+        $contentView = $this->resolver->resolve('1', 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content->getMetadata());
     }
 }

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SnippetSelectionPropertyResolver;
 
@@ -125,22 +124,12 @@ class SnippetSelectionPropertyResolverTest extends TestCase
 
     public function testResolveWithMetadata(): void
     {
-        $propertyOption1 = new OptionMetadata();
-        $propertyOption1->setName('property1');
-        $propertyOption1->setValue('value1');
-
-        $propertyOption2 = new OptionMetadata();
-        $propertyOption2->setName('property2');
-        $propertyOption2->setValue('value2');
-
-        $propertiesOption = new OptionMetadata();
-        $propertiesOption->setName('properties');
-        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
-
-        $metadata = new FieldMetadata('test_field');
-        $metadata->addOption($propertiesOption);
-
-        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+        $contentView = $this->resolver->resolve(['1'], 'en', [
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ]);
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
@@ -16,6 +16,8 @@ namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Infrastructure\Sulu\Content\Prope
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SnippetSelectionPropertyResolver;
 
@@ -119,5 +121,64 @@ class SnippetSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content[0]);
         $this->assertSame('1', $content[0]->getId());
         $this->assertSame('custom_snippet', $content[0]->getResourceLoaderKey());
+    }
+
+    public function testResolveWithMetadata(): void
+    {
+        $propertyOption1 = new OptionMetadata();
+        $propertyOption1->setName('property1');
+        $propertyOption1->setValue('value1');
+
+        $propertyOption2 = new OptionMetadata();
+        $propertyOption2->setName('property2');
+        $propertyOption2->setValue('value2');
+
+        $propertiesOption = new OptionMetadata();
+        $propertiesOption->setName('properties');
+        $propertiesOption->setValue([$propertyOption1, $propertyOption2]);
+
+        $metadata = new FieldMetadata('test_field');
+        $metadata->addOption($propertiesOption);
+
+        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => [
+                'property1' => 'value1',
+                'property2' => 'value2',
+            ],
+        ], $content[0]->getMetadata());
+    }
+
+    public function testResolveWithoutMetadata(): void
+    {
+        $contentView = $this->resolver->resolve(['1'], 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content[0]->getMetadata());
+    }
+
+    public function testResolveWithEmptyMetadata(): void
+    {
+        $metadata = new FieldMetadata('test_field');
+
+        $contentView = $this->resolver->resolve(['1'], 'en', ['metadata' => $metadata]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => null,
+        ], $content[0]->getMetadata());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Related issues/PRs | #7672 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds support for the mapping properties e.g. xml params for selections.

#### Why?

2.6 did support it and we need it for twig extension / performance optimizations
