### PR TITLE
Remove Document handling in HashSerializeEventSubscriber

### DIFF
--- a/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
+++ b/src/Sulu/Component/Hash/Serializer/Subscriber/HashSerializeEventSubscriber.php
@@ -15,7 +15,6 @@ use JMS\Serializer\EventDispatcher\EventSubscriberInterface;
 use JMS\Serializer\EventDispatcher\ObjectEvent;
 use JMS\Serializer\Metadata\StaticPropertyMetadata;
 use JMS\Serializer\Visitor\SerializationVisitorInterface;
-use Sulu\Component\Content\Document\Behavior\LocalizedAuditableBehavior;
 use Sulu\Component\Hash\HasherInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Rest\ApiWrapper;
@@ -48,7 +47,7 @@ class HashSerializeEventSubscriber implements EventSubscriberInterface
             $object = $object->getEntity();
         }
 
-        if (!$object instanceof AuditableInterface && !$object instanceof LocalizedAuditableBehavior) {
+        if (!$object instanceof AuditableInterface) {
             return;
         }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove Document handling in HashSerializeEventSubscriber.

#### Why?

Document classes will be removed in #8137.