### PR TITLE
Remove old content directory configuration in new bundles

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -495,6 +495,34 @@ now independent of the locale and contain all metadata for all locales this mean
 +$metadata->setPlaceholder($placeholder, $locale);
 ```
 
+### Template path configuration changed
+
+**Old**:
+
+```yaml
+sulu_core:
+    content:
+        structure:
+            default_type:
+                snippet: 'my_snippet_key'
+            paths:
+                snippet_project_a:
+                    path: '%kernel.project_dir%/config/templates/snippets/projectA'
+                    type: snippet
+```
+
+**New**:
+
+```yaml
+sulu_admin:
+    templates:
+        snippets:
+            default_type: 'my_snippet_key'
+            directories:
+                snippet_project_a:
+                    path: '%kernel.project_dir%/config/templates/snippets/projectA'
+```
+
 ### ResourceLocator endpoint changed
 
 The ResourceLocator endpoint was moved from PageBundle to the new RouteBundle.  

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -374,27 +374,6 @@ final class SuluArticleBundle extends AbstractBundle
             );
         }
 
-        if ($builder->hasExtension('sulu_core')) {
-            $builder->prependExtensionConfig(
-                'sulu_core',
-                [
-                    'content' => [
-                        'structure' => [
-                            'paths' => [
-                                ArticleInterface::TEMPLATE_TYPE => [
-                                    'path' => '%kernel.project_dir%/config/templates/articles',
-                                    'type' => 'article',
-                                ],
-                            ],
-                            'default_type' => [
-                                ArticleInterface::TEMPLATE_TYPE => 'default',
-                            ],
-                        ],
-                    ],
-                ],
-            );
-        }
-
         if ($builder->hasExtension('sulu_route')) {
             $builder->prependExtensionConfig(
                 'sulu_route',

--- a/packages/article/tests/Application/config/config.yml
+++ b/packages/article/tests/Application/config/config.yml
@@ -1,11 +1,5 @@
 sulu_article: {}
 
-sulu_core:
-    content:
-        structure:
-            default_type:
-                article: 'article'
-
 framework:
     # symfony recipe default configuration:
     workflows: null

--- a/packages/content/tests/Application/ExampleTestBundle/DependencyInjection/ExampleTestExtension.php
+++ b/packages/content/tests/Application/ExampleTestBundle/DependencyInjection/ExampleTestExtension.php
@@ -24,27 +24,6 @@ class ExampleTestExtension extends Extension implements PrependExtensionInterfac
 {
     public function prepend(ContainerBuilder $container): void
     {
-        if ($container->hasExtension('sulu_core')) {
-            $container->prependExtensionConfig(
-                'sulu_core',
-                [
-                    'content' => [
-                        'structure' => [
-                            'paths' => [
-                                Example::TEMPLATE_TYPE => [
-                                    'path' => '%kernel.project_dir%/config/templates/examples',
-                                    'type' => 'example',
-                                ],
-                            ],
-                            'default_type' => [
-                                Example::TEMPLATE_TYPE => 'default', // TODO should not be hardcoded
-                            ],
-                        ],
-                    ],
-                ]
-            );
-        }
-
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
                 'sulu_admin',

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -540,27 +540,6 @@ final class SuluPageBundle extends AbstractBundle
             );
         }
 
-        if ($builder->hasExtension('sulu_core')) {
-            $builder->prependExtensionConfig(
-                'sulu_core',
-                [
-                    'content' => [
-                        'structure' => [
-                            'paths' => [
-                                PageInterface::TEMPLATE_TYPE => [
-                                    'path' => '%kernel.project_dir%/config/templates/pages',
-                                    'type' => 'page',
-                                ],
-                            ],
-                            'default_type' => [
-                                PageInterface::TEMPLATE_TYPE => 'default',
-                            ],
-                        ],
-                    ],
-                ],
-            );
-        }
-
         if ($builder->hasExtension('sulu_route')) {
             $builder->prependExtensionConfig(
                 'sulu_route',

--- a/packages/page/tests/Application/config/config.yml
+++ b/packages/page/tests/Application/config/config.yml
@@ -1,9 +1,3 @@
-sulu_core:
-    content:
-        structure:
-            default_type:
-                page: 'page'
-
 framework:
     # symfony recipe default configuration:
     workflows: null

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -362,27 +362,6 @@ final class SuluSnippetBundle extends AbstractBundle
             );
         }
 
-        if ($builder->hasExtension('sulu_core')) {
-            $builder->prependExtensionConfig(
-                'sulu_core',
-                [
-                    'content' => [
-                        'structure' => [
-                            'paths' => [
-                                SnippetInterface::TEMPLATE_TYPE => [
-                                    'path' => '%kernel.project_dir%/config/templates/snippets',
-                                    'type' => 'snippet',
-                                ],
-                            ],
-                            'default_type' => [
-                                SnippetInterface::TEMPLATE_TYPE => 'default',
-                            ],
-                        ],
-                    ],
-                ],
-            );
-        }
-
         if ($builder->hasExtension('sulu_route')) {
             $builder->prependExtensionConfig(
                 'sulu_route',

--- a/packages/snippet/tests/Application/config/config.yml
+++ b/packages/snippet/tests/Application/config/config.yml
@@ -1,11 +1,5 @@
 sulu_snippet: {}
 
-sulu_core:
-    content:
-        structure:
-            default_type:
-                snippet: 'snippet'
-
 framework:
     # symfony recipe default configuration:
     workflows: null

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/SuluCoreExtensionTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/DependencyInjection/SuluCoreExtensionTest.php
@@ -13,8 +13,6 @@ namespace Sulu\Bundle\CoreBundle\Tests\Unit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sulu\Bundle\CoreBundle\DependencyInjection\SuluCoreExtension;
-use Sulu\Component\Content\Compat\Structure\PageBridge;
-use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 
 class SuluCoreExtensionTest extends AbstractExtensionTestCase
 {
@@ -37,61 +35,23 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
 
     public function testLoadNoConfig(): void
     {
-        $this->load([
-            'content' => [
-                'structure' => [
-                    'default_type' => [
-                        'snippet' => 'default',
-                        'test' => 'default_test',
-                    ],
-                    'paths' => [],
-                    'type_map' => [
-                        'page' => '\\' . PageBridge::class,
-                        'home' => '\\' . PageBridge::class,
-                        'snippet' => '\\' . SnippetBridge::class,
-                    ],
-                ],
-            ],
-            'locales' => ['en' => 'English', 'de' => 'Deutsch'],
-            'translations' => ['de', 'en'],
-            'fallback_locale' => 'en',
-        ]);
+        $this->load([]);
 
         $this->assertEquals(
-            'default',
-            $this->container->getParameter('sulu.content.structure.default_type.snippet')
+            ['de', 'en'],
+            $this->container->getParameter('sulu_core.locales')
         );
-
         $this->assertEquals(
-            'default_test',
-            $this->container->getParameter('sulu.content.structure.default_type.test')
+            ['en' => 'English', 'de' => 'Deutsch'],
+            $this->container->getParameter('sulu_core.translated_locales')
         );
-    }
-
-    public function testDefaults(): void
-    {
-        $this->load([
-            'content' => [
-                'structure' => [
-                    'default_type' => [
-                        'snippet' => 'barfoo',
-                    ],
-                    'paths' => [],
-                    'type_map' => [
-                        'page' => '\\' . PageBridge::class,
-                        'home' => '\\' . PageBridge::class,
-                        'snippet' => '\\' . SnippetBridge::class,
-                    ],
-                ],
-            ],
-            'locales' => ['en' => 'English', 'de' => 'Deutsch'],
-            'translations' => ['de', 'en'],
-            'fallback_locale' => 'en',
-        ]);
-
         $this->assertEquals(
-            'barfoo',
-            $this->container->getParameter('sulu.content.structure.default_type.snippet')
+            ['de', 'en'],
+            $this->container->getParameter('sulu_core.translations')
+        );
+        $this->assertEquals(
+            'en',
+            $this->container->getParameter('sulu_core.fallback_locale')
         );
     }
 
@@ -99,19 +59,6 @@ class SuluCoreExtensionTest extends AbstractExtensionTestCase
     {
         $this->load(
             [
-                'content' => [
-                    'structure' => [
-                        'default_type' => [
-                            'snippet' => 'barfoo',
-                        ],
-                        'paths' => [],
-                        'type_map' => [
-                            'page' => '\\' . PageBridge::class,
-                            'home' => '\\' . PageBridge::class,
-                            'snippet' => '\\' . SnippetBridge::class,
-                        ],
-                    ],
-                ],
                 'locales' => ['en' => 'English', 'de' => 'Deutsch', 'fr' => 'France'],
                 'translations' => ['de', 'en'],
                 'fallback_locale' => 'en',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #8137 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove old content directory configuration in new bundles.

#### Why?

Stumbled over this in #8137 where we remove that config tree.