### PR TITLE
Remove unneeded call to initPhpcr in AudienceTargetingBundle AdminControllerTest

### DIFF
--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -26,7 +26,6 @@ class AdminControllerTest extends SuluTestCase
         $this->client = $this->createAuthenticatedClient();
         parent::setUp();
         $this->purgeDatabase();
-        $this->initPhpcr();
     }
 
     public function testRulesConfig(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | for https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove unneeded call to initPhpcr in AudienceTargetingBundle AdminControllerTest

#### Why?

The initPhpcr method will be removed in https://github.com/sulu/sulu/pull/7995 to make the AudienceTargetingBundle tests pass this methods will be removed as not longer required.