### PR TITLE
Remove unneeded access to PHPCR in TagControllerTest

### DIFF
--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\TagBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use PHPCR\SessionInterface;
 use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -23,11 +22,6 @@ class TagControllerTest extends SuluTestCase
      * @var EntityManagerInterface
      */
     protected $em;
-
-    /**
-     * @var SessionInterface
-     */
-    protected $session;
 
     /**
      * @var TagRepositoryInterface
@@ -44,7 +38,6 @@ class TagControllerTest extends SuluTestCase
         $this->client = $this->createAuthenticatedClient();
         $this->em = $this->getEntityManager();
 
-        $this->session = $this->getContainer()->get('doctrine_phpcr')->getConnection();
         $this->tagRepository = $this->getContainer()->get('sulu.repository.tag');
 
         $this->initOrm();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove unneeded access to PHPCR in TagControllerTest

#### Why?

Was never used just accessed.