### PR TITLE
Remove unused referenceWorkflowStage parameter from ReferenceCollectorTest

### DIFF
--- a/src/Sulu/Bundle/ReferenceBundle/Tests/Unit/Application/Collector/ReferenceCollectorTest.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Tests/Unit/Application/Collector/ReferenceCollectorTest.php
@@ -18,7 +18,6 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollector;
 use Sulu\Bundle\ReferenceBundle\Domain\Model\Reference;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
-use Sulu\Component\Content\Document\WorkflowStage;
 
 class ReferenceCollectorTest extends TestCase
 {
@@ -76,7 +75,6 @@ class ReferenceCollectorTest extends TestCase
             referenceRouterAttributes: [
                 'webspace' => 'sulu',
             ],
-            referenceWorkflowStage: WorkflowStage::PUBLISHED,
         );
         $reference = $referenceCollector->addReference('media', '1', 'headerImage');
 
@@ -128,7 +126,6 @@ class ReferenceCollectorTest extends TestCase
         string $referenceTitle = 'Title',
         string $referenceContext = 'default',
         array $referenceRouterAttributes = [],
-        ?int $referenceWorkflowStage = null
     ): ReferenceCollector {
         return new ReferenceCollector(
             $this->referenceRepository->reveal(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #8137 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove unused referenceWorkflowStage parameter from ReferenceCollectorTest.

#### Why?

Stumbled over this in #8137 tests failing as the WorkflowBehaviour class was removed. The param is not even used.