### PR TITLE
Fix missing global block copy reference

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -42375,7 +42375,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''href'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 4
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
 
 		-
@@ -42385,9 +42385,9 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
 
 		-
-			message: '#^Cannot access offset ''items'' on mixed\.$#'
+			message: '#^Cannot access offset ''link_to_page'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
 
 		-
@@ -42399,7 +42399,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 3
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
 
 		-
@@ -68965,12 +68965,6 @@ parameters:
 			path: src/Sulu/Component/Content/Document/Structure/Structure.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Document\\Structure\\Structure\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Content/Document/Structure/Structure.php
-
-		-
 			message: '#^Parameter \#1 \$name of method Sulu\\Component\\Content\\Document\\Structure\\Structure\:\:getProperty\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
@@ -68980,12 +68974,6 @@ parameters:
 			message: '#^Possibly invalid array key type mixed\.$#'
 			identifier: offsetAccess.invalidOffset
 			count: 2
-			path: src/Sulu/Component/Content/Document/Structure/Structure.php
-
-		-
-			message: '#^Property Sulu\\Component\\Content\\Document\\Structure\\Structure\:\:\$properties type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
 			path: src/Sulu/Component/Content/Document/Structure/Structure.php
 
 		-
@@ -69038,12 +69026,6 @@ parameters:
 
 		-
 			message: '#^Method Sulu\\Component\\Content\\Document\\Structure\\StructureInterface\:\:setStagedData\(\) has parameter \$stagedData with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Content/Document/Structure/StructureInterface.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Document\\Structure\\StructureInterface\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Content/Document/Structure/StructureInterface.php

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -783,7 +783,7 @@ class WebspaceCopyCommand extends Command
             return $children;
         }
         $result = $this->structureMetadataFactory->getStructureMetadata('block', $refType);
-        if(!$result) {
+        if (!$result) {
             return $children;
         }
 

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -27,7 +27,6 @@ use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\ItemMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
-use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -24,6 +24,7 @@ use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Metadata\BlockMetadata;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\ItemMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
@@ -63,7 +64,8 @@ class WebspaceCopyCommand extends Command
         private DocumentManagerInterface $documentManager,
         private SessionManagerInterface $sessionManager,
         private DocumentInspector $documentInspector,
-        private HtmlTagExtractor $htmlTagExtractor
+        private HtmlTagExtractor $htmlTagExtractor,
+        private StructureMetadataFactoryInterface $structureMetadataFactory,
     ) {
         parent::__construct();
     }
@@ -474,8 +476,15 @@ class WebspaceCopyCommand extends Command
         foreach ($structureArray[$property->getName()] as &$structure) {
             /** @var ItemMetadata $component */
             $component = $property->getComponentByName($structure['type']);
+            $children = $component->getChildren();
+            if ($component->hasTag('sulu.global_block')) {
+                $tag = $component->getTag('sulu.global_block');
+                $refType = $tag['attributes']['global_block'];
+                $result = $this->structureMetadataFactory->getStructureMetadata('block', $refType);
+                $children = $result->getProperties();
+            }
             /** @var PropertyMetadata $child */
-            foreach ($component->getChildren() as $child) {
+            foreach ($children as $child) {
                 if ($structure[$child->getName()]) {
                     $this->processContentType(
                         $child,

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -476,13 +476,7 @@ class WebspaceCopyCommand extends Command
         foreach ($structureArray[$property->getName()] as &$structure) {
             /** @var ItemMetadata $component */
             $component = $property->getComponentByName($structure['type']);
-            $children = $component->getChildren();
-            if ($component->hasTag('sulu.global_block')) {
-                $tag = $component->getTag('sulu.global_block');
-                $refType = $tag['attributes']['global_block'];
-                $result = $this->structureMetadataFactory->getStructureMetadata('block', $refType);
-                $children = $result->getProperties();
-            }
+            $children = $this->getBlockConfigChildren($component);
             /** @var PropertyMetadata $child */
             foreach ($children as $child) {
                 if ($structure[$child->getName()]) {
@@ -771,5 +765,24 @@ class WebspaceCopyCommand extends Command
 
         $this->documentManager->persist($document, $locale, $persistOptions);
         $this->documentManager->flush();
+    }
+
+    /**
+     * @param ItemMetadata $component
+     * @return PropertyMetadata[]
+     */
+    protected function getBlockConfigChildren(ItemMetadata $component): array
+    {
+        $children = $component->getChildren();
+        if ($component->hasTag('sulu.global_block') === false) {
+            return $children;
+        }
+        $tag = $component->getTag('sulu.global_block');
+        $refType = $tag['attributes']['global_block'] ?? null;
+        if(empty($refType)) {
+            return $children;
+        }
+        $result = $this->structureMetadataFactory->getStructureMetadata('block', $refType);
+        return $result->getProperties();
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -27,6 +27,7 @@ use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\ItemMetadata;
 use Sulu\Component\Content\Metadata\PropertyMetadata;
+use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\PHPCR\SessionManager\SessionManagerInterface;
@@ -768,7 +769,7 @@ class WebspaceCopyCommand extends Command
     }
 
     /**
-     * @return PropertyMetadata[]
+     * @return ItemMetadata[]
      */
     protected function getBlockConfigChildren(ItemMetadata $component): array
     {
@@ -782,6 +783,9 @@ class WebspaceCopyCommand extends Command
             return $children;
         }
         $result = $this->structureMetadataFactory->getStructureMetadata('block', $refType);
+        if(!$result) {
+            return $children;
+        }
 
         return $result->getProperties();
     }

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -777,8 +777,11 @@ class WebspaceCopyCommand extends Command
             return $children;
         }
         $tag = $component->getTag('sulu.global_block');
+        if (!\is_array($tag['attributes'] ?? null)) {
+            return $children;
+        }
         $refType = $tag['attributes']['global_block'] ?? null;
-        if (empty($refType)) {
+        if (!\is_string($refType)) {
             return $children;
         }
         $result = $this->structureMetadataFactory->getStructureMetadata('block', $refType);

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -774,15 +774,16 @@ class WebspaceCopyCommand extends Command
     protected function getBlockConfigChildren(ItemMetadata $component): array
     {
         $children = $component->getChildren();
-        if ($component->hasTag('sulu.global_block') === false) {
+        if (!$component->hasTag('sulu.global_block')) {
             return $children;
         }
         $tag = $component->getTag('sulu.global_block');
         $refType = $tag['attributes']['global_block'] ?? null;
-        if(empty($refType)) {
+        if (empty($refType)) {
             return $children;
         }
         $result = $this->structureMetadataFactory->getStructureMetadata('block', $refType);
+
         return $result->getProperties();
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -768,7 +768,6 @@ class WebspaceCopyCommand extends Command
     }
 
     /**
-     * @param ItemMetadata $component
      * @return PropertyMetadata[]
      */
     protected function getBlockConfigChildren(ItemMetadata $component): array

--- a/src/Sulu/Bundle/PageBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/PageBundle/Resources/config/command.xml
@@ -65,6 +65,7 @@
             <argument type="service" id="sulu.phpcr.session"/>
             <argument type="service" id="sulu_document_manager.document_inspector"/>
             <argument type="service" id="sulu_markup.parser.html_extractor"/>
+            <argument type="service" id="sulu_page.structure.factory"/>
 
             <tag name="console.command"/>
         </service>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/blocks/link.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/blocks/link.xml
@@ -1,0 +1,12 @@
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd"
+>
+    <key>link</key>
+    <meta>
+        <title>Link</title>
+    </meta>
+    <properties>
+        <property name="link_to_page" type="link"/>
+    </properties>
+</template>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/ref_content_links.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/ref_content_links.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>internallinks</key>
+
+    <view>default</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line"/>
+        <property name="url" type="resource_locator">
+            <tag name="sulu.rlp"/>
+        </property>
+        <block name="modules">
+            <types>
+                <type ref="link" />
+            </types>
+        </block>
+    </properties>
+</template>

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
@@ -49,7 +49,8 @@ class WebspaceCopyCommandTest extends SuluTestCase
             $this->getContainer()->get('sulu_document_manager.document_manager'),
             $this->getContainer()->get('sulu.phpcr.session'),
             $this->getContainer()->get('sulu_document_manager.document_inspector'),
-            $this->getContainer()->get('sulu_markup.parser.html_extractor')
+            $this->getContainer()->get('sulu_markup.parser.html_extractor'),
+            $this->getContainer()->get('sulu_page.structure.factory')
         );
         $command->setApplication($application);
         $this->tester = new CommandTester($command);
@@ -109,7 +110,7 @@ class WebspaceCopyCommandTest extends SuluTestCase
 
         /** @var HomeDocument $baseDocument */
         $homeDocumentDestination = $this->documentManager->find('/cmf/destination_io/contents');
-        $this->assertCount(6, $homeDocumentDestination->getChildren());
+        $this->assertCount(7, $homeDocumentDestination->getChildren());
 
         $this->checkRedirectInternal();
         $this->checkSmartContentReference();
@@ -119,6 +120,7 @@ class WebspaceCopyCommandTest extends SuluTestCase
         $this->checkSingleInternalLink();
         $this->checkTextEditorLinkInBlock();
         $this->checkLinkContentType();
+        $this->checkLinksInGlobalBlock();
     }
 
     protected function checkRedirectInternal()
@@ -217,6 +219,18 @@ class WebspaceCopyCommandTest extends SuluTestCase
         $this->assertSame($targetDocument->getUuid(), $page6->getStructure()->toArray()['link_to_page']['href']);
         $this->assertSame($targetDocumentMagicProvider->getUuid(), $page6->getStructure()->toArray()['link_to_other_page']['href']);
         $this->assertSame('https://sulu.io', $page6->getStructure()->toArray()['external_link']['href']);
+    }
+
+    /**
+     * @return void
+     */
+    protected function checkLinksInGlobalBlock()
+    {
+        /** @var PageDocument $targetDocument */
+        $targetDocument = $this->documentManager->find('/cmf/destination_io/contents/node6', 'de');
+        /** @var PageDocument $page7 */
+        $page7 = $this->documentManager->find('/cmf/destination_io/contents/node7', 'de');
+        $this->assertSame($targetDocument->getUuid(), $page7->getStructure()->toArray()['modules'][0]['link_to_page']['href']);
     }
 
     /**
@@ -496,6 +510,35 @@ class WebspaceCopyCommandTest extends SuluTestCase
         );
         $this->documentManager->persist(
             $page6,
+            'de',
+            [
+                'parent_path' => '/cmf/sulu_io/contents',
+            ]
+        );
+
+        $page7 = $this->documentManager->create('page');
+        $page7->setStructureType('ref_content_links');
+        $page7->setTitle('Node7');
+        $page7->getStructure()->bind(
+            [
+                'title' => 'Node7',
+                'modules' => [
+                    'type' => 'link',
+                    'link_to_page' => [
+                        'provider' => 'page',
+                        'target' => '_self',
+                        'anchor' => null,
+                        'query' => null,
+                        'href' => $page6->getUuid(),
+                        'title' => null,
+                        'rel' => null,
+                        'locale' => 'de',
+                    ],
+                ],
+            ]
+        );
+        $this->documentManager->persist(
+            $page7,
             'de',
             [
                 'parent_path' => '/cmf/sulu_io/contents',

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
@@ -516,6 +516,7 @@ class WebspaceCopyCommandTest extends SuluTestCase
             ]
         );
 
+        /** @var PageDocument $page7 */
         $page7 = $this->documentManager->create('page');
         $page7->setStructureType('ref_content_links');
         $page7->setTitle('Node7');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Command/WebspaceCopyCommandTest.php
@@ -163,7 +163,8 @@ class WebspaceCopyCommandTest extends SuluTestCase
         $targetDocument3 = $this->documentManager->find('/cmf/test_io/contents', 'es');
         /** @var PageDocument $page2_1 */
         $page2_1 = $this->documentManager->find('/cmf/destination_io/contents/node5', 'es');
-        $structure = $page2_1->getStructure()->toArray()['teasers'];
+        $structure = $page2_1->getStructure()->toArray()['teasers'] ?? [];
+        $this->assertIsArray($structure);
         $this->assertSame($targetDocument1->getUuid(), $structure['items'][0]['id']);
         $this->assertSame($targetDocument2->getUuid(), $structure['items'][1]['id']);
         $this->assertSame($targetDocument3->getUuid(), $structure['items'][2]['id']);

--- a/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
+++ b/src/Sulu/Component/Content/Document/Structure/ManagedStructure.php
@@ -35,12 +35,12 @@ class ManagedStructure extends Structure
     private $node;
 
     /**
-     * @var PropertyInterface[]
+     * @var array<string, PropertyInterface>
      */
     private $legacyProperties = [];
 
     /**
-     * @var PropertyValue[]
+     * @var array<string, PropertyValue>
      */
     private $propertyValues = [];
 

--- a/src/Sulu/Component/Content/Document/Structure/Structure.php
+++ b/src/Sulu/Component/Content/Document/Structure/Structure.php
@@ -17,7 +17,7 @@ namespace Sulu\Component\Content\Document\Structure;
 class Structure implements StructureInterface
 {
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $properties = [];
 

--- a/src/Sulu/Component/Content/Document/Structure/StructureInterface.php
+++ b/src/Sulu/Component/Content/Document/Structure/StructureInterface.php
@@ -56,7 +56,7 @@ interface StructureInterface extends \ArrayAccess
     /**
      * Return an array representation of the containers property values.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function toArray();
 


### PR DESCRIPTION
#8120

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #8120 
| License | MIT

#### What's in this PR?

Replaces link references during websiteCopyCommand, whcih are configured "below" global block configuration.

#### Why?

Fixes #8120 . This allow to update more link references.
