### PR TITLE
Add new endpoint resource locator generateUrl endpoint

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -93,6 +93,10 @@ Then you need to update the route configuration in your `config/routes/sulu_admi
 +    resource: "@SuluSnippetBundle/config/routing_admin_api.yaml"
      prefix: /admin/api
 
++sulu_next_route_api:
++    resource: "@SuluNextRouteBundle/config/routing_admin_api.yaml"
++    prefix: /admin/api
++
 +sulu_next_page_api:
 +    resource: "@SuluNextPageBundle/config/routing_admin_api.yaml"
 +    prefix: /admin/api
@@ -485,6 +489,12 @@ now independent of the locale and contain all metadata for all locales this mean
 -$metadata->setPlaceholder($placeholder);
 +$metadata->setPlaceholder($placeholder, $locale);
 ```
+
+### ResourceLocator endpoint changed
+
+The ResourceLocator endpoint was moved from PageBundle to the new RouteBundle.  
+It changed from `/admin/api/resourcelocators?action=generate` to `/admin/api/resource-locators`.
+Also, the endpoint no longer expects `entityClass` or `entityId` instead the `resourceKey` and `resourceId` are expected.
 
 ### FOSRestRouting Bundle removed
 

--- a/composer.json
+++ b/composer.json
@@ -146,6 +146,7 @@
         "symfony/debug-bundle": "^6.4 || ^7.1",
         "symfony/dotenv": "^6.4 || ^7.1",
         "symfony/error-handler": "^6.4 || ^7.1",
+        "symfony/emoji": "^7.1",
         "symfony/monolog-bundle": "^3.7",
         "symfony/phpunit-bridge": "^6.4 || ^7.1",
         "symfony/runtime": "^6.4 || ^7.1",

--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -30,6 +30,10 @@ sulu_next_page_api:
     resource: "@SuluNextPageBundle/config/routing_admin_api.yaml"
     prefix: /admin/api
 
+sulu_next_route_api:
+    resource: "@SuluNextRouteBundle/config/routing_admin_api.yaml"
+    prefix: /admin/api
+
 sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing.yaml"
     prefix: /admin/media

--- a/packages/route/config/routing_admin_api.yaml
+++ b/packages/route/config/routing_admin_api.yaml
@@ -1,0 +1,5 @@
+sulu_route.post_resource_locator:
+    path: /resource-locators.{_format}
+    methods: POST
+    controller: sulu_route.resource_locator_generate_controller
+    format: json

--- a/packages/route/src/Application/ResourceLocator/PathCleanup/PathCleanup.php
+++ b/packages/route/src/Application/ResourceLocator/PathCleanup/PathCleanup.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Application\ResourceLocator\PathCleanup;
+
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+final readonly class PathCleanup implements PathCleanupInterface
+{
+    /**
+     * @param array<string, array<string, string>> $replacers
+     */
+    public function __construct(
+        private SluggerInterface $slugger,
+        private array $replacers = [],
+    ) {
+    }
+
+    public function cleanup(string $path, string $locale): string
+    {
+        $replacers = $this->replacers['default'] ?? [];
+
+        $replacers = \array_merge(
+            $replacers,
+            $this->replacers[$locale] ?? []
+        );
+        $locale = \str_replace('-', '_', $locale);
+
+        if (\count($replacers) > 0) {
+            foreach ($replacers as $key => $value) {
+                $path = \str_replace($key, $value, $path);
+            }
+        }
+        // replace multiple dash with one
+        $path = \preg_replace('/([-]+)/', '-', $path);
+
+        // remove dash before slash
+        $path = \preg_replace('/[-]+\//', '/', $path); // @phpstan-ignore-line argument.type
+
+        // remove dash after slash
+        $path = \preg_replace('/\/[-]+/', '/', $path); // @phpstan-ignore-line argument.type
+
+        // delete dash at the beginning or end
+        $path = \preg_replace('/^([-])/', '', $path); // @phpstan-ignore-line argument.type
+        $path = \preg_replace('/([-])$/', '', $path); // @phpstan-ignore-line argument.type
+
+        // replace multiple slashes
+        $path = \preg_replace('/([\/]+)/', '/', $path); // @phpstan-ignore-line argument.type
+
+        $parts = \explode('/', $path); // @phpstan-ignore-line argument.type
+        $newParts = [];
+
+        $totalParts = \count($parts);
+        foreach ($parts as $i => $part) {
+            $slug = $this->slugger->slug($part, '-', $locale);
+            $slug = $slug->lower();
+            if (0 === $i || $i + 1 === $totalParts || !$slug->isEmpty()) {
+                $newParts[] = $slug->toString();
+            }
+        }
+
+        return \implode('/', $newParts);
+    }
+}

--- a/packages/route/src/Application/ResourceLocator/PathCleanup/PathCleanupInterface.php
+++ b/packages/route/src/Application/ResourceLocator/PathCleanup/PathCleanupInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Application\ResourceLocator\PathCleanup;
+
+interface PathCleanupInterface
+{
+    public function cleanup(string $path, string $locale): string;
+}

--- a/packages/route/src/Application/ResourceLocator/ResourceLocatorGenerator.php
+++ b/packages/route/src/Application/ResourceLocator/ResourceLocatorGenerator.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Application\ResourceLocator;
+
+use Sulu\Route\Application\ResourceLocator\PathCleanup\PathCleanupInterface;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+
+final readonly class ResourceLocatorGenerator implements ResourceLocatorGeneratorInterface
+{
+    /**
+     * @internal get the service always from the Service Container and never instantiate it directly
+     */
+    public function __construct(
+        private RouteRepositoryInterface $routeRepository,
+        private PathCleanupInterface $pathCleanup,
+    ) {
+    }
+
+    public function generate(ResourceLocatorRequest $request): string
+    {
+        $parentPath = '/';
+        if ($request->parentResourceId) {
+            $parentRoute = $this->routeRepository->findOneBy([
+                'resourceKey' => $request->parentResourceKey,
+                'resourceId' => $request->parentResourceId,
+                'locale' => $request->locale,
+                'site' => $request->site,
+            ]);
+
+            $parentPath = $parentRoute?->getSlug() ?: '/';
+        }
+
+        $parts = \array_map(fn ($part) => $this->pathCleanup->cleanup($part, $request->locale), $request->parts);
+
+        $path = '/' . \implode('-', $parts);
+
+        // TODO routeSchema
+
+        return $this->createUnique( // TODO own service called during doctrine listener also?
+            \rtrim($parentPath, '/') . $path,
+            $request->locale,
+            $request->site,
+            $request->resourceKey,
+            $request->resourceId,
+        );
+    }
+
+    private function createUnique(
+        string $path,
+        string $locale,
+        ?string $site,
+        string $resourceKey,
+        ?string $resourceId,
+    ): string {
+        $originalPath = $path;
+        $i = 0;
+
+        while ($this->routeRepository->existBy(
+            $resourceId ? [
+                'locale' => $locale,
+                'site' => $site,
+                'slug' => $path,
+                'excludeResource' => [
+                    'resourceKey' => $resourceKey,
+                    'resourceId' => $resourceId,
+                ],
+            ] : [
+                'locale' => $locale,
+                'site' => $site,
+                'slug' => $path,
+            ],
+        )) {
+            $path = $originalPath . '-' . (++$i);
+        }
+
+        return $path;
+    }
+}

--- a/packages/route/src/Application/ResourceLocator/ResourceLocatorGeneratorInterface.php
+++ b/packages/route/src/Application/ResourceLocator/ResourceLocatorGeneratorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Application\ResourceLocator;
+
+interface ResourceLocatorGeneratorInterface
+{
+    public function generate(ResourceLocatorRequest $request): string;
+}

--- a/packages/route/src/Application/ResourceLocator/ResourceLocatorRequest.php
+++ b/packages/route/src/Application/ResourceLocator/ResourceLocatorRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Application\ResourceLocator;
+
+final readonly class ResourceLocatorRequest
+{
+    public string $parentResourceKey;
+
+    /**
+     * @param array<string, string> $parts
+     */
+    public function __construct(
+        public array $parts,
+        public string $locale,
+        public ?string $site,
+        public string $resourceKey,
+        public ?string $resourceId,
+        public ?string $parentResourceId,
+        ?string $parentResourceKey,
+        public ?string $routeSchema,
+    ) {
+        $this->parentResourceKey = $parentResourceKey ?? $this->resourceKey;
+    }
+}

--- a/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
+++ b/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
@@ -21,6 +21,10 @@ use Sulu\Route\Domain\Model\Route;
  *     slug?: string,
  *     resourceKey?: string,
  *     resourceId?: string,
+ *     excludeResource?: array{
+ *         resourceKey: string,
+ *         resourceId: string,
+ *     },
  * }
  */
 interface RouteRepositoryInterface
@@ -31,6 +35,11 @@ interface RouteRepositoryInterface
      * @param RouteFilter $filters
      */
     public function findOneBy(array $filters): ?Route;
+
+    /**
+     * @param RouteFilter $filters
+     */
+    public function existBy(array $filters): bool;
 
     /**
      * @param RouteFilter $filters

--- a/packages/route/src/Userinterface/Controller/Admin/ResourceLocatorGenerateController.php
+++ b/packages/route/src/Userinterface/Controller/Admin/ResourceLocatorGenerateController.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Userinterface\Controller\Admin;
+
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorGeneratorInterface;
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorRequest;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Webmozart\Assert\Assert;
+
+final readonly class ResourceLocatorGenerateController
+{
+    public function __construct(private ResourceLocatorGeneratorInterface $resourceLocatorGenerator)
+    {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $resourceLocatorRequest = $this->createResourceLocatorRequestByRequest($request);
+
+        return new JsonResponse([
+            'resourceLocator' => $this->resourceLocatorGenerator->generate($resourceLocatorRequest),
+        ]);
+    }
+
+    private function createResourceLocatorRequestByRequest(Request $request): ResourceLocatorRequest
+    {
+        $payload = $request->getPayload();
+
+        $parts = \array_filter($payload->all('parts'));
+        foreach ($parts as $key => $part) {
+            Assert::string($key);
+            Assert::string($part);
+        }
+
+        /** @var array<string, string>  $parts */
+        $locale = $payload->getString('locale');
+        $site = $payload->getString('webspace') ?: null;
+        $resourceKey = $payload->getString('resourceKey');
+        $resourceId = $payload->getString('resourceId') ?: null;
+        $parentResourceId = $payload->getString('parentId') ?: null;
+        $parentResourceKey = $payload->getString('parentKey') ?: $resourceKey;
+        $routeSchema = $payload->getString('routeSchema') ?: null;
+
+        return new ResourceLocatorRequest(
+            $parts,
+            $locale,
+            $site,
+            $resourceKey,
+            $resourceId,
+            $parentResourceId,
+            $parentResourceKey,
+            $routeSchema,
+        );
+    }
+}

--- a/packages/route/tests/Application/config/routing.yml
+++ b/packages/route/tests/Application/config/routing.yml
@@ -1,0 +1,3 @@
+sulu_next_route_api:
+    resource: "@SuluNextRouteBundle/config/routing_admin_api.yaml"
+    prefix: /admin/api

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
@@ -145,4 +145,35 @@ class RouteRepositoryTest extends KernelTestCase
 
         $this->assertNull($route);
     }
+
+    public function testExistBySiteSlugLocale(): void
+    {
+        $this->assertTrue($this->routeRepository->existBy([
+            'site' => 'the_site',
+            'slug' => '/example',
+            'locale' => 'en',
+        ]));
+    }
+
+    public function testExistBySiteWithExclude(): void
+    {
+        $this->assertFalse($this->routeRepository->existBy([
+            'site' => 'the_site',
+            'slug' => '/example',
+            'locale' => 'en',
+            'excludeResource' => [
+                'resourceKey' => 'example',
+                'resourceId' => '1',
+            ],
+        ]));
+    }
+
+    public function testExistBySiteSlugLocaleNotFound(): void
+    {
+        $this->assertFalse($this->routeRepository->existBy([
+            'site' => 'the_site',
+            'slug' => '/example-1',
+            'locale' => 'en',
+        ]));
+    }
 }

--- a/packages/route/tests/Functional/Infrastructure/Symfony/Router/UrlGeneratorTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Symfony/Router/UrlGeneratorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Tests\Functional\Infrastructure\Symfony\Router;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\TestWith;
+use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversNothing]
+class UrlGeneratorTest extends KernelTestCase
+{
+    /**
+     * @var array<string, string>
+     */
+    private static array $testedRoutes = [];
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    #[TestWith(['sulu_route.post_resource_locator', [], '/admin/api/resource-locators'])]
+    public function testRoutes(string $route, array $params, string $expectedUrl): void
+    {
+        $urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
+
+        self::$testedRoutes[$route] = $route;
+
+        $this->assertSame(
+            $expectedUrl,
+            $urlGenerator->generate($route, $params)
+        );
+    }
+
+    #[Depends('testRoutes')]
+    public function testAllRoutesTested(): void
+    {
+        $routes = Yaml::parse(\file_get_contents(__DIR__ . '/../../../../../config/routing_admin_api.yaml') ?: '') ?? [];
+        $this->assertIsArray($routes);
+        $this->assertGreaterThan(0, \count($routes), 'No routes found in routing_admin_api.yaml');
+
+        $this->assertSame(
+            \array_keys($routes),
+            \array_keys(self::$testedRoutes),
+        );
+    }
+
+    public static function teardownAfterClass(): void
+    {
+        self::$testedRoutes = [];
+        parent::teardownAfterClass();
+    }
+}

--- a/packages/route/tests/Functional/UserInterface/Controller/Admin/ResourceLocatorGenerateControllerTest.php
+++ b/packages/route/tests/Functional/UserInterface/Controller/Admin/ResourceLocatorGenerateControllerTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Tests\Functional\UserInterface\Controller\Admin;
+
+use Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Userinterface\Controller\Admin\ResourceLocatorGenerateController;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+#[CoversClass(ResourceLocatorGenerateController::class)]
+class ResourceLocatorGenerateControllerTest extends SuluTestCase
+{
+    use PHPMatcherAssertions;
+
+    private KernelBrowser $client;
+
+    public static function setUpBeforeClass(): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->getConnection()->executeStatement('DELETE FROM ro_next_routes WHERE 1 = 1');
+
+        $homepageEn = new Route('pages', '1', 'en', '/', 'website');
+        $entityManager->persist($homepageEn);
+        $homepageDe = new Route('pages', '1', 'de', '/', 'website');
+        $entityManager->persist($homepageDe);
+        $homepageFr = new Route('pages', '1', 'fr', $homepageEn->getSlug(), 'website');
+        $entityManager->persist($homepageFr);
+
+        $parentEn = new Route('pages', '2', 'en', '/parent', 'website', $homepageEn);
+        $entityManager->persist($parentEn);
+        $parentDe = new Route('pages', '2', 'de', '/eltern', 'website', $homepageDe);
+        $entityManager->persist($parentDe);
+        $parentFr = new Route('pages', '2', 'fr', $parentEn->getSlug(), 'website', $homepageFr);
+        $entityManager->persist($parentFr);
+
+        $childAEn = new Route('pages', '3', 'en', '/parent/child-a', 'website', $parentEn);
+        $entityManager->persist($childAEn);
+        $childADe = new Route('pages', '3', 'de', '/eltern/kind-a', 'website', $parentDe);
+        $entityManager->persist($childADe);
+        $childAFr = new Route('pages', '3', 'fr', $childAEn->getSlug(), 'website', $parentFr);
+        $entityManager->persist($childAFr);
+
+        $childBEn = new Route('pages', '4', 'en', '/parent/child-b', 'website', $parentEn);
+        $entityManager->persist($childBEn);
+        $childBDe = new Route('pages', '4', 'de', '/eltern/kind-b', 'website', $parentDe);
+        $entityManager->persist($childBDe);
+        $childBFr = new Route('pages', '4', 'fr', $childBEn->getSlug(), 'website', $parentFr);
+        $entityManager->persist($childBFr);
+
+        $otherHomepageEn = new Route('pages', '5', 'en', '/', 'intranet');
+        $entityManager->persist($otherHomepageEn);
+        $homepageDe = new Route('pages', '5', 'de', '/', 'intranet');
+        $entityManager->persist($homepageDe);
+
+        $parentEn = new Route('pages', '6', 'en', '/parent', 'intranet', $homepageEn);
+        $entityManager->persist($parentEn);
+        $parentDe = new Route('pages', '6', 'de', '/eltern', 'intranet', $homepageDe);
+        $entityManager->persist($parentDe);
+
+        $historyRoute1 = new Route(Route::HISTORY_RESOURCE_KEY, 'pages::2', 'en', '/test', 'website');
+        $entityManager->persist($historyRoute1);
+        $historyRoute2 = new Route(Route::HISTORY_RESOURCE_KEY, 'pages::3', 'en', '/test/child-a', 'website');
+        $entityManager->persist($historyRoute2);
+
+        $entityManager->flush();
+        $entityManager->clear();
+
+        self::ensureKernelShutdown();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->getConnection()->executeStatement('DELETE FROM ro_next_routes WHERE 1 = 1');
+
+        self::ensureKernelShutdown();
+    }
+
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+    }
+
+    public function testGenerateNewArticle(): void
+    {
+        $this->client->request('POST', '/admin/api/resource-locators', content: \json_encode([
+            'parts' => ['title' => 'Hello World'],
+            'locale' => 'en',
+            'webspace' => 'website',
+            'resourceKey' => 'articles',
+            'resourceId' => null,
+        ], \JSON_THROW_ON_ERROR));
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertMatchesPattern(<<<'JSON'
+            {
+                "resourceLocator": "/hello-world"
+            }
+        JSON, $response->getContent() ?: '');
+    }
+
+    public function testGenerateNewPageWithParent(): void
+    {
+        $this->client->request('POST', '/admin/api/resource-locators', content: \json_encode([
+            'parts' => ['title' => 'Hello World'],
+            'locale' => 'en',
+            'webspace' => 'website',
+            'resourceKey' => 'pages',
+            'resourceId' => null,
+            'parentId' => '2',
+        ], \JSON_THROW_ON_ERROR));
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertMatchesPattern(<<<'JSON'
+            {
+                "resourceLocator": "/parent/hello-world"
+            }
+        JSON, $response->getContent() ?: '');
+    }
+
+    public function testGenerateNewPageWithConflict(): void
+    {
+        $this->client->request('POST', '/admin/api/resource-locators', content: \json_encode([
+            'parts' => ['title' => 'test'],
+            'locale' => 'en',
+            'webspace' => 'website',
+            'resourceKey' => 'pages',
+            'resourceId' => null,
+        ], \JSON_THROW_ON_ERROR));
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertMatchesPattern(<<<'JSON'
+            {
+                "resourceLocator": "/test-1"
+            }
+        JSON, $response->getContent() ?: '');
+    }
+
+    public function testGenerateNewPageWithHistoryConflict(): void
+    {
+        $this->client->request('POST', '/admin/api/resource-locators', content: \json_encode([
+            'parts' => ['title' => 'Parent'],
+            'locale' => 'en',
+            'webspace' => 'website',
+            'resourceKey' => 'pages',
+            'resourceId' => null,
+        ], \JSON_THROW_ON_ERROR));
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertMatchesPattern(<<<'JSON'
+            {
+                "resourceLocator": "/parent-1"
+            }
+        JSON, $response->getContent() ?: '');
+    }
+
+    public function testGenerateNewPageNoConflictOtherSide(): void
+    {
+        $this->client->request('POST', '/admin/api/resource-locators', content: \json_encode([
+            'parts' => ['title' => 'Child A'],
+            'locale' => 'en',
+            'webspace' => 'intranet',
+            'resourceKey' => 'pages',
+            'resourceId' => null,
+            'parentId' => '6',
+        ], \JSON_THROW_ON_ERROR));
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertMatchesPattern(<<<'JSON'
+            {
+                "resourceLocator": "/parent/child-a"
+            }
+        JSON, $response->getContent() ?: '');
+    }
+
+    public function testGenerateExistPage(): void
+    {
+        $this->client->request('POST', '/admin/api/resource-locators', content: \json_encode([
+            'parts' => ['title' => 'Parent'],
+            'locale' => 'en',
+            'webspace' => 'website',
+            'resourceKey' => 'pages',
+            'resourceId' => '2',
+            'parentId' => '1',
+        ], \JSON_THROW_ON_ERROR));
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertMatchesPattern(<<<'JSON'
+            {
+                "resourceLocator": "/parent"
+            }
+        JSON, $response->getContent() ?: '');
+    }
+
+    public function testGenerateExistPageOtherResourceId(): void
+    {
+        $this->client->request('POST', '/admin/api/resource-locators', content: \json_encode([
+            'parts' => ['title' => 'Parent'],
+            'locale' => 'en',
+            'webspace' => 'website',
+            'resourceKey' => 'pages',
+            'resourceId' => '3',
+            'parentId' => '1',
+        ], \JSON_THROW_ON_ERROR));
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertMatchesPattern(<<<'JSON'
+            {
+                "resourceLocator": "/parent-1"
+            }
+        JSON, $response->getContent() ?: '');
+    }
+}

--- a/packages/route/tests/Unit/Application/ResourceLocator/PathCleanup/PathCleanupTest.php
+++ b/packages/route/tests/Unit/Application/ResourceLocator/PathCleanup/PathCleanupTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Tests\Unit\Application\ResourceLocator\PathCleanup;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Sulu\Route\Application\ResourceLocator\PathCleanup\PathCleanup;
+use Sulu\Route\Application\ResourceLocator\PathCleanup\PathCleanupInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+#[CoversClass(PathCleanup::class)]
+class PathCleanupTest extends TestCase
+{
+    private PathCleanupInterface $pathCleanup;
+
+    public function setUp(): void
+    {
+        $slugger = new AsciiSlugger();
+        $slugger = $slugger->withEmoji();
+
+        $this->pathCleanup = new PathCleanup(
+            $slugger,
+            replacers: [
+                'default' => [
+                    ' ' => '-',
+                    '+' => '-',
+                    '.' => '-',
+                ],
+                'de' => [
+                    'ä' => 'ae',
+                    'ö' => 'oe',
+                    'ü' => 'ue',
+                    'Ä' => 'ae',
+                    'Ö' => 'oe',
+                    'Ü' => 'ue',
+                    'ß' => 'ss',
+                    '&' => 'und',
+                ],
+                'en' => [
+                    '&' => 'and',
+                ],
+                'bg' => [
+                    '&' => 'и',
+                ],
+            ],
+        );
+    }
+
+    #[TestWith(['-Hello World-', 'hello-world'])]
+    #[TestWith(['Hello--World', 'hello-world'])]
+    #[TestWith(['Hello//World', 'hello/world'])]
+    #[TestWith(['Hello / World', 'hello/world'])]
+    public function testSlashAndDashes(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->pathCleanup->cleanup($input, 'en'));
+    }
+
+    #[TestWith(['Hello World', 'hello-world'])]
+    #[TestWith(['Hello.World', 'hello-world'])]
+    #[TestWith(['Hello^World', 'hello-world'])]
+    #[TestWith(['Hello~World', 'hello-world'])]
+    #[TestWith(['Hello[World', 'hello-world'])]
+    #[TestWith(['Hello]World', 'hello-world'])]
+    #[TestWith(['Hello)World', 'hello-world'])]
+    #[TestWith(['Hello(World', 'hello-world'])]
+    #[TestWith(['Hello}World', 'hello-world'])]
+    #[TestWith(['Hello{World', 'hello-world'])]
+    public function testSpecialChars(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->pathCleanup->cleanup($input, 'en'));
+    }
+
+    #[TestWith(['Hello WÁrld', 'hello-warld'])]
+    #[TestWith(['Hállo World', 'hallo-world'])]
+    #[TestWith(['HÉllo World', 'hello-world'])]
+    #[TestWith(['HĬllo World', 'hillo-world'])]
+    #[TestWith(['Helloř', 'hellor'])]
+    #[TestWith(['Straße', 'strasse'])]
+    public function testSlugger(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->pathCleanup->cleanup($input, 'en'));
+    }
+
+    #[TestWith(['Hallo & Welt', 'hallo-und-welt'])]
+    #[TestWith(['Hällö Welt', 'haelloe-welt'])]
+    public function testReplacers(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->pathCleanup->cleanup($input, 'de'));
+    }
+
+    #[TestWith(['The 🍕 and 🍝 World', 'the-pizza-and-spaghetti-world'])]
+    public function testEmoji(string $input, string $expected): void
+    {
+        $this->assertSame($expected, $this->pathCleanup->cleanup($input, 'en'));
+    }
+}

--- a/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorGeneratorTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Tests\Unit\Application\ResourceLocator;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Route\Application\ResourceLocator\PathCleanup\PathCleanup;
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorGenerator;
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorRequest;
+use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+#[CoversClass(ResourceLocatorGenerator::class)]
+class ResourceLocatorGeneratorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<RouteRepositoryInterface>
+     */
+    private ObjectProphecy $routeRepository;
+
+    private ResourceLocatorGenerator $resourceLocatorGenerator;
+
+    public function setUp(): void
+    {
+        $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
+
+        $this->resourceLocatorGenerator = new ResourceLocatorGenerator(
+            $this->routeRepository->reveal(),
+            new PathCleanup(new AsciiSlugger(), []),
+        );
+    }
+
+    public function testGenerate(): void
+    {
+        $request = $this->createResourceLocatorRequest(
+            parts: ['title' => 'Hello World'],
+        );
+
+        $this->routeRepository->existBy(Argument::any())->willReturn(false);
+
+        $this->assertSame('/hello-world', $this->resourceLocatorGenerator->generate($request));
+    }
+
+    public function testGenerateWithParent(): void
+    {
+        $request = $this->createResourceLocatorRequest(
+            parts: [
+                'title' => 'Hello World',
+            ],
+            locale: 'de',
+            site: 'website',
+            resourceKey: 'articles',
+            parentResourceId: 'cff165a7-ae8e-46b4-8f32-f0a339173207',
+            parentResourceKey: 'pages',
+        );
+
+        $parentRoute = $this->createRoute(
+            resourceKey: 'pages',
+            resourceId: 'cff165a7-ae8e-46b4-8f32-f0a339173207',
+            locale: 'de',
+            slug: '/news',
+            site: 'website',
+        );
+        $this->routeRepository->findOneBy([
+            'resourceId' => 'cff165a7-ae8e-46b4-8f32-f0a339173207',
+            'resourceKey' => 'pages',
+            'locale' => 'de',
+            'site' => 'website',
+        ])
+            ->willReturn($parentRoute)
+            ->shouldBeCalled();
+
+        $this->routeRepository->existBy(Argument::any())->willReturn(false);
+
+        $this->assertSame('/news/hello-world', $this->resourceLocatorGenerator->generate($request));
+    }
+
+    public function testGenerateAlreadyExists(): void
+    {
+        $request = $this->createResourceLocatorRequest(
+            parts: ['title' => 'Hello World'],
+        );
+
+        $this->routeRepository->existBy([
+            'slug' => '/hello-world',
+            'locale' => 'en',
+            'site' => null,
+        ])->willReturn(true);
+
+        $this->routeRepository->existBy([
+            'slug' => '/hello-world-1',
+            'locale' => 'en',
+            'site' => null,
+        ])->willReturn(true);
+
+        $this->routeRepository->existBy([
+            'slug' => '/hello-world-2',
+            'locale' => 'en',
+            'site' => null,
+        ])->willReturn(false);
+
+        $this->assertSame('/hello-world-2', $this->resourceLocatorGenerator->generate($request));
+    }
+
+    /**
+     * @param array<string, string> $parts
+     */
+    private function createResourceLocatorRequest(
+        array $parts = [],
+        string $locale = 'en',
+        ?string $site = null,
+        string $resourceKey = 'pages',
+        ?string $resourceId = null,
+        ?string $parentResourceId = null,
+        ?string $parentResourceKey = null,
+        ?string $routeSchema = null,
+    ): ResourceLocatorRequest {
+        return new ResourceLocatorRequest(
+            parts: $parts,
+            locale: $locale,
+            site: $site,
+            resourceKey: $resourceKey,
+            resourceId: $resourceId,
+            parentResourceId: $parentResourceId,
+            parentResourceKey: $parentResourceKey,
+            routeSchema: $routeSchema,
+        );
+    }
+
+    public function createRoute(
+        string $resourceKey = 'resource',
+        string $resourceId = '12345',
+        string $locale = 'en',
+        string $slug = '/',
+        ?string $site = null,
+        ?Route $parentRoute = null,
+    ): Route {
+        return new Route(
+            $resourceKey,
+            $resourceId,
+            $locale,
+            $slug,
+            $site,
+            $parentRoute,
+        );
+    }
+}

--- a/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorRequestTest.php
+++ b/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorRequestTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Tests\Unit\Application\ResourceLocator;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorRequest;
+use Symfony\Component\Uid\Uuid;
+
+#[CoversClass(ResourceLocatorRequest::class)]
+class ResourceLocatorRequestTest extends TestCase
+{
+    public function testParts(): void
+    {
+        $instance = $this->createInstance(parts: ['title' => 'Hello World']);
+
+        $this->assertSame(['title' => 'Hello World'], $instance->parts);
+    }
+
+    public function testLocale(): void
+    {
+        $instance = $this->createInstance(locale: 'de');
+
+        $this->assertSame('de', $instance->locale);
+    }
+
+    public function testSite(): void
+    {
+        $instance = $this->createInstance(site: 'sulu');
+
+        $this->assertSame('sulu', $instance->site);
+    }
+
+    public function testResourceKey(): void
+    {
+        $instance = $this->createInstance(resourceKey: 'articles');
+
+        $this->assertSame('articles', $instance->resourceKey);
+    }
+
+    public function testResourceId(): void
+    {
+        $uuid = Uuid::v7()->toRfc4122();
+        $instance = $this->createInstance(resourceId: $uuid);
+
+        $this->assertSame($uuid, $instance->resourceId);
+    }
+
+    public function testParentId(): void
+    {
+        $uuid = Uuid::v7()->toRfc4122();
+        $instance = $this->createInstance(parentResourceId: $uuid);
+
+        $this->assertSame($uuid, $instance->parentResourceId);
+    }
+
+    public function testParentKey(): void
+    {
+        $instance = $this->createInstance(parentResourceKey: 'pages');
+
+        $this->assertSame('pages', $instance->parentResourceKey);
+    }
+
+    public function testParentKeyFallbackToResourceKey(): void
+    {
+        $instance = $this->createInstance();
+
+        $this->assertSame('pages', $instance->parentResourceKey);
+    }
+
+    public function testRouteSchema(): void
+    {
+        $instance = $this->createInstance(routeSchema: '/{implode(parts, \'-\')}');
+
+        $this->assertSame('/{implode(parts, \'-\')}', $instance->routeSchema);
+    }
+
+    /**
+     * @param array<string, string> $parts
+     */
+    private function createInstance(
+        array $parts = [],
+        string $locale = 'en',
+        ?string $site = null,
+        string $resourceKey = 'pages',
+        ?string $resourceId = null,
+        ?string $parentResourceId = null,
+        ?string $parentResourceKey = null,
+        ?string $routeSchema = null,
+    ): ResourceLocatorRequest {
+        return new ResourceLocatorRequest(
+            parts: $parts,
+            locale: $locale,
+            site: $site,
+            resourceKey: $resourceKey,
+            resourceId: $resourceId,
+            parentResourceId: $parentResourceId,
+            parentResourceKey: $parentResourceKey,
+            routeSchema: $routeSchema,
+        );
+    }
+}

--- a/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Route\Tests\Unit\Application\Generator;
+namespace Sulu\Route\Tests\Unit\Application\Routing\Generator;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;

--- a/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Route\Tests\Unit\Application\Matcher;
+namespace Sulu\Route\Tests\Unit\Application\Routing\Matcher;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;

--- a/packages/route/tests/Unit/Application/Routing/Matcher/RouteHistoryDefaultsProviderTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Matcher/RouteHistoryDefaultsProviderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Route\Tests\Unit\Application\Matcher;
+namespace Sulu\Route\Tests\Unit\Application\Routing\Matcher;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Badge/tests/stores/BadgeStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Badge/tests/stores/BadgeStore.test.js
@@ -45,16 +45,16 @@ test('Should load data using the Requester', () => {
         '/value',
         {
             limit: 0,
-            entityClass: 'Foo',
+            resourceKey: 'Foo',
         },
         {
-            id: 'entityId',
+            id: 'resourceId',
             locale: 'locale',
         },
         mockTabViewRoute
     );
 
-    expect(Requester.get).toBeCalledWith('foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toBeCalledWith('foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     return promise.then(() => {
         expect(badgeStore.value).toEqual('2');
@@ -77,16 +77,16 @@ test('Should load data without datapath', () => {
         null,
         {
             limit: 0,
-            entityClass: 'Foo',
+            resourceKey: 'Foo',
         },
         {
-            id: 'entityId',
+            id: 'resourceId',
             locale: 'locale',
         },
         mockTabViewRoute
     );
 
-    expect(Requester.get).toBeCalledWith('foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toBeCalledWith('foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     return promise.then(() => {
         expect(badgeStore.value).toEqual('hello');
@@ -109,20 +109,20 @@ test('Should load data if route changes', () => {
         null,
         {
             limit: 0,
-            entityClass: 'Foo',
+            resourceKey: 'Foo',
         },
         {
-            id: 'entityId',
+            id: 'resourceId',
             locale: 'locale',
         },
         mockTabViewRoute
     );
 
-    expect(Requester.get).toHaveBeenNthCalledWith(1, 'foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toHaveBeenNthCalledWith(1, 'foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     router.route = ({property: 'value', parent: mockTabViewRoute}: any);
 
-    expect(Requester.get).toHaveBeenNthCalledWith(2, 'foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toHaveBeenNthCalledWith(2, 'foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 });
 
 test('Should not load data if route changes to other parent', () => {
@@ -141,17 +141,17 @@ test('Should not load data if route changes to other parent', () => {
         null,
         {
             limit: 0,
-            entityClass: 'Foo',
+            resourceKey: 'Foo',
         },
         {
-            id: 'entityId',
+            id: 'resourceId',
             locale: 'locale',
         },
         mockTabViewRoute
     );
 
     expect(Requester.get).toHaveBeenCalledTimes(1);
-    expect(Requester.get).toHaveBeenNthCalledWith(1, 'foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toHaveBeenNthCalledWith(1, 'foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     router.route = ({property: 'value', parent: {other: true}}: any);
 
@@ -174,10 +174,10 @@ test('Should load data on response hook callback', () => {
         null,
         {
             limit: 0,
-            entityClass: 'Foo',
+            resourceKey: 'Foo',
         },
         {
-            id: 'entityId',
+            id: 'resourceId',
             locale: 'locale',
         },
         mockTabViewRoute
@@ -187,7 +187,7 @@ test('Should load data on response hook callback', () => {
 
     // Initial request
     expect(Requester.get).toHaveBeenCalledTimes(1);
-    expect(Requester.get).toHaveBeenNthCalledWith(1, 'foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toHaveBeenNthCalledWith(1, 'foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     // Should not perform request because of a "GET" request
     const response1: any = {url: 'http://sulu.lo/admin/api/anything'};
@@ -204,7 +204,7 @@ test('Should load data on response hook callback', () => {
         {method: 'POST'}
     );
     expect(Requester.get).toHaveBeenCalledTimes(2);
-    expect(Requester.get).toHaveBeenNthCalledWith(2, 'foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toHaveBeenNthCalledWith(2, 'foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     // Should perform request
     const response3: any = {url: 'http://sulu.lo/admin/api/anything'};
@@ -213,7 +213,7 @@ test('Should load data on response hook callback', () => {
         {method: 'PUT'}
     );
     expect(Requester.get).toHaveBeenCalledTimes(3);
-    expect(Requester.get).toHaveBeenNthCalledWith(3, 'foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toHaveBeenNthCalledWith(3, 'foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     // Should perform request
     const response4: any = {url: 'http://sulu.lo/admin/api/anything'};
@@ -222,7 +222,7 @@ test('Should load data on response hook callback', () => {
         {method: 'PATCH'}
     );
     expect(Requester.get).toHaveBeenCalledTimes(4);
-    expect(Requester.get).toHaveBeenNthCalledWith(4, 'foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toHaveBeenNthCalledWith(4, 'foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     // Should perform request
     const response5: any = {url: 'http://sulu.lo/admin/api/anything'};
@@ -231,7 +231,7 @@ test('Should load data on response hook callback', () => {
         {method: 'DELETE'}
     );
     expect(Requester.get).toHaveBeenCalledTimes(5);
-    expect(Requester.get).toHaveBeenNthCalledWith(5, 'foo?entityId=5&locale=en&limit=0&entityClass=Foo');
+    expect(Requester.get).toHaveBeenNthCalledWith(5, 'foo?resourceId=5&locale=en&limit=0&resourceKey=Foo');
 
     // Should not perform request because of a collaboration request
     const response6: any = {url: 'http://sulu.lo/admin/api/collaborations?id=1234&resourceKey=pages'};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -127,9 +127,6 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
             formInspector,
             onChange,
             schemaOptions: {
-                entity_class: {
-                    value: entityClass,
-                } = {},
                 route_schema: {
                     value: routeSchema,
                 } = {},
@@ -155,7 +152,6 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                 resourceKey: formInspector.resourceKey,
                 locale: formInspector.locale ? formInspector.locale.get() : userStore.contentLocale,
                 id: formInspector.id,
-                entityClass,
                 routeSchema,
                 ...requestOptions,
             }
@@ -206,11 +202,6 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
             dataPath,
             disabled,
             formInspector,
-            schemaOptions: {
-                entity_class: {
-                    value: entityClass,
-                } = {},
-            } = {},
             value,
         } = this.props;
 
@@ -245,7 +236,6 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                             locale: formInspector.locale ? formInspector.locale.get() : userStore.contentLocale,
                             resourceKey: formInspector.resourceKey,
                             webspace: formInspector.options.webspace,
-                            entityClass,
                             ...options,
                         }}
                         resourceKey={historyResourceKey}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -71,8 +71,8 @@ test('Pass props correctly to ResourceLocator', () => {
             {...fieldTypeDefaultProps}
             disabled={true}
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -101,8 +101,8 @@ test('Render just slash instead of ResourceLocatorComponent if used on the homep
             {...fieldTypeDefaultProps}
             disabled={true}
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -132,7 +132,7 @@ test('Pass correct options to ResourceLocatorHistory if resource already existed
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators',
-                historyResourceKey: 'sulu_route.generate',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
                 options: {history: true},
             }}
@@ -146,7 +146,7 @@ test('Pass correct options to ResourceLocatorHistory if resource already existed
         expect(resourceLocator.find('ResourceLocatorHistory')).toHaveLength(1);
         expect(resourceLocator.find('ResourceLocatorHistory').prop('options'))
             .toEqual({history: true, webspace: 'sulu', resourceKey: 'test'});
-        expect(resourceLocator.find('ResourceLocatorHistory').prop('resourceKey')).toEqual('sulu_route.generate');
+        expect(resourceLocator.find('ResourceLocatorHistory').prop('resourceKey')).toEqual('resource-locators');
         expect(resourceLocator.find('ResourceLocatorHistory').prop('id')).toEqual(1);
     });
 });
@@ -170,8 +170,8 @@ test('Pass locale from userStore to ResourceLocator and ResourceLocatorHistory i
             {...fieldTypeDefaultProps}
             disabled={true}
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
                 options: {history: true},
             }}
@@ -192,8 +192,8 @@ test('Do not add an addFinishFieldHandler for URL generation if used on the home
         <ResourceLocator
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -211,7 +211,7 @@ test('Do not add an addFinishFieldHandler for URL generation if no generationUrl
         <ResourceLocator
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
-                historyResourceKey: 'sulu_route.generate',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -229,8 +229,8 @@ test.each(['leaf', 'full'])('Set mode correctly', (mode) => {
         <ResourceLocator
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -254,8 +254,8 @@ test('Should fire onFinish callback without argument when ResourceLocatorCompone
         <ResourceLocator
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -292,8 +292,8 @@ test('Should automatically request new URL when part field is finished on add fo
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -320,7 +320,7 @@ test('Should automatically request new URL when part field is finished on add fo
     expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/title');
     expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
     expect(Requester.post).toBeCalledWith(
-        '/admin/api/resourcelocators?action=generate',
+        '/admin/api/resource-locators',
         {
             locale: 'en',
             resourceKey: 'tests',
@@ -356,8 +356,8 @@ test('Should request URL with parameters from FormInspector options, fieldTypeOp
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => Promise.resolve('leaf'),
                 resourceStorePropertiesToRequest: {
                     propertyName: 'requestParamKey',
@@ -390,7 +390,7 @@ test('Should request URL with parameters from FormInspector options, fieldTypeOp
     expect(formInspector.getSchemaEntryByPath).toBeCalledWith('/title');
     expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
     expect(Requester.post).toBeCalledWith(
-        '/admin/api/resourcelocators?action=generate',
+        '/admin/api/resource-locators',
         {
             locale: 'en',
             parts: {title: 'title-value', subtitle: 'subtitle-value'},
@@ -426,8 +426,8 @@ test('Should not request new URL when part field is finished on edit form', () =
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -468,8 +468,8 @@ test('Should not request new URL when part field is finished if all parts are em
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -518,8 +518,8 @@ test('Should not request new URL when part field is finished if input was alread
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -566,8 +566,8 @@ test('Should not request new URL when field without the "sulu.rlp.part" tag is f
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -609,8 +609,8 @@ test('Should not request new URL when field without any tags has finished editin
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -649,8 +649,8 @@ test('Should enable refresh button when value of part field changes on edit form
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -689,8 +689,8 @@ test('Should enable refresh button when input is changed manually on edit form',
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -729,8 +729,8 @@ test('Should not enable refresh button when value of part field changes on add f
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -769,8 +769,8 @@ test('Should enable refresh button when input is changed manually on add form', 
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -809,8 +809,8 @@ test('Should not enable refresh button when value of part field changes if all p
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -857,8 +857,8 @@ test('Should request new URL with correct options and disable button when refres
             {...fieldTypeDefaultProps}
             dataPath="/block/0/url"
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'sulu_route.generate',
+                generationUrl: '/admin/api/resource-locators',
+                historyResourceKey: 'resource-locators',
                 modeResolver: () => modePromise,
                 resourceStorePropertiesToRequest: {
                     propertyName: 'requestParamKey',
@@ -885,7 +885,7 @@ test('Should request new URL with correct options and disable button when refres
         expect(resourceLocator.find('Button').props().disabled).toBeTruthy();
         expect(formInspector.getPathsByTag).toBeCalledWith('sulu.rlp.part');
         expect(Requester.post).toBeCalledWith(
-            '/admin/api/resourcelocators?action=generate',
+            '/admin/api/resource-locators',
             {
                 id: 5,
                 locale: 'en',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -72,7 +72,7 @@ test('Pass props correctly to ResourceLocator', () => {
             disabled={true}
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -102,7 +102,7 @@ test('Render just slash instead of ResourceLocatorComponent if used on the homep
             disabled={true}
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -120,7 +120,7 @@ test('Render just slash instead of ResourceLocatorComponent if used on the homep
     });
 });
 
-test('Pass correct options to ResourceLocatorHistory if entity already existed', () => {
+test('Pass correct options to ResourceLocatorHistory if resource already existed', () => {
     const formInspector = new FormInspector(
         new ResourceFormStore(new ResourceStore('test', 1), 'test', {webspace: 'sulu'})
     );
@@ -131,15 +131,13 @@ test('Pass correct options to ResourceLocatorHistory if entity already existed',
         <ResourceLocator
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
-                generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                generationUrl: '/admin/api/resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
                 options: {history: true},
             }}
             formInspector={formInspector}
-            schemaOptions={{
-                entity_class: {name: 'entity_class', value: 'entity-class-value'},
-            }}
+            schemaOptions={{}}
         />
     );
 
@@ -147,8 +145,8 @@ test('Pass correct options to ResourceLocatorHistory if entity already existed',
         resourceLocator.update();
         expect(resourceLocator.find('ResourceLocatorHistory')).toHaveLength(1);
         expect(resourceLocator.find('ResourceLocatorHistory').prop('options'))
-            .toEqual({entityClass: 'entity-class-value', history: true, webspace: 'sulu', resourceKey: 'test'});
-        expect(resourceLocator.find('ResourceLocatorHistory').prop('resourceKey')).toEqual('page_resourcelocators');
+            .toEqual({history: true, webspace: 'sulu', resourceKey: 'test'});
+        expect(resourceLocator.find('ResourceLocatorHistory').prop('resourceKey')).toEqual('sulu_route.generate');
         expect(resourceLocator.find('ResourceLocatorHistory').prop('id')).toEqual(1);
     });
 });
@@ -173,7 +171,7 @@ test('Pass locale from userStore to ResourceLocator and ResourceLocatorHistory i
             disabled={true}
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
                 options: {history: true},
             }}
@@ -195,7 +193,7 @@ test('Do not add an addFinishFieldHandler for URL generation if used on the home
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -213,7 +211,7 @@ test('Do not add an addFinishFieldHandler for URL generation if no generationUrl
         <ResourceLocator
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -232,7 +230,7 @@ test.each(['leaf', 'full'])('Set mode correctly', (mode) => {
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -257,7 +255,7 @@ test('Should fire onFinish callback without argument when ResourceLocatorCompone
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -295,7 +293,7 @@ test('Should automatically request new URL when part field is finished on add fo
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -359,7 +357,7 @@ test('Should request URL with parameters from FormInspector options, fieldTypeOp
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => Promise.resolve('leaf'),
                 resourceStorePropertiesToRequest: {
                     propertyName: 'requestParamKey',
@@ -368,8 +366,7 @@ test('Should request URL with parameters from FormInspector options, fieldTypeOp
             formInspector={formInspector}
             onChange={changeSpy}
             schemaOptions={{
-                entity_class: {name: 'entity_class', value: 'entity-class-value'},
-                route_schema: {name: 'entity_class', value: '/events/{implode("-", object)}'},
+                route_schema: {name: 'route_schema', value: '/events/{implode("-", object)}'},
             }}
             schemaPath="/url"
         />
@@ -398,7 +395,6 @@ test('Should request URL with parameters from FormInspector options, fieldTypeOp
             locale: 'en',
             parts: {title: 'title-value', subtitle: 'subtitle-value'},
             resourceKey: 'test',
-            entityClass: 'entity-class-value',
             routeSchema: '/events/{implode("-", object)}',
             webspace: 'example',
             requestParamKey: 'property-value',
@@ -431,7 +427,7 @@ test('Should not request new URL when part field is finished on edit form', () =
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -473,7 +469,7 @@ test('Should not request new URL when part field is finished if all parts are em
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -523,7 +519,7 @@ test('Should not request new URL when part field is finished if input was alread
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -571,7 +567,7 @@ test('Should not request new URL when field without the "sulu.rlp.part" tag is f
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -614,7 +610,7 @@ test('Should not request new URL when field without any tags has finished editin
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => Promise.resolve('leaf'),
             }}
             formInspector={formInspector}
@@ -654,7 +650,7 @@ test('Should enable refresh button when value of part field changes on edit form
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -694,7 +690,7 @@ test('Should enable refresh button when input is changed manually on edit form',
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -734,7 +730,7 @@ test('Should not enable refresh button when value of part field changes on add f
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -774,7 +770,7 @@ test('Should enable refresh button when input is changed manually on add form', 
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -814,7 +810,7 @@ test('Should not enable refresh button when value of part field changes if all p
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
             }}
             formInspector={formInspector}
@@ -862,7 +858,7 @@ test('Should request new URL with correct options and disable button when refres
             dataPath="/block/0/url"
             fieldTypeOptions={{
                 generationUrl: '/admin/api/resourcelocators?action=generate',
-                historyResourceKey: 'page_resourcelocators',
+                historyResourceKey: 'sulu_route.generate',
                 modeResolver: () => modePromise,
                 resourceStorePropertiesToRequest: {
                     propertyName: 'requestParamKey',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/7995
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add new endpoint resource locator generateUrl endpoint.

#### Why?

The old endpoint was based on the old route and old phpcr bundles. The new route bundle should be handlel this now. As the old one will be removed in https://github.com/sulu/sulu/pull/7995.

#### To Do

- [x] Breaking change not longer sends EntityClass or EntityId instead resourceKey and resourceId
- [x] New endpoint to register in the Skeleton