### PR TITLE
Use flysystem in memory adapter for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
     "require-dev": {
         "coduo/php-matcher": "^6.0.14",
         "jangregor/phpstan-prophecy": "^2.0",
-        "league/flysystem-memory": "^3.29",
+        "league/flysystem-memory": "^3.0",
         "matthiasnoback/symfony-config-test": "^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^6.1",
         "monolog/monolog": "^1.26.1 || ^2.3 || ^3.0",
@@ -138,8 +138,8 @@
         "symfony/browser-kit": "^6.4 || ^7.1",
         "symfony/debug-bundle": "^6.4 || ^7.1",
         "symfony/dotenv": "^6.4 || ^7.1",
-        "symfony/error-handler": "^6.4 || ^7.1",
         "symfony/emoji": "^7.1",
+        "symfony/error-handler": "^6.4 || ^7.1",
         "symfony/monolog-bundle": "^3.7",
         "symfony/phpunit-bridge": "^6.4 || ^7.1",
         "symfony/runtime": "^6.4 || ^7.1",

--- a/config/packages/flysystem.yaml
+++ b/config/packages/flysystem.yaml
@@ -9,4 +9,4 @@ when@test:
     flysystem:
         storages:
             default.storage:
-                    adapter: 'memory'
+                adapter: 'memory'

--- a/config/packages/flysystem.yaml
+++ b/config/packages/flysystem.yaml
@@ -4,3 +4,9 @@ flysystem:
             adapter: 'local'
             options:
                 directory: '%kernel.project_dir%/var/uploads'
+
+when@test:
+    flysystem:
+        storages:
+            default.storage:
+                    adapter: 'memory'

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
@@ -38,4 +38,8 @@ return static function(PhpFileLoader $loader, ContainerBuilder $container) {
     } else {
         $loader->import('symfony-5-4.yml');
     }
+
+    if (\str_starts_with($container->getParameter('kernel.environment'), 'test')) {
+        $loader->import('flysystem_test.yml');
+    }
 };

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/flysystem_test.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/flysystem_test.yml
@@ -1,0 +1,4 @@
+flysystem:
+    storages:
+        default.storage:
+            adapter: 'memory'

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -25,6 +25,4 @@ jms_serializer:
 flysystem:
     storages:
         default.storage:
-            adapter: 'local'
-            options:
-                directory: '%kernel.project_dir%/var/uploads'
+            adapter: 'memory'

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -25,4 +25,6 @@ jms_serializer:
 flysystem:
     storages:
         default.storage:
-            adapter: 'memory'
+            adapter: 'local'
+            options:
+                directory: '%kernel.project_dir%/var/uploads'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use flysystem in memory adapter for tests.

#### Why?

Avoids that we need cleanup old files in test runs.