### PR TITLE
Do not depend on Page Bundle Translations in Trash Tests

### DIFF
--- a/src/Sulu/Bundle/TrashBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Application/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends SuluTestKernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         parent::registerContainerConfiguration($loader);
+        $loader->load(__DIR__ . '/config/config.yaml');
 
         $envSpecificFile = __DIR__ . '/config/' . $this->getEnvironment() . '/config.yaml';
 

--- a/src/Sulu/Bundle/TrashBundle/Tests/Application/config/config.yaml
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Application/config/config.yaml
@@ -1,0 +1,4 @@
+framework:
+    translator:
+        paths:
+            - '%kernel.project_dir%/translations'

--- a/src/Sulu/Bundle/TrashBundle/Tests/Application/translations/admin.de.json
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Application/translations/admin.de.json
@@ -1,0 +1,4 @@
+{
+    "sulu_activity.resource.examples": "Beispiel",
+    "sulu_activity.resource.examples.translation": "Übersetzung"
+}

--- a/src/Sulu/Bundle/TrashBundle/Tests/Application/translations/admin.en.json
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Application/translations/admin.en.json
@@ -1,0 +1,4 @@
+{
+    "sulu_activity.resource.examples": "Example",
+    "sulu_activity.resource.examples.translation": "Translation"
+}

--- a/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
@@ -68,14 +68,14 @@ class TrashItemControllerTest extends SuluTestCase
         self::setUpUserRole();
 
         static::createTrashItem(
-            'pages',
+            'examples',
             'resource-id-1',
             'unlocalized title',
             ['key1' => 'value1', 'key2' => 'value2']
         );
 
         static::createTrashItem(
-            'pages',
+            'examples',
             'resource-id-2',
             ['de' => 'german title', 'en' => 'english title', 'fr' => 'french title'],
             ['key1' => 'value1', 'key2' => 'value2'],
@@ -89,8 +89,8 @@ class TrashItemControllerTest extends SuluTestCase
         self::assertCount(2, $content['_embedded']['trash_items']);
         self::assertSame('unlocalized title', $content['_embedded']['trash_items'][0]['resourceTitle']);
         self::assertSame('german title', $content['_embedded']['trash_items'][1]['resourceTitle']);
-        self::assertSame('Page', $content['_embedded']['trash_items'][0]['resourceType']);
-        self::assertSame('Page (Translation)', $content['_embedded']['trash_items'][1]['resourceType']);
+        self::assertSame('Example', $content['_embedded']['trash_items'][0]['resourceType']);
+        self::assertSame('Example (Translation)', $content['_embedded']['trash_items'][1]['resourceType']);
 
         $this->client->jsonRequest('GET', '/api/trash-items', ['locale' => 'en']);
         $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -98,8 +98,8 @@ class TrashItemControllerTest extends SuluTestCase
         self::assertCount(2, $content['_embedded']['trash_items']);
         self::assertSame('unlocalized title', $content['_embedded']['trash_items'][0]['resourceTitle']);
         self::assertSame('english title', $content['_embedded']['trash_items'][1]['resourceTitle']);
-        self::assertSame('Page', $content['_embedded']['trash_items'][0]['resourceType']);
-        self::assertSame('Page (Translation)', $content['_embedded']['trash_items'][1]['resourceType']);
+        self::assertSame('Example', $content['_embedded']['trash_items'][0]['resourceType']);
+        self::assertSame('Example (Translation)', $content['_embedded']['trash_items'][1]['resourceType']);
     }
 
     public function testCgetActionWithSecurity(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Do not depend on Page Bundle Translations in Trash Tests.

#### Why?

Tests should work without the other bundles translations. Stumbled over this when removing the old phpcr page bundle: https://github.com/sulu/sulu/pull/7995.