### PR TITLE
Fix warning on none exist resource in FlysystemStorage save method on lowest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
     "require-dev": {
         "coduo/php-matcher": "^6.0.14",
         "jangregor/phpstan-prophecy": "^2.0",
-        "league/flysystem-memory": "^3.29",
+        "league/flysystem-memory": "^3.0",
         "matthiasnoback/symfony-config-test": "^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^6.1",
         "monolog/monolog": "^1.26.1 || ^2.3 || ^3.0",

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/FlysystemStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/FlysystemStorage.php
@@ -54,7 +54,7 @@ class FlysystemStorage implements StorageInterface
         try {
             $this->filesystem->writeStream(
                 $filePath,
-                \fopen($tempPath, 'r'),
+                @\fopen($tempPath, 'r'),
                 ['visibility' => Visibility::PUBLIC]
             );
         } catch (FilesystemException) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | CI fix for #8161
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix warning on none exist resource in FlysystemStorage save method.

#### Why?

Unexpected CI fail in https://github.com/sulu/sulu/pull/8161