### PR TITLE
Add groups and add the full functionality to the article-bundle

### DIFF
--- a/packages/article/config/lists/articles.xml
+++ b/packages/article/config/lists/articles.xml
@@ -87,6 +87,20 @@
             <transformer type="title"/>
         </case-property>
 
+        <property name="dimensionContentTemplateKey" visibility="never">
+            <field-name>templateKey</field-name>
+            <entity-name>dimensionContent</entity-name>
+
+            <joins ref="dimensionContent"/>
+        </property>
+
+        <property name="ghostDimensionContentTemplateKey" visibility="never">
+            <field-name>templateKey</field-name>
+            <entity-name>ghostDimensionContent</entity-name>
+
+            <joins ref="ghostDimensionContent"/>
+        </property>
+
         <concatenation-property name="author" visibility="yes" translation="sulu_admin.author" glue=" " sortable="false">
             <field>
                 <field-name>firstName</field-name>

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -19,6 +19,8 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -49,111 +51,192 @@ class ArticleAdmin extends Admin
         private SecurityCheckerInterface $securityChecker,
         private LocalizationManagerInterface $localizationManager,
         private ActivityViewBuilderFactoryInterface $activityViewBuilderFactory,
+        private GroupProviderInterface $groupProvider,
     ) {
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
     {
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $navigationItem = new NavigationItem('sulu_article.articles');
-            $navigationItem->setPosition(20);
-            $navigationItem->setIcon('su-newspaper');
-            $navigationItem->setView(static::LIST_VIEW);
-
-            $navigationItemCollection->add($navigationItem);
+        if (!$this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            return;
         }
+
+        $hasArticleTypeWithEditPermissions = false;
+        foreach ($this->groupProvider->getGroups() as $group) {
+            $securityContext = static::getArticleSecurityContext($group->identifier);
+            if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
+                continue;
+            }
+
+            $hasArticleTypeWithEditPermissions = true;
+
+            break;
+        }
+
+        if (!$hasArticleTypeWithEditPermissions) {
+            return;
+        }
+
+        $navigationItem = new NavigationItem('sulu_article.articles');
+        $navigationItem->setPosition(20);
+        $navigationItem->setIcon('su-newspaper');
+        $navigationItem->setView(static::LIST_VIEW);
+
+        $navigationItemCollection->add($navigationItem);
     }
 
     public function configureViews(ViewCollection $viewCollection): void
     {
-        $bundlePrefix = 'sulu_article.';
+        if (!$this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            return;
+        }
+
         $locales = $this->localizationManager->getLocales();
         $resourceKey = ArticleInterface::RESOURCE_KEY;
 
-        $listToolbarActions = [];
+        $viewCollection->add(
+            $this->viewBuilderFactory->createTabViewBuilder(static::LIST_VIEW, '/articles')
+                ->addRouterAttributesToBlacklist(['active', 'filter', 'limit', 'page', 'search', 'sortColumn', 'sortOrder']),
+        );
 
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
-        }
-
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
-        }
-
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
-            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
-        }
-
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $viewCollection->add(
-                $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/' . $resourceKey . '/:locale')
-                    ->setResourceKey($resourceKey)
-                    ->setListKey($resourceKey)
-                    ->setTitle($bundlePrefix . $resourceKey)
-                    ->addListAdapters(['table'])
-                    ->addLocales($locales)
-                    ->setDefaultLocale($locales[0])
-                    ->setAddView(static::ADD_TABS_VIEW)
-                    ->setEditView(static::EDIT_TABS_VIEW)
-                    ->addToolbarActions($listToolbarActions)
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_TABS_VIEW, '/' . $resourceKey . '/:locale/add')
-                    ->setResourceKey($resourceKey)
-                    ->addLocales($locales)
-                    ->setBackView(static::LIST_VIEW)
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_TABS_VIEW, '/' . $resourceKey . '/:locale/:id') // TODO should be uuid
-                    ->setResourceKey($resourceKey)
-                    ->addLocales($locales)
-                    ->setBackView(static::LIST_VIEW)
-                    ->setTitleProperty('name')
-            );
-
-            $viewBuilders = $this->contentViewBuilderFactory->createViews(
-                ArticleInterface::class,
-                static::EDIT_TABS_VIEW,
-                static::ADD_TABS_VIEW,
-                static::SECURITY_CONTEXT
-            );
-
-            foreach ($viewBuilders as $viewBuilder) {
-                $viewCollection->add($viewBuilder);
-            }
-
-            if ($this->activityViewBuilderFactory->hasActivityListPermission()) {
-                $insightsResourceTabViewName = ArticleAdmin::EDIT_TABS_VIEW . '.insights';
-                $viewCollection->add(
-                    $this->activityViewBuilderFactory
-                        ->createActivityListViewBuilder(
-                            $insightsResourceTabViewName . '.activity',
-                            '/activities',
-                            ArticleInterface::RESOURCE_KEY
-                        )
-                        ->setParent($insightsResourceTabViewName)
-                );
-            }
+        foreach ($this->groupProvider->getGroups() as $group) {
+            $this->configureGroupViews($group, $locales, $resourceKey, $viewCollection);
         }
     }
 
+    private function hasPermission(string $groupIdentifier, string $permission): bool
+    {
+        return $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, $permission)
+            && $this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), $permission);
+    }
+
     /**
-     * @return mixed[]
+     * @param string[] $locales
      */
+    private function configureGroupViews(FormGroup $group, array $locales, string $resourceKey, ViewCollection $viewCollection): void
+    {
+        if (!$this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+            return;
+        }
+
+        $groupIdentifier = $group->identifier;
+
+        $listToolbarActions = [];
+
+        if ($this->hasPermission($groupIdentifier, PermissionTypes::ADD)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
+        }
+
+        if ($this->hasPermission($groupIdentifier, PermissionTypes::DELETE)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
+        }
+
+        if ($this->hasPermission($groupIdentifier, PermissionTypes::VIEW)) {
+            $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
+        }
+
+        $viewCollection->add(
+            $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW . '_' . $groupIdentifier, '/:locale/' . $groupIdentifier)
+                ->setResourceKey($resourceKey)
+                ->setListKey($resourceKey)
+                ->setTitle($group->title)
+                ->addListAdapters(['table'])
+                ->setTabTitle($group->title)
+                ->addLocales($locales)
+                ->addRequestParameters(['templates' => \implode(',', $group->templates)])
+                ->setDefaultLocale($locales[0] ?? '')
+                ->setAddView(static::ADD_TABS_VIEW . '_' . $groupIdentifier)
+                ->setEditView(static::EDIT_TABS_VIEW . '_' . $groupIdentifier)
+                ->addToolbarActions($listToolbarActions)
+                ->setParent(static::LIST_VIEW),
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_TABS_VIEW . '_' . $groupIdentifier, '/:locale/' . $groupIdentifier . '/add')
+                ->setResourceKey($resourceKey)
+                ->addLocales($locales)
+                ->setBackView(static::LIST_VIEW),
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_TABS_VIEW . '_' . $groupIdentifier, '/:locale/' . $groupIdentifier . '/:id') // TODO should be uuid
+                ->setResourceKey($resourceKey)
+                ->addLocales($locales)
+                ->setBackView(static::LIST_VIEW)
+                ->setTitleProperty('name'),
+        );
+
+        $viewBuilders = $this->contentViewBuilderFactory->createViews(
+            ArticleInterface::class,
+            static::EDIT_TABS_VIEW . '_' . $groupIdentifier,
+            static::ADD_TABS_VIEW . '_' . $groupIdentifier,
+            $this->getArticleSecurityContext($groupIdentifier),
+        );
+
+        foreach ($viewBuilders as $viewBuilder) {
+            $viewCollection->add($viewBuilder);
+        }
+
+        $editView = $viewCollection->get(static::EDIT_TABS_VIEW . '_' . $groupIdentifier . '.content');
+        if (\method_exists($editView, 'addMetadataRequestParameters')) {
+            $editView->addMetadataRequestParameters([
+                'templates' => \implode(',', $group->templates),
+            ]);
+        }
+
+        $addView = $viewCollection->get(static::ADD_TABS_VIEW . '_' . $groupIdentifier . '.content');
+        if (\method_exists($addView, 'addMetadataRequestParameters')) {
+            $addView->addMetadataRequestParameters([
+                'templates' => \implode(',', $group->templates),
+            ]);
+        }
+
+        $insightsResourceTabViewName = self::EDIT_TABS_VIEW . '_' . $groupIdentifier . '.insights';
+        if ($viewCollection->has($insightsResourceTabViewName) && $this->activityViewBuilderFactory->hasActivityListPermission()) {
+            $viewCollection->add(
+                $this->activityViewBuilderFactory
+                    ->createActivityListViewBuilder(
+                        $insightsResourceTabViewName . '.activity',
+                        '/activities',
+                        ArticleInterface::RESOURCE_KEY,
+                    )
+                    ->setParent($insightsResourceTabViewName),
+            );
+        }
+    }
+
     public function getSecurityContexts()
     {
+        $securityContext = [];
+
+        foreach ($this->groupProvider->getGroups() as $group) {
+            $securityContext[static::getArticleSecurityContext($group->identifier)] = [
+                PermissionTypes::VIEW,
+                PermissionTypes::ADD,
+                PermissionTypes::EDIT,
+                PermissionTypes::DELETE,
+                PermissionTypes::LIVE,
+            ];
+        }
+
         return [
             'Sulu' => [
-                'Global' => [
-                    static::SECURITY_CONTEXT => [
-                        PermissionTypes::VIEW,
-                        PermissionTypes::ADD,
-                        PermissionTypes::EDIT,
-                        PermissionTypes::DELETE,
-                        PermissionTypes::LIVE,
+                'Article' => \array_merge(
+                    [
+                        static::SECURITY_CONTEXT => [
+                            PermissionTypes::VIEW,
+                            PermissionTypes::ADD,
+                            PermissionTypes::EDIT,
+                            PermissionTypes::DELETE,
+                            PermissionTypes::LIVE,
+                        ],
                     ],
-                ],
+                    $securityContext,
+                ),
             ],
         ];
+    }
+
+    public static function getArticleSecurityContext(string $groupIdentifier): string
+    {
+        return \sprintf('%s_%s', static::SECURITY_CONTEXT, $groupIdentifier);
     }
 }

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -62,15 +64,19 @@ class ArticleAdmin extends Admin
         }
 
         $hasArticleTypeWithEditPermissions = false;
-        foreach ($this->groupProvider->getGroups() as $group) {
-            $securityContext = static::getArticleSecurityContext($group->identifier);
-            if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
-                continue;
-            }
-
+        if (1 === \count($this->groupProvider->getGroups())) {
             $hasArticleTypeWithEditPermissions = true;
+        } else {
+            foreach ($this->groupProvider->getGroups() as $group) {
+                $securityContext = static::getArticleSecurityContext($group->identifier);
+                if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
+                    continue;
+                }
 
-            break;
+                $hasArticleTypeWithEditPermissions = true;
+
+                break;
+            }
         }
 
         if (!$hasArticleTypeWithEditPermissions) {
@@ -99,23 +105,29 @@ class ArticleAdmin extends Admin
                 ->addRouterAttributesToBlacklist(['active', 'filter', 'limit', 'page', 'search', 'sortColumn', 'sortOrder']),
         );
 
-        foreach ($this->groupProvider->getGroups() as $group) {
-            $this->configureGroupViews($group, $locales, $resourceKey, $viewCollection);
+        $groups = $this->groupProvider->getGroups();
+        foreach ($groups as $group) {
+            $securityContext = static::getArticleSecurityContext($group->identifier);
+            if (1 === \count($groups)) {
+                $securityContext = static::SECURITY_CONTEXT;
+            }
+
+            $this->configureGroupViews($group, $locales, $resourceKey, $viewCollection, $securityContext);
         }
     }
 
-    private function hasPermission(string $groupIdentifier, string $permission): bool
+    private function hasPermission(string $groupIdentifier, string $permission, bool $checkGroup): bool
     {
         return $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, $permission)
-            && $this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), $permission);
+            && (false === $checkGroup || $this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), $permission));
     }
 
     /**
      * @param string[] $locales
      */
-    private function configureGroupViews(FormGroup $group, array $locales, string $resourceKey, ViewCollection $viewCollection): void
+    private function configureGroupViews(FormGroup $group, array $locales, string $resourceKey, ViewCollection $viewCollection, string $securityContext): void
     {
-        if (!$this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+        if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
             return;
         }
 
@@ -123,15 +135,15 @@ class ArticleAdmin extends Admin
 
         $listToolbarActions = [];
 
-        if ($this->hasPermission($groupIdentifier, PermissionTypes::ADD)) {
+        if ($this->hasPermission($groupIdentifier, PermissionTypes::ADD, $securityContext !== static::SECURITY_CONTEXT)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
-        if ($this->hasPermission($groupIdentifier, PermissionTypes::DELETE)) {
+        if ($this->hasPermission($groupIdentifier, PermissionTypes::DELETE, $securityContext !== static::SECURITY_CONTEXT)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
-        if ($this->hasPermission($groupIdentifier, PermissionTypes::VIEW)) {
+        if ($this->hasPermission($groupIdentifier, PermissionTypes::VIEW, $securityContext !== static::SECURITY_CONTEXT)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
@@ -154,13 +166,13 @@ class ArticleAdmin extends Admin
             $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_TABS_VIEW . '_' . $groupIdentifier, '/:locale/' . $groupIdentifier . '/add')
                 ->setResourceKey($resourceKey)
                 ->addLocales($locales)
-                ->setBackView(static::LIST_VIEW),
+                ->setBackView(static::LIST_VIEW . '_' . $groupIdentifier),
         );
         $viewCollection->add(
             $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_TABS_VIEW . '_' . $groupIdentifier, '/:locale/' . $groupIdentifier . '/:id') // TODO should be uuid
                 ->setResourceKey($resourceKey)
                 ->addLocales($locales)
-                ->setBackView(static::LIST_VIEW)
+                ->setBackView(static::LIST_VIEW . '_' . $groupIdentifier)
                 ->setTitleProperty('name'),
         );
 
@@ -168,8 +180,12 @@ class ArticleAdmin extends Admin
             ArticleInterface::class,
             static::EDIT_TABS_VIEW . '_' . $groupIdentifier,
             static::ADD_TABS_VIEW . '_' . $groupIdentifier,
-            $this->getArticleSecurityContext($groupIdentifier),
+            $securityContext,
         );
+
+        if (0 === \count($viewBuilders)) {
+            return;
+        }
 
         foreach ($viewBuilders as $viewBuilder) {
             $viewCollection->add($viewBuilder);
@@ -206,15 +222,17 @@ class ArticleAdmin extends Admin
     public function getSecurityContexts()
     {
         $securityContext = [];
-
-        foreach ($this->groupProvider->getGroups() as $group) {
-            $securityContext[static::getArticleSecurityContext($group->identifier)] = [
-                PermissionTypes::VIEW,
-                PermissionTypes::ADD,
-                PermissionTypes::EDIT,
-                PermissionTypes::DELETE,
-                PermissionTypes::LIVE,
-            ];
+        $groups = $this->groupProvider->getGroups();
+        if (1 !== \count($groups)) {
+            foreach ($this->groupProvider->getGroups() as $group) {
+                $securityContext[static::getArticleSecurityContext($group->identifier)] = [
+                    PermissionTypes::VIEW,
+                    PermissionTypes::ADD,
+                    PermissionTypes::EDIT,
+                    PermissionTypes::DELETE,
+                    PermissionTypes::LIVE,
+                ];
+            }
         }
 
         return [

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\QueryBuilder;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\Builder;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\BuilderInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfigurationInterface;
@@ -91,6 +92,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         private DimensionContentQueryEnhancer $dimensionContentQueryEnhancer,
         private SmartContentQueryEnhancer $smartContentQueryEnhancer,
         EntityManagerInterface $entityManager,
+        private GroupProviderInterface $groupProvider,
     ) {
         $this->entityRepository = $entityManager->getRepository(ArticleInterface::class);
         $this->entityDimensionContentRepository = $entityManager->getRepository(ArticleDimensionContentInterface::class);
@@ -118,7 +120,16 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
                     ['column' => 'changed', 'title' => 'sulu_admin.changed'],
                     ['column' => 'title', 'title' => 'sulu_admin.title'],
                 ],
-            );
+            )
+            ->enableTypes(\array_values(\array_map(
+                function($group) {
+                    return [
+                        'title' => $group->title,
+                        'type' => $group->identifier,
+                    ];
+                },
+                $this->groupProvider->getGroups(),
+            )));
 
         // TODO
         //        if ($this->hasAudienceTargeting) {
@@ -238,7 +249,14 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
     protected function mapFilters(array $filters): array
     {
         if ($filters['types']) {
-            $filters['templateKeys'] = $filters['types'];
+            $templates = [];
+            foreach ($this->groupProvider->getGroups() as $group) {
+                if (\in_array($group->identifier, $filters['types'], true)) {
+                    $templates = \array_merge($templates, \array_filter($group->templates, 'is_string'));
+                }
+            }
+
+            $filters['templateKeys'] = $templates;
             unset($filters['types']);
         }
 

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -250,6 +250,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_security.security_checker'),
                 new Reference('sulu.core.localization_manager'),
                 new Reference('sulu_activity.activity_list_view_builder_factory'),
+                new Reference('sulu_admin.metadata_group_provider'),
             ])
             ->tag('sulu.context', ['context' => 'admin'])
             ->tag('sulu.admin');
@@ -333,6 +334,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_content.dimension_content_query_enhancer'),
                 new Reference('sulu_admin.smart_content_query_enhancer'),
                 new Reference('doctrine.orm.entity_manager'),
+                new Reference('sulu_admin.metadata_group_provider'),
             ])
         ->tag('sulu_content.smart_content_provider', ['type' => ArticleInterface::RESOURCE_KEY]);
 

--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -83,7 +83,7 @@ final class ArticleController
         ContentManagerInterface $contentManager,
         FieldDescriptorFactoryInterface $fieldDescriptorFactory,
         DoctrineListBuilderFactoryInterface $listBuilderFactory,
-        RestHelperInterface $restHelper
+        RestHelperInterface $restHelper,
     ) {
         $this->articleRepository = $articleRepository;
         $this->messageBus = $messageBus;
@@ -98,6 +98,9 @@ final class ArticleController
 
     public function cgetAction(Request $request): Response
     {
+        $templatesParam = $request->get('templates', '');
+        $templates = \array_filter(\explode(',', \is_string($templatesParam) ? $templatesParam : ''));
+
         // TODO this should be ArticleRepository::findFlatBy / ::countFlatBy methods
         //      but first we would need to avoid that the restHelper requires the request.
         //
@@ -112,6 +115,22 @@ final class ArticleController
         $listBuilder->addSelectField($fieldDescriptors['publishedState']);
         $listBuilder->setParameter('locale', $request->query->get('locale'));
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
+        if (0 !== \count($templates)) {
+            $dimensionContentTemplateKey = $fieldDescriptors['dimensionContentTemplateKey'];
+            $ghostDimensionContentTemplateKey = $fieldDescriptors['ghostDimensionContentTemplateKey'];
+            $expression = $listBuilder->createOrExpression([
+                $listBuilder->createAndExpression([
+                    $listBuilder->createIsNotNullExpression($dimensionContentTemplateKey),
+                    $listBuilder->createInExpression($dimensionContentTemplateKey, $templates),
+                ]),
+                $listBuilder->createAndExpression([
+                    $listBuilder->createIsNullExpression($dimensionContentTemplateKey),
+                    $listBuilder->createInExpression($ghostDimensionContentTemplateKey, $templates),
+                ]),
+            ]);
+
+            $listBuilder->addExpression($expression);
+        }
 
         $listRepresentation = new PaginatedRepresentation(
             $listBuilder->execute(),
@@ -161,7 +180,7 @@ final class ArticleController
             $this->normalizer->normalize(
                 $listRepresentation->toArray(),
                 'json',
-            )
+            ),
         );
     }
 
@@ -182,7 +201,7 @@ final class ArticleController
             ),
             [
                 ArticleRepositoryInterface::GROUP_SELECT_ARTICLE_ADMIN => true,
-            ]
+            ],
         );
 
         // TODO the `$article` should just be serialized
@@ -249,7 +268,7 @@ final class ArticleController
             $request->request->all(),
             [
                 'locale' => $this->getLocale($request),
-            ]
+            ],
         );
     }
 
@@ -270,14 +289,14 @@ final class ArticleController
             $message = new CopyLocaleArticleMessage(
                 ['uuid' => $uuid],
                 (string) $request->query->get('src'),
-                (string) $request->query->get('dest')
+                (string) $request->query->get('dest'),
             );
 
             /** @see Sulu\Article\Application\MessageHandler\CopyLocaleArticleMessageHandler */
             /** @var ArticleInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('restore' === $action) {
-            $version = \intval($request->query->get('version'));
+            $version = (int) $request->query->get('version');
             if (!$version) {
                 throw new \InvalidArgumentException('The "version" query parameter is required for restoring a version.');
             }
@@ -292,12 +311,11 @@ final class ArticleController
             /** @see Sulu\Article\Application\MessageHandler\RestoreArticleVersionMessageHandler */
             /** @var ArticleInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
-        } else {
-            $message = new ApplyWorkflowTransitionArticleMessage(['uuid' => $uuid], $this->getLocale($request), $action);
-
-            /** @see Sulu\Article\Application\MessageHandler\ApplyWorkflowTransitionArticleMessageHandler */
-            /** @var null */
-            return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         }
+        $message = new ApplyWorkflowTransitionArticleMessage(['uuid' => $uuid], $this->getLocale($request), $action);
+
+        /** @see Sulu\Article\Application\MessageHandler\ApplyWorkflowTransitionArticleMessageHandler */
+        /** @var null */
+        return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
     }
 }

--- a/packages/article/tests/Application/config/templates/articles/blog.xml
+++ b/packages/article/tests/Application/config/templates/articles/blog.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>blog</key>
+    <group>blog-group</group>
+
+    <view>views/articles/article</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Blog</title>
+        <title lang="de">Blog</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+            <tag name="sulu.search.field" role="title"/>
+        </property>
+
+        <property name="url" type="route">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+            <tag name="sulu.search.field" role="url"/>
+        </property>
+
+        <property name="description" type="text_area">
+            <meta>
+                <title lang="en">Description</title>
+                <title lang="de">Beschreibung</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="description"/>
+        </property>
+
+        <property name="image" type="single_media_selection">
+            <meta>
+                <title lang="en">Image</title>
+                <title lang="de">Bild</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="image"/>
+        </property>
+    </properties>
+</template>

--- a/packages/article/tests/Application/config/templates/articles/news.xml
+++ b/packages/article/tests/Application/config/templates/articles/news.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>news</key>
+    <group>news-group</group>
+
+    <view>views/articles/article</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">News</title>
+        <title lang="de">News</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+            <tag name="sulu.search.field" role="title"/>
+        </property>
+
+        <property name="url" type="route">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+            <tag name="sulu.search.field" role="url"/>
+        </property>
+
+        <property name="description" type="text_area">
+            <meta>
+                <title lang="en">Description</title>
+                <title lang="de">Beschreibung</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="description"/>
+        </property>
+
+        <property name="image" type="single_media_selection">
+            <meta>
+                <title lang="en">Image</title>
+                <title lang="de">Bild</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="image"/>
+        </property>
+    </properties>
+</template>

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
@@ -125,6 +125,7 @@ class ArticleSmartContentProviderTest extends SuluTestCase
             'excerptCategories' => [self::$categories['tech']->getId(), self::$categories['business']->getId()],
             'excerptTags' => [self::$tags['cloud']],
             'authored' => '2023-02-20T14:30:00+00:00',
+            'template' => 'blog',
         ]);
 
         self::$articles['sports1'] = self::createArticle([
@@ -139,6 +140,7 @@ class ArticleSmartContentProviderTest extends SuluTestCase
             'excerptCategories' => [self::$categories['sports']->getId()],
             'excerptTags' => [self::$tags['tennis']],
             'authored' => '2023-04-05T16:45:00+00:00',
+            'template' => 'news',
         ]);
 
         self::$articles['health1'] = self::createArticle([
@@ -167,6 +169,7 @@ class ArticleSmartContentProviderTest extends SuluTestCase
             'excerptCategories' => [self::$categories['business']->getId()],
             'excerptTags' => [self::$tags['finance']],
             'authored' => '2023-08-30T13:45:00+00:00',
+            'template' => 'blog',
         ]);
 
         self::$articles['entertainment1'] = self::createArticle([
@@ -181,6 +184,7 @@ class ArticleSmartContentProviderTest extends SuluTestCase
             'excerptCategories' => [self::$categories['entertainment']->getId()],
             'excerptTags' => [self::$tags['music']],
             'authored' => '2023-10-12T17:15:00+00:00',
+            'template' => 'news',
         ]);
 
         self::$articles['tech_health'] = self::createArticle([
@@ -697,6 +701,53 @@ class ArticleSmartContentProviderTest extends SuluTestCase
         );
 
         return $article;
+    }
+
+    /**
+     * @param string[] $groups
+     * @param string[] $articleKeys
+     */
+    #[DataProvider('groupDataProvider')]
+    public function testFindFlatByTypesSingleGroupFilter(array $groups, array $articleKeys): void
+    {
+        $result = $this->smartContentProvider->findFlatBy([
+            ...$this->getDefaultFilters(),
+            ...['locale' => 'en', 'types' => $groups],
+        ], []);
+
+        $this->assertCount(\count($articleKeys), $result);
+        $this->assertSame(
+            \count($articleKeys),
+            $this->smartContentProvider->countBy([
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en', 'types' => $groups],
+            ]),
+        );
+
+        $resultIds = \array_map(
+            fn ($article) => $article['id'],
+            $result,
+        );
+
+        foreach (self::$articles as $key => $article) {
+            if (!\in_array($key, $articleKeys, true)) {
+                return;
+            }
+            $this->assertContains($article->getUuid(), $resultIds, "Article '$key' should be in the default group");
+        }
+    }
+
+    /**
+     * @return array<int, array{string[], string[]}>
+     */
+    public static function groupDataProvider(): array
+    {
+        return [
+            [['default'], ['tech1', 'sports1', 'health1', 'health2', 'business1', 'entertainment1', 'tech_health', 'sports_health', 'business_tech', 'entertainment_business', 'multi_category_multi_tag']],
+            [['blog-group'], ['tech2', 'business2']],
+            [['news-group'], ['sports2', 'entertainment2']],
+            [['blog-group', 'news-group'], ['tech2', 'business2', 'sports2', 'entertainment2']],
+        ];
     }
 
     /**

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -40,7 +38,7 @@ class ArticleControllerTest extends SuluTestCase
     {
         $this->client = $this->createAuthenticatedClient(
             [],
-            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json']
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
         );
 
         // TODO this should not be necessary
@@ -120,7 +118,11 @@ class ArticleControllerTest extends SuluTestCase
         \sleep(1); // Ensure that the version timestamp is different from the previous version
 
         $this->client->request(
-            'PUT', '/admin/api/articles/' . $id . '?locale=en&action=publish', [], [], [],
+            'PUT',
+            '/admin/api/articles/' . $id . '?locale=en&action=publish',
+            [],
+            [],
+            [],
             \json_encode(
                 [
                     'template' => 'article',
@@ -362,6 +364,113 @@ class ArticleControllerTest extends SuluTestCase
         $this->client->request('GET', '/admin/api/articles/' . $trashItem->getResourceId() . '?locale=en');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('article_post_restore.json', $response, 200);
+    }
+
+    public function testGetListWithTemplateFiltering(): void
+    {
+        self::purgeDatabase();
+
+        // Create articles with different templates
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'Article Template Test',
+            'url' => '/article-template',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+
+        $response1 = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response1);
+        $content1 = \json_decode((string) $response1->getContent(), true);
+        $this->assertIsArray($content1);
+        $articleId = $content1['id'];
+
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'blog',
+            'title' => 'Blog Template Test',
+            'url' => '/blog-template',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+
+        $response2 = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response2);
+
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'news',
+            'title' => 'News Template Test',
+            'url' => '/news-template',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+
+        $response3 = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response3);
+
+        // Test single template filter
+        $this->client->request('GET', '/admin/api/articles?locale=en&templates=article');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+
+        $this->assertSame(1, $content['total']);
+        $this->assertIsArray($content['_embedded']);
+        $this->assertIsArray($content['_embedded']['articles']);
+        $this->assertIsArray($content['_embedded']['articles'][0]);
+        $this->assertSame('Article Template Test', $content['_embedded']['articles'][0]['title']);
+
+        // Test multiple template filter
+        $this->client->request('GET', '/admin/api/articles?locale=en&templates=article,blog');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+
+        $this->assertSame(2, $content['total']);
+        $this->assertIsArray($content['_embedded']);
+        $this->assertIsArray($content['_embedded']['articles']);
+        $titles = \array_column($content['_embedded']['articles'], 'title');
+        $this->assertContains('Article Template Test', $titles);
+        $this->assertContains('Blog Template Test', $titles);
+
+        // Test template filter with empty values (should be filtered out)
+        $this->client->request('GET', '/admin/api/articles?locale=en&templates=article,,blog,');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+
+        $this->assertSame(2, $content['total']);
+        $this->assertIsArray($content['_embedded']);
+        $this->assertIsArray($content['_embedded']['articles']);
+        $titles = \array_column($content['_embedded']['articles'], 'title');
+        $this->assertContains('Article Template Test', $titles);
+        $this->assertContains('Blog Template Test', $titles);
+
+        // Test all templates (no filter)
+        $this->client->request('GET', '/admin/api/articles?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+
+        $this->assertSame(3, $content['total']);
+
+        // Test empty template filter (should return all)
+        $this->client->request('GET', '/admin/api/articles?locale=en&templates=');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+
+        $this->assertSame(3, $content['total']);
+
+        // Test non-existent template (should return no results)
+        $this->client->request('GET', '/admin/api/articles?locale=en&templates=nonexistent');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+
+        $this->assertSame(0, $content['total']);
     }
 
     protected function getSnapshotFolder(): string

--- a/packages/content/src/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
+++ b/packages/content/src/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
@@ -73,7 +73,7 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
                 'sulu_admin.type',
                 [
                     'disabled_condition' => '(_permissions && !_permissions.edit)',
-                ]
+                ],
             );
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormGroup.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormGroup.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
+
+final readonly class FormGroup
+{
+    /**
+     * @param string[] $templates
+     */
+    public function __construct(
+        public string $identifier,
+        public string $title,
+        public array $templates = [],
+    ) {
+    }
+
+    public function withTemplate(string $template): self
+    {
+        return new self(
+            $this->identifier,
+            $this->title,
+            [...$this->templates, $template],
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -51,6 +51,12 @@ class FormMetadata extends AbstractMetadata
     private $key;
 
     /**
+     * @var string|null
+     */
+    #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
+    private $group = null;
+
+    /**
      * @var TagMetadata[]
      */
     #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
@@ -88,6 +94,16 @@ class FormMetadata extends AbstractMetadata
     public function getKey(): string
     {
         return $this->key;
+    }
+
+    public function setGroup(?string $group): void
+    {
+        $this->group = $group;
+    }
+
+    public function getGroup(): ?string
+    {
+        return $this->group;
     }
 
     public function setTitle(string $title, string $locale)

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
@@ -66,6 +66,12 @@ class TemplateXmlLoader extends AbstractLoader
         \assert(\is_string($templateKey), 'Expected the template key of "' . $resource . '" to be defined.');
         $form->setKey($templateKey);
 
+        $templateGroup = $this->getValueFromXPath('/x:template/x:group', $xpath);
+        if (null !== $templateGroup) {
+            \assert(\is_string($templateGroup), 'Expected the template group to be "' . $resource . '" string or undefined.');
+        }
+        $form->setGroup($templateGroup);
+
         $tagNodes = $xpath->query('/x:template/x:tag') ?: [];
         $form->setTags($this->tagXmlParser->load($xpath, $tagNodes));
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
@@ -68,7 +68,7 @@ class TemplateXmlLoader extends AbstractLoader
 
         $templateGroup = $this->getValueFromXPath('/x:template/x:group', $xpath);
         if (null !== $templateGroup) {
-            \assert(\is_string($templateGroup), 'Expected the template group to be "' . $resource . '" string or undefined.');
+            \assert(\is_string($templateGroup), 'Expected the template group to be "' . $templateGroup . '" string or undefined.');
         }
         $form->setGroup($templateGroup);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TemplateFilterTypedFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/TemplateFilterTypedFormMetadataVisitor.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
+
+/**
+ * @internal This class is internal. Create a separate visitor if you want to manipulate the metadata in your project.
+ */
+class TemplateFilterTypedFormMetadataVisitor implements TypedFormMetadataVisitorInterface
+{
+    public static function getDefaultPriority(): int
+    {
+        return -100;
+    }
+
+    public function visitTypedFormMetadata(TypedFormMetadata $formMetadata, string $key, string $locale, array $metadataOptions = []): void
+    {
+        if (!\array_key_exists('templates', $metadataOptions)) {
+            return;
+        }
+
+        $templates = $metadataOptions['templates'];
+        if (!\is_array($templates)) {
+            if (!\is_string($templates)) {
+                return; // Skip if not string or array
+            }
+            $templates = \array_filter(\explode(',', $templates));
+        }
+
+        foreach ($formMetadata->getForms() as $formKey => $childForm) {
+            if (!\in_array($formKey, $templates, true)) {
+                $formMetadata->removeForm($formKey);
+            }
+        }
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/GroupProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/GroupProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata;
+
+use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+
+final readonly class GroupProvider implements GroupProviderInterface
+{
+    public function __construct(
+        private MetadataProviderRegistry $metadataProviderRegistry,
+    ) {
+    }
+
+    public function getGroups(): array
+    {
+        /** @var TypedFormMetadata $metadata */
+        $metadata = $this->metadataProviderRegistry->getMetadataProvider('form')
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', []);
+
+        $groups = [];
+
+        foreach ($metadata->getForms() as $articleForm) {
+            $group = $articleForm->getGroup() ?: 'default';
+
+            if (!\array_key_exists($group, $groups)) {
+                $groups[$group] = new FormGroup($group, $this->getGroupTitle($group));
+            }
+            $groups[$group] = $groups[$group]->withTemplate($articleForm->getKey());
+        }
+
+        return $groups;
+    }
+
+    private function getGroupTitle(string $groupIdentifier): string
+    {
+        return \ucfirst($groupIdentifier);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/GroupProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/GroupProviderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
+
+interface GroupProviderInterface
+{
+    /**
+     * @return array<string, FormGroup>
+     */
+    public function getGroups(): array;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/schema/template-1.0.xsd
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/schema/template-1.0.xsd
@@ -25,6 +25,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
+            <xs:element type="xs:string" name="group" minOccurs="0" maxOccurs="1"/>
             <xs:element type="indexType" name="index" minOccurs="1" maxOccurs="1"/>
             <xs:element type="tagType" name="tag" maxOccurs="unbounded"/>
             <xs:element type="xs:string" name="view" minOccurs="1" maxOccurs="1"/>

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -46,6 +46,10 @@
             <argument type="tagged_locator" tag="sulu_admin.metadata_provider" index-by="type" />
          </service>
 
+        <service id="sulu_admin.metadata_group_provider" class="Sulu\Bundle\AdminBundle\Metadata\GroupProvider">
+            <argument type="service" id="sulu_admin.metadata_provider_registry"/>
+        </service>
+
         <service
             id="sulu_admin.form_metadata_provider"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider"
@@ -125,6 +129,13 @@
 
             <tag name="sulu_admin.typed_form_metadata_visitor"/>
             <tag name="sulu_admin.form_metadata_visitor" />
+        </service>
+
+        <service
+            id="sulu_admin.template_filter_typed_form_metadata_visitor"
+            class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TemplateFilterTypedFormMetadataVisitor"
+        >
+            <tag name="sulu_admin.typed_form_metadata_visitor" />
         </service>
 
         <service

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
@@ -44,8 +44,8 @@ class Builder implements BuilderInterface
                 function($type) {
                     return new PropertyParameter($type['title'], $type['type']);
                 },
-                $types
-            )
+                $types,
+            ),
         );
 
         return $this;
@@ -102,8 +102,8 @@ class Builder implements BuilderInterface
                 function($item) {
                     return new PropertyParameter($item['column'], $item['title'] ?: \ucfirst($item['column']));
                 },
-                $sorting
-            )
+                $sorting,
+            ),
         );
 
         return $this;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/grouped.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/grouped.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd"
+          >
+
+    <key>grouped</key>
+    <group>content</group>
+
+    <view>pages/grouped</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>3600</cacheLifetime>
+
+    <meta>
+        <title lang="de">Gruppierte Vorlage</title>
+        <title lang="en">Grouped Template</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="de">Titel</title>
+                <title lang="en">Title</title>
+            </meta>
+
+            <tag name="sulu.rlp.part" priority="100"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="de">Adresse</title>
+                <title lang="en">Resourcelocator</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="description" type="text_area" mandatory="false">
+            <meta>
+                <title lang="de">Beschreibung</title>
+                <title lang="en">Description</title>
+            </meta>
+        </property>
+    </properties>
+</template>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -112,6 +112,7 @@
                                 ]
                             },
                             "key": "text_block",
+                            "group": null,
                             "tags": [
                                 {
                                     "name": "sulu.global_block",
@@ -137,6 +138,7 @@
                                 ]
                             },
                             "key": "text_block2",
+                            "group": null,
                             "tags": [
                                 {
                                     "name": "sulu.global_block",
@@ -180,6 +182,7 @@
                                 ]
                             },
                             "key": "editor",
+                            "group": null,
                             "tags": [],
                             "title": "Editor"
                         },
@@ -229,6 +232,7 @@
                                                 ]
                                             },
                                             "key": "text_block2",
+                                            "group": null,
                                             "tags": [
                                                 {
                                                     "name": "sulu.global_block",
@@ -254,6 +258,7 @@
                                                 ]
                                             },
                                             "key": "text_block3",
+                                            "group": null,
                                             "tags": [
                                                 {
                                                     "name": "sulu.global_block",
@@ -287,6 +292,7 @@
                                 ]
                             },
                             "key": "block",
+                            "group": null,
                             "tags": [],
                             "title": "Block"
                         }
@@ -582,6 +588,7 @@
         }
     },
     "key": "default",
+    "group": null,
     "tags": [
         {
             "name": "test",

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
@@ -154,6 +154,7 @@
                         ]
                     },
                     "key": "editor",
+                    "group": null,
                     "tags": [],
                     "title": "Editor"
                 }
@@ -212,6 +213,7 @@
                         ]
                     },
                     "key": "editor",
+                    "group": null,
                     "tags": [],
                     "title": "Editor"
                 }
@@ -342,6 +344,7 @@
         ]
     },
     "key": "overview",
+    "group": null,
     "tags": [
         {
             "name": "test3",

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -80,7 +80,7 @@ class FormMetadataProviderTest extends KernelTestCase
     {
         $typedForm = $this->formMetadataProvider->getMetadata('page', 'en');
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
-        $this->assertCount(2, $typedForm->getForms());
+        $this->assertCount(3, $typedForm->getForms());
     }
 
     public function testGetMetadataTagFiltered(): void
@@ -125,8 +125,8 @@ class FormMetadataProviderTest extends KernelTestCase
             ['tags' => ['test' => false]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
-        $this->assertCount(1, $typedForm->getForms());
-        $this->assertEquals(['overview'], \array_keys($typedForm->getForms()));
+        $this->assertCount(2, $typedForm->getForms());
+        $this->assertEquals(['overview', 'grouped'], \array_keys($typedForm->getForms()));
 
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FormGroupTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FormGroupTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
+
+class FormGroupTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $formGroup = new FormGroup('content', 'Content');
+
+        $this->assertSame('content', $formGroup->identifier);
+        $this->assertSame('Content', $formGroup->title);
+        $this->assertSame([], $formGroup->templates);
+    }
+
+    public function testConstructorWithTemplates(): void
+    {
+        $templates = ['article', 'blog'];
+        $formGroup = new FormGroup('content', 'Content', $templates);
+
+        $this->assertSame('content', $formGroup->identifier);
+        $this->assertSame('Content', $formGroup->title);
+        $this->assertSame($templates, $formGroup->templates);
+    }
+
+    public function testWithTemplate(): void
+    {
+        $formGroup = new FormGroup('content', 'Content');
+        $updatedFormGroup = $formGroup->withTemplate('article');
+
+        // Original object should remain unchanged (immutable)
+        $this->assertSame([], $formGroup->templates);
+
+        // New object should contain the template
+        $this->assertSame(['article'], $updatedFormGroup->templates);
+        $this->assertSame('content', $updatedFormGroup->identifier);
+        $this->assertSame('Content', $updatedFormGroup->title);
+    }
+
+    public function testWithMultipleTemplates(): void
+    {
+        $formGroup = new FormGroup('content', 'Content');
+        $updatedFormGroup1 = $formGroup->withTemplate('article');
+        $updatedFormGroup2 = $updatedFormGroup1->withTemplate('blog');
+        $updatedFormGroup3 = $updatedFormGroup2->withTemplate('news');
+
+        // Original object should remain unchanged
+        $this->assertSame([], $formGroup->templates);
+
+        // Each subsequent object should contain previous templates plus the new one
+        $this->assertSame(['article'], $updatedFormGroup1->templates);
+        $this->assertSame(['article', 'blog'], $updatedFormGroup2->templates);
+        $this->assertSame(['article', 'blog', 'news'], $updatedFormGroup3->templates);
+    }
+
+    public function testWithTemplatePreservesExistingTemplates(): void
+    {
+        $initialTemplates = ['existing1', 'existing2'];
+        $formGroup = new FormGroup('content', 'Content', $initialTemplates);
+        $updatedFormGroup = $formGroup->withTemplate('new_template');
+
+        $expectedTemplates = ['existing1', 'existing2', 'new_template'];
+        $this->assertSame($expectedTemplates, $updatedFormGroup->templates);
+    }
+
+    public function testWithTemplateCreatesNewInstance(): void
+    {
+        $formGroup = new FormGroup('content', 'Content');
+        $updatedFormGroup = $formGroup->withTemplate('article');
+
+        $this->assertNotSame($formGroup, $updatedFormGroup);
+    }
+
+    public function testWithDuplicateTemplate(): void
+    {
+        $formGroup = new FormGroup('content', 'Content', ['article']);
+        $updatedFormGroup = $formGroup->withTemplate('article');
+
+        // Should add duplicate template (no uniqueness constraint)
+        $this->assertSame(['article', 'article'], $updatedFormGroup->templates);
+    }
+
+    public function testWithEmptyTemplate(): void
+    {
+        $formGroup = new FormGroup('content', 'Content');
+        $updatedFormGroup = $formGroup->withTemplate('');
+
+        $this->assertSame([''], $updatedFormGroup->templates);
+    }
+
+    public function testReadonlyProperties(): void
+    {
+        $formGroup = new FormGroup('content', 'Content', ['article']);
+
+        // Test that properties are accessible
+        $this->assertSame('content', $formGroup->identifier);
+        $this->assertSame('Content', $formGroup->title);
+        $this->assertSame(['article'], $formGroup->templates);
+    }
+
+    public function testImmutability(): void
+    {
+        $originalTemplates = ['template1'];
+        $formGroup = new FormGroup('content', 'Content', $originalTemplates);
+
+        // Modify the original array
+        $originalTemplates[] = 'template2';
+
+        // FormGroup should not be affected
+        $this->assertSame(['template1'], $formGroup->templates);
+    }
+
+    /**
+     * @param string[] $templates
+     */
+    #[DataProvider('formGroupDataProvider')]
+    public function testVariousInputs(string $identifier, string $title, array $templates): void
+    {
+        $formGroup = new FormGroup($identifier, $title, $templates);
+
+        $this->assertSame($identifier, $formGroup->identifier);
+        $this->assertSame($title, $formGroup->title);
+        $this->assertSame($templates, $formGroup->templates);
+    }
+
+    /**
+     * @return array<string, array{string, string, string[]}>
+     */
+    public static function formGroupDataProvider(): array
+    {
+        return [
+            'basic_content' => ['content', 'Content', ['article', 'blog']],
+            'news_group' => ['news', 'News Articles', ['breaking', 'sport', 'weather']],
+            'empty_templates' => ['empty', 'Empty Group', []],
+            'single_template' => ['single', 'Single Template', ['only_template']],
+            'special_chars' => ['special-chars_123', 'Special & Chars!', ['temp_1', 'temp-2']],
+            'numeric_identifier' => ['123', '123 Group', ['template123']],
+            'empty_strings' => ['', '', ['']],
+        ];
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FormMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FormMetadataTest.php
@@ -29,12 +29,12 @@ class FormMetadataTest extends TestCase
 
         $this->assertSame(
             $tag1,
-            $formMetadata->findTag('tag1')
+            $formMetadata->findTag('tag1'),
         );
 
         $this->assertSame(
             $tag2,
-            $formMetadata->findTag('tag2')
+            $formMetadata->findTag('tag2'),
         );
 
         $this->assertNull($formMetadata->findTag('not-existing'));
@@ -53,5 +53,13 @@ class FormMetadataTest extends TestCase
         $this->assertTrue($formMetadata->hasTag('tag1'));
         $this->assertTrue($formMetadata->hasTag('tag2'));
         $this->assertFalse($formMetadata->hasTag('not-existing'));
+    }
+
+    public function testGroup(): void
+    {
+        $formMetadata = new FormMetadata();
+        $this->assertNull($formMetadata->getGroup());
+        $formMetadata->setGroup('test-group');
+        $this->assertSame('test-group', $formMetadata->getGroup());
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/TemplateXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/TemplateXmlLoaderTest.php
@@ -42,13 +42,13 @@ class TemplateXmlLoaderTest extends TestCase
      */
     private $translator;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->translator = $this->prophesize(TranslatorInterface::class);
         $tagXmlParser = new TagXmlParser();
         $metaXmlParser = new MetaXmlParser(
             $this->translator->reveal(),
-            ['en' => 'en', 'de' => 'de', 'fr' => 'fr', 'nl' => 'nl']
+            ['en' => 'en', 'de' => 'de', 'fr' => 'fr', 'nl' => 'nl'],
         );
         $propertiesXmlParser = new PropertiesXmlParser(
             $tagXmlParser,
@@ -445,6 +445,23 @@ class TemplateXmlLoaderTest extends TestCase
                 ],
             ],
         ], $this->metadataToArray($formMetadata));
+    }
+
+    public function testLoadGroupedTemplate(): void
+    {
+        $formMetadata = $this->loader->load($this->getTemplatesDirectory() . 'grouped.xml');
+
+        $this->assertSame('grouped', $formMetadata->getKey());
+        $this->assertSame('content', $formMetadata->getGroup());
+    }
+
+    public function testLoadTemplateWithoutGroup(): void
+    {
+        // Test that templates without a group element return null for the group
+        $formMetadata = $this->loader->load($this->getTemplatesDirectory() . 'overview.xml');
+
+        $this->assertSame('overview', $formMetadata->getKey());
+        $this->assertNull($formMetadata->getGroup());
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/TemplateFilterTypedFormMetadataVisitorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/TemplateFilterTypedFormMetadataVisitorTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TemplateFilterTypedFormMetadataVisitor;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterface;
+
+class TemplateFilterTypedFormMetadataVisitorTest extends TestCase
+{
+    private TemplateFilterTypedFormMetadataVisitor $visitor;
+
+    protected function setUp(): void
+    {
+        $this->visitor = new TemplateFilterTypedFormMetadataVisitor();
+    }
+
+    public function testImplementsInterface(): void
+    {
+        // This test verifies the visitor implements the correct interface
+        $interfaces = \class_implements($this->visitor);
+        $this->assertContains(TypedFormMetadataVisitorInterface::class, $interfaces);
+    }
+
+    public function testGetDefaultPriority(): void
+    {
+        $this->assertSame(-100, TemplateFilterTypedFormMetadataVisitor::getDefaultPriority());
+    }
+
+    public function testVisitWithoutTemplatesOption(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+        $formMetadata3 = new FormMetadata();
+        $formMetadata3->setKey('news');
+
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+        $typedFormMetadata->addForm('news', $formMetadata3);
+
+        // No templates option provided - should not filter anything
+        $this->visitor->visitTypedFormMetadata($typedFormMetadata, 'test', 'en', []);
+
+        $this->assertCount(3, $typedFormMetadata->getForms());
+        $this->assertArrayHasKey('article', $typedFormMetadata->getForms());
+        $this->assertArrayHasKey('blog', $typedFormMetadata->getForms());
+        $this->assertArrayHasKey('news', $typedFormMetadata->getForms());
+    }
+
+    public function testVisitWithStringTemplatesOption(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+        $formMetadata3 = new FormMetadata();
+        $formMetadata3->setKey('news');
+
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+        $typedFormMetadata->addForm('news', $formMetadata3);
+
+        // Filter using comma-separated string
+        $this->visitor->visitTypedFormMetadata($typedFormMetadata, 'test', 'en', [
+            'templates' => 'article,news',
+        ]);
+
+        $this->assertCount(2, $typedFormMetadata->getForms());
+        $this->assertArrayHasKey('article', $typedFormMetadata->getForms());
+        $this->assertArrayHasKey('news', $typedFormMetadata->getForms());
+        $this->assertArrayNotHasKey('blog', $typedFormMetadata->getForms());
+    }
+
+    public function testVisitWithEmptyString(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+
+        $typedFormMetadata->addForm('article', $formMetadata1);
+
+        // Empty string should result in no templates kept
+        $this->visitor->visitTypedFormMetadata($typedFormMetadata, 'test', 'en', [
+            'templates' => '',
+        ]);
+
+        $this->assertCount(0, $typedFormMetadata->getForms());
+    }
+
+    public function testVisitWithNonExistentTemplates(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+
+        // Filter for templates that don't exist
+        $this->visitor->visitTypedFormMetadata($typedFormMetadata, 'test', 'en', [
+            'templates' => ['non-existent', 'also-missing'],
+        ]);
+
+        // All forms should be removed since none match
+        $this->assertCount(0, $typedFormMetadata->getForms());
+    }
+
+    /**
+     * @param string[] $initialTemplates
+     * @param string[] $expectedRemainingTemplates
+     */
+    #[DataProvider('templateFilteringDataProvider')]
+    public function testVariousTemplateFilteringScenarios(
+        array $initialTemplates,
+        mixed $templatesFilter,
+        array $expectedRemainingTemplates,
+    ): void {
+        $typedFormMetadata = new TypedFormMetadata();
+
+        // Add all initial templates
+        foreach ($initialTemplates as $templateKey) {
+            $formMetadata = new FormMetadata();
+            $formMetadata->setKey($templateKey);
+            $typedFormMetadata->addForm($templateKey, $formMetadata);
+        }
+
+        // Apply filter
+        $this->visitor->visitTypedFormMetadata($typedFormMetadata, 'test', 'en', [
+            'templates' => $templatesFilter,
+        ]);
+
+        // Verify results
+        $remainingForms = $typedFormMetadata->getForms();
+        $this->assertCount(\count($expectedRemainingTemplates), $remainingForms);
+
+        foreach ($expectedRemainingTemplates as $expectedTemplate) {
+            $this->assertArrayHasKey($expectedTemplate, $remainingForms);
+        }
+    }
+
+    /**
+     * @return array<string, mixed[]>
+     */
+    public static function templateFilteringDataProvider(): array
+    {
+        return [
+            'keep_all_with_array' => [
+                ['article', 'blog', 'news'],
+                ['article', 'blog', 'news'],
+                ['article', 'blog', 'news'],
+            ],
+            'keep_subset_with_array' => [
+                ['article', 'blog', 'news', 'event'],
+                ['article', 'news'],
+                ['article', 'news'],
+            ],
+            'keep_single_with_string' => [
+                ['article', 'blog'],
+                'article',
+                ['article'],
+            ],
+            'keep_multiple_with_string' => [
+                ['article', 'blog', 'news'],
+                'article,news',
+                ['article', 'news'],
+            ],
+            'keep_none_empty_array' => [
+                ['article', 'blog'],
+                [],
+                [],
+            ],
+            'keep_none_empty_string' => [
+                ['article', 'blog'],
+                '',
+                [],
+            ],
+            'filter_with_spaces_in_string' => [
+                ['article', 'blog', 'news'],
+                'article, blog , news',
+                ['article'], // Only 'article' matches exactly; ' blog ' and ' news' have spaces
+            ],
+            'filter_with_empty_values' => [
+                ['article', 'blog', 'news'],
+                'article,,blog,',
+                ['article', 'blog'],
+            ],
+        ];
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProvider;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
+
+class GroupProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private GroupProvider $groupProvider;
+
+    /**
+     * @var ObjectProphecy<MetadataProviderRegistry>
+     */
+    private ObjectProphecy $metadataProviderRegistry;
+
+    /**
+     * @var ObjectProphecy<MetadataProviderInterface>
+     */
+    private ObjectProphecy $metadataProvider;
+
+    protected function setUp(): void
+    {
+        $this->metadataProviderRegistry = $this->prophesize(MetadataProviderRegistry::class);
+        $this->metadataProvider = $this->prophesize(MetadataProviderInterface::class);
+
+        $this->groupProvider = new GroupProvider($this->metadataProviderRegistry->reveal());
+    }
+
+    public function testGetGroupsWithSingleGroup(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('content');
+
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+        $formMetadata2->setGroup('content');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+
+        $this->metadataProviderRegistry
+            ->getMetadataProvider('form')
+            ->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $groups = $this->groupProvider->getGroups();
+
+        $this->assertCount(1, $groups);
+        $this->assertArrayHasKey('content', $groups);
+        $this->assertEquals(FormGroup::class, \get_class($groups['content']));
+        $this->assertSame('content', $groups['content']->identifier);
+        $this->assertSame('Content', $groups['content']->title);
+        $this->assertSame(['article', 'blog'], $groups['content']->templates);
+    }
+
+    public function testGetGroupsWithMultipleGroups(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('content');
+
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+        $formMetadata2->setGroup('blog');
+
+        $formMetadata3 = new FormMetadata();
+        $formMetadata3->setKey('news');
+        $formMetadata3->setGroup('news');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+        $typedFormMetadata->addForm('news', $formMetadata3);
+
+        $this->metadataProviderRegistry
+            ->getMetadataProvider('form')
+            ->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $groups = $this->groupProvider->getGroups();
+
+        $this->assertCount(3, $groups);
+        $this->assertArrayHasKey('content', $groups);
+        $this->assertArrayHasKey('blog', $groups);
+        $this->assertArrayHasKey('news', $groups);
+
+        $this->assertSame('content', $groups['content']->identifier);
+        $this->assertSame('Content', $groups['content']->title);
+        $this->assertSame(['article'], $groups['content']->templates);
+
+        $this->assertSame('blog', $groups['blog']->identifier);
+        $this->assertSame('Blog', $groups['blog']->title);
+        $this->assertSame(['blog'], $groups['blog']->templates);
+
+        $this->assertSame('news', $groups['news']->identifier);
+        $this->assertSame('News', $groups['news']->title);
+        $this->assertSame(['news'], $groups['news']->templates);
+    }
+
+    public function testGetGroupsWithDefaultGroup(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        // No group set, should fall back to default
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+
+        $this->metadataProviderRegistry
+            ->getMetadataProvider('form')
+            ->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $groups = $this->groupProvider->getGroups();
+
+        $this->assertCount(1, $groups);
+        $this->assertArrayHasKey('default', $groups);
+        $this->assertSame('default', $groups['default']->identifier);
+        $this->assertSame('Default', $groups['default']->title);
+        $this->assertSame(['article'], $groups['default']->templates);
+    }
+
+    public function testGetGroupsWithEmptyForms(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+
+        $this->metadataProviderRegistry
+            ->getMetadataProvider('form')
+            ->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $groups = $this->groupProvider->getGroups();
+
+        $this->assertCount(0, $groups);
+        $this->assertEmpty($groups);
+    }
+
+    public function testGetGroupsWithMixedGroupsAndDefault(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('content');
+
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+        // No group set, should fall back to default
+
+        $formMetadata3 = new FormMetadata();
+        $formMetadata3->setKey('news');
+        $formMetadata3->setGroup('content');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+        $typedFormMetadata->addForm('news', $formMetadata3);
+
+        $this->metadataProviderRegistry
+            ->getMetadataProvider('form')
+            ->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $groups = $this->groupProvider->getGroups();
+
+        $this->assertCount(2, $groups);
+        $this->assertArrayHasKey('content', $groups);
+        $this->assertArrayHasKey('default', $groups);
+
+        $this->assertSame(['article', 'news'], $groups['content']->templates);
+        $this->assertSame(['blog'], $groups['default']->templates);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('groupTitleProvider')]
+    public function testGetGroupTitle(string $groupIdentifier, string $expectedTitle): void
+    {
+        // Use reflection to test the private method
+        $reflection = new \ReflectionClass($this->groupProvider);
+        $method = $reflection->getMethod('getGroupTitle');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->groupProvider, $groupIdentifier);
+
+        $this->assertSame($expectedTitle, $result);
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function groupTitleProvider(): array
+    {
+        return [
+            'simple_group' => ['content', 'Content'],
+            'lowercase_group' => ['blog', 'Blog'],
+            'uppercase_group' => ['NEWS', 'NEWS'],
+            'mixed_case_group' => ['myGroup', 'MyGroup'],
+            'hyphenated_group' => ['my-group', 'My-group'],
+            'underscore_group' => ['my_group', 'My_group'],
+            'single_char' => ['a', 'A'],
+            'empty_string' => ['', ''],
+        ];
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
@@ -28,10 +29,12 @@ class GroupProviderTest extends TestCase
 
     private GroupProvider $groupProvider;
 
+    private MetadataProviderRegistry $metadataProviderRegistry;
+
     /**
-     * @var ObjectProphecy<MetadataProviderRegistry>
+     * @var ObjectProphecy<ContainerInterface>
      */
-    private ObjectProphecy $metadataProviderRegistry;
+    private ObjectProphecy $container;
 
     /**
      * @var ObjectProphecy<MetadataProviderInterface>
@@ -40,10 +43,11 @@ class GroupProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->metadataProviderRegistry = $this->prophesize(MetadataProviderRegistry::class);
+        $this->container = $this->prophesize(ContainerInterface::class);
         $this->metadataProvider = $this->prophesize(MetadataProviderInterface::class);
 
-        $this->groupProvider = new GroupProvider($this->metadataProviderRegistry->reveal());
+        $this->metadataProviderRegistry = new MetadataProviderRegistry($this->container->reveal());
+        $this->groupProvider = new GroupProvider($this->metadataProviderRegistry);
     }
 
     public function testGetGroupsWithSingleGroup(): void
@@ -60,9 +64,8 @@ class GroupProviderTest extends TestCase
         $typedFormMetadata->addForm('article', $formMetadata1);
         $typedFormMetadata->addForm('blog', $formMetadata2);
 
-        $this->metadataProviderRegistry
-            ->getMetadataProvider('form')
-            ->willReturn($this->metadataProvider->reveal());
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
 
         $this->metadataProvider
             ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
@@ -97,9 +100,8 @@ class GroupProviderTest extends TestCase
         $typedFormMetadata->addForm('blog', $formMetadata2);
         $typedFormMetadata->addForm('news', $formMetadata3);
 
-        $this->metadataProviderRegistry
-            ->getMetadataProvider('form')
-            ->willReturn($this->metadataProvider->reveal());
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
 
         $this->metadataProvider
             ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
@@ -134,9 +136,8 @@ class GroupProviderTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('article', $formMetadata1);
 
-        $this->metadataProviderRegistry
-            ->getMetadataProvider('form')
-            ->willReturn($this->metadataProvider->reveal());
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
 
         $this->metadataProvider
             ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
@@ -155,9 +156,8 @@ class GroupProviderTest extends TestCase
     {
         $typedFormMetadata = new TypedFormMetadata();
 
-        $this->metadataProviderRegistry
-            ->getMetadataProvider('form')
-            ->willReturn($this->metadataProvider->reveal());
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
 
         $this->metadataProvider
             ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
@@ -188,9 +188,8 @@ class GroupProviderTest extends TestCase
         $typedFormMetadata->addForm('blog', $formMetadata2);
         $typedFormMetadata->addForm('news', $formMetadata3);
 
-        $this->metadataProviderRegistry
-            ->getMetadataProvider('form')
-            ->willReturn($this->metadataProvider->reveal());
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
 
         $this->metadataProvider
             ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * This file is part of Sulu.
  *
@@ -178,5 +176,46 @@ class BuilderTest extends TestCase
 
         $this->assertSame('edit_form', $configuration->getView());
         $this->assertSame(['id' => 'id'], $configuration->getResultToView());
+    }
+
+    public function testTypes(): void
+    {
+        $builder = Builder::create();
+
+        $this->assertSame($builder, $builder->enableTypes([
+            ['title' => 'Default Group', 'type' => 'default'],
+            ['title' => 'Blog Group', 'type' => 'blog'],
+            ['title' => 'News Group', 'type' => 'news'],
+        ]));
+
+        $configuration = $builder->getConfiguration();
+
+        $this->assertTrue($configuration->hasTypes());
+        $this->assertFalse($configuration->hasTags());
+        $this->assertFalse($configuration->hasDatasource());
+        $this->assertFalse($configuration->hasCategories());
+        $this->assertFalse($configuration->hasLimit());
+        $this->assertFalse($configuration->hasPresentAs());
+        $this->assertFalse($configuration->hasSorting());
+        $this->assertFalse($configuration->hasPagination());
+
+        $types = $configuration->getTypes();
+        $this->assertIsArray($types);
+        $this->assertCount(3, $types);
+
+        // Check first group
+        $this->assertEquals(PropertyParameter::class, \get_class($types[0]));
+        $this->assertSame('default', $types[0]->getValue());
+        $this->assertSame('Default Group', $types[0]->getName());
+
+        // Check second group
+        $this->assertEquals(PropertyParameter::class, \get_class($types[1]));
+        $this->assertSame('blog', $types[1]->getValue());
+        $this->assertSame('Blog Group', $types[1]->getName());
+
+        // Check third group
+        $this->assertEquals(PropertyParameter::class, \get_class($types[2]));
+        $this->assertSame('news', $types[2]->getValue());
+        $this->assertSame('News Group', $types[2]->getName());
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/collection_details.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/collection_details.json
@@ -69,6 +69,7 @@
         ]
     },
     "key": "collection_details",
+    "group": null,
     "tags": [],
     "title": "Collection details"
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/media_details.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/media_details.json
@@ -337,6 +337,7 @@
         ]
     },
     "key": "media_details",
+    "group": null,
     "tags": [],
     "title": "Media details"
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/role_details.json
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/role_details.json
@@ -132,6 +132,7 @@
         ]
     },
     "key": "role_details",
+    "group": null,
     "tags": [],
     "title": "Role details"
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/user_details.json
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/snapshots/user_details.json
@@ -160,6 +160,7 @@
         ]
     },
     "key": "user_details",
+    "group": null,
     "tags": [],
     "title": "User details"
 }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -28,6 +28,8 @@ use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\AbstractDoctrineExpressi
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineAndExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineBetweenExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineInExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNotNullExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNullExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineNotExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineOrExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineWhereExpression;
@@ -873,5 +875,23 @@ class DoctrineListBuilder extends AbstractListBuilder
     {
         return $field instanceof DoctrineCountFieldDescriptor
             || $field instanceof DoctrineGroupConcatFieldDescriptor;
+    }
+
+    public function createIsNullExpression(FieldDescriptorInterface $fieldDescriptor)
+    {
+        if (!$fieldDescriptor instanceof DoctrineFieldDescriptorInterface) {
+            throw new InvalidExpressionArgumentException('is_null', 'fieldDescriptor');
+        }
+
+        return new DoctrineIsNullExpression($fieldDescriptor);
+    }
+
+    public function createIsNotNullExpression(FieldDescriptorInterface $fieldDescriptor)
+    {
+        if (!$fieldDescriptor instanceof DoctrineFieldDescriptorInterface) {
+            throw new InvalidExpressionArgumentException('is_not_null', 'fieldDescriptor');
+        }
+
+        return new DoctrineIsNotNullExpression($fieldDescriptor);
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineIsNotNullExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineIsNotNullExpression.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNotNullExpressionInterface;
+
+class DoctrineIsNotNullExpression extends AbstractDoctrineExpression implements IsNotNullExpressionInterface
+{
+    public function __construct(protected DoctrineFieldDescriptorInterface $field)
+    {
+    }
+
+    public function getStatement(QueryBuilder $queryBuilder)
+    {
+        return $this->field->getSelect() . ' IS NOT NULL';
+    }
+
+    public function getFieldName()
+    {
+        return $this->field->getName();
+    }
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineIsNullExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineIsNullExpression.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNullExpressionInterface;
+
+class DoctrineIsNullExpression extends AbstractDoctrineExpression implements IsNullExpressionInterface
+{
+    public function __construct(protected DoctrineFieldDescriptorInterface $field)
+    {
+    }
+
+    public function getStatement(QueryBuilder $queryBuilder)
+    {
+        return $this->field->getSelect() . ' IS NULL';
+    }
+
+    public function getFieldName()
+    {
+        return $this->field->getName();
+    }
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/IsNotNullExpressionInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/IsNotNullExpressionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression;
+
+/**
+ * Interfaces which provides the needed information to build an in-expression.
+ */
+interface IsNotNullExpressionInterface extends BasicExpressionInterface
+{
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/IsNullExpressionInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/IsNullExpressionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression;
+
+/**
+ * Interfaces which provides the needed information to build an in-expression.
+ */
+interface IsNullExpressionInterface extends BasicExpressionInterface
+{
+}

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -15,6 +15,8 @@ use Sulu\Component\Rest\ListBuilder\Expression\BetweenExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\Expression\ConjunctionExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\Expression\ExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\Expression\InExpressionInterface;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNotNullExpressionInterface;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNullExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\Expression\WhereExpressionInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 
@@ -304,4 +306,18 @@ interface ListBuilderInterface
      * @return ConjunctionExpressionInterface
      */
     public function createOrExpression(array $expressions);
+
+    /**
+     * Creates an is null expression.
+     *
+     * @return IsNullExpressionInterface
+     */
+    public function createIsNullExpression(FieldDescriptorInterface $fieldDescriptor);
+
+    /**
+     * Creates an is not null expression.
+     *
+     * @return IsNotNullExpressionInterface
+     */
+    public function createIsNotNullExpression(FieldDescriptorInterface $fieldDescriptor);
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -36,6 +36,8 @@ use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescri
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescriptor;
 use Sulu\Component\Rest\ListBuilder\Event\ListBuilderCreateEvent;
 use Sulu\Component\Rest\ListBuilder\Event\ListBuilderEvents;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNotNullExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNullExpression;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeInterface;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry;
@@ -105,12 +107,7 @@ class DoctrineListBuilderTest extends TestCase
         ['id' => '3'],
     ];
 
-    /**
-     * @var class-string
-     *
-     * @phpstan-ignore property.defaultValue
-     */
-    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
+    private static string $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
 
     /** @var string */
     private static $entityNameAlias = 'Sulu_Bundle_CoreBundle_Entity_Example';
@@ -155,7 +152,7 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->doctrineListBuilder = new DoctrineListBuilder(
             $this->entityManager->reveal(),
-            self::$entityName,
+            self::$entityName, // @phpstan-ignore-line
             $this->filterTypeRegistry->reveal(),
             $this->eventDispatcher->reveal(),
             [PermissionTypes::VIEW => 64],
@@ -1563,5 +1560,27 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
+    }
+
+    public function testCreateIsNullExpression(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('test', 'test', self::$entityName);
+        $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
+
+        $expression = $this->doctrineListBuilder->createIsNullExpression($fieldDescriptor);
+
+        $this->assertInstanceOf(DoctrineIsNullExpression::class, $expression);
+        $this->assertEquals('test', $expression->getFieldName());
+    }
+
+    public function testCreateIsNotNullExpression(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('test', 'test', self::$entityName);
+        $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
+
+        $expression = $this->doctrineListBuilder->createIsNotNullExpression($fieldDescriptor);
+
+        $this->assertInstanceOf(DoctrineIsNotNullExpression::class, $expression);
+        $this->assertEquals('test', $expression->getFieldName());
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineIsNotNullExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineIsNotNullExpressionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNotNullExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNotNullExpressionInterface;
+
+class DoctrineIsNotNullExpressionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<QueryBuilder>
+     */
+    private ObjectProphecy $queryBuilder;
+
+    /**
+     * @var string
+     */
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
+
+    protected function setUp(): void
+    {
+        $this->queryBuilder = $this->prophesize(QueryBuilder::class);
+    }
+
+    public function testImplementsInterface(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNotNullExpression($fieldDescriptor);
+
+        $interfaces = \class_implements($expression);
+        $this->assertContains(IsNotNullExpressionInterface::class, $interfaces);
+    }
+
+    public function testGetStatement(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNotNullExpression($fieldDescriptor);
+
+        $statement = $expression->getStatement($this->queryBuilder->reveal());
+
+        $this->assertSame('Sulu_Bundle_CoreBundle_Entity_Example.name IS NOT NULL', $statement);
+    }
+
+    public function testGetFieldName(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNotNullExpression($fieldDescriptor);
+
+        $fieldName = $expression->getFieldName();
+
+        $this->assertSame('name', $fieldName);
+    }
+
+    public function testQueryBuilderNotModified(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNotNullExpression($fieldDescriptor);
+
+        // The QueryBuilder should not have any methods called on it
+        $statement = $expression->getStatement($this->queryBuilder->reveal());
+
+        // Just verify that we got a statement back and it contains expected content
+        $this->assertNotEmpty($statement);
+        $this->assertStringContainsString('IS NOT NULL', $statement);
+    }
+}

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineIsNullExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineIsNullExpressionTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNullExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNullExpressionInterface;
+
+class DoctrineIsNullExpressionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<QueryBuilder>
+     */
+    private ObjectProphecy $queryBuilder;
+
+    /**
+     * @var string
+     */
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
+
+    protected function setUp(): void
+    {
+        $this->queryBuilder = $this->prophesize(QueryBuilder::class);
+    }
+
+    public function testImplementsInterface(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNullExpression($fieldDescriptor);
+
+        $interfaces = \class_implements($expression);
+        $this->assertContains(IsNullExpressionInterface::class, $interfaces);
+    }
+
+    public function testGetStatement(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNullExpression($fieldDescriptor);
+
+        $statement = $expression->getStatement($this->queryBuilder->reveal());
+
+        $this->assertSame('Sulu_Bundle_CoreBundle_Entity_Example.name IS NULL', $statement);
+    }
+
+    public function testGetFieldName(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNullExpression($fieldDescriptor);
+
+        $fieldName = $expression->getFieldName();
+
+        $this->assertSame('name', $fieldName);
+    }
+
+    public function testQueryBuilderNotModified(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNullExpression($fieldDescriptor);
+
+        // The QueryBuilder should not have any methods called on it
+        $statement = $expression->getStatement($this->queryBuilder->reveal());
+
+        // Just verify that we got a statement back
+        $this->assertNotEmpty($statement);
+        $this->assertStringContainsString('IS NULL', $statement);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes type => group
| Fixed tickets | fixes parts of #7672 
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add groups to the template and use this as a replacement of article-types.

#### Why?

Missing feature in 3.0.

#### Example Usage

```xml
<?xml version="1.0" ?>
<template xmlns="http://schemas.sulu.io/template/template"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">

    <key>article</key>
    <group>blog</group>

    <view>articles/article</view>
    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
    <cacheLifetime>604800</cacheLifetime>

    ...
```

#### To Do

- [ ] Add breaking changes to UPGRADE.md
- [x] Update Tests

<!--

Dear Contributors,

Thank you for contributing to the Sulu ecosystem!

We appreciate your effort to improve our project.  
If you need assistance or have questions about your pull request, our team is here to help.  
Please join our Slack channel for support: https://sulu.io/services/support#chat.

Best Regards, 
The Sulu Core Team

-->
