### PR TITLE
Use request context service instead of container params if no request is available

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.xml
@@ -41,8 +41,7 @@
                 <argument key="base_class">%sulu_core.webspace.base_class%</argument>
             </argument>
             <argument>%kernel.environment%</argument>
-            <argument>%router.request_context.host%</argument>
-            <argument>%router.request_context.scheme%</argument>
+            <argument type="service" id="router.request_context" />
             <argument type="service" id="sulu_admin.metadata_provider_registry" />
 
             <tag name="sulu.localization_provider"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Routing\RequestContext;
 
 #[AsCommand(name: 'sulu:website:dump-sitemap')]
 class DumpSitemapCommand extends Command
@@ -53,24 +54,15 @@ class DumpSitemapCommand extends Command
      */
     private $baseDirectory;
 
-    /**
-     * @var string
-     */
-    private $defaultHost;
-
-    /**
-     * @var string
-     */
-    private $scheme;
-
     public function __construct(
         WebspaceManagerInterface $webspaceManager,
         XmlSitemapDumperInterface $sitemapDumper,
         Filesystem $filesystem,
         string $baseDirectory,
         string $environment,
-        string $scheme,
-        string $defaultHost
+        private string $scheme,
+        string $defaultHost,
+        ?RequestContext $requestContext = null
     ) {
         parent::__construct();
 
@@ -79,8 +71,12 @@ class DumpSitemapCommand extends Command
         $this->filesystem = $filesystem;
         $this->environment = $environment;
         $this->baseDirectory = $baseDirectory;
-        $this->scheme = $scheme;
-        $this->defaultHost = $defaultHost;
+
+        if (null === $requestContext) {
+            @trigger_deprecation('sulu/sulu', '2.6', 'It is deprecated to not pass the request context to "%s".', self::class);
+        } elseif ($requestContext->getScheme() !== $scheme) {
+            @trigger_deprecation('sulu/sulu', '2.6', 'It is deprecated to define a different scheme in kernel parameter "router.request_context.scheme" and "framework.router.default_uri" config. Starting with Sulu 3.0 only "framework.router.default_uri" will be respected in "%s".', self::class);
+        }
     }
 
     protected function configure(): void
@@ -124,7 +120,7 @@ class DumpSitemapCommand extends Command
     /**
      * Clear the sitemap-cache.
      */
-    private function clear()
+    private function clear(): void
     {
         $this->filesystem->remove(\rtrim($this->baseDirectory, '/') . '/' . $this->scheme);
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -24,11 +24,6 @@ use Symfony\Component\Routing\RequestContext;
 #[AsCommand(name: 'sulu:website:dump-sitemap')]
 class DumpSitemapCommand extends Command
 {
-    /**
-     * @var OutputInterface
-     */
-    private $output;
-
     public function __construct(
         private WebspaceManagerInterface $webspaceManager,
         private XmlSitemapDumperInterface $sitemapDumper,
@@ -47,8 +42,6 @@ class DumpSitemapCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->output = $output;
-
         if ($input->getOption('clear')) {
             $this->clear();
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
@@ -25,73 +25,29 @@ use Symfony\Component\Routing\RequestContext;
 class DumpSitemapCommand extends Command
 {
     /**
-     * @var WebspaceManagerInterface
-     */
-    private $webspaceManager;
-
-    /**
-     * @var XmlSitemapDumperInterface
-     */
-    private $sitemapDumper;
-
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
      * @var OutputInterface
      */
     private $output;
 
-    /**
-     * @var string
-     */
-    private $environment;
-
-    /**
-     * @var string
-     */
-    private $baseDirectory;
-
     public function __construct(
-        WebspaceManagerInterface $webspaceManager,
-        XmlSitemapDumperInterface $sitemapDumper,
-        Filesystem $filesystem,
-        string $baseDirectory,
-        string $environment,
-        private string $scheme,
-        string $defaultHost,
-        ?RequestContext $requestContext = null
+        private WebspaceManagerInterface $webspaceManager,
+        private XmlSitemapDumperInterface $sitemapDumper,
+        private Filesystem $filesystem,
+        private string $baseDirectory,
+        private string $environment,
+        private RequestContext $requestContext,
     ) {
         parent::__construct();
-
-        $this->webspaceManager = $webspaceManager;
-        $this->sitemapDumper = $sitemapDumper;
-        $this->filesystem = $filesystem;
-        $this->environment = $environment;
-        $this->baseDirectory = $baseDirectory;
-
-        if (null === $requestContext) {
-            @trigger_deprecation('sulu/sulu', '2.6', 'It is deprecated to not pass the request context to "%s".', self::class);
-        } elseif ($requestContext->getScheme() !== $scheme) {
-            @trigger_deprecation('sulu/sulu', '2.6', 'It is deprecated to define a different scheme in kernel parameter "router.request_context.scheme" and "framework.router.default_uri" config. Starting with Sulu 3.0 only "framework.router.default_uri" will be respected in "%s".', self::class);
-        }
     }
 
     protected function configure(): void
     {
-        $this->addOption('https', null, InputOption::VALUE_NONE, 'Use https scheme for url generation.')
-            ->addOption('clear', null, InputOption::VALUE_NONE, 'Delete all file before start.');
+        $this->addOption('clear', null, InputOption::VALUE_NONE, 'Delete all file before start.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
-
-        if ($input->getOption('https')) {
-            $this->scheme = 'https';
-        }
 
         if ($input->getOption('clear')) {
             $this->clear();
@@ -104,14 +60,14 @@ class DumpSitemapCommand extends Command
         $hosts = [];
         foreach ($portalInformations as $portalInformation) {
             $portalUrl = $portalInformation->getUrl();
-            $urlParts = \parse_url($this->scheme . '://' . $portalUrl);
+            $urlParts = \parse_url($this->requestContext->getScheme() . '://' . $portalUrl);
             $hosts[] = $urlParts['host'];
         }
 
         $hosts = \array_unique(\array_filter($hosts));
 
         foreach ($hosts as $host) {
-            $this->sitemapDumper->dumpHost($this->scheme, $host);
+            $this->sitemapDumper->dumpHost($this->requestContext->getScheme(), $host);
         }
 
         return 0;
@@ -122,6 +78,6 @@ class DumpSitemapCommand extends Command
      */
     private function clear(): void
     {
-        $this->filesystem->remove(\rtrim($this->baseDirectory, '/') . '/' . $this->scheme);
+        $this->filesystem->remove(\rtrim($this->baseDirectory, '/') . '/' . $this->requestContext->getScheme());
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/command.xml
@@ -9,8 +9,6 @@
             <argument type="service" id="filesystem"/>
             <argument>%sulu_website.sitemap.dump_dir%</argument>
             <argument>%kernel.environment%</argument>
-            <argument>%router.request_context.scheme%</argument>
-            <argument>%router.request_context.host%</argument>
             <argument type="service" id="router.request_context" />
 
             <tag name="console.command" />

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/command.xml
@@ -11,6 +11,7 @@
             <argument>%kernel.environment%</argument>
             <argument>%router.request_context.scheme%</argument>
             <argument>%router.request_context.host%</argument>
+            <argument type="service" id="router.request_context" />
 
             <tag name="console.command" />
         </service>

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -27,6 +27,7 @@ use Sulu\Page\Domain\Model\PageInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
 
 /**
  * This class is responsible for loading, reading and caching the portal configuration files.
@@ -54,8 +55,7 @@ class WebspaceManager implements WebspaceManagerInterface
         private RequestStack $requestStack,
         array $options,
         private string $environment,
-        private string $defaultHost,
-        private string $defaultScheme,
+        private RequestContext $requestContext,
         private MetadataProviderRegistry $metadataProviderRegistry,
     ) {
         $this->setOptions($options);
@@ -437,7 +437,7 @@ class WebspaceManager implements WebspaceManagerInterface
 
             $currentRequest = $this->requestStack->getCurrentRequest();
 
-            $host = $currentRequest ? $currentRequest->getHost() : $this->defaultHost;
+            $host = $currentRequest ? $currentRequest->getHost() : $this->requestContext->getHost();
             foreach ($this->getPortalInformations() as $portalInformation) {
                 $portalInformation->setUrl($this->urlReplacer->replaceHost($portalInformation->getUrl(), $host));
                 $portalInformation->setUrlExpression(
@@ -542,7 +542,7 @@ class WebspaceManager implements WebspaceManagerInterface
         $currentRequest = $this->requestStack->getCurrentRequest();
 
         if (!$scheme) {
-            $scheme = $currentRequest ? $currentRequest->getScheme() : $this->defaultScheme;
+            $scheme = $currentRequest ? $currentRequest->getScheme() : $this->requestContext->getScheme();
         }
 
         if (false !== \strpos($portalUrl, '/')) {

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
 
 class WebspaceManagerTest extends WebspaceTestCase
 {
@@ -56,6 +57,11 @@ class WebspaceManagerTest extends WebspaceTestCase
     protected WebspaceManager $webspaceManager;
 
     private string $cacheDirectory;
+
+    /**
+     * @var ObjectProphecy<RequestContext>
+     */
+    private $requestContext;
 
     public function setUp(): void
     {
@@ -93,6 +99,10 @@ class WebspaceManagerTest extends WebspaceTestCase
         $typedMetadata->addForm($overviewMetadata->getKey(), $overviewMetadata);
         $this->formMetadataProvider->getMetadata('page', Argument::cetera())->willReturn($typedMetadata);
 
+        $this->requestContext = $this->prophesize(RequestContext::class);
+        $this->requestContext->getScheme()->willReturn('http');
+        $this->requestContext->getHost()->willReturn('sulu.io');
+
         $this->webspaceManager = new WebspaceManager(
             $this->loader,
             new Replacer(),
@@ -103,8 +113,7 @@ class WebspaceManagerTest extends WebspaceTestCase
                 'cache_class' => 'WebspaceCollectionCache' . \uniqid(),
             ],
             'test',
-            'sulu.io',
-            'http',
+            $this->requestContext->reveal(),
             $this->metadataProviderRegistry,
         );
     }
@@ -564,8 +573,7 @@ class WebspaceManagerTest extends WebspaceTestCase
                 'cache_class' => 'WebspaceCollectionCache' . \uniqid(),
             ],
             'test',
-            'sulu.io',
-            'http',
+            $this->requestContext->reveal(),
             $this->metadataProviderRegistry
         );
 
@@ -606,8 +614,7 @@ class WebspaceManagerTest extends WebspaceTestCase
                 'cache_class' => 'WebspaceCollectionCache' . \uniqid(),
             ],
             'prod',
-            'sulu.io',
-            'http',
+            $this->requestContext->reveal(),
             $this->metadataProviderRegistry,
         );
 
@@ -628,9 +635,8 @@ class WebspaceManagerTest extends WebspaceTestCase
                 'cache_class' => 'WebspaceCollectionCache' . \uniqid(),
             ],
             'prod',
-            'sulu.io',
-            'http',
-            $this->metadataProviderRegistry
+            $this->requestContext->reveal(),
+            $this->metadataProviderRegistry,
         );
 
         $webspaces = $this->webspaceManager->getWebspaceCollection();


### PR DESCRIPTION


This change fixes this issue (described in #7280).

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #7280
| License | MIT

#### What's in this PR?

Changed the way how the default host and scheme is fetched in the WebspaceManager and DumpSitemapCommand. Instead of directly accessing the container params `router.request_context.host` and `router.request_context.scheme` the information is fetched via the `RequestContext` service of Symfony.

#### Why?

The webspace manager, which is configured in the core bundle, relied on the request context container parameters `router.request_context.host` and `router.request_context.scheme` as fallback when no actual request object is available. This might happen during cache warming in a functional test.

But if the request context is configured by Symfony's `framework.router.default_uri` setting like it is described in their [docs](https://symfony.com/doc/current/routing.html#generating-urls-in-commands), the mentioned container parameters still uses the defaults (localhost and http). There is a issue which points this out https://github.com/symfony/symfony/issues/53919.

This could have lead to wrong url generation in a functional test (kernel test case) when the cache is warmed.

