### PR TITLE
Support properties named "view" or "content"

### DIFF
--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -109,7 +109,7 @@ readonly class ContentResolver implements ContentResolverInterface
                             $resolvedValue = [
                                 'content' => $normalizedContentData['content']['0'],
                                 // All resolved resources have the same view structure, so we can just take the first one
-                                'view' => \reset($normalizedContentData['view']['0']) ?? $normalizedContentData['view']['0'],
+                                'view' => $normalizedContentData['view']['0'],
                             ];
 
                             // Add resolvable resources to priority queue

--- a/packages/content/tests/Application/config/templates/examples/default-content-view-properties.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-content-view-properties.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default-content-view-properties</key>
+
+    <view>@ExampleTest/examples/default</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Example</title>
+        <title lang="de">Example</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+            <tag name="sulu.search.field" role="title"/>
+        </property>
+
+        <property name="url" type="route">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+            <tag name="sulu.search.field" role="url"/>
+        </property>
+
+        <block name="content">
+            <meta>
+                <title lang="en">Content</title>
+                <title lang="de">Inhalt</title>
+            </meta>
+
+            <types>
+                <type name="text">
+                    <meta>
+                        <title lang="en">Text</title>
+                        <title lang="de">Text</title>
+                    </meta>
+
+                    <properties>
+                        <property name="text" type="text_editor">
+                            <meta>
+                                <title lang="en">Text</title>
+                                <title lang="de">Text</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </type>
+
+                <type name="media">
+                    <meta>
+                        <title lang="en">Media</title>
+                        <title lang="de">Medien</title>
+                    </meta>
+
+                    <properties>
+                        <property name="media" type="media_selection">
+                            <meta>
+                                <title lang="en">Media</title>
+                                <title lang="de">Medien</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </type>
+            </types>
+        </block>
+
+
+        <block name="view">
+            <meta>
+                <title lang="en">View</title>
+                <title lang="de">View</title>
+            </meta>
+
+            <types>
+                <type name="text">
+                    <meta>
+                        <title lang="en">Text</title>
+                        <title lang="de">Text</title>
+                    </meta>
+
+                    <properties>
+                        <property name="text" type="text_editor">
+                            <meta>
+                                <title lang="en">Text</title>
+                                <title lang="de">Text</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </type>
+
+                <type name="media">
+                    <meta>
+                        <title lang="en">Media</title>
+                        <title lang="de">Medien</title>
+                    </meta>
+
+                    <properties>
+                        <property name="media" type="media_selection">
+                            <meta>
+                                <title lang="en">Media</title>
+                                <title lang="de">Medien</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </type>
+            </types>
+        </block>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | depends on https://github.com/sulu/sulu/pull/8086
| License | MIT

#### What's in this PR?

❗ depends on https://github.com/sulu/sulu/pull/8086
❗ therefore https://github.com/sulu/sulu/pull/8086 should be merged first to review this properly

Adjusts the logic to properly resolve properties that are called `content` or `view`.

#### Why?

Because we should allow properties named `content` or `view`