### PR TITLE
Remove unneeded usage of initPhpcr for ContactBundle AdminControllerTest

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AdminControllerTest.php
@@ -38,7 +38,6 @@ class AdminControllerTest extends SuluTestCase
 
     public function testContactsConfig(): void
     {
-        $this->initPhpcr();
         $em = $this->getEntityManager();
 
         $addressType1 = new AddressType();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995/
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove unneeded usage of initPhpcr for ContactBundle AdminContorllerTest.

#### Why?

PHPCR is not required for this case and we remove all PHPCR related parts in 3.0