### PR TITLE
Change return types that were marked as `ReturnTypeWillChange`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -829,6 +829,22 @@ The following methods have been updated with a return type hint:
 - `TimestampableInterface::getChanged()`: now returns `\DateTimeImmutable`
 - `UserBlameInterface::getCreator()`: now returns `?UserInterface`
 - `UserBlameInterface::getChanger()`: now returns `?UserInterface`
+- `NavigationItem::current()`: returns `NavigationItem`
+- `NavigationItem::next()`: returns `void`
+- `NavigationItem::key()`: returns `int`
+- `NavigationItem::valid()`: returns `bool`
+- `NavigationItem::rewind()`: returns `void`
+- `AddressType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `ContactType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `EmailType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `FaxType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `PhoneType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `Position::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `SocialMediaProfileType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `UrlType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `PropertyParameter::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `Localization::jsonSerialize()` returns `array` (see its typehint for the exact shape)
+- `WebspaceCollection::getIterator()` returns `\Traversable`
 
 The corresponding traits `TimestampableTrait` and `UserBlameTrait` have been updated with these return type hints.
 

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
@@ -374,11 +374,8 @@ class NavigationItem implements \Iterator
      * Return the current element.
      *
      * @see http://php.net/manual/en/iterator.current.php
-     *
-     * @return mixed Can return any type
      */
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): self
     {
         return $this->children[$this->position];
     }
@@ -388,8 +385,7 @@ class NavigationItem implements \Iterator
      *
      * @see http://php.net/manual/en/iterator.next.php
      */
-    #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -401,8 +397,7 @@ class NavigationItem implements \Iterator
      *
      * @return mixed scalar on success, or null on failure
      */
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -415,8 +410,7 @@ class NavigationItem implements \Iterator
      * @return bool The return value will be casted to boolean and then evaluated.
      *              Returns true on success or false on failure
      */
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->position < \count($this->children);
     }
@@ -426,8 +420,7 @@ class NavigationItem implements \Iterator
      *
      * @see http://php.net/manual/en/iterator.rewind.php
      */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
@@ -394,8 +394,6 @@ class NavigationItem implements \Iterator
      * Return the key of the current element.
      *
      * @see http://php.net/manual/en/iterator.key.php
-     *
-     * @return mixed scalar on success, or null on failure
      */
     public function key(): int
     {

--- a/src/Sulu/Bundle/ContactBundle/Entity/AddressType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AddressType.php
@@ -126,12 +126,8 @@ class AddressType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Sulu/Bundle/ContactBundle/Entity/AddressType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/AddressType.php
@@ -126,6 +126,8 @@ class AddressType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return array{id: int, name: string}
      */
     public function jsonSerialize(): array
     {

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactTitle.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactTitle.php
@@ -71,12 +71,8 @@ class ContactTitle implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactTitle.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactTitle.php
@@ -71,6 +71,8 @@ class ContactTitle implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return array{id: int, title: string}
      */
     public function jsonSerialize(): array
     {

--- a/src/Sulu/Bundle/ContactBundle/Entity/EmailType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/EmailType.php
@@ -126,6 +126,8 @@ class EmailType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return array{id: int, name: string}
      */
     public function jsonSerialize(): mixed
     {

--- a/src/Sulu/Bundle/ContactBundle/Entity/EmailType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/EmailType.php
@@ -126,12 +126,8 @@ class EmailType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'id' => $this->getId(),

--- a/src/Sulu/Bundle/ContactBundle/Entity/FaxType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/FaxType.php
@@ -126,6 +126,8 @@ class FaxType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return array{id: int, name: string}
      */
     public function jsonSerialize(): array
     {

--- a/src/Sulu/Bundle/ContactBundle/Entity/FaxType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/FaxType.php
@@ -126,12 +126,8 @@ class FaxType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Sulu/Bundle/ContactBundle/Entity/PhoneType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/PhoneType.php
@@ -126,6 +126,8 @@ class PhoneType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return array{id: int, name: string}
      */
     public function jsonSerialize(): array
     {

--- a/src/Sulu/Bundle/ContactBundle/Entity/PhoneType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/PhoneType.php
@@ -126,12 +126,8 @@ class PhoneType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Sulu/Bundle/ContactBundle/Entity/Position.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Position.php
@@ -71,6 +71,8 @@ class Position implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return array{id: int, position: string}
      */
     public function jsonSerialize(): array
     {

--- a/src/Sulu/Bundle/ContactBundle/Entity/Position.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Position.php
@@ -71,12 +71,8 @@ class Position implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Sulu/Bundle/ContactBundle/Entity/SocialMediaProfileType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/SocialMediaProfileType.php
@@ -119,6 +119,8 @@ class SocialMediaProfileType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return array{id: int, name: string}
      */
     public function jsonSerialize(): array
     {

--- a/src/Sulu/Bundle/ContactBundle/Entity/SocialMediaProfileType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/SocialMediaProfileType.php
@@ -119,12 +119,8 @@ class SocialMediaProfileType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Sulu/Bundle/ContactBundle/Entity/UrlType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/UrlType.php
@@ -126,12 +126,8 @@ class UrlType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'id' => $this->getId(),

--- a/src/Sulu/Bundle/ContactBundle/Entity/UrlType.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/UrlType.php
@@ -126,6 +126,8 @@ class UrlType implements \JsonSerializable
      * Specify data which should be serialized to JSON.
      *
      * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return array{id: int, name: string}
      */
     public function jsonSerialize(): array
     {

--- a/src/Sulu/Component/Content/Compat/PropertyParameter.php
+++ b/src/Sulu/Component/Content/Compat/PropertyParameter.php
@@ -151,8 +151,7 @@ class PropertyParameter implements \JsonSerializable
         }
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'value' => $this->getValue(),

--- a/src/Sulu/Component/Content/Compat/PropertyParameter.php
+++ b/src/Sulu/Component/Content/Compat/PropertyParameter.php
@@ -151,6 +151,9 @@ class PropertyParameter implements \JsonSerializable
         }
     }
 
+    /**
+     * @return array{value: mixed, type: string}
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -340,6 +340,9 @@ class Localization implements \JsonSerializable, ArrayableInterface
         return $this->getLocale();
     }
 
+    /**
+     * @return array{'localization': string, 'name': string}
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -340,8 +340,7 @@ class Localization implements \JsonSerializable, ArrayableInterface
         return $this->getLocale();
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'localization' => $this->getLocale(),

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -132,8 +132,7 @@ class WebspaceCollection implements \IteratorAggregate
         return \count($this->webspaces);
     }
 
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->webspaces);
     }


### PR DESCRIPTION
This reverts commit a27da83fc121576e94377e99471929d08e7eaa62.

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7547 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Replace the `ReturnTypeWillChange` with the changed return type.

#### Why?
Keeping our promises of changing return types. :laughing: 

#### Example Usage
Same as before but now just better.