### PR TITLE
Add missing upgrade for Sitemap services removal

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -641,6 +641,12 @@ Removed classes / services:
 - `Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapper`
 - `Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface`
 - `Sulu\Bundle\WebsiteBundle\Navigation\NavigationItem`
+- `Sulu\Bundle\WebsiteBundle\Sitemap\SitemapContentQueryBuilder`
+- `Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGenerator`
+- `Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGeneratorInterface`
+- `Sulu\Bundle\WebsiteBundle\Twig\Sitemap\MemoizedSitemapTwigExtension`
+- `Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtension`
+- `Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtensionInterface`
 
 Removed deprecated functions and properties:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs |  https://github.com/sulu/sulu/pull/8101, https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add Upgrade lines about removed sitemap related phpcr services.

#### Why?

Was forgotten in https://github.com/sulu/sulu/pull/8101