### PR TITLE
Fix category tree search

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -260,7 +260,8 @@ class CategoryController extends AbstractRestController implements ClassResource
             }
         }
 
-        if (!empty($expandedIds) && $request->get('search', false)) {
+        $search = $request->get('search');
+        if (!empty($expandedIds) && empty($search)) {
             $categoriesByParentId = [];
             foreach ($categories as &$category) {
                 $categoryParentId = $category['parent'];

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -260,7 +260,7 @@ class CategoryController extends AbstractRestController implements ClassResource
             }
         }
 
-        if (!empty($expandedIds)) {
+        if (!empty($expandedIds) && $request->get('search', false)) {
             $categoriesByParentId = [];
             foreach ($categories as &$category) {
                 $categoryParentId = $category['parent'];

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -518,6 +518,35 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertTrue($categories[0]->hasChildren);
     }
 
+    public function testCGetFlatWithSearchAndExpandedIds(): void
+    {
+        $category1 = $this->createCategory('first-category-key', 'en');
+        $this->createCategoryTranslation($category1, 'en', 'First Category');
+        $category3 = $this->createCategory(null, 'en', $category1);
+        $this->createCategoryTranslation($category3, 'en', 'Third Category');
+        $category4 = $this->createCategory(null, 'en', $category3);
+        $this->createCategoryTranslation($category4, 'en', 'Fourth Category');
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/categories?locale=en&flat=true&search=Third&searchFields=name&expandedIds=' . $category1->getId()
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $response = \json_decode($this->client->getResponse()->getContent());
+        $categories = $response->_embedded->categories;
+
+        $this->assertCount(1, $categories);
+        $this->assertEquals(1, $response->total);
+
+        $this->assertEquals('Third Category', $categories[0]->name);
+        $this->assertTrue($categories[0]->hasChildren);
+    }
+
     public function testCGetWithNoLocale(): void
     {
         $this->client->jsonRequest(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | Replaces #8045
| License | MIT

#### What's in this PR?

When searching for a category string, nearly always the expandedIds parameter is set in the query string to the controller.
As in a full tree view in the category administration, there is no $parentId in the request parameters, thus $categoriesByParentId[$parentId] delivers null, which leads to iterator_to_array(): Argument https://github.com/sulu/sulu/pull/1 ($iterator) must be of type Traversable|array, null given at src/Sulu/Component/Rest/ListBuilder/CollectionRepresentation.php:35, though categories were found, but not with parent "null"
This fixes this behaviour. and allows to search a full tree.

#### Why?

The server responds with a 500 Exception.
Replaces #8045 as suggested.

#### Example Usage

Call url https://sulu.rocks/admin/api/categories?page=1&locale=en&expandedIds=3&limit=10&fields=name,id&search=Test3&flat=true
