### PR TITLE
Remove twig extensions calls in content bundle tests

### DIFF
--- a/packages/content/tests/Application/ExampleTestBundle/Resources/views/base.html.twig
+++ b/packages/content/tests/Application/ExampleTestBundle/Resources/views/base.html.twig
@@ -19,22 +19,7 @@
 </head>
 <body>
 <header>
-    {% block header %}
-        <nav>
-            <ul>
-                <li>
-                    <a href="{{ sulu_content_root_path() }}">Homepage</a>
-                </li>
-
-                {% for item in sulu_navigation_root_tree('main') %}
-                    <li>
-                        <a href="{{ sulu_content_path(item.url, item.webspaceKey) }}"
-                           title="{{ item.title }}">{{ item.title }}</a>
-                    </li>
-                {% endfor %}
-            </ul>
-        </nav>
-    {% endblock %}
+    {% block header %}{% endblock %}
 </header>
 
 <section id="content">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove twig extensions calls in content bundle tests.

#### Why?

Its not in responsability of the content bundle to test or call this twig extensions so keep them out of the content bundle test setup.