### PR TITLE
Add tests for routing configurations of new bundles

### DIFF
--- a/packages/article/config/routing_admin_api.yaml
+++ b/packages/article/config/routing_admin_api.yaml
@@ -4,12 +4,6 @@ sulu_article.get_articles:
     controller: sulu_article.admin_article_controller::cgetAction
     format: json
 
-sulu_article.get_article_versions:
-    path: /articles/{id}/versions.{_format}
-    methods: GET
-    controller: sulu_article.admin_article_controller::getVersionsAction
-    format: json
-
 sulu_article.get_article:
     path: /articles/{id}.{_format}
     methods: GET
@@ -38,4 +32,10 @@ sulu_article.post_article_trigger:
     path: /articles/{id}.{_format}
     methods: POST
     controller: sulu_article.admin_article_controller::postTriggerAction
+    format: json
+
+sulu_article.get_article_versions:
+    path: /articles/{id}/versions.{_format}
+    methods: GET
+    controller: sulu_article.admin_article_controller::getVersionsAction
     format: json

--- a/packages/article/tests/Functional/Infrastructure/Symfony/Router/UrlGeneratorTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Symfony/Router/UrlGeneratorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Tests\Functional\Infrastructure\Symfony\Router;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\TestWith;
+use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversNothing]
+class UrlGeneratorTest extends KernelTestCase
+{
+    /**
+     * @var array<string, string>
+     */
+    private static array $testedRoutes = [];
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    #[TestWith(['sulu_article.get_articles', [], '/admin/api/articles'])]
+    #[TestWith(['sulu_article.get_article', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/articles/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_article.post_article', [], '/admin/api/articles'])]
+    #[TestWith(['sulu_article.put_article', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/articles/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_article.delete_article', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/articles/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_article.post_article_trigger', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/articles/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_article.get_article_versions', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/articles/019905eb-ae9a-7136-93f2-06557330e3ad/versions'])]
+    public function testRoutes(string $route, array $params, string $expectedUrl): void
+    {
+        $urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
+
+        self::$testedRoutes[$route] = $route;
+
+        $this->assertSame(
+            $expectedUrl,
+            $urlGenerator->generate($route, $params)
+        );
+    }
+
+    #[Depends('testRoutes')]
+    public function testAllRoutesTested(): void
+    {
+        $routes = Yaml::parse(\file_get_contents(__DIR__ . '/../../../../../config/routing_admin_api.yaml') ?: '') ?? [];
+        $this->assertIsArray($routes);
+        $this->assertGreaterThan(0, \count($routes), 'No routes found in routing_admin_api.yaml');
+
+        $this->assertSame(
+            \array_keys($routes),
+            \array_keys(self::$testedRoutes),
+        );
+    }
+
+    public static function teardownAfterClass(): void
+    {
+        self::$testedRoutes = [];
+        parent::teardownAfterClass();
+    }
+}

--- a/packages/page/config/routing_admin_api.yaml
+++ b/packages/page/config/routing_admin_api.yaml
@@ -4,12 +4,6 @@ sulu_page.get_pages:
     controller: sulu_page.admin_page_controller::cgetAction
     format: json
 
-sulu_page.get_page_versions:
-    path: /pages/{id}/versions.{_format}
-    methods: GET
-    controller: sulu_page.admin_page_controller::getVersionsAction
-    format: json
-
 sulu_page.get_page:
     path: /pages/{id}.{_format}
     methods: GET
@@ -38,4 +32,10 @@ sulu_page.post_page_trigger:
     path: /pages/{id}.{_format}
     methods: POST
     controller: sulu_page.admin_page_controller::postTriggerAction
+    format: json
+
+sulu_page.get_page_versions:
+    path: /pages/{id}/versions.{_format}
+    methods: GET
+    controller: sulu_page.admin_page_controller::getVersionsAction
     format: json

--- a/packages/page/tests/Functional/Infrastructure/Symfony/Router/UrlGeneratorTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Symfony/Router/UrlGeneratorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Symfony\Router;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\TestWith;
+use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversNothing]
+class UrlGeneratorTest extends KernelTestCase
+{
+    /**
+     * @var array<string, string>
+     */
+    private static array $testedRoutes = [];
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    #[TestWith(['sulu_page.get_pages', [], '/admin/api/pages'])]
+    #[TestWith(['sulu_page.get_page', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/pages/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_page.post_page', [], '/admin/api/pages'])]
+    #[TestWith(['sulu_page.put_page', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/pages/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_page.delete_page', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/pages/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_page.post_page_trigger', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/pages/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_page.get_page_versions', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/pages/019905eb-ae9a-7136-93f2-06557330e3ad/versions'])]
+    public function testRoutes(string $route, array $params, string $expectedUrl): void
+    {
+        $urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
+
+        self::$testedRoutes[$route] = $route;
+
+        $this->assertSame(
+            $expectedUrl,
+            $urlGenerator->generate($route, $params)
+        );
+    }
+
+    #[Depends('testRoutes')]
+    public function testAllRoutesTested(): void
+    {
+        $routes = Yaml::parse(\file_get_contents(__DIR__ . '/../../../../../config/routing_admin_api.yaml') ?: '') ?? [];
+        $this->assertIsArray($routes);
+        $this->assertGreaterThan(0, \count($routes), 'No routes found in routing_admin_api.yaml');
+
+        $this->assertSame(
+            \array_keys($routes),
+            \array_keys(self::$testedRoutes),
+        );
+    }
+
+    public static function teardownAfterClass(): void
+    {
+        self::$testedRoutes = [];
+        parent::teardownAfterClass();
+    }
+}

--- a/packages/snippet/config/routing_admin_api.yaml
+++ b/packages/snippet/config/routing_admin_api.yaml
@@ -4,12 +4,6 @@ sulu_snippet.get_snippets:
     controller: sulu_snippet.admin_snippet_controller::cgetAction
     format: json
 
-sulu_snippet.get_snippet_versions:
-    path: /snippets/{id}/versions.{_format}
-    methods: GET
-    controller: sulu_snippet.admin_snippet_controller::getVersionsAction
-    format: json
-
 sulu_snippet.get_snippet:
     path: /snippets/{id}.{_format}
     methods: GET
@@ -38,4 +32,10 @@ sulu_snippet.post_snippet_trigger:
     path: /snippets/{id}.{_format}
     methods: POST
     controller: sulu_snippet.admin_snippet_controller::postTriggerAction
+    format: json
+
+sulu_snippet.get_snippet_versions:
+    path: /snippets/{id}/versions.{_format}
+    methods: GET
+    controller: sulu_snippet.admin_snippet_controller::getVersionsAction
     format: json

--- a/packages/snippet/tests/Functional/Infrastructure/Symfony/Router/UrlGeneratorTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Symfony/Router/UrlGeneratorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Tests\Functional\Infrastructure\Symfony\Router;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\TestWith;
+use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Yaml\Yaml;
+
+#[CoversNothing]
+class UrlGeneratorTest extends KernelTestCase
+{
+    /**
+     * @var array<string, string>
+     */
+    private static array $testedRoutes = [];
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    #[TestWith(['sulu_snippet.get_snippets', [], '/admin/api/snippets'])]
+    #[TestWith(['sulu_snippet.get_snippet', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/snippets/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_snippet.post_snippet', [], '/admin/api/snippets'])]
+    #[TestWith(['sulu_snippet.put_snippet', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/snippets/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_snippet.delete_snippet', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/snippets/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_snippet.post_snippet_trigger', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/snippets/019905eb-ae9a-7136-93f2-06557330e3ad'])]
+    #[TestWith(['sulu_snippet.get_snippet_versions', ['id' => '019905eb-ae9a-7136-93f2-06557330e3ad'], '/admin/api/snippets/019905eb-ae9a-7136-93f2-06557330e3ad/versions'])]
+    public function testRoutes(string $route, array $params, string $expectedUrl): void
+    {
+        $urlGenerator = static::getContainer()->get(UrlGeneratorInterface::class);
+
+        self::$testedRoutes[$route] = $route;
+
+        $this->assertSame(
+            $expectedUrl,
+            $urlGenerator->generate($route, $params)
+        );
+    }
+
+    #[Depends('testRoutes')]
+    public function testAllRoutesTested(): void
+    {
+        $routes = Yaml::parse(\file_get_contents(__DIR__ . '/../../../../../config/routing_admin_api.yaml') ?: '') ?? [];
+        $this->assertIsArray($routes);
+        $this->assertGreaterThan(0, \count($routes), 'No routes found in routing_admin_api.yaml');
+
+        $this->assertSame(
+            \array_keys($routes),
+            \array_keys(self::$testedRoutes),
+        );
+    }
+
+    public static function teardownAfterClass(): void
+    {
+        self::$testedRoutes = [];
+        parent::teardownAfterClass();
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add tests for routing configurations of new bundles.

#### Why?

Changing a route name is a backwards compatibility break with this test we make sure a test fails if a route get accidently renamed. I already added this to the route bundle in #8125 