### PR TITLE
Create own DataProviderNotExistsException in AdminBundle for SmartContent

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/SmartContentItemController.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Sulu\Bundle\AdminBundle\Controller;
 
 use FOS\RestBundle\View\ViewHandlerInterface;
+use Sulu\Bundle\AdminBundle\SmartContent\Exception\DataProviderNotExistsException;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Component\Content\Compat\PropertyParameter;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
-use Sulu\Component\SmartContent\Exception\DataProviderNotExistsException;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Exception/DataProviderNotExistsException.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Exception/DataProviderNotExistsException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\SmartContent\Exception;
+
+/**
+ * Indicates a not existing DataProvider.
+ */
+class DataProviderNotExistsException extends \Exception
+{
+    public function __construct(string $alias)
+    {
+        parent::__construct(\sprintf('DataProvider with alias "%s" not exists.', $alias));
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #
| Related issues/PRs | #8137
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Create own DataProviderNotExistsException in AdminBundle for SmartContent,

#### Why?

The old exception will be removed in #8137