### PR TITLE
Move GlobalBlocksTypedFormMetadataVisitor to AdminBundle

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/GlobalBlocksTypedFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/GlobalBlocksTypedFormMetadataVisitor.php
@@ -11,18 +11,14 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Types\Metadata;
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterface;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 
+/**
+ * @internal this class is not part of the public API and may be changed or removed without further notice
+ */
 class GlobalBlocksTypedFormMetadataVisitor implements TypedFormMetadataVisitorInterface, FormMetadataVisitorInterface
 {
     public function __construct(
@@ -72,6 +68,7 @@ class GlobalBlocksTypedFormMetadataVisitor implements TypedFormMetadataVisitorIn
                 }
 
                 $globalBlockType = $globalBlockTag->getAttribute('global_block');
+                \assert(\is_string($globalBlockType), 'The "global_block" attribute of the "sulu.global_block" tag must be a string' . \get_debug_type($globalBlockType) . ' given.');
                 $blockMetadata = $this->getGlobalBlockMetadata($globalBlockType, $locale);
                 if (!$blockMetadata) {
                     continue;

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -121,6 +121,16 @@
         </service>
 
         <service
+            id="sulu_admin.global_block_form_metadata_visitor"
+            class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\GlobalBlocksTypedFormMetadataVisitor"
+        >
+            <argument type="service" id="sulu_admin.metadata_provider_registry" />
+
+            <tag name="sulu_admin.typed_form_metadata_visitor"/>
+            <tag name="sulu_admin.form_metadata_visitor" />
+        </service>
+
+        <service
             id="sulu_admin.xml_form_metadata_loader"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\XmlFormMetadataLoader"
         >

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/GlobalBlocksTypedFormMetadataVisitorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/GlobalBlocksTypedFormMetadataVisitorTest.php
@@ -11,20 +11,20 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Tests\Unit\Types\Metadata;
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\GlobalBlocksTypedFormMetadataVisitor;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
-use Sulu\Component\Content\Types\Metadata\GlobalBlocksTypedFormMetadataVisitor;
 
 class GlobalBlocksTypedFormMetadataVisitorTest extends TestCase
 {

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/content.xml
@@ -92,16 +92,6 @@
             <tag name="sulu_content.deprecated_block_visitor" />
         </service>
 
-        <service
-            id="sulu.content.type.block.global_block_visitor"
-            class="Sulu\Component\Content\Types\Metadata\GlobalBlocksTypedFormMetadataVisitor"
-        >
-            <argument type="service" id="sulu_admin.metadata_provider_registry" />
-
-            <tag name="sulu_admin.typed_form_metadata_visitor"/>
-            <tag name="sulu_admin.form_metadata_visitor" />
-        </service>
-
         <!-- sulu node helper -->
         <service id="sulu.content.localization_finder" class="Sulu\Component\Content\Compat\LocalizationFinder" public="true">
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #8137
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Move GlobalBlocksTypedFormMetadataVisitor to AdminBundle

#### Why?

Stumbled in #8137 over that this was still registered in core bundle and class in components.