### PR TITLE
Remove Document LocalizedAuditableBehavior from AuditableHasher

### DIFF
--- a/src/Sulu/Component/Hash/AuditableHasher.php
+++ b/src/Sulu/Component/Hash/AuditableHasher.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Hash;
 
-use Sulu\Component\Content\Document\Behavior\LocalizedAuditableBehavior;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 
 /**
@@ -26,10 +25,6 @@ class AuditableHasher implements HasherInterface
                 ($object->getChanger() ? $object->getChanger()->getId() : '')
                 . ($object->getChanged() ? $object->getChanged()->getTimestamp() : '')
             );
-        }
-
-        if ($object instanceof LocalizedAuditableBehavior) {
-            return \md5($object->getChanger() . ($object->getChanged() ? $object->getChanged()->getTimestamp() : ''));
         }
 
         throw new \InvalidArgumentException(

--- a/src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
+++ b/src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Component\Hash\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Sulu\Component\Content\Document\Behavior\LocalizedAuditableBehavior;
 use Sulu\Component\Hash\AuditableHasher;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
@@ -88,24 +87,6 @@ class AuditableHasherTest extends TestCase
         $object = $this->prophesize(AuditableInterface::class);
         $object->getChanger()->willReturn(null);
         $object->getChanged()->willReturn(new \DateTimeImmutable('2016-02-05'));
-
-        $this->assertIsString($this->hasher->hash($object->reveal()));
-    }
-
-    public function testHashAuditableBehavior(): void
-    {
-        $object = $this->prophesize(LocalizedAuditableBehavior::class);
-        $object->getChanger()->willReturn(1);
-        $object->getChanged()->willReturn(new \DateTimeImmutable('2016-02-09'));
-
-        $this->assertIsString($this->hasher->hash($object->reveal()));
-    }
-
-    public function testHashAuditableBehaviorWithoutDate(): void
-    {
-        $object = $this->prophesize(LocalizedAuditableBehavior::class);
-        $object->getChanger()->willReturn(1);
-        $object->getChanged()->willReturn(null);
 
         $this->assertIsString($this->hasher->hash($object->reveal()));
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #8137 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove Document LocalizedAuditableBehavior from AuditableHasher

#### Why?

The LocalizedAuditableBehavior will be removed in #8137 so the hasher not longer requires to handle that interface.