### PR TITLE
Add CacheLifeTime Handling to ContentController and ContentRouteProvider

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -669,10 +669,11 @@ Removed kernel parameters:
 - All `sulu_*.class` parameters for services where removed (use compilerpasses to replace class of a service definition)
 - Parameter `%permissions%` was replaced in favor of `%sulu_security.permissions%`
 
-### Added return type hints for TimestampableInterface and UserBlameInterface
+### Added return type hints
 
-Return type hints have been added to the `TimestampableInterface` and `UserBlameInterface` methods in Sulu 3.0. This affects the following methods:
+The following methods have been updated with a return type hint:
 
+- `CacheLifetimeRequestStore::setCacheLifetime()` now returns `void`
 - `TimestampableInterface::getCreated()`: now returns `\DateTimeImmutable`
 - `TimestampableInterface::getChanged()`: now returns `\DateTimeImmutable`
 - `UserBlameInterface::getCreator()`: now returns `?UserInterface`

--- a/packages/content/config/services.xml
+++ b/packages/content/config/services.xml
@@ -93,6 +93,7 @@
             <argument type="service" id="sulu_content.content_aggregator"/>
             <argument type="service" id="sulu_admin.metadata_provider_registry"/>
             <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
+            <argument type="service" id="sulu_http_cache.cache_lifetime.request_store"/>
 
             <tag name="sulu_route.route_defaults_provider" resource-key="examples"/>
             <tag name="sulu_route.route_defaults_provider" resource-key="articles"/>

--- a/packages/content/src/Infrastructure/Sulu/Route/ContentRouteDefaultsProvider.php
+++ b/packages/content/src/Infrastructure/Sulu/Route/ContentRouteDefaultsProvider.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TemplateMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
+use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeRequestStore;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
@@ -106,12 +107,18 @@ class ContentRouteDefaultsProvider implements RouteDefaultsProviderInterface
 
         $templateMetadata = $this->resolveTemplateMetadata($dimensionContent::getTemplateType(), $templateKey, $contentLocale);
 
-        return [
+        $attributes = [
             'object' => $dimensionContent,
             'view' => $templateMetadata->getView(),
             '_controller' => $templateMetadata->getController(),
-            '_cacheLifetime' => $this->getCacheLifetime($templateMetadata),
         ];
+
+        $cacheLifetime = $this->getCacheLifetime($templateMetadata);
+        if ($cacheLifetime) {
+            $attributes[CacheLifetimeRequestStore::ATTRIBUTE_KEY] = $cacheLifetime;
+        }
+
+        return $attributes;
     }
 
     /**

--- a/packages/content/src/UserInterface/Controller/Website/ContentController.php
+++ b/packages/content/src/UserInterface/Controller/Website/ContentController.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\UserInterface\Controller\Website;
 
+use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancerInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Preview;
 use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
@@ -68,10 +69,7 @@ class ContentController extends AbstractController
             $response = new Response($this->renderSuluView($view, $requestFormat, $parameters, $preview, $partial));
         }
 
-        $response->setPublic();
-
-        // TODO resolve cachelifetime
-        // TODO implement cacheLifetimeRequestStore
+        $this->enhanceSuluCacheLifeTime($response);
 
         return $response;
     }
@@ -84,6 +82,11 @@ class ContentController extends AbstractController
     protected function resolveSuluParameters(DimensionContentInterface $object, bool $normalize): array
     {
         return $this->container->get('sulu_content.content_resolver')->resolve($object); // TODO should the resolver already normalize the data based on metadata inside the template (serialization group)
+    }
+
+    protected function enhanceSuluCacheLifeTime(Response $response): void
+    {
+        $this->container->get('sulu_http_cache.cache_lifetime.enhancer')->enhance($response);
     }
 
     /**
@@ -120,6 +123,7 @@ class ContentController extends AbstractController
         $services = parent::getSubscribedServices();
 
         $services['sulu_content.content_resolver'] = ContentResolverInterface::class;
+        $services['sulu_http_cache.cache_lifetime.enhancer'] = CacheLifetimeEnhancerInterface::class;
 
         return $services;
     }

--- a/packages/content/tests/Application/AppCache.php
+++ b/packages/content/tests/Application/AppCache.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Application;
+
+use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
+use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
+use Toflar\Psr6HttpCacheStore\Psr6Store;
+
+class AppCache extends SuluHttpCache implements KernelInterface
+{
+    public function __construct(KernelInterface $kernel)
+    {
+        parent::__construct($kernel);
+    }
+
+    protected function createStore(): StoreInterface
+    {
+        return new Psr6Store([
+            'cache' => new ArrayAdapter(),
+            'lock_factory' => new LockFactory(new InMemoryStore()),
+            'cache_tags_header' => TagHeaderFormatter::DEFAULT_HEADER_NAME,
+        ]);
+    }
+
+    public function registerBundles(): iterable
+    {
+        return $this->kernel->registerBundles();
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $this->kernel->registerContainerConfiguration($loader);
+    }
+
+    public function boot(): void
+    {
+        $this->kernel->boot();
+    }
+
+    public function shutdown(): void
+    {
+        $this->kernel->shutdown();
+    }
+
+    public function getBundles(): array
+    {
+        return $this->kernel->getBundles();
+    }
+
+    public function getBundle(string $name): BundleInterface
+    {
+        return $this->kernel->getBundle($name);
+    }
+
+    public function locateResource(string $name): string
+    {
+        return $this->kernel->locateResource($name);
+    }
+
+    public function getEnvironment(): string
+    {
+        return $this->kernel->getEnvironment();
+    }
+
+    public function isDebug(): bool
+    {
+        return $this->kernel->isDebug();
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->kernel->getProjectDir();
+    }
+
+    public function getContainer(): ContainerInterface
+    {
+        return $this->kernel->getContainer();
+    }
+
+    public function getStartTime(): float
+    {
+        return $this->kernel->getStartTime();
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->kernel->getCacheDir();
+    }
+
+    public function getBuildDir(): string
+    {
+        return $this->kernel->getBuildDir();
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->kernel->getLogDir();
+    }
+
+    public function getCharset(): string
+    {
+        return $this->kernel->getCharset();
+    }
+}

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProviderTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Route/ContentRouteDefaultsProviderTest.php
@@ -59,7 +59,7 @@ class ContentRouteDefaultsProviderTest extends TestCase
      */
     private ObjectProphecy $formMetadataProvider;
 
-    private CacheLifetimeResolverInterface $cacheLifetimeResolver;
+    private CacheLifetimeResolver $cacheLifetimeResolver;
 
     private ContentRouteDefaultsProvider $contentRouteDefaultsProvider;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -23701,42 +23701,6 @@ parameters:
 			path: src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
 
 		-
-			message: '#^Cannot access offset ''type'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
-
-		-
-			message: '#^Cannot access offset ''value'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\HttpCacheBundle\\CacheLifetime\\CacheLifetimeEnhancer\:\:enhance\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
-
-		-
-			message: '#^Parameter \#1 \$type of method Sulu\\Bundle\\HttpCacheBundle\\CacheLifetime\\CacheLifetimeResolverInterface\:\:resolve\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
-
-		-
-			message: '#^Parameter \#2 \$values of method Symfony\\Component\\HttpFoundation\\ResponseHeaderBag\:\:set\(\) expects array\<string\>\|string\|null, int\<min, \-1\>\|int\<1, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancer.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\HttpCacheBundle\\CacheLifetime\\CacheLifetimeEnhancerInterface\:\:enhance\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancerInterface.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\HttpCacheBundle\\CacheLifetime\\CacheLifetimeRequestStore\:\:getCacheLifetime\(\) should return int\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1

--- a/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancerInterface.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeEnhancerInterface.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\HttpCacheBundle\CacheLifetime;
 
-use Sulu\Component\Content\Compat\StructureInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -22,5 +21,5 @@ interface CacheLifetimeEnhancerInterface
     /**
      * Call this method to enhance the response.
      */
-    public function enhance(Response $response, StructureInterface $structure);
+    public function enhance(Response $response): void;
 }

--- a/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeRequestStore.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/CacheLifetime/CacheLifetimeRequestStore.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\HttpCacheBundle\CacheLifetime;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class CacheLifetimeRequestStore
@@ -21,11 +22,11 @@ class CacheLifetimeRequestStore
     {
     }
 
-    public function setCacheLifetime(int $cacheLifetime)
+    public function setCacheLifetime(int $cacheLifetime): void
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        if (!$request) {
+        if (!$request instanceof Request) {
             return;
         }
 
@@ -43,7 +44,7 @@ class CacheLifetimeRequestStore
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        if (!$request) {
+        if (!$request instanceof Request) {
             return null;
         }
 

--- a/src/Sulu/Bundle/HttpCacheBundle/Resources/config/cache-lifetime-enhancer.xml
+++ b/src/Sulu/Bundle/HttpCacheBundle/Resources/config/cache-lifetime-enhancer.xml
@@ -6,10 +6,9 @@
         <service id="sulu_http_cache.cache_lifetime.enhancer"
                  class="Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancer"
                  public="true">
-            <argument type="service" id="sulu_http_cache.cache_lifetime.resolver"/>
+            <argument type="service" id="sulu_http_cache.cache_lifetime.request_store"/>
             <argument>%sulu_http_cache.cache.max_age%</argument>
             <argument>%sulu_http_cache.cache.shared_max_age%</argument>
-            <argument type="service" id="sulu_http_cache.cache_lifetime.request_store"/>
         </service>
 
         <service

--- a/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/HttpCacheBundle/phpunit.xml.dist
@@ -25,5 +25,4 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
         <ini name="date.timezone" value="UTC"/>
     </php>
-
 </phpunit>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | requires #8073
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add CacheLifeTime Handling to ContentController and RouteProvider.

#### Why?

We are not setting the CacheLifeTime currently in the Controller.

#### ToDo

 - [x] Upgrade with changed services