### PR TITLE
Remove unneeded access to PHPCR in ErrorControllerTest

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ErrorControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/ErrorControllerTest.php
@@ -24,12 +24,10 @@ class ErrorControllerTest extends WebsiteTestCase
     public function setUp(): void
     {
         $this->client = $this->createWebsiteClient();
-        $this->initPhpcr();
     }
 
     public function test404ErrorTemplate(): void
     {
-        /* @var KernelBrowser $client */
         $this->client->request('GET', 'http://sulu.lo/_error/404');
 
         $response = $this->client->getResponse();
@@ -39,7 +37,6 @@ class ErrorControllerTest extends WebsiteTestCase
 
     public function testDefaultErrorTemplate(): void
     {
-        /* @var KernelBrowser $client */
         $this->client->request('GET', 'http://sulu.lo/_error/500');
 
         $response = $this->client->getResponse();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove unneeded access to PHPCR in ErrorControllerTest.

#### Why?

For https://github.com/sulu/sulu/pull/7995