### PR TITLE
Fix first route matching and loading route by site

### DIFF
--- a/packages/route/src/Application/ResourceLocator/ResourceLocatorGenerator.php
+++ b/packages/route/src/Application/ResourceLocator/ResourceLocatorGenerator.php
@@ -33,7 +33,6 @@ final readonly class ResourceLocatorGenerator implements ResourceLocatorGenerato
                 'resourceKey' => $request->parentResourceKey,
                 'resourceId' => $request->parentResourceId,
                 'locale' => $request->locale,
-                'site' => $request->site,
             ]);
 
             $parentPath = $parentRoute?->getSlug() ?: '/';

--- a/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
+++ b/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
@@ -82,11 +82,11 @@ final readonly class RouteCollectionForRequestRouteLoader implements RouteCollec
             return new RouteCollection();
         }
 
-        $route = $this->routeRepository->findOneBy([
+        $route = $this->routeRepository->findFirstBy([
             'siteOrNull' => $site,
             'locale' => $locale,
             'slug' => $slug,
-        ]);
+        ], ['site' => 'DESC']);
 
         if (null === $route) {
             return new RouteCollection();

--- a/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
+++ b/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
@@ -86,7 +86,7 @@ final readonly class RouteCollectionForRequestRouteLoader implements RouteCollec
             'siteOrNull' => $site,
             'locale' => $locale,
             'slug' => $slug,
-        ], ['site' => 'DESC']);
+        ], ['site' => 'desc']);
 
         if (null === $route) {
             return new RouteCollection();

--- a/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
+++ b/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
@@ -83,7 +83,7 @@ final readonly class RouteCollectionForRequestRouteLoader implements RouteCollec
         }
 
         $route = $this->routeRepository->findOneBy([
-            'site' => $site,
+            'siteOrNull' => $site,
             'locale' => $locale,
             'slug' => $slug,
         ]);

--- a/packages/route/src/Application/Routing/Matcher/RouteHistoryDefaultsProvider.php
+++ b/packages/route/src/Application/Routing/Matcher/RouteHistoryDefaultsProvider.php
@@ -45,7 +45,6 @@ final readonly class RouteHistoryDefaultsProvider implements RouteDefaultsProvid
         $targetRoute = $this->routeRepository->findOneBy([
             'resourceKey' => $resourceKey,
             'resourceId' => $resourceId,
-            'site' => $route->getSite(),
             'locale' => $route->getLocale(),
         ]);
 

--- a/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
+++ b/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
@@ -27,7 +27,6 @@ use Sulu\Route\Domain\Model\Route;
  *         resourceId: string,
  *     },
  * }
- *
  * @phpstan-type RouteSortBy array{
  *     site?: 'asc'|'desc',
  * }

--- a/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
+++ b/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
@@ -16,6 +16,7 @@ use Sulu\Route\Domain\Model\Route;
 /**
  * @phpstan-type RouteFilter array{
  *     site?: string|null,
+ *     siteOrNull?: string|null,
  *     locale?: string,
  *     locales?: string[],
  *     slug?: string,
@@ -25,6 +26,10 @@ use Sulu\Route\Domain\Model\Route;
  *         resourceKey: string,
  *         resourceId: string,
  *     },
+ * }
+ *
+ * @phpstan-type RouteSortBy array{
+ *     site?: 'asc'|'desc',
  * }
  */
 interface RouteRepositoryInterface
@@ -38,13 +43,20 @@ interface RouteRepositoryInterface
 
     /**
      * @param RouteFilter $filters
+     * @param RouteSortBy $sortBys
+     */
+    public function findFirstBy(array $filters, array $sortBys = []): ?Route;
+
+    /**
+     * @param RouteFilter $filters
      */
     public function existBy(array $filters): bool;
 
     /**
      * @param RouteFilter $filters
+     * @param RouteSortBy $sortBys
      *
      * @return iterable<Route>
      */
-    public function findBy(array $filters): iterable;
+    public function findBy(array $filters, array $sortBys = []): iterable;
 }

--- a/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
+++ b/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
@@ -20,6 +20,7 @@ use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 
 /**
  * @phpstan-import-type RouteFilter from RouteRepositoryInterface
+ * @phpstan-import-type RouteSortBy from RouteRepositoryInterface
  */
 class RouteRepository implements RouteRepositoryInterface
 {
@@ -49,6 +50,18 @@ class RouteRepository implements RouteRepositoryInterface
         return $queryBuilder->getQuery()->getOneOrNullResult(Query::HYDRATE_OBJECT);
     }
 
+    public function findFirstBy(array $filters, array $sortBys = []): ?Route
+    {
+        $queryBuilder = $this->createQueryBuilder($filters, $sortBys);
+        $queryBuilder->select('route');
+        $queryBuilder->setMaxResults(1);
+
+        // Hydrate Object is default, but we need to specify it here to make PHPStan happy:
+        //     see: https://github.com/phpstan/phpstan-doctrine?tab=readme-ov-file#supported-methods
+        /** @var Route */
+        return $queryBuilder->getQuery()->getOneOrNullResult(Query::HYDRATE_OBJECT);
+    }
+
     public function existBy(array $filters): bool
     {
         $queryBuilder = $this->createQueryBuilder($filters);
@@ -58,7 +71,7 @@ class RouteRepository implements RouteRepositoryInterface
         return $queryBuilder->getQuery()->getOneOrNullResult() ? true : false;
     }
 
-    public function findBy(array $filters): iterable
+    public function findBy(array $filters, array $sortBys = []): iterable
     {
         $queryBuilder = $this->createQueryBuilder($filters);
         $queryBuilder->select('route');
@@ -71,13 +84,25 @@ class RouteRepository implements RouteRepositoryInterface
 
     /**
      * @param RouteFilter $filters
+     * @param RouteSortBy $sortBys
      */
-    protected function createQueryBuilder(array $filters): QueryBuilder
+    protected function createQueryBuilder(array $filters, array $sortBys = []): QueryBuilder
     {
         $queryBuilder = $this->repository->createQueryBuilder('route');
 
         if (\array_key_exists('site', $filters)) {
             $site = $filters['site'] ?? null;
+            $queryBuilder->andWhere(
+                null === $site ? 'route.site IS NULL' : 'route.site = :site'
+            );
+
+            if (null !== $site) {
+                $queryBuilder->setParameter('site', $site);
+            }
+        }
+
+        if (\array_key_exists('siteOrNull', $filters)) {
+            $site = $filters['siteOrNull'] ?? null;
             $queryBuilder->andWhere(
                 null === $site ? 'route.site IS NULL' : '(route.site = :site OR route.site IS NULL)'
             );
@@ -128,6 +153,12 @@ class RouteRepository implements RouteRepositoryInterface
                 )))
                 ->setParameter('excludeResourceKey', $excludeResource['resourceKey'])
                 ->setParameter('excludeResourceId', $excludeResource['resourceId']);
+        }
+
+        if ([] !== $sortBys) {
+            foreach ($sortBys as $field => $order) {
+                $queryBuilder->addOrderBy(\sprintf('route.%s', $field), $order);
+            }
         }
 
         return $queryBuilder;

--- a/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
+++ b/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Route\Infrastructure\Doctrine\Repository;
 
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query;
@@ -157,6 +159,22 @@ class RouteRepository implements RouteRepositoryInterface
 
         if ([] !== $sortBys) {
             foreach ($sortBys as $field => $order) {
+                $order = match (true) {
+                    // if we filter by siteOrNull and order by site we need invert the order for specific platforms
+                    // TODO if possible in future use something like ASC NULLS FIRST / DESC NULLS LAST directly
+                    ('site' === $field // @phpstan-ignore-line identical.alwaysTrue
+                        && (
+                            $this->entityManager->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform
+                            || $this->entityManager->getConnection()->getDatabasePlatform() instanceof OraclePlatform
+                        )
+                        && \array_key_exists('siteOrNull', $filters)
+                    ) => match ($order) {
+                        'asc' => 'desc',
+                        'desc' => 'asc',
+                    },
+                    default => $order,
+                };
+
                 $queryBuilder->addOrderBy(\sprintf('route.%s', $field), $order);
             }
         }

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
@@ -43,7 +43,7 @@ class RouteRepositoryTest extends KernelTestCase
         $multiSiteRouteEn = new Route('multisite', '1', 'en', '/example', null);
         $entityManager->persist($multiSiteRouteEn);
 
-        $multiSiteRouteDe = new Route('multisite', '1', 'en', '/beispiel', null);
+        $multiSiteRouteDe = new Route('multisite', '1', 'de', '/beispiel', null);
         $entityManager->persist($multiSiteRouteDe);
 
         $entityManager->flush();
@@ -95,14 +95,22 @@ class RouteRepositoryTest extends KernelTestCase
 
     public function testFindFirstBySiteOrNullSlugLocale(): void
     {
+        $routes = $this->routeRepository->findBy([
+            'siteOrNull' => 'the_site',
+            'slug' => '/example',
+            'locale' => 'en',
+        ], ['site' => 'desc']);
+
+        $this->assertGreaterThanOrEqual(2, \count([...$routes]), 'This test requires at least two routes on the same slug and locale.');
+
         $route = $this->routeRepository->findFirstBy([
             'siteOrNull' => 'the_site',
-            'slug' => '/test',
+            'slug' => '/example',
             'locale' => 'en',
-        ], ['site' => 'DESC']);
+        ], ['site' => 'desc']);
 
         $this->assertNotNull($route);
-        $this->assertSame('/test', $route->getSlug());
+        $this->assertSame('/example', $route->getSlug());
         $this->assertSame('en', $route->getLocale());
         $this->assertSame('the_site', $route->getSite());
     }
@@ -110,13 +118,13 @@ class RouteRepositoryTest extends KernelTestCase
     public function testFindFirstBySiteSlugLocale(): void
     {
         $route = $this->routeRepository->findFirstBy([
-            'site' => null,
-            'slug' => '/test',
+            'siteOrNull' => null,
+            'slug' => '/example',
             'locale' => 'en',
-        ], ['site' => 'DESC']);
+        ], ['site' => 'desc']);
 
         $this->assertNotNull($route);
-        $this->assertSame('/test', $route->getSlug());
+        $this->assertSame('/example', $route->getSlug());
         $this->assertSame('en', $route->getLocale());
         $this->assertNull($route->getSite());
     }
@@ -127,7 +135,7 @@ class RouteRepositoryTest extends KernelTestCase
             'siteOrNull' => 'the_site',
             'slug' => '/not-exist',
             'locale' => 'en',
-        ], ['site' => 'DESC']);
+        ], ['site' => 'desc']);
 
         $this->assertNull($route);
     }

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
@@ -40,6 +40,12 @@ class RouteRepositoryTest extends KernelTestCase
         $unexpectedLocalesRouteEs = new Route('example', '1', 'es', '/ejemplo', 'the_site');
         $entityManager->persist($unexpectedLocalesRouteEs);
 
+        $multiSiteRouteEn = new Route('multisite', '1', 'en', '/example', null);
+        $entityManager->persist($multiSiteRouteEn);
+
+        $multiSiteRouteDe = new Route('multisite', '1', 'en', '/beispiel', null);
+        $entityManager->persist($multiSiteRouteDe);
+
         $entityManager->flush();
         $entityManager->clear();
 
@@ -85,6 +91,31 @@ class RouteRepositoryTest extends KernelTestCase
         $this->assertSame('en', $route->getLocale());
         $this->assertSame(Route::HISTORY_RESOURCE_KEY, $route->getResourceKey());
         $this->assertSame('example::1', $route->getResourceId());
+    }
+
+    public function testFindFirstBySiteOrNullSlugLocale(): void
+    {
+        $route = $this->routeRepository->findFirstBy([
+            'siteOrNull' => 'the_site',
+            'slug' => '/test',
+            'locale' => 'en',
+        ], ['site' => 'DESC']);
+
+        $this->assertNotNull($route);
+        $this->assertSame('/test', $route->getSlug());
+        $this->assertSame('en', $route->getLocale());
+        $this->assertSame('the_site', $route->getSite());
+    }
+
+    public function testFindFirstByNotExist(): void
+    {
+        $route = $this->routeRepository->findFirstBy([
+            'siteOrNull' => 'the_site',
+            'slug' => '/not-exist',
+            'locale' => 'en',
+        ], ['site' => 'DESC']);
+
+        $this->assertNull($route);
     }
 
     public function testFindOneByResourceAndLocales(): void

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
@@ -107,6 +107,20 @@ class RouteRepositoryTest extends KernelTestCase
         $this->assertSame('the_site', $route->getSite());
     }
 
+    public function testFindFirstBySiteSlugLocale(): void
+    {
+        $route = $this->routeRepository->findFirstBy([
+            'site' => null,
+            'slug' => '/test',
+            'locale' => 'en',
+        ], ['site' => 'DESC']);
+
+        $this->assertNotNull($route);
+        $this->assertSame('/test', $route->getSlug());
+        $this->assertSame('en', $route->getLocale());
+        $this->assertNull($route->getSite());
+    }
+
     public function testFindFirstByNotExist(): void
     {
         $route = $this->routeRepository->findFirstBy([

--- a/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorGeneratorTest.php
@@ -80,7 +80,6 @@ class ResourceLocatorGeneratorTest extends TestCase
             'resourceId' => 'cff165a7-ae8e-46b4-8f32-f0a339173207',
             'resourceKey' => 'pages',
             'locale' => 'de',
-            'site' => 'website',
         ])
             ->willReturn($parentRoute)
             ->shouldBeCalled();

--- a/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
@@ -68,7 +68,7 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
         $request = Request::create('/en/test');
         $request->attributes->set(RequestAttributeEnum::SLUG->value, new \stdClass());
 
-        $this->routeRepository->findOneBy(Argument::any())->shouldNotBeCalled();
+        $this->routeRepository->findFirstBy(Argument::cetera())->shouldNotBeCalled();
         $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
 
         $this->assertCount(0, $routeCollection);
@@ -79,7 +79,7 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
         $request = Request::create('/en/test');
         $request->attributes->set(RequestAttributeEnum::SITE->value, 'the_site');
 
-        $this->routeRepository->findOneBy(Argument::any())->shouldNotBeCalled();
+        $this->routeRepository->findFirstBy(Argument::cetera())->shouldNotBeCalled();
         $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
 
         $this->assertCount(0, $routeCollection);
@@ -91,7 +91,7 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
         $request->attributes->set(RequestAttributeEnum::SITE->value, 'the_site');
         $request->attributes->set(RequestAttributeEnum::SLUG->value, '/test');
 
-        $this->routeRepository->findOneBy(Argument::any())->willReturn(null);
+        $this->routeRepository->findFirstBy(Argument::cetera())->willReturn(null);
         $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
 
         $this->assertCount(0, $routeCollection);
@@ -106,7 +106,7 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
         $routeModel = new Route('resource_key_example', '1', 'en', '/test', 'the_site');
         static::setPrivateProperty($routeModel, 'id', 1);
 
-        $this->routeRepository->findOneBy(Argument::any())->willReturn($routeModel);
+        $this->routeRepository->findFirstBy(Argument::cetera())->willReturn($routeModel);
         $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
 
         $this->assertCount(1, $routeCollection);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Get the first route match in the routes provider.

#### Why?

Technically there can exists a route on e.g. slug `/test` with and without a `site` defined.