### PR TITLE
Simplify Reference Path / extraction logic

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Reference/ArticleReferenceRefresher.php
+++ b/packages/article/src/Infrastructure/Sulu/Reference/ArticleReferenceRefresher.php
@@ -23,7 +23,6 @@ use Sulu\Bundle\ReferenceBundle\Application\Refresh\ReferenceRefresherInterface;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
 use Sulu\Content\Application\ContentMerger\ContentMergerInterface;
 use Sulu\Content\Application\ContentResolver\ContentViewResolver\ContentViewResolverInterface;
-use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 
@@ -114,11 +113,16 @@ class ArticleReferenceRefresher implements ReferenceRefresherInterface
         $contentViews = $this->contentViewResolver->getContentViews(dimensionContent: $articleDimensionContent);
 
         foreach ($contentViews as $key => $contentView) {
-            $this->addReferences(
-                $referenceCollector,
-                $contentView,
-                'template' !== $key ? (string) $key : ''
-            );
+            $basePath = 'template' !== $key ? (string) $key : '';
+            $references = $contentView->getAllReferencesRecursively($basePath);
+
+            foreach ($references as $reference) {
+                $referenceCollector->addReference(
+                    $reference->getResourceKey(),
+                    (string) $reference->getResourceId(),
+                    $reference->getPath()
+                );
+            }
         }
 
         $referenceCollector->persistReferences();
@@ -194,28 +198,6 @@ class ArticleReferenceRefresher implements ReferenceRefresherInterface
                 }
                 $unlocalizedDimensionContent = null;
             }
-        }
-    }
-
-    private function addReferences(ReferenceCollector $referenceCollector, ContentView $contentView, string $path): void
-    {
-        $content = $contentView->getContent();
-
-        if (\is_iterable($content)) {
-            foreach ($content as $key => $value) {
-                $keyStr = \is_string($key) || \is_numeric($key) ? (string) $key : '';
-                $newPath = \ltrim($path . '.' . $keyStr, '.');
-                if ($value instanceof ContentView) {
-                    $this->addReferences($referenceCollector, $value, $newPath);
-                }
-            }
-        }
-        foreach ($contentView->getReferences() as $reference) {
-            $referenceCollector->addReference(
-                $reference->getResourceKey(),
-                (string) $reference->getResourceId(),
-                $path
-            );
         }
     }
 }

--- a/packages/content/src/Application/ContentResolver/Value/ContentView.php
+++ b/packages/content/src/Application/ContentResolver/Value/ContentView.php
@@ -224,14 +224,12 @@ class ContentView
      * Recursively collect all references from this ContentView and nested ContentViews.
      * Each reference will have its path set to indicate where it was found.
      *
-     * @return array<Reference>
+     * @return iterable<Reference>
      */
-    public function getAllReferencesRecursively(string $basePath = ''): array
+    public function getAllReferencesRecursively(string $basePath = ''): iterable
     {
-        $allReferences = [];
-
         foreach ($this->references as $reference) {
-            $allReferences[] = new Reference(
+            yield new Reference(
                 $reference->getResourceId(),
                 $reference->getResourceKey(),
                 $basePath
@@ -241,15 +239,28 @@ class ContentView
         $content = $this->getContent();
         if (\is_iterable($content)) {
             foreach ($content as $key => $value) {
+                $keyStr = \is_string($key) || \is_numeric($key) ? (string) $key : '';
+                $newPath = \ltrim($basePath . '.' . $keyStr, '.');
+
                 if ($value instanceof ContentView) {
-                    $keyStr = \is_string($key) || \is_numeric($key) ? (string) $key : '';
-                    $newPath = \ltrim($basePath . '.' . $keyStr, '.');
                     $nestedReferences = $value->getAllReferencesRecursively($newPath);
-                    $allReferences = \array_merge($allReferences, $nestedReferences);
+                    foreach ($nestedReferences as $reference) {
+                        yield $reference;
+                    }
+                } elseif (\is_iterable($value)) {
+                    // Handle arrays that might contain ContentViews
+                    foreach ($value as $subKey => $subValue) {
+                        if ($subValue instanceof ContentView) {
+                            $subKeyStr = \is_string($subKey) || \is_numeric($subKey) ? (string) $subKey : '';
+                            $subPath = \ltrim($newPath . '.' . $subKeyStr, '.');
+                            $nestedReferences = $subValue->getAllReferencesRecursively($subPath);
+                            foreach ($nestedReferences as $reference) {
+                                yield $reference;
+                            }
+                        }
+                    }
                 }
             }
         }
-
-        return $allReferences;
     }
 }

--- a/packages/content/src/Application/ContentResolver/Value/ContentView.php
+++ b/packages/content/src/Application/ContentResolver/Value/ContentView.php
@@ -217,4 +217,37 @@ class ContentView
 
         return $this;
     }
+
+    /**
+     * Recursively collect all references from this ContentView and nested ContentViews.
+     * Each reference will have its path set to indicate where it was found.
+     *
+     * @return array<Reference>
+     */
+    public function getAllReferencesRecursively(string $basePath = ''): array
+    {
+        $allReferences = [];
+
+        foreach ($this->references as $reference) {
+            $allReferences[] = new Reference(
+                $reference->getResourceId(),
+                $reference->getResourceKey(),
+                $basePath
+            );
+        }
+
+        $content = $this->getContent();
+        if (\is_iterable($content)) {
+            foreach ($content as $key => $value) {
+                if ($value instanceof ContentView) {
+                    $keyStr = \is_string($key) || \is_numeric($key) ? (string) $key : '';
+                    $newPath = \ltrim($basePath . '.' . $keyStr, '.');
+                    $nestedReferences = $value->getAllReferencesRecursively($newPath);
+                    $allReferences = \array_merge($allReferences, $nestedReferences);
+                }
+            }
+        }
+
+        return $allReferences;
+    }
 }

--- a/packages/content/src/Application/ContentResolver/Value/ContentView.php
+++ b/packages/content/src/Application/ContentResolver/Value/ContentView.php
@@ -219,6 +219,8 @@ class ContentView
     }
 
     /**
+     * @internal This method can be removed at any time no backwards compatibility promise is given for this.
+     *
      * Recursively collect all references from this ContentView and nested ContentViews.
      * Each reference will have its path set to indicate where it was found.
      *

--- a/packages/content/src/Application/ContentResolver/Value/Reference.php
+++ b/packages/content/src/Application/ContentResolver/Value/Reference.php
@@ -16,6 +16,7 @@ class Reference
     public function __construct(
         private string|int $resourceId,
         private string $resourceKey,
+        private string $path = '',
     ) {
     }
 
@@ -27,5 +28,10 @@ class Reference
     public function getResourceId(): string|int
     {
         return $this->resourceId;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ContentViewTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ContentViewTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver\Value;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\Reference;
@@ -99,8 +100,7 @@ class ContentViewTest extends TestCase
 
         $references = $contentView->getReferences();
         self::assertCount(1, $references);
-        self::assertSame(5, $references[0]->getResourceId());
-        self::assertSame('pages', $references[0]->getResourceKey());
+        $this->assertReferenceEquals(5, 'pages', '', $references[0]);
     }
 
     public function testCreateResolvablesWithReferences(): void
@@ -121,12 +121,11 @@ class ContentViewTest extends TestCase
         self::assertSame('resourceLoaderKey', $resolvables[1]->getResourceLoaderKey());
         self::assertSame(['view' => 'data'], $contentView->getView());
 
-        $references = $contentView->getReferences();
-        self::assertCount(2, $references);
-        self::assertSame(5, $references[0]->getResourceId());
-        self::assertSame('articles', $references[0]->getResourceKey());
-        self::assertSame(6, $references[1]->getResourceId());
-        self::assertSame('articles', $references[1]->getResourceKey());
+        $expectedReferences = [
+            ['id' => 5, 'key' => 'articles', 'path' => ''],
+            ['id' => 6, 'key' => 'articles', 'path' => ''],
+        ];
+        $this->assertReferencesMatch($expectedReferences, $contentView->getReferences());
     }
 
     public function testGetReferences(): void
@@ -156,5 +155,161 @@ class ContentViewTest extends TestCase
         self::assertSame('content', $contentView->getContent());
         self::assertSame(['view' => 'data'], $contentView->getView());
         self::assertEmpty($contentView->getReferences());
+    }
+
+    /**
+     * @param array<Reference> $inputReferences
+     * @param array<array{id: string|int, key: string, path: string}> $expectedReferences
+     */
+    #[DataProvider('simpleReferenceTestDataProvider')]
+    public function testGetAllReferencesRecursivelySimpleCases(
+        array $inputReferences,
+        string $basePath,
+        array $expectedReferences,
+        mixed $content = 'content'
+    ): void {
+        $contentView = ContentView::createWithReferences($content, ['view' => 'data'], $inputReferences);
+
+        $allReferences = $contentView->getAllReferencesRecursively($basePath);
+
+        $this->assertReferencesMatch($expectedReferences, $allReferences);
+    }
+
+    public function testGetAllReferencesRecursivelyWithNestedContentViews(): void
+    {
+        $nestedRef1 = new Reference(10, 'snippets');
+        $nestedRef2 = new Reference(20, 'media');
+
+        $nestedContentView1 = ContentView::createWithReferences('nested1', [], [$nestedRef1]);
+        $nestedContentView2 = ContentView::createWithReferences('nested2', [], [$nestedRef2]);
+
+        $mainRef = new Reference(1, 'pages');
+        $mainContentView = ContentView::createWithReferences(
+            ['child1' => $nestedContentView1, 'child2' => $nestedContentView2],
+            [],
+            [$mainRef]
+        );
+
+        $allReferences = $mainContentView->getAllReferencesRecursively('content');
+
+        $expectedReferences = [
+            ['id' => 1, 'key' => 'pages', 'path' => 'content'],
+            ['id' => 10, 'key' => 'snippets', 'path' => 'content.child1'],
+            ['id' => 20, 'key' => 'media', 'path' => 'content.child2'],
+        ];
+
+        $this->assertReferencesMatch($expectedReferences, $allReferences);
+    }
+
+    public function testGetAllReferencesRecursivelyWithDeeplyNestedContentViews(): void
+    {
+        $deepNestedRef = new Reference(100, 'contacts');
+        $deepNestedContentView = ContentView::createWithReferences('deep', [], [$deepNestedRef]);
+
+        $middleContentView = ContentView::createWithReferences(['level3' => $deepNestedContentView], [], []);
+        $topContentView = ContentView::createWithReferences(['level2' => $middleContentView], [], []);
+
+        $allReferences = $topContentView->getAllReferencesRecursively('content');
+
+        $this->assertReferenceEquals(100, 'contacts', 'content.level2.level3', $allReferences[0]);
+        self::assertCount(1, $allReferences);
+    }
+
+    public function testGetAllReferencesRecursivelyWithMixedContent(): void
+    {
+        $nestedRef = new Reference(50, 'categories');
+        $nestedContentView = ContentView::createWithReferences('nested', [], [$nestedRef]);
+
+        $mixedContent = [
+            'text' => 'some text',
+            0 => $nestedContentView,
+            'number' => 123,
+            'nested' => $nestedContentView,
+        ];
+
+        $mainRef = new Reference(1, 'pages');
+        $mainContentView = ContentView::createWithReferences($mixedContent, [], [$mainRef]);
+
+        $allReferences = $mainContentView->getAllReferencesRecursively();
+
+        $expectedReferences = [
+            ['id' => 1, 'key' => 'pages', 'path' => ''],
+            ['id' => 50, 'key' => 'categories', 'path' => '0'],
+            ['id' => 50, 'key' => 'categories', 'path' => 'nested'],
+        ];
+
+        $this->assertReferencesMatch($expectedReferences, $allReferences);
+    }
+
+    public function testGetAllReferencesRecursivelyWithEmptyContent(): void
+    {
+        $contentView = ContentView::create('simple content', []);
+
+        $allReferences = $contentView->getAllReferencesRecursively();
+
+        self::assertEmpty($allReferences);
+    }
+
+    /**
+     * Data provider for simple reference test cases.
+     *
+     * @return array<string, array{0: array<Reference>, 1: string, 2: array<array{id: string|int, key: string, path: string}>, 3?: mixed}>
+     */
+    public static function simpleReferenceTestDataProvider(): array
+    {
+        return [
+            'single reference without base path' => [
+                [new Reference(1, 'pages')],
+                '',
+                [['id' => 1, 'key' => 'pages', 'path' => '']],
+            ],
+            'multiple references without base path' => [
+                [
+                    new Reference(1, 'pages'),
+                    new Reference('uuid-123', 'articles'),
+                ],
+                '',
+                [
+                    ['id' => 1, 'key' => 'pages', 'path' => ''],
+                    ['id' => 'uuid-123', 'key' => 'articles', 'path' => ''],
+                ],
+            ],
+            'single reference with base path' => [
+                [new Reference(1, 'pages')],
+                'seo.title',
+                [['id' => 1, 'key' => 'pages', 'path' => 'seo.title']],
+            ],
+            'single reference with non-iterable content and path' => [
+                [new Reference(1, 'pages')],
+                'test',
+                [['id' => 1, 'key' => 'pages', 'path' => 'test']],
+                'string content',
+            ],
+        ];
+    }
+
+    private function assertReferenceEquals(string|int $expectedId, string $expectedKey, string $expectedPath, Reference $actual): void
+    {
+        self::assertSame($expectedId, $actual->getResourceId());
+        self::assertSame($expectedKey, $actual->getResourceKey());
+        self::assertSame($expectedPath, $actual->getPath());
+    }
+
+    /**
+     * @param array<array{id: string|int, key: string, path: string}> $expectedReferences
+     * @param array<Reference> $actualReferences
+     */
+    private function assertReferencesMatch(array $expectedReferences, array $actualReferences): void
+    {
+        self::assertCount(\count($expectedReferences), $actualReferences);
+
+        foreach ($expectedReferences as $index => $expected) {
+            $this->assertReferenceEquals(
+                $expected['id'],
+                $expected['key'],
+                $expected['path'],
+                $actualReferences[$index]
+            );
+        }
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ContentViewTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ContentViewTest.php
@@ -170,7 +170,7 @@ class ContentViewTest extends TestCase
     ): void {
         $contentView = ContentView::createWithReferences($content, ['view' => 'data'], $inputReferences);
 
-        $allReferences = $contentView->getAllReferencesRecursively($basePath);
+        $allReferences = \iterator_to_array($contentView->getAllReferencesRecursively($basePath));
 
         $this->assertReferencesMatch($expectedReferences, $allReferences);
     }
@@ -190,7 +190,7 @@ class ContentViewTest extends TestCase
             [$mainRef]
         );
 
-        $allReferences = $mainContentView->getAllReferencesRecursively('content');
+        $allReferences = \iterator_to_array($mainContentView->getAllReferencesRecursively('content'));
 
         $expectedReferences = [
             ['id' => 1, 'key' => 'pages', 'path' => 'content'],
@@ -209,7 +209,7 @@ class ContentViewTest extends TestCase
         $middleContentView = ContentView::createWithReferences(['level3' => $deepNestedContentView], [], []);
         $topContentView = ContentView::createWithReferences(['level2' => $middleContentView], [], []);
 
-        $allReferences = $topContentView->getAllReferencesRecursively('content');
+        $allReferences = \iterator_to_array($topContentView->getAllReferencesRecursively('content'));
 
         $this->assertReferenceEquals(100, 'contacts', 'content.level2.level3', $allReferences[0]);
         self::assertCount(1, $allReferences);
@@ -230,7 +230,7 @@ class ContentViewTest extends TestCase
         $mainRef = new Reference(1, 'pages');
         $mainContentView = ContentView::createWithReferences($mixedContent, [], [$mainRef]);
 
-        $allReferences = $mainContentView->getAllReferencesRecursively();
+        $allReferences = \iterator_to_array($mainContentView->getAllReferencesRecursively());
 
         $expectedReferences = [
             ['id' => 1, 'key' => 'pages', 'path' => ''],
@@ -245,7 +245,7 @@ class ContentViewTest extends TestCase
     {
         $contentView = ContentView::create('simple content', []);
 
-        $allReferences = $contentView->getAllReferencesRecursively();
+        $allReferences = \iterator_to_array($contentView->getAllReferencesRecursively());
 
         self::assertEmpty($allReferences);
     }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ReferenceTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Value/ReferenceTest.php
@@ -41,4 +41,31 @@ class ReferenceTest extends TestCase
         self::assertSame(456, $reference->getResourceId());
         self::assertSame('contacts', $reference->getResourceKey());
     }
+
+    public function testConstructorWithPath(): void
+    {
+        $reference = new Reference(789, 'pages', 'content.blocks.0');
+
+        self::assertSame(789, $reference->getResourceId());
+        self::assertSame('pages', $reference->getResourceKey());
+        self::assertSame('content.blocks.0', $reference->getPath());
+    }
+
+    public function testConstructorWithoutPath(): void
+    {
+        $reference = new Reference('uuid-123', 'articles');
+
+        self::assertSame('uuid-123', $reference->getResourceId());
+        self::assertSame('articles', $reference->getResourceKey());
+        self::assertSame('', $reference->getPath());
+    }
+
+    public function testConstructorWithEmptyPath(): void
+    {
+        $reference = new Reference(999, 'snippets', '');
+
+        self::assertSame(999, $reference->getResourceId());
+        self::assertSame('snippets', $reference->getResourceKey());
+        self::assertSame('', $reference->getPath());
+    }
 }

--- a/packages/page/src/Infrastructure/Sulu/Reference/PageReferenceRefresher.php
+++ b/packages/page/src/Infrastructure/Sulu/Reference/PageReferenceRefresher.php
@@ -19,7 +19,6 @@ use Sulu\Bundle\ReferenceBundle\Application\Refresh\ReferenceRefresherInterface;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
 use Sulu\Content\Application\ContentMerger\ContentMergerInterface;
 use Sulu\Content\Application\ContentResolver\ContentViewResolver\ContentViewResolverInterface;
-use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\Page;
@@ -115,11 +114,16 @@ class PageReferenceRefresher implements ReferenceRefresherInterface
         $contentViews = $this->contentViewResolver->getContentViews(dimensionContent: $pageDimensionContent);
 
         foreach ($contentViews as $key => $contentView) {
-            $this->addReferences(
-                $referenceCollector,
-                $contentView,
-                'template' !== $key ? (string) $key : ''
-            );
+            $basePath = 'template' !== $key ? (string) $key : '';
+            $references = $contentView->getAllReferencesRecursively($basePath);
+
+            foreach ($references as $reference) {
+                $referenceCollector->addReference(
+                    $reference->getResourceKey(),
+                    (string) $reference->getResourceId(),
+                    $reference->getPath()
+                );
+            }
         }
 
         $referenceCollector->persistReferences();
@@ -195,28 +199,6 @@ class PageReferenceRefresher implements ReferenceRefresherInterface
                 }
                 $unlocalizedDimensionContent = null;
             }
-        }
-    }
-
-    private function addReferences(ReferenceCollector $referenceCollector, ContentView $contentView, string $path): void
-    {
-        $content = $contentView->getContent();
-
-        if (\is_iterable($content)) {
-            foreach ($content as $key => $value) {
-                $keyStr = \is_string($key) || \is_numeric($key) ? (string) $key : '';
-                $newPath = \ltrim($path . '.' . $keyStr, '.');
-                if ($value instanceof ContentView) {
-                    $this->addReferences($referenceCollector, $value, $newPath);
-                }
-            }
-        }
-        foreach ($contentView->getReferences() as $reference) {
-            $referenceCollector->addReference(
-                $reference->getResourceKey(),
-                (string) $reference->getResourceId(),
-                $path
-            );
         }
     }
 }

--- a/packages/snippet/src/Infrastructure/Sulu/Reference/SnippetReferenceRefresher.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Reference/SnippetReferenceRefresher.php
@@ -19,7 +19,6 @@ use Sulu\Bundle\ReferenceBundle\Application\Refresh\ReferenceRefresherInterface;
 use Sulu\Bundle\ReferenceBundle\Domain\Repository\ReferenceRepositoryInterface;
 use Sulu\Content\Application\ContentMerger\ContentMergerInterface;
 use Sulu\Content\Application\ContentResolver\ContentViewResolver\ContentViewResolverInterface;
-use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Snippet\Domain\Model\Snippet;
@@ -114,11 +113,16 @@ class SnippetReferenceRefresher implements ReferenceRefresherInterface
         $contentViews = $this->contentViewResolver->getContentViews(dimensionContent: $snippetDimensionContent);
 
         foreach ($contentViews as $key => $contentView) {
-            $this->addReferences(
-                $referenceCollector,
-                $contentView,
-                'template' !== $key ? (string) $key : ''
-            );
+            $basePath = 'template' !== $key ? (string) $key : '';
+            $references = $contentView->getAllReferencesRecursively($basePath);
+
+            foreach ($references as $reference) {
+                $referenceCollector->addReference(
+                    $reference->getResourceKey(),
+                    (string) $reference->getResourceId(),
+                    $reference->getPath()
+                );
+            }
         }
 
         $referenceCollector->persistReferences();
@@ -194,28 +198,6 @@ class SnippetReferenceRefresher implements ReferenceRefresherInterface
                 }
                 $unlocalizedDimensionContent = null;
             }
-        }
-    }
-
-    private function addReferences(ReferenceCollector $referenceCollector, ContentView $contentView, string $path): void
-    {
-        $content = $contentView->getContent();
-
-        if (\is_iterable($content)) {
-            foreach ($content as $key => $value) {
-                $keyStr = \is_string($key) || \is_numeric($key) ? (string) $key : '';
-                $newPath = \ltrim($path . '.' . $keyStr, '.');
-                if ($value instanceof ContentView) {
-                    $this->addReferences($referenceCollector, $value, $newPath);
-                }
-            }
-        }
-        foreach ($contentView->getReferences() as $reference) {
-            $referenceCollector->addReference(
-                $reference->getResourceKey(),
-                (string) $reference->getResourceId(),
-                $path
-            );
         }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds the `path` directly to the `Reference` dto.
Adds the recursive extraction logic for References on the ContentView class instead of the ReferenceRefreshers

#### Why?

Simplified and less duplicated code.
