### PR TITLE
Fix no search results on repeated search

### DIFF
--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/stores/searchStore.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/stores/searchStore.js
@@ -39,7 +39,6 @@ class SearchStore {
     }
 
     @action search(query: ?string, index: ?string) {
-        this.resetResults();
         this.query = query;
         this.indexName = index;
     }

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/stores/searchStore.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/stores/searchStore.js
@@ -39,12 +39,12 @@ class SearchStore {
     }
 
     @action search(query: ?string, index: ?string) {
+        this.resetResults();
         this.query = query;
         this.indexName = index;
     }
 
     @action resetResults() {
-        this.result.splice(0, this.result.length);
         this.page = 1;
         this.pages = undefined;
         this.total = undefined;

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/stores/SearchStore.test.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/stores/SearchStore.test.js
@@ -40,8 +40,8 @@ test.each([
     });
 });
 
-test('Do not send search request when no search term is given and reset to empty array', () => {
+test('Do not send search request when no search term is given', () => {
     searchStore.search(undefined);
     expect(ResourceRequester.getList).not.toBeCalled();
-    expect(searchStore.result).toEqual([]);
+    expect(searchStore.result).toEqual([{ id: 1 }]);
 });

--- a/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/stores/SearchStore.test.js
+++ b/src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/stores/SearchStore.test.js
@@ -43,5 +43,5 @@ test.each([
 test('Do not send search request when no search term is given', () => {
     searchStore.search(undefined);
     expect(ResourceRequester.getList).not.toBeCalled();
-    expect(searchStore.result).toEqual([{ id: 1 }]);
+    expect(searchStore.result).toEqual([{id: 1}]);
 });


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8058
| Related issues/PRs | #8058
| License | MIT
| Documentation PR | -

# What's in this PR?

Fixes the issue with the global search where it wouldn't display search results if you press enter immediately again after searching.

#### Why?

#8058