### PR TITLE
Add settings translation key to content bundle

### DIFF
--- a/packages/content/src/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
+++ b/packages/content/src/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
@@ -302,7 +302,7 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
             ->addMetadataRequestParameters(['forms' => $forms])
             ->setResourceKey($resourceKey)
             ->setFormKey('content_settings')
-            ->setTabTitle('sulu_page.settings')
+            ->setTabTitle('sulu_content.settings')
             ->setTitleVisible(true)
             ->addToolbarActions(\array_values($toolbarActions))
             ->setTabOrder(50)

--- a/packages/content/translations/admin.de.json
+++ b/packages/content/translations/admin.de.json
@@ -11,6 +11,7 @@
     "sulu_content.enable_shadow_page": "Shadow Seite aktivieren",
     "sulu_content.enable_shadow_page_info_text": "Diese Funktion ist deaktiviert, wenn die aktuelle Sprache bereits als Shadow verwendet wird.",
     "sulu_content.shadow_locale": "Shadow Sprache",
+    "sulu_content.settings": "Einstellungen",
     "sulu_content.webspace": "Webspace",
     "sulu_content.main_webspace": "Hauptwebspace",
     "sulu_content.additional_webspaces": "Weitere Webspaces",

--- a/packages/content/translations/admin.en.json
+++ b/packages/content/translations/admin.en.json
@@ -11,6 +11,7 @@
     "sulu_content.enable_shadow_page": "Enable Shadow page",
     "sulu_content.enable_shadow_page_info_text": "This function is disabled if the current locale is already used as shadow locale.",
     "sulu_content.shadow_locale": "Shadow locale",
+    "sulu_content.settings": "Settings",
     "sulu_content.webspace": "Webspace",
     "sulu_content.main_webspace": "Main Webspace",
     "sulu_content.additional_webspaces": "Additional Webspaces",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add settings translation key to content bundle.

#### Why?

Settings tab is part of the new content bundle and so the new translation should be in the content bundle.