### PR TITLE
Remove Document constant usage from ActivityBundle tests

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Tests/Functional/Infrastructure/Doctrine/Repository/ActivityRepositoryTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Functional/Infrastructure/Doctrine/Repository/ActivityRepositoryTest.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
 use Sulu\Bundle\ActivityBundle\Domain\Model\ActivityInterface;
 use Sulu\Bundle\ActivityBundle\Infrastructure\Doctrine\Repository\ActivityRepository;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 class ActivityRepositoryTest extends SuluTestCase
@@ -60,7 +59,7 @@ class ActivityRepositoryTest extends SuluTestCase
         $this->domainEvent->getResourceTitle()->willReturn('Test Page 1234');
         $this->domainEvent->getResourceTitleLocale()->willReturn('en');
         $this->domainEvent->getResourceSecurityContext()->willReturn('sulu.webspaces.sulu-io');
-        $this->domainEvent->getResourceSecurityObjectType()->willReturn(SecurityBehavior::class);
+        $this->domainEvent->getResourceSecurityObjectType()->willReturn('pages');
         $this->domainEvent->getResourceSecurityObjectId()->willReturn('1234-1234-1234-1234');
     }
 
@@ -87,7 +86,7 @@ class ActivityRepositoryTest extends SuluTestCase
         static::assertSame('Test Page 1234', $activity->getResourceTitle());
         static::assertSame('en', $activity->getResourceTitleLocale());
         static::assertSame('sulu.webspaces.sulu-io', $activity->getResourceSecurityContext());
-        static::assertSame(SecurityBehavior::class, $activity->getResourceSecurityObjectType());
+        static::assertSame('pages', $activity->getResourceSecurityObjectType());
         static::assertSame('1234-1234-1234-1234', $activity->getResourceSecurityObjectId());
     }
 

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Domain/Model/ActivityTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Domain/Model/ActivityTest.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\ActivityBundle\Tests\Unit\Model\Event;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\ActivityBundle\Domain\Model\Activity;
-use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 class ActivityTest extends TestCase
@@ -143,8 +142,8 @@ class ActivityTest extends TestCase
         $event = $this->createActivity();
 
         static::assertNull($event->getResourceSecurityObjectType());
-        static::assertSame($event, $event->setResourceSecurityObjectType(SecurityBehavior::class));
-        static::assertSame(SecurityBehavior::class, $event->getResourceSecurityObjectType());
+        static::assertSame($event, $event->setResourceSecurityObjectType('pages'));
+        static::assertSame('pages', $event->getResourceSecurityObjectType());
     }
 
     public function testResourceSecurityObjectId(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #8137
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove Document constant usage from ActivityBundle tests.

#### Why?

Stumbled over this in #8137. We should not build ontop of external interfaces the tests.