### PR TITLE
Do not depend on PageBundle SitemapProviders in SitemapControllerTest

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/SitemapControllerTest.php
@@ -13,16 +13,29 @@ namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
 
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
 use Sulu\Bundle\SecurityBundle\Entity\Permission;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
+use Sulu\Bundle\WebsiteBundle\Sitemap\Sitemap;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapAlternateLink;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderPoolInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
 use Sulu\Component\Security\Authentication\RoleInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class SitemapControllerTest extends WebsiteTestCase
 {
+    use SetGetPrivatePropertyTrait;
+
     /**
      * @var RoleInterface
      */
     private $anonymousRole;
+
+    /**
+     * @var SitemapProviderPoolInterface
+     */
+    private $sitemapProviderPool;
 
     /**
      * @var KernelBrowser
@@ -33,7 +46,9 @@ class SitemapControllerTest extends WebsiteTestCase
     {
         $this->client = $this->createWebsiteClient();
         $this->purgeDatabase();
-        $this->initPhpcr();
+
+        $this->sitemapProviderPool = self::getContainer()->get('sulu_website.sitemap.pool');
+        $this->sitemapProviderPool->reset();
 
         $this->getContainer()->get('sulu_security.system_store')->setSystem('sulu_io');
 
@@ -56,6 +71,10 @@ class SitemapControllerTest extends WebsiteTestCase
 
     public function testIndexSingleLanguage(): void
     {
+        self::setPrivateProperty($this->sitemapProviderPool, 'providers', [
+            'pages' => $this->createSitemapProvider('pages', 1, 1),
+        ]);
+
         $crawler = $this->client->request('GET', 'http://sulu.lo/sitemap.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $response = $this->client->getResponse();
@@ -66,11 +85,15 @@ class SitemapControllerTest extends WebsiteTestCase
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:loc'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:lastmod'));
         $this->assertCount(0, $crawler->filterXPath('//x:urlset/x:url/xhtml:link'));
-        $this->assertEquals('http://sulu.lo/', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
+        $this->assertEquals('http://sulu.lo/en/test-1-0', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
     }
 
     public function testIndexMultipleLanguage(): void
     {
+        self::setPrivateProperty($this->sitemapProviderPool, 'providers', [
+            'pages' => $this->createSitemapProvider('pages', 1, 1, ['en', 'en-us']),
+        ]);
+
         $crawler = $this->client->request('GET', 'http://test.lo/sitemap.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $response = $this->client->getResponse();
@@ -79,62 +102,59 @@ class SitemapControllerTest extends WebsiteTestCase
 
         $this->assertCount(2, $crawler->filterXPath('//x:urlset/x:url'));
 
-        $this->assertEquals('http://test.lo/en-us', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc')->text());
+        $this->assertEquals('http://test.lo/en/test-1-0', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc')->text());
         $this->assertEquals(
-            'en-us',
+            'en',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[1]')->attr('hreflang')
         );
         $this->assertEquals(
-            'http://test.lo/en-us',
+            'http://test.lo/en/test-1-0',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[1]')->attr('href')
         );
         $this->assertEquals(
-            'en',
+            'en-us',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[2]')->attr('hreflang')
         );
         $this->assertEquals(
-            'http://test.lo/en',
+            'http://test.lo/en-us/test-1-0',
             $crawler->filterXPath('//x:urlset/x:url[1]/xhtml:link[2]')->attr('href')
         );
 
-        $this->assertEquals('http://test.lo/en', $crawler->filterXPath('//x:urlset/x:url[2]/x:loc')->text());
+        $this->assertEquals('http://test.lo/en-us/test-1-0', $crawler->filterXPath('//x:urlset/x:url[2]/x:loc')->text());
         $this->assertEquals(
-            'en',
+            'en-us',
             $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[1]')->attr('hreflang')
         );
         $this->assertEquals(
-            'http://test.lo/en',
+            'http://test.lo/en-us/test-1-0',
             $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[1]')->attr('href')
         );
         $this->assertEquals(
-            'en-us',
+            'en',
             $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[2]')->attr('hreflang')
         );
         $this->assertEquals(
-            'http://test.lo/en-us',
+            'http://test.lo/en/test-1-0',
             $crawler->filterXPath('//x:urlset/x:url[2]/xhtml:link[2]')->attr('href')
         );
-
-        $this->assertEquals('http://test.lo/en', $crawler->filterXPath('//x:urlset/x:url[2]/x:loc')->text());
     }
 
-    public function testIndexMultipleTlds(): void
+    public function testSingleProviderRedirect(): void
     {
-        $crawler = $this->client->request('GET', 'http://sulu.com/sitemap.xml');
-        $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        self::setPrivateProperty($this->sitemapProviderPool, 'providers', [
+            'pages' => $this->createSitemapProvider('pages', 1, 1),
+        ]);
 
-        $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url'));
-        $this->assertStringNotContainsString('sulu.at', $crawler->text());
-    }
-
-    public function testProvider(): void
-    {
         $this->client->request('GET', 'http://sulu.lo/sitemaps/pages.xml');
         $this->assertHttpStatusCode(301, $this->client->getResponse());
     }
 
     public function testPaginated(): void
     {
+        self::setPrivateProperty($this->sitemapProviderPool, 'providers', [
+            'pages' => $this->createSitemapProvider('pages', 2, 1),
+        ]);
+
         $crawler = $this->client->request('GET', 'http://sulu.lo/sitemaps/pages-1.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $response = $this->client->getResponse();
@@ -144,18 +164,26 @@ class SitemapControllerTest extends WebsiteTestCase
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:loc'));
         $this->assertCount(1, $crawler->filterXPath('//x:urlset/x:url/x:lastmod'));
-        $this->assertEquals('http://sulu.lo/', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
+        $this->assertEquals('http://sulu.lo/en/test-1-0', $crawler->filterXPath('//x:urlset/x:url[1]/x:loc[1]')->text());
     }
 
     public function testPaginatedOverMax(): void
     {
-        $crawler = $this->client->request('GET', 'http://sulu.lo/sitemaps/pages-2.xml');
+        self::setPrivateProperty($this->sitemapProviderPool, 'providers', [
+            'pages' => $this->createSitemapProvider('pages', 2, 1),
+        ]);
+
+        $crawler = $this->client->request('GET', 'http://sulu.lo/sitemaps/pages-3.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $this->assertHttpStatusCode(404, $this->client->getResponse());
     }
 
     public function testNotExistingProvider(): void
     {
+        self::setPrivateProperty($this->sitemapProviderPool, 'providers', [
+            'pages' => $this->createSitemapProvider('pages', 2, 1),
+        ]);
+
         $crawler = $this->client->request('GET', 'http://sulu.lo/sitemaps/test-2.xml');
         $crawler->registerNamespace('x', 'http://www.sitemaps.org/schemas/sitemap/0.9');
         $this->assertHttpStatusCode(404, $this->client->getResponse());
@@ -163,10 +191,74 @@ class SitemapControllerTest extends WebsiteTestCase
 
     public function testSitemapIndexFile(): void
     {
+        self::setPrivateProperty($this->sitemapProviderPool, 'providers', [
+            'test' => $this->createSitemapProvider('test', 1, 1),
+            'pages' => $this->createSitemapProvider('pages', 1, 1),
+        ]);
+
         $crawler = $this->client->request('GET', 'http://sulu.index/sitemap.xml');
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertSame('http://sulu.index/sitemaps/test-1.xml', $crawler->filterXPath('//sitemapindex/sitemap[1]/loc[1]')->text());
         $this->assertSame('http://sulu.index/sitemaps/pages-1.xml', $crawler->filterXPath('//sitemapindex/sitemap[2]/loc[1]')->text());
+    }
+
+    /**
+     * @param string[] $locales
+     */
+    private function createSitemapProvider(string $sitemapName, int $pages, int $perPage, array $locales = ['en']): SitemapProviderInterface
+    {
+        return new class($sitemapName, $pages, $perPage, $locales) implements SitemapProviderInterface {
+            /**
+             * @param string[] $locales
+             */
+            public function __construct(private string $sitemapName, private int $pages, private int $perPage, private array $locales)
+            {
+            }
+
+            public function build($page, $scheme, $host)
+            {
+                $sitemapUrls = [];
+                for ($i = 0; $i < $this->perPage; ++$i) {
+                    $defaultLocale = $this->locales[0];
+                    foreach ($this->locales as $locale) {
+                        $sitemapUrl = new SitemapUrl(
+                            $scheme . '://' . $host . '/' . $locale . '/test-' . $page . '-' . $i,
+                            $locale,
+                            $defaultLocale,
+                            new \DateTime('2020-01-01 00:00:00')
+                        );
+
+                        foreach ($this->locales as $altLocale) {
+                            if ($altLocale !== $locale) {
+                                $sitemapUrl->addAlternateLink(new SitemapAlternateLink(
+                                    $scheme . '://' . $host . '/' . $altLocale . '/test-' . $page . '-' . $i,
+                                    $altLocale
+                                ));
+                            }
+                        }
+
+                        $sitemapUrls[] = $sitemapUrl;
+                    }
+                }
+
+                return $sitemapUrls;
+            }
+
+            public function createSitemap($scheme, $host)
+            {
+                return new Sitemap($this->sitemapName, $this->pages);
+            }
+
+            public function getAlias()
+            {
+                return $this->sitemapName;
+            }
+
+            public function getMaxPage($scheme, $host)
+            {
+                return $this->pages;
+            }
+        };
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7995, ontopof https://github.com/sulu/sulu/pull/8133
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The sitemap provider test depends currently on PHPCR this does refactor it to not depend on any external sitemap providers.

#### Why?

For #7995