### PR TITLE
Remove Page Bundle usage from Preview Tests

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Application/Manager/PreviewLinkManager.php
+++ b/src/Sulu/Bundle/PreviewBundle/Application/Manager/PreviewLinkManager.php
@@ -17,6 +17,8 @@ use Sulu\Bundle\PreviewBundle\Domain\Event\PreviewLinkRevokedEvent;
 use Sulu\Bundle\PreviewBundle\Domain\Model\PreviewLinkInterface;
 use Sulu\Bundle\PreviewBundle\Domain\Repository\PreviewLinkRepositoryInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistryInterface;
+use Sulu\Bundle\PreviewBundle\Preview\PreviewContext;
+use Sulu\Bundle\PreviewBundle\Preview\Provider\PreviewDefaultsProviderInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 class PreviewLinkManager implements PreviewLinkManagerInterface
@@ -87,6 +89,10 @@ class PreviewLinkManager implements PreviewLinkManagerInterface
     protected function resolveSecurityContext(string $resourceKey, string $resourceId, string $locale): ?string
     {
         $provider = $this->previewObjectProviderRegistry->getPreviewObjectProvider($resourceKey);
+
+        if ($provider instanceof PreviewDefaultsProviderInterface) {
+            return $provider->getSecurityContext(new PreviewContext($resourceId, $locale));
+        }
 
         return $provider->getSecurityContext($resourceId, $locale);
     }

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/ExamplePreviewDefaultsProvider.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/ExamplePreviewDefaultsProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Tests\Application;
+
+use Sulu\Bundle\PreviewBundle\Preview\PreviewContext;
+use Sulu\Bundle\PreviewBundle\Preview\Provider\PreviewDefaultsProviderInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
+
+/**
+ * @internal only for tests
+ */
+final readonly class ExamplePreviewDefaultsProvider implements PreviewDefaultsProviderInterface
+{
+    public function getDefaults(PreviewContext $previewContext): array
+    {
+        return [
+            '_controller' => TemplateController::class . '::templateAction',
+            'template' => 'example.html.twig',
+            'previewContext' => $previewContext,
+        ];
+    }
+
+    public function updateValues(PreviewContext $previewContext, array $defaults, array $data): array
+    {
+        return [
+            ...$defaults,
+            ...$data,
+        ];
+    }
+
+    public function updateContext(PreviewContext $previewContext, array $defaults, array $context): array
+    {
+        return [
+            ...$defaults,
+            ...$context,
+        ];
+    }
+
+    public function getSecurityContext(PreviewContext $previewContext): ?string
+    {
+        return null;
+    }
+}

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/Kernel.php
@@ -23,3 +23,6 @@ class Kernel extends SuluTestKernel
         $loader->load(__DIR__ . '/config/config.yml');
     }
 }
+
+// Needed for preview PreviewKernelFactory
+\class_alias(Kernel::class, 'App\\Kernel');

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/PreviewKernel.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/PreviewKernel.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Tests\Application;
+
+use Sulu\Bundle\PreviewBundle\Preview\Renderer\PreviewKernel as SuluPreviewKernel;
+
+class PreviewKernel extends SuluPreviewKernel
+{
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+}

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/PreviewKernelFactory.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/PreviewKernelFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PreviewBundle\Tests\Application;
+
+use Sulu\Bundle\PreviewBundle\Preview\Renderer\KernelFactoryInterface;
+use Sulu\Component\HttpKernel\SuluKernel;
+
+class PreviewKernelFactory implements KernelFactoryInterface
+{
+    public function __construct(private readonly string $environment)
+    {
+    }
+
+    public function create()
+    {
+        $kernel = new PreviewKernel($this->environment, 'dev' === $this->environment, SuluKernel::CONTEXT_WEBSITE);
+        $kernel->boot();
+
+        return $kernel;
+    }
+}

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/config/config.yml
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/config/config.yml
@@ -2,3 +2,21 @@ services:
     sulu_preview_test.preview.renderer:
         alias: sulu_preview.preview.renderer
         public: true
+
+    sulu_preview_test.example_preview_object_provider:
+        class: Sulu\Bundle\PreviewBundle\Tests\Application\ExamplePreviewDefaultsProvider
+        arguments: []
+        tags:
+            - { name: 'sulu.context', context: 'admin' }
+            - { name: 'sulu_preview.object_provider', provider-key: 'examples' }
+
+    sulu_preview.preview.kernel_factory:
+        class: Sulu\Bundle\PreviewBundle\Tests\Application\PreviewKernelFactory
+        arguments:
+            - '%kernel.environment%'
+
+sulu_admin: # ToDo Remove as soon as not required anymore
+    templates:
+        page:
+            directories:
+                app: '%kernel.project_dir%/config/templates/pages'

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/templates/example.html.twig
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/templates/example.html.twig
@@ -1,0 +1,11 @@
+<html>
+    <head>
+        <title>Test</title>
+    </head>
+    <body>
+        {% block content %}
+            ID: {{ app.request.attributes.get('previewContext').id }} <br/>
+            Locale: {{ app.request.attributes.get('previewContext').locale }}
+        {% endblock %}
+    </body>
+</html>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove Page Bundle usage from Preview Tests.

#### Why?

For the [cleanup](https://github.com/sulu/sulu/pull/7995) I stumbled over that the PreviewLink tests depend on the page bundle. Instead a own preview defaults route provider is now created unrelated to any entity.