### PR TITLE
Fix Crowdin translations by merge 2.6 and 3.0 translation files

### DIFF
--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -1,7 +1,6 @@
 name: Crowdin Upload
 
 on:
-    pull_request:
     push:
         tags:
             - '*'

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -1,7 +1,6 @@
 name: Crowdin Upload
 
 on:
-    pull_request: ~
     push:
         tags:
             - '*'

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -18,6 +18,10 @@ jobs:
               with:
                   ref: '2.6'
 
+            - name: Prepare Directory
+              run: |
+                  mkdir -p var/translations
+
             - name: Merge all translation files from 2.6
               run: |
                   jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json > var/translations/admin-2-6.en.json

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -1,6 +1,7 @@
 name: Crowdin Upload
 
 on:
+    pull_request: ~
     push:
         tags:
             - '*'
@@ -36,15 +37,19 @@ jobs:
 
             - name: Merge all translation files from 3.0
               run: |
-                  jq -s '.|add' var/translations/admin-2-6.en.json src/Sulu/Bundle/*/Resources/translations/admin.en.json packages/*/translations/admin.en.json > var/translations/admin.en.json
+                  jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json packages/*/translations/admin.en.json > var/translations/admin-3-0.en.json
 
             - name: Output merged translations 3.0
               run: |
-                  cat var/translations/admin.en.json
+                  cat var/translations/admin-3-0.en.json
 
-            - name: Move to root directory for upload
+            - name: Merge branches
               run: |
-                  mv var/translations/admin.en.json admin.en.json                
+                  jq -s '.|add' ar/translations/admin-2-6.en.json ar/translations/admin-3-0.en.json > admin.en.json
+
+            - name: Output merged translations 3.0
+              run: |
+                  cat var/translations/admin.en.json           
 
             - name: Download Crowdin CLI
               run: curl "https://downloads.crowdin.com/cli/v3/crowdin-cli.zip" --output crowdin-cli.zip && unzip crowdin-cli.zip

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -1,6 +1,7 @@
 name: Crowdin Upload
 
 on:
+    pull_request:
     push:
         tags:
             - '*'
@@ -14,9 +15,34 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                  ref: '2.6'
 
-            - name: Merge all translation files
-              run: jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.*.json > admin.en.json
+            - name: Prepare translation directory
+              run: |
+                  mkdir -p var/translations
+                  echo '{}' > var/translations/admin.en.json
+
+            - name: Merge all translation files from 2.6
+              run: |
+                  jq -s '.|add' var/translations/admin.en.json src/Sulu/Bundle/*/Resources/translations/admin.en.json > var/translations/admin.en.json
+
+            - name: Switch Branch to 3.0
+              run: |
+                  git fetch origin 3.0
+                  git checkout 3.0
+
+            - name: Output merged translations 2.6
+              run: |
+                  cat var/translations/admin.en.json
+
+            - name: Merge all translation files from 3.0
+              run: |
+                  jq -s '.|add' var/translations/admin.en.json src/Sulu/Bundle/*/Resources/translations/admin.en.json packages/*/translations/admin.en.json > var/translations/admin.en.json
+
+            - name: Output merged translations 3.0
+              run: |
+                  cat var/translations/admin.en.json
 
             - name: Download Crowdin CLI
               run: curl "https://downloads.crowdin.com/cli/v3/crowdin-cli.zip" --output crowdin-cli.zip && unzip crowdin-cli.zip
@@ -24,4 +50,5 @@ jobs:
             - name: Upload translations to crowdin
               env:
                   CROWDIN_TOKEN: ${{ secrets.CrowdinToken }}
-              run: java -jar $(find . -name crowdin-cli.jar) upload sources -s "admin.en.json" -t "admin.%two_letters_code%.json" -i 15 --base-url=https://sulu.crowdin.com --base-path=. --token=$CROWDIN_TOKEN
+              run: |
+                  # java -jar $(find . -name crowdin-cli.jar) upload sources -s "admin.en.json" -t "admin.%two_letters_code%.json" -i 15 --base-url=https://sulu.crowdin.com --base-path=. --token=$CROWDIN_TOKEN

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -45,11 +45,11 @@ jobs:
 
             - name: Merge branches
               run: |
-                  jq -s '.|add' ar/translations/admin-2-6.en.json ar/translations/admin-3-0.en.json > admin.en.json
+                  jq -s '.|add' var/translations/admin-2-6.en.json var/translations/admin-3-0.en.json > admin.en.json
 
             - name: Output merged translations 3.0
               run: |
-                  cat var/translations/admin.en.json           
+                  cat admin.en.json          
 
             - name: Download Crowdin CLI
               run: curl "https://downloads.crowdin.com/cli/v3/crowdin-cli.zip" --output crowdin-cli.zip && unzip crowdin-cli.zip

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -52,5 +52,4 @@ jobs:
             - name: Upload translations to crowdin
               env:
                   CROWDIN_TOKEN: ${{ secrets.CrowdinToken }}
-              run: |
-                  java -jar $(find . -name crowdin-cli.jar) upload sources -s "admin.en.json" -t "admin.%two_letters_code%.json" -i 15 --base-url=https://sulu.crowdin.com --base-path=. --token=$CROWDIN_TOKEN
+              run: java -jar $(find . -name crowdin-cli.jar) upload sources -s "admin.en.json" -t "admin.%two_letters_code%.json" -i 15 --base-url=https://sulu.crowdin.com --base-path=. --token=$CROWDIN_TOKEN

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -24,11 +24,11 @@ jobs:
 
             - name: Merge all translation files from 2.6
               run: |
-                  jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json > var/translations/admin-2-6.en.json
+                  jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json > var/translations/admin-merged-2-6.en.json
 
             - name: Output merged translations 2.6
               run: |
-                  cat var/translations/admin-2-6.en.json
+                  cat var/translations/admin-merged-2-6.en.json
 
             - name: Switch Branch to 3.0
               run: |
@@ -37,19 +37,19 @@ jobs:
 
             - name: Merge all translation files from 3.0
               run: |
-                  jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json packages/*/translations/admin.en.json > var/translations/admin-3-0.en.json
+                  jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json packages/*/translations/admin.en.json > var/translations/admin-merged-3-0.en.json
 
             - name: Output merged translations 3.0
               run: |
-                  cat var/translations/admin-3-0.en.json
+                  cat var/translations/admin-merged-3-0.en.json
 
             - name: Merge branches
               run: |
-                  jq -s '.|add' var/translations/admin-2-6.en.json var/translations/admin-3-0.en.json > admin.en.json
+                  jq -s '.|add' var/translations/admin-merged-2-6.en.json var/translations/admin-merged-3-0.en.json > admin.en.json
 
-            - name: Output merged translations 3.0
+            - name: Output merged all translations
               run: |
-                  cat admin.en.json          
+                  cat admin.en.json
 
             - name: Download Crowdin CLI
               run: curl "https://downloads.crowdin.com/cli/v3/crowdin-cli.zip" --output crowdin-cli.zip && unzip crowdin-cli.zip

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -18,14 +18,9 @@ jobs:
               with:
                   ref: '2.6'
 
-            - name: Prepare translation directory
-              run: |
-                  mkdir -p var/translations
-                  echo '{}' > var/translations/admin.en.json
-
             - name: Merge all translation files from 2.6
               run: |
-                  jq -s '.|add' var/translations/admin.en.json src/Sulu/Bundle/*/Resources/translations/admin.en.json > var/translations/admin.en.json
+                  jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json > var/translations/admin-2-6.en.json
 
             - name: Switch Branch to 3.0
               run: |
@@ -34,11 +29,11 @@ jobs:
 
             - name: Output merged translations 2.6
               run: |
-                  cat var/translations/admin.en.json
+                  cat var/translations/admin-2-6.en.json
 
             - name: Merge all translation files from 3.0
               run: |
-                  jq -s '.|add' var/translations/admin.en.json src/Sulu/Bundle/*/Resources/translations/admin.en.json packages/*/translations/admin.en.json > var/translations/admin.en.json
+                  jq -s '.|add' var/translations/admin-2-6.en.json src/Sulu/Bundle/*/Resources/translations/admin.en.json packages/*/translations/admin.en.json > var/translations/admin.en.json
 
             - name: Output merged translations 3.0
               run: |

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -43,6 +43,10 @@ jobs:
               run: |
                   cat var/translations/admin.en.json
 
+            - name: Move to root directory for upload
+              run: |
+                  mv var/translations/admin.en.json admin.en.json                
+
             - name: Download Crowdin CLI
               run: curl "https://downloads.crowdin.com/cli/v3/crowdin-cli.zip" --output crowdin-cli.zip && unzip crowdin-cli.zip
 
@@ -50,4 +54,4 @@ jobs:
               env:
                   CROWDIN_TOKEN: ${{ secrets.CrowdinToken }}
               run: |
-                  # java -jar $(find . -name crowdin-cli.jar) upload sources -s "admin.en.json" -t "admin.%two_letters_code%.json" -i 15 --base-url=https://sulu.crowdin.com --base-path=. --token=$CROWDIN_TOKEN
+                  java -jar $(find . -name crowdin-cli.jar) upload sources -s "admin.en.json" -t "admin.%two_letters_code%.json" -i 15 --base-url=https://sulu.crowdin.com --base-path=. --token=$CROWDIN_TOKEN

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -30,9 +30,10 @@ jobs:
               run: |
                   cat var/translations/admin-2-6.en.json
 
-            - uses: actions/checkout@v4
-              with:
-                  ref: '3.0'
+            - name: Switch Branch to 3.0
+              run: |
+                  git fetch origin 3.0
+                  git checkout origin/3.0
 
             - name: Merge all translation files from 3.0
               run: |

--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -26,14 +26,13 @@ jobs:
               run: |
                   jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json > var/translations/admin-2-6.en.json
 
-            - name: Switch Branch to 3.0
-              run: |
-                  git fetch origin 3.0
-                  git checkout 3.0
-
             - name: Output merged translations 2.6
               run: |
                   cat var/translations/admin-2-6.en.json
+
+            - uses: actions/checkout@v4
+              with:
+                  ref: '3.0'
 
             - name: Merge all translation files from 3.0
               run: |


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Merge 2.6 and 3.0 translation files.

#### Why?

That 2.6 translations don't get removed during upload to 3.0.