### PR TITLE
Add PropertyResolverMetadataAwareInterface

### DIFF
--- a/packages/content/src/Application/MetadataResolver/MetadataResolver.php
+++ b/packages/content/src/Application/MetadataResolver/MetadataResolver.php
@@ -65,10 +65,9 @@ class MetadataResolver
         $propertyResolver = $this->propertyResolverProvider->getPropertyResolver($type);
 
         if ($propertyResolver instanceof PropertyResolverMetadataAwareInterface && $metadata instanceof FieldMetadata) {
-            return $propertyResolver->resolve($data, $locale, $metadata, $params);
+            return $propertyResolver->resolve($data, $locale, $params, $metadata);
         }
 
-        // ensure metadata is not included in params for non-aware resolvers
         return $propertyResolver->resolve($data, $locale, $params);
     }
 

--- a/packages/content/src/Application/MetadataResolver/MetadataResolver.php
+++ b/packages/content/src/Application/MetadataResolver/MetadataResolver.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\OptionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\PropertyResolverProviderInterface;
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 
 /**
  * @internal This class is intended for internal use only within the library. Modifying or depending on this class may result in unexpected behavior and is not supported.
@@ -48,12 +49,8 @@ class MetadataResolver
                     $this->resolveItems($item->getItems(), $data, $locale)
                 );
             } else {
-                // TODO remove metadata as soon as we implemented a MetadataAwarePropertyResolverInterface
-                $params = [
-                    'metadata' => $item,
-                    ...($item instanceof FieldMetadata ? $this->serializeFieldMetadataOptions($item) : []),
-                ];
-                $contentViews[$name] = $this->resolveProperty($type, $data[$name] ?? null, $locale, $params);
+                $params = $item instanceof FieldMetadata ? $this->serializeFieldMetadataOptions($item) : [];
+                $contentViews[$name] = $this->resolveProperty($type, $data[$name] ?? null, $locale, $item, $params);
             }
         }
 
@@ -63,10 +60,15 @@ class MetadataResolver
     /**
      * @param array<string, mixed> $params
      */
-    private function resolveProperty(string $type, mixed $data, string $locale, array $params = []): ContentView
+    private function resolveProperty(string $type, mixed $data, string $locale, ItemMetadata $metadata, array $params = []): ContentView
     {
         $propertyResolver = $this->propertyResolverProvider->getPropertyResolver($type);
 
+        if ($propertyResolver instanceof PropertyResolverMetadataAwareInterface && $metadata instanceof FieldMetadata) {
+            return $propertyResolver->resolve($data, $locale, $metadata, $params);
+        }
+
+        // ensure metadata is not included in params for non-aware resolvers
         return $propertyResolver->resolve($data, $locale, $params);
     }
 

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sulu\Content\Application\PropertyResolver;
 
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
-use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 
 /**
  * @internal The constructor of this class may change in future releases to add new features or improve performance.
@@ -27,19 +26,19 @@ use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataA
 final class PropertyResolverProvider implements PropertyResolverProviderInterface
 {
     /**
-     * @var array<PropertyResolverInterface|PropertyResolverMetadataAwareInterface>
+     * @var array<PropertyResolverInterface>
      */
     private array $propertyResolvers;
 
     /**
-     * @param iterable<PropertyResolverInterface|PropertyResolverMetadataAwareInterface> $propertyResolvers
+     * @param iterable<PropertyResolverInterface> $propertyResolvers
      */
     public function __construct(iterable $propertyResolvers)
     {
         $this->propertyResolvers = \iterator_to_array($propertyResolvers);
     }
 
-    public function getPropertyResolver(string $type): PropertyResolverInterface|PropertyResolverMetadataAwareInterface
+    public function getPropertyResolver(string $type): PropertyResolverInterface
     {
         if (!\array_key_exists($type, $this->propertyResolvers)) {
             return $this->propertyResolvers['default'];

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Content\Application\PropertyResolver;
 
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 
 /**
  * @internal The constructor of this class may change in future releases to add new features or improve performance.
@@ -26,19 +27,19 @@ use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface
 final class PropertyResolverProvider implements PropertyResolverProviderInterface
 {
     /**
-     * @var PropertyResolverInterface[]
+     * @var array<PropertyResolverInterface|PropertyResolverMetadataAwareInterface>
      */
     private array $propertyResolvers;
 
     /**
-     * @param iterable<PropertyResolverInterface> $propertyResolvers
+     * @param iterable<PropertyResolverInterface|PropertyResolverMetadataAwareInterface> $propertyResolvers
      */
     public function __construct(iterable $propertyResolvers)
     {
         $this->propertyResolvers = \iterator_to_array($propertyResolvers);
     }
 
-    public function getPropertyResolver(string $type): PropertyResolverInterface
+    public function getPropertyResolver(string $type): PropertyResolverInterface|PropertyResolverMetadataAwareInterface
     {
         if (!\array_key_exists($type, $this->propertyResolvers)) {
             return $this->propertyResolvers['default'];

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProviderInterface.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProviderInterface.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
 namespace Sulu\Content\Application\PropertyResolver;
 
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
-use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 
 interface PropertyResolverProviderInterface
 {
-    public function getPropertyResolver(string $type): PropertyResolverInterface|PropertyResolverMetadataAwareInterface;
+    public function getPropertyResolver(string $type): PropertyResolverInterface;
 }

--- a/packages/content/src/Application/PropertyResolver/PropertyResolverProviderInterface.php
+++ b/packages/content/src/Application/PropertyResolver/PropertyResolverProviderInterface.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace Sulu\Content\Application\PropertyResolver;
 
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 
 interface PropertyResolverProviderInterface
 {
-    public function getPropertyResolver(string $type): PropertyResolverInterface;
+    public function getPropertyResolver(string $type): PropertyResolverInterface|PropertyResolverMetadataAwareInterface;
 }

--- a/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
@@ -22,7 +22,7 @@ use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\MetadataResolver\MetadataResolver;
 use Sulu\Content\Application\PropertyResolver\BlockVisitor\BlockVisitorInterface;
 
-class BlockPropertyResolver implements PropertyResolverInterface
+class BlockPropertyResolver implements PropertyResolverMetadataAwareInterface
 {
     private MetadataResolver $metadataResolver;
 
@@ -43,17 +43,17 @@ class BlockPropertyResolver implements PropertyResolverInterface
         $this->metadataResolver = $metadataResolver;
     }
 
-    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function resolve(mixed $data, string $locale, FieldMetadata $metadata, array $params = []): ContentView
     {
-        $metadata = $params['metadata'] ?? null;
         $returnedParams = $params;
-        unset($returnedParams['metadata']); // TODO we may should implement a PropertyResolverAwareMetadataInterface
 
         if (!\is_array($data) || !\array_is_list($data)) {
             return ContentView::create([], [...$returnedParams]);
         }
 
-        \assert($metadata instanceof FieldMetadata, 'Metadata must be set to resolve blocks.');
         $metadataTypes = $metadata->getTypes();
 
         $typedFormMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')

--- a/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
@@ -46,12 +46,16 @@ class BlockPropertyResolver implements PropertyResolverMetadataAwareInterface
     /**
      * @param array<string, mixed> $params
      */
-    public function resolve(mixed $data, string $locale, FieldMetadata $metadata, array $params = []): ContentView
+    public function resolve(mixed $data, string $locale, array $params = [], ?FieldMetadata $metadata = null): ContentView
     {
         $returnedParams = $params;
 
         if (!\is_array($data) || !\array_is_list($data)) {
             return ContentView::create([], [...$returnedParams]);
+        }
+
+        if (null === $metadata) {
+            throw new \InvalidArgumentException('Metadata must be provided for block resolving.');
         }
 
         $metadataTypes = $metadata->getTypes();

--- a/packages/content/src/Application/PropertyResolver/Resolver/PropertyResolverMetadataAwareInterface.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/PropertyResolverMetadataAwareInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\PropertyResolver\Resolver;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+
+/**
+ * Implement this interface for resolvers that need direct access to the field metadata.
+ */
+interface PropertyResolverMetadataAwareInterface
+{
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function resolve(mixed $data, string $locale, FieldMetadata $metadata, array $params = []): ContentView;
+
+    public static function getType(): string;
+}

--- a/packages/content/src/Application/PropertyResolver/Resolver/PropertyResolverMetadataAwareInterface.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/PropertyResolverMetadataAwareInterface.php
@@ -19,12 +19,12 @@ use Sulu\Content\Application\ContentResolver\Value\ContentView;
 /**
  * Implement this interface for resolvers that need direct access to the field metadata.
  */
-interface PropertyResolverMetadataAwareInterface
+interface PropertyResolverMetadataAwareInterface extends PropertyResolverInterface
 {
     /**
      * @param array<string, mixed> $params
      */
-    public function resolve(mixed $data, string $locale, FieldMetadata $metadata, array $params = []): ContentView;
+    public function resolve(mixed $data, string $locale, array $params = [], ?FieldMetadata $metadata = null): ContentView;
 
     public static function getType(): string;
 }

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Content\Infrastructure\Symfony\HttpKernel;
 
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\ResourceLoaderCacheCompilerPass;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\SettingsFormPass;
@@ -97,6 +98,10 @@ final class SuluContentBundle extends AbstractBundle
             ->addTag('sulu_content.resource_loader');
 
         $container->registerForAutoconfiguration(PropertyResolverInterface::class)
+            ->addTag('sulu_content.property_resolver');
+
+        // ensure metadata-aware property resolvers are also tagged
+        $container->registerForAutoconfiguration(PropertyResolverMetadataAwareInterface::class)
             ->addTag('sulu_content.property_resolver');
     }
 }

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/BlockPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/BlockPropertyResolverTest.php
@@ -15,7 +15,6 @@ namespace Sulu\Content\Tests\Unit\Content\Application\PropertyResolver\Resolver;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Util\Type;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
@@ -65,7 +64,7 @@ class BlockPropertyResolverTest extends TestCase
 
     public function testResolveEmpty(): void
     {
-        $contentView = $this->resolver->resolve(null, 'en');
+        $contentView = $this->resolver->resolve(null, 'en', new FieldMetadata('example'));
 
         $this->assertSame([], $contentView->getContent());
         $this->assertSame([], $contentView->getView());
@@ -74,7 +73,7 @@ class BlockPropertyResolverTest extends TestCase
 
     public function testResolveParams(): void
     {
-        $contentView = $this->resolver->resolve([], 'en', ['metadata' => new FieldMetadata('example'), 'custom' => 'params']);
+        $contentView = $this->resolver->resolve([], 'en', new FieldMetadata('example'), ['custom' => 'params']);
 
         $this->assertSame([], $contentView->getContent());
         $this->assertSame([
@@ -100,7 +99,7 @@ class BlockPropertyResolverTest extends TestCase
     #[DataProvider('provideUnresolvableData')]
     public function testResolveUnresolvableData(mixed $data): void
     {
-        $contentView = $this->resolver->resolve($data, 'en', ['metadata' => new FieldMetadata('example')]);
+        $contentView = $this->resolver->resolve($data, 'en', new FieldMetadata('example'));
 
         $this->assertSame([], $contentView->getContent());
         $this->assertSame([], $contentView->getView());
@@ -131,11 +130,8 @@ class BlockPropertyResolverTest extends TestCase
 
         $formMetadata->addItem($tileFieldMetadata);
         $formMetadata->addItem($descriptionFieldMetadata);
-        $params = [
-            'metadata' => $blockFieldMetadata,
-        ];
 
-        $content = $this->resolver->resolve($data, $locale, $params);
+        $content = $this->resolver->resolve($data, $locale, $blockFieldMetadata);
         /** @var ContentView[] $innerContent */
         $innerContent = $content->getContent();
         $this->assertCount(1, $innerContent);
@@ -174,10 +170,6 @@ class BlockPropertyResolverTest extends TestCase
         $blockFieldMetadata = new FieldMetadata('text_block');
         $blockFieldMetadata->addType($formMetadata);
 
-        $params = [
-            'metadata' => $blockFieldMetadata,
-        ];
-
         $globalFormMetadata = new FormMetadata();
         $globalFormMetadata->setKey('text_block');
         $globalBlockFieldMetadata = new FieldMetadata('text_block');
@@ -203,7 +195,7 @@ class BlockPropertyResolverTest extends TestCase
             }
         });
 
-        $content = $this->resolver->resolve($data, $locale, $params);
+        $content = $this->resolver->resolve($data, $locale, $blockFieldMetadata);
         /** @var ContentView[] $innerContent */
         $innerContent = $content->getContent();
         $this->assertCount(1, $innerContent);
@@ -247,11 +239,7 @@ class BlockPropertyResolverTest extends TestCase
         $formMetadata->addItem($tileFieldMetadata);
         $formMetadata->addItem($descriptionFieldMetadata);
 
-        $params = [
-            'metadata' => $blockFieldMetadata,
-        ];
-
-        $content = $this->resolver->resolve($data, $locale, $params);
+        $content = $this->resolver->resolve($data, $locale, $blockFieldMetadata);
         /** @var array<string, mixed> $innerContent */
         $innerContent = $content->getContent();
         // title / description / type

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/BlockPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/BlockPropertyResolverTest.php
@@ -64,7 +64,7 @@ class BlockPropertyResolverTest extends TestCase
 
     public function testResolveEmpty(): void
     {
-        $contentView = $this->resolver->resolve(null, 'en', new FieldMetadata('example'));
+        $contentView = $this->resolver->resolve(null, 'en', [], new FieldMetadata('example'));
 
         $this->assertSame([], $contentView->getContent());
         $this->assertSame([], $contentView->getView());
@@ -73,7 +73,7 @@ class BlockPropertyResolverTest extends TestCase
 
     public function testResolveParams(): void
     {
-        $contentView = $this->resolver->resolve([], 'en', new FieldMetadata('example'), ['custom' => 'params']);
+        $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params'], new FieldMetadata('example'));
 
         $this->assertSame([], $contentView->getContent());
         $this->assertSame([
@@ -99,7 +99,7 @@ class BlockPropertyResolverTest extends TestCase
     #[DataProvider('provideUnresolvableData')]
     public function testResolveUnresolvableData(mixed $data): void
     {
-        $contentView = $this->resolver->resolve($data, 'en', new FieldMetadata('example'));
+        $contentView = $this->resolver->resolve($data, 'en', [], new FieldMetadata('example'));
 
         $this->assertSame([], $contentView->getContent());
         $this->assertSame([], $contentView->getView());
@@ -131,7 +131,7 @@ class BlockPropertyResolverTest extends TestCase
         $formMetadata->addItem($tileFieldMetadata);
         $formMetadata->addItem($descriptionFieldMetadata);
 
-        $content = $this->resolver->resolve($data, $locale, $blockFieldMetadata);
+        $content = $this->resolver->resolve($data, $locale, [], $blockFieldMetadata);
         /** @var ContentView[] $innerContent */
         $innerContent = $content->getContent();
         $this->assertCount(1, $innerContent);
@@ -195,7 +195,7 @@ class BlockPropertyResolverTest extends TestCase
             }
         });
 
-        $content = $this->resolver->resolve($data, $locale, $blockFieldMetadata);
+        $content = $this->resolver->resolve($data, $locale, [], $blockFieldMetadata);
         /** @var ContentView[] $innerContent */
         $innerContent = $content->getContent();
         $this->assertCount(1, $innerContent);
@@ -239,7 +239,7 @@ class BlockPropertyResolverTest extends TestCase
         $formMetadata->addItem($tileFieldMetadata);
         $formMetadata->addItem($descriptionFieldMetadata);
 
-        $content = $this->resolver->resolve($data, $locale, $blockFieldMetadata);
+        $content = $this->resolver->resolve($data, $locale, [], $blockFieldMetadata);
         /** @var array<string, mixed> $innerContent */
         $innerContent = $content->getContent();
         // title / description / type

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
@@ -53,11 +53,15 @@ class ImageMapPropertyResolver implements PropertyResolverMetadataAwareInterface
     /**
      * @param array<string, mixed> $params
      */
-    public function resolve(mixed $data, string $locale, FieldMetadata $metadata, array $params = []): ContentView
+    public function resolve(mixed $data, string $locale, array $params = [], ?FieldMetadata $metadata = null): ContentView
     {
         $hotspots = (\is_array($data) && isset($data['hotspots']) && \is_array($data['hotspots'])) && \array_is_list($data['hotspots'])
             ? $data['hotspots']
             : [];
+
+        if (null === $metadata) {
+            throw new \InvalidArgumentException('Metadata must be provided for block resolving.');
+        }
 
         $hotspots = [] !== $hotspots ? $this->resolveHotspots($hotspots, $locale, $metadata) : ContentView::create([], []);
 

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
@@ -22,14 +22,14 @@ use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaReso
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Content\Application\MetadataResolver\MetadataResolver;
-use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 
 /**
  * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
  *
  * @final
  */
-class ImageMapPropertyResolver implements PropertyResolverInterface // TODO we may should implement a PropertyResolverAwareMetadataInterface
+class ImageMapPropertyResolver implements PropertyResolverMetadataAwareInterface
 {
     private MetadataResolver $metadataResolver;
 
@@ -50,16 +50,18 @@ class ImageMapPropertyResolver implements PropertyResolverInterface // TODO we m
         $this->metadataResolver = $metadataResolver;
     }
 
-    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function resolve(mixed $data, string $locale, FieldMetadata $metadata, array $params = []): ContentView
     {
         $hotspots = (\is_array($data) && isset($data['hotspots']) && \is_array($data['hotspots'])) && \array_is_list($data['hotspots'])
             ? $data['hotspots']
             : [];
 
-        $hotspots = [] !== $hotspots ? $this->resolveHotspots($hotspots, $locale, $params) : ContentView::create([], []);
+        $hotspots = [] !== $hotspots ? $this->resolveHotspots($hotspots, $locale, $metadata) : ContentView::create([], []);
 
         $returnedParams = $params;
-        unset($returnedParams['metadata']); // TODO we may should implement a PropertyResolverAwareMetadataInterface
 
         if (!\is_array($data)
             || !isset($data['imageId'])
@@ -92,12 +94,9 @@ class ImageMapPropertyResolver implements PropertyResolverInterface // TODO we m
 
     /**
      * @param non-empty-list<mixed> $hotspots
-     * @param array<string, mixed> $params
      */
-    private function resolveHotspots(array $hotspots, string $locale, array $params): ContentView
+    private function resolveHotspots(array $hotspots, string $locale, FieldMetadata $metadata): ContentView
     {
-        $metadata = $params['metadata'] ?? null;
-        \assert($metadata instanceof FieldMetadata, 'Metadata must be set to resolve hotspots.');
         $metadataTypes = $metadata->getTypes();
 
         $typedFormMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
@@ -239,17 +239,27 @@ class ImageMapPropertyResolverTest extends TestCase
         $this->assertSame(1, $image->getId());
         $this->assertSame('custom_media', $image->getResourceLoaderKey());
 
-        // hotspots represented as ContentView
         $this->assertInstanceOf(ContentView::class, $content['hotspots'] ?? null);
-        $this->assertSame([], $content['hotspots']->getContent());
-        $this->assertSame([], $content['hotspots']->getView());
+        $hotspotsContentView = $content['hotspots'];
+        $this->assertSame([], $hotspotsContentView->getView());
+
+        $hotspots = $hotspotsContentView->getContent();
+        $this->assertIsArray($hotspots);
+        $this->assertCount(2, $hotspots);
+
+        foreach ($hotspots as $hotspotView) {
+            $this->assertInstanceOf(ContentView::class, $hotspotView);
+            $hotspotContent = $hotspotView->getContent();
+            $this->assertIsArray($hotspotContent);
+            $this->assertSame('text', $hotspotContent['type'] ?? null);
+            $this->assertSame(['type' => 'circle'], $hotspotContent['hotspot'] ?? null);
+            $this->assertInstanceOf(ContentView::class, $hotspotContent['title'] ?? null);
+            $this->assertSame('Title', $hotspotContent['title']->getContent());
+            $this->assertSame([], $hotspotContent['title']->getView());
+        }
 
         $this->assertSame([
             'imageId' => 1,
-            'hotspots' => [
-                ['title' => []],
-                ['title' => []],
-            ],
             'resourceLoader' => 'custom_media',
         ], $contentView->getView());
         $this->assertCount(0, $this->logger->cleanLogs());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
@@ -62,7 +62,7 @@ class ImageMapPropertyResolverTest extends TestCase
 
     public function testResolveEmpty(): void
     {
-        $contentView = $this->resolver->resolve(null, 'en');
+        $contentView = $this->resolver->resolve(null, 'en', $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -78,7 +78,7 @@ class ImageMapPropertyResolverTest extends TestCase
 
     public function testResolveParams(): void
     {
-        $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);
+        $contentView = $this->resolver->resolve(null, 'en', $this->createMetadata(), ['custom' => 'params']);
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -98,7 +98,7 @@ class ImageMapPropertyResolverTest extends TestCase
     #[DataProvider('provideUnresolvableData')]
     public function testResolveUnresolvableData(mixed $data): void
     {
-        $contentView = $this->resolver->resolve($data, 'en');
+        $contentView = $this->resolver->resolve($data, 'en', $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -143,7 +143,7 @@ class ImageMapPropertyResolverTest extends TestCase
     #[DataProvider('provideResolvableData')]
     public function testResolveResolvableData(array $data): void
     {
-        $contentView = $this->resolver->resolve($data, 'en', ['metadata' => $this->createMetadata()]);
+        $contentView = $this->resolver->resolve($data, 'en', $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -203,19 +203,31 @@ class ImageMapPropertyResolverTest extends TestCase
         yield 'empty' => [[]];
         yield 'int_id' => [['imageId' => 1]];
         yield 'int_id_with_hotspots' => [
-            ['imageId' => 1, 'hotspots' => [['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'], ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2']]],
+            ['imageId' => 1, 'hotspots' => [
+                ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'],
+                ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2'],
+            ]],
         ];
         yield 'string_id' => [['imageId' => '1']];
-        yield 'string_id_with_hotspots' => [['imageId' => '1', 'hotspots' => [['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'], ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2']]]];
+        yield 'string_id_with_hotspots' => [[
+            'imageId' => '1',
+            'hotspots' => [
+                ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'],
+                ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2'],
+            ],
+        ]];
     }
 
     public function testCustomResourceLoader(): void
     {
         $contentView = $this->resolver->resolve(
-            ['imageId' => 1, 'hotspots' => [['type' => 'text', 'title' => 'Title'], ['type' => 'text', 'title' => 'Title']]],
+            ['imageId' => 1, 'hotspots' => [
+                ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title'],
+                ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title'],
+            ]],
             'en',
+            $this->createMetadata(),
             [
-                'metadata' => $this->createMetadata(),
                 'resourceLoader' => 'custom_media',
             ]
         );
@@ -234,6 +246,10 @@ class ImageMapPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'imageId' => 1,
+            'hotspots' => [
+                ['title' => []],
+                ['title' => []],
+            ],
             'resourceLoader' => 'custom_media',
         ], $contentView->getView());
         $this->assertCount(0, $this->logger->cleanLogs());
@@ -252,7 +268,7 @@ class ImageMapPropertyResolverTest extends TestCase
     #[DataProvider('provideUnresolvableHotspotData')]
     public function testResolveUnresolvableHotspotData(array $data): void
     {
-        $contentView = $this->resolver->resolve($data, 'en', ['metadata' => $this->createMetadata()]);
+        $contentView = $this->resolver->resolve($data, 'en', $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -301,7 +317,10 @@ class ImageMapPropertyResolverTest extends TestCase
 
     public function testResolveGlobalBlockHotspot(): void
     {
-        $data = ['imageId' => 1, 'hotspots' => [['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'], ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2']]];
+        $data = ['imageId' => 1, 'hotspots' => [
+            ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 1'],
+            ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title 2'],
+        ]];
 
         $textFormMetadata = new FormMetadata();
         $textFormMetadata->setKey('text');
@@ -322,7 +341,7 @@ class ImageMapPropertyResolverTest extends TestCase
             }
         });
 
-        $contentView = $this->resolver->resolve($data, 'en', ['metadata' => $this->createGlobalBlockMetadata()]);
+        $contentView = $this->resolver->resolve($data, 'en', $this->createGlobalBlockMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
@@ -62,7 +62,7 @@ class ImageMapPropertyResolverTest extends TestCase
 
     public function testResolveEmpty(): void
     {
-        $contentView = $this->resolver->resolve(null, 'en', $this->createMetadata());
+        $contentView = $this->resolver->resolve(null, 'en', [], $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -78,7 +78,7 @@ class ImageMapPropertyResolverTest extends TestCase
 
     public function testResolveParams(): void
     {
-        $contentView = $this->resolver->resolve(null, 'en', $this->createMetadata(), ['custom' => 'params']);
+        $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params'], $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -98,7 +98,7 @@ class ImageMapPropertyResolverTest extends TestCase
     #[DataProvider('provideUnresolvableData')]
     public function testResolveUnresolvableData(mixed $data): void
     {
-        $contentView = $this->resolver->resolve($data, 'en', $this->createMetadata());
+        $contentView = $this->resolver->resolve($data, 'en', [], $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -143,7 +143,7 @@ class ImageMapPropertyResolverTest extends TestCase
     #[DataProvider('provideResolvableData')]
     public function testResolveResolvableData(array $data): void
     {
-        $contentView = $this->resolver->resolve($data, 'en', $this->createMetadata());
+        $contentView = $this->resolver->resolve($data, 'en', [], $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -226,10 +226,10 @@ class ImageMapPropertyResolverTest extends TestCase
                 ['type' => 'text', 'hotspot' => ['type' => 'circle'], 'title' => 'Title'],
             ]],
             'en',
-            $this->createMetadata(),
             [
                 'resourceLoader' => 'custom_media',
-            ]
+            ],
+            $this->createMetadata(),
         );
 
         $content = $contentView->getContent();
@@ -268,7 +268,7 @@ class ImageMapPropertyResolverTest extends TestCase
     #[DataProvider('provideUnresolvableHotspotData')]
     public function testResolveUnresolvableHotspotData(array $data): void
     {
-        $contentView = $this->resolver->resolve($data, 'en', $this->createMetadata());
+        $contentView = $this->resolver->resolve($data, 'en', [], $this->createMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
@@ -341,7 +341,7 @@ class ImageMapPropertyResolverTest extends TestCase
             }
         });
 
-        $contentView = $this->resolver->resolve($data, 'en', $this->createGlobalBlockMetadata());
+        $contentView = $this->resolver->resolve($data, 'en', [], $this->createGlobalBlockMetadata());
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Related issues/PRs | #7672 
| License | MIT

#### What's in this PR?

Adds the PropertyResolverMetadataAwareInterface.

#### Why?

The BlockPropertyResolver and ImageMapPropertyResolver need the metadata to dynamically resolve the properties. PropertyResolver that do not need the Metadata should not have them in the "params" array, so that they will not be forwarded to the FE.
