### PR TITLE
Fix usage of correct EventSubscriberInterface interface for SystemListener and SecurityListener

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/EventListener/SystemListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/SystemListener.php
@@ -13,9 +13,9 @@ namespace Sulu\Bundle\SecurityBundle\EventListener;
 
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
-use Sulu\Component\DocumentManager\Subscriber\EventSubscriberInterface;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/SecurityListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/SecurityListener.php
@@ -13,11 +13,11 @@ namespace Sulu\Bundle\WebsiteBundle\EventListener;
 
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Component\Content\Compat\Structure\PageBridge;
-use Sulu\Component\DocumentManager\Subscriber\EventSubscriberInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix usage of correct EventSubscriberInterface interface for SystemListener and SecurityListener

#### Why?

Actually it has functional no effects, but its basically the wrong interface for `kernel.request` listeners and that class will be removed in 3.0.

Stumbled over this fall interface while remove document manager here: https://github.com/sulu/sulu/pull/8137