### PR TITLE
Fix reference to old PageAdmin classes by using new PageAdmin class

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
+++ b/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
@@ -455,9 +455,4 @@ class PageAdmin extends Admin
     {
         return \sprintf('%s%s', self::SECURITY_CONTEXT_PREFIX, $webspaceKey);
     }
-
-    public static function getPriority(): int
-    {
-        return \Sulu\Bundle\PageBundle\Admin\PageAdmin::getPriority() - 1;
-    }
 }

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
@@ -86,7 +86,6 @@ class SuluHttpCacheExtensionTest extends AbstractExtensionTestCase
         $this->container->set('logger', $this->logger->reveal());
         $this->container->set('sulu_website.reference_store_pool', $this->referenceStore->reveal());
         $this->container->set('sulu.content.structure_manager', $this->prophesize(StructureManagerInterface::class)->reveal());
-        $this->container->set('sulu_document_manager.document_inspector', $this->prophesize(DocumentInspector::class)->reveal());
         $this->container->set('sulu.content.resource_locator.strategy_pool', $this->prophesize(ResourceLocatorStrategyPoolInterface::class)->reveal());
         $this->container->set('sulu_tag.tag_manager', $this->prophesize(TagManagerInterface::class)->reveal());
         $this->container->set('fos_http_cache.cache_manager', $this->prophesize(CacheManager::class)->reveal());

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/DependencyInjection/SuluHttpCacheExtensionTest.php
@@ -17,7 +17,6 @@ use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
-use Sulu\Bundle\DocumentManagerBundle\Bridge\DocumentInspector;
 use Sulu\Bundle\HttpCacheBundle\DependencyInjection\SuluHttpCacheExtension;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStorePoolInterface;

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Application/Manager/PreviewLinkManagerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Application/Manager/PreviewLinkManagerTest.php
@@ -16,7 +16,6 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\PreviewBundle\Application\Manager\PreviewLinkManager;
 use Sulu\Bundle\PreviewBundle\Domain\Event\PreviewLinkGeneratedEvent;
 use Sulu\Bundle\PreviewBundle\Domain\Event\PreviewLinkRevokedEvent;
@@ -24,6 +23,7 @@ use Sulu\Bundle\PreviewBundle\Domain\Model\PreviewLinkInterface;
 use Sulu\Bundle\PreviewBundle\Domain\Repository\PreviewLinkRepositoryInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistryInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Provider\PreviewDefaultsProviderInterface;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Symfony\Component\Routing\RouterInterface;
 
 class PreviewLinkManagerTest extends TestCase

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/SystemListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/SystemListener.php
@@ -13,9 +13,9 @@ namespace Sulu\Bundle\SecurityBundle\EventListener;
 
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
-use Sulu\Component\DocumentManager\Subscriber\EventSubscriberInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 

--- a/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/Serializer/Subscriber/SecuritySubscriber.php
@@ -16,12 +16,12 @@ use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -15,12 +15,12 @@ use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\WebsiteBundle\Entity\AnalyticsInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class WebsiteAdmin extends Admin

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
@@ -11,12 +11,12 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Controller;
 
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\WebsiteBundle\Cache\CacheClearerInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\WebspaceReferenceStore;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/src/Sulu/Bundle/WebsiteBundle/Domain/Event/CacheClearedEvent.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Domain/Event/CacheClearedEvent.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\WebsiteBundle\Domain\Event;
 
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 
 class CacheClearedEvent extends DomainEvent
 {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/CacheControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/CacheControllerTest.php
@@ -13,12 +13,12 @@ namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Controller;
 
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 

--- a/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
+++ b/src/Sulu/Component/Content/Repository/Serializer/SerializerEventListener.php
@@ -16,13 +16,13 @@ use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
-use Sulu\Bundle\PageBundle\Admin\PageAdmin;
 use Sulu\Component\Content\Document\LocalizationState;
 use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Repository\Content;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | for #8137
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix reference to old PageAdmin classes by using new PageAdmin class.

#### Why?

Using the new PageAdmin class instead of the old one.