### PR TITLE
Move localizations handling to fix saving of Articles

### DIFF
--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -49,10 +49,6 @@
         <!-- Settings Resolver -->
         <service id="sulu_content.settings_resolver"
                  class="Sulu\Content\Application\ContentResolver\Resolver\SettingsResolver">
-            <argument type="service" id="sulu_route.route_generator"/>
-            <argument type="service" id="sulu_route.route_repository"/>
-            <argument type="service" id="router.request_context"/>
-
             <tag name="sulu_content.content_resolver" type="settings"/>
         </service>
 

--- a/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
@@ -21,9 +21,6 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\ShadowInterface;
 use Sulu\Content\Domain\Model\TemplateInterface;
 use Sulu\Content\Domain\Model\WebspaceInterface;
-use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
-use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
-use Symfony\Component\Routing\RequestContext;
 
 /**
  * @phpstan-type SettingsData array{
@@ -44,13 +41,6 @@ use Symfony\Component\Routing\RequestContext;
  */
 readonly class SettingsResolver implements ResolverInterface
 {
-    public function __construct(
-        private RouteGeneratorInterface $routeGenerator,
-        private RouteRepositoryInterface $routeRepository,
-        private RequestContext $requestContext
-    ) {
-    }
-
     public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
     {
         /** @var SettingsData $result */

--- a/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
@@ -17,15 +17,12 @@ use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\Reference;
 use Sulu\Content\Domain\Model\AuthorInterface;
-use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Content\Domain\Model\RoutableInterface;
 use Sulu\Content\Domain\Model\ShadowInterface;
 use Sulu\Content\Domain\Model\TemplateInterface;
 use Sulu\Content\Domain\Model\WebspaceInterface;
 use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
-use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\Routing\RequestContext;
 
 /**
@@ -63,11 +60,6 @@ readonly class SettingsResolver implements ResolverInterface
 
         $references = [];
 
-        // TODO handle properties filtering
-        if ($dimensionContent instanceof RoutableInterface && $dimensionContent instanceof TemplateInterface) {
-            $result = \array_merge($result, $this->getLocalizationsData($dimensionContent));
-        }
-
         if ($dimensionContent instanceof WebspaceInterface) {
             $result = \array_merge($result, $this->getWebspaceData($dimensionContent));
         }
@@ -85,63 +77,6 @@ readonly class SettingsResolver implements ResolverInterface
         }
 
         return ContentView::createWithReferences($result, [], $references);
-    }
-
-    /**
-     * @template T of ContentRichEntityInterface
-     *
-     * @param RoutableInterface&TemplateInterface&DimensionContentInterface<T> $dimensionContent
-     *
-     * @return array{
-     *     localizations?: array<string, array{
-     *         locale: string,
-     *         url: string,
-     *         alternate: bool
-     *     }>
-     * }
-     */
-    protected function getLocalizationsData(RoutableInterface&TemplateInterface&DimensionContentInterface $dimensionContent): array
-    {
-        $localizationData = [];
-
-        $availableLocales = $dimensionContent->getAvailableLocales();
-
-        if (null === $availableLocales) {
-            return [];
-        }
-
-        $routes = $this->routeRepository->findBy([
-            'locales' => $availableLocales,
-            'resourceKey' => $dimensionContent->getResourceKey(),
-            'resourceId' => (string) $dimensionContent->getResourceId(),
-        ]);
-
-        foreach ($routes as $route) {
-            // TODO remove this hack, when we have a better way to determine the current site
-            if (null === $this->requestContext->getParameter(RequestAttributeEnum::SITE->value)) {
-                $this->requestContext->setParameter(RequestAttributeEnum::SITE->value, $route->getSite());
-            }
-
-            $locale = $route->getLocale();
-
-            $resolvedUrl = $this->routeGenerator->generate(
-                $route->getSlug(),
-                $locale,
-                $route->getSite(),
-            );
-
-            $localizationData[$locale] = [
-                'locale' => $locale,
-                'url' => $resolvedUrl,
-                'alternate' => '' !== $resolvedUrl,
-            ];
-        }
-
-        \ksort($localizationData);
-
-        return [
-            'localizations' => $localizationData,
-        ];
     }
 
     /**

--- a/packages/content/tests/Application/ExampleTestBundle/Resources/views/base.html.twig
+++ b/packages/content/tests/Application/ExampleTestBundle/Resources/views/base.html.twig
@@ -11,6 +11,14 @@
 </head>
 <body>
 <header>
+    {% for localization in localizations|default([]) %}
+        <nav aria-label="Language switcher">
+            <a href="{{ localization.url }}">
+                {{ localization.locale }}
+            </a>
+        </nav>
+    {% endfor %}
+
     {% block header %}{% endblock %}
 </header>
 

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SettingsResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SettingsResolverTest.php
@@ -14,20 +14,14 @@ declare(strict_types=1);
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver\Resolver;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Content\Application\ContentResolver\Resolver\SettingsResolver;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Content\Application\ContentResolver\Value\Reference;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
-use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
-use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
-use Symfony\Component\Routing\RequestContext;
 
 /**
  * @phpstan-import-type SettingsData from SettingsResolver
@@ -39,30 +33,9 @@ class SettingsResolverTest extends TestCase
 
     private SettingsResolver $resolver;
 
-    /** @var ObjectProphecy<RouteGeneratorInterface> */
-    private ObjectProphecy $routeGenerator;
-
-    /** @var ObjectProphecy<RouteRepositoryInterface> */
-    private ObjectProphecy $routeRepository;
-
-    /** @var ObjectProphecy<RequestContext> */
-    private ObjectProphecy $requestContext;
-
     protected function setUp(): void
     {
-        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
-        $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
-        $this->requestContext = $this->prophesize(RequestContext::class);
-
-        // Mock RequestContext methods
-        $this->requestContext->getParameter(Argument::any())->willReturn(null);
-        $this->requestContext->setParameter(Argument::any(), Argument::any())->willReturn($this->requestContext->reveal());
-
-        $this->resolver = new SettingsResolver(
-            $this->routeGenerator->reveal(),
-            $this->routeRepository->reveal(),
-            $this->requestContext->reveal(),
-        );
+        $this->resolver = new SettingsResolver();
     }
 
     public function testResolveAvailableLocales(): void

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SettingsResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SettingsResolverTest.php
@@ -26,7 +26,6 @@ use Sulu\Content\Application\ContentResolver\Value\Reference;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
-use Sulu\Route\Domain\Model\Route;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Symfony\Component\Routing\RequestContext;
 
@@ -77,10 +76,6 @@ class SettingsResolverTest extends TestCase
         $exampleDimension->addAvailableLocale('en');
         $example->addDimensionContent($exampleDimension);
 
-        $this->routeRepository->findBy(Argument::cetera())
-            ->willReturn([])
-            ->shouldBeCalled();
-
         $result = $this->resolver->resolve($exampleDimension);
         self::assertInstanceOf(ContentView::class, $result);
 
@@ -102,87 +97,6 @@ class SettingsResolverTest extends TestCase
         $content = $result->getContent();
 
         self::assertSame([], $content['availableLocales'] ?? null);
-    }
-
-    public function testResolveLocalizationsNoUrl(): void
-    {
-        $example = new Example();
-        $this->setPrivateProperty($example, 'id', 1);
-        $exampleDimensionUnlocalized = new ExampleDimensionContent($example);
-        $example->addDimensionContent($exampleDimensionUnlocalized);
-        $exampleDimension = new ExampleDimensionContent($example);
-        $exampleDimension->addAvailableLocale('de');
-        $exampleDimension->addAvailableLocale('en');
-        $example->addDimensionContent($exampleDimension);
-
-        $this->routeRepository->findBy(Argument::cetera())
-            ->willReturn([])
-            ->shouldBeCalled();
-
-        $result = $this->resolver->resolve($exampleDimension);
-        self::assertInstanceOf(ContentView::class, $result);
-
-        /** @var SettingsData $content */
-        $content = $result->getContent();
-
-        self::assertSame([], $content['localizations'] ?? null);
-    }
-
-    public function testResolveLocalizations(): void
-    {
-        $example = new Example();
-        $this->setPrivateProperty($example, 'id', 1);
-        $exampleDimensionUnlocalized = new ExampleDimensionContent($example);
-        $exampleDimension = new ExampleDimensionContent($example);
-        $exampleDimension->setLocale('de');
-        $exampleDimension->setTemplateData(['url' => '/test']);
-        $exampleDimension->setMainWebspace('sulu_io');
-        $exampleDimension->addAvailableLocale('de');
-        $exampleDimension->addAvailableLocale('en');
-        $example->addDimensionContent($exampleDimensionUnlocalized);
-        $example->addDimensionContent($exampleDimension);
-
-        $routeEn = new Route('example', '1', 'en', '/example');
-        $this->setPrivateProperty($routeEn, 'id', 10);
-        $routeDe = new Route('example', '1', 'de', '/beispiel');
-        $this->setPrivateProperty($routeEn, 'id', 11);
-        $routeFr = new Route('example', '1', 'fr', '/exemple');
-        $this->setPrivateProperty($routeFr, 'id', 12);
-
-        $this->routeRepository->findBy([
-            'locales' => ['de', 'en'],
-            'resourceKey' => 'examples',
-            'resourceId' => '1',
-        ])
-            ->willReturn([$routeDe, $routeEn])
-            ->shouldBeCalled();
-
-        $this->routeGenerator->generate('/example', 'en', null)
-            ->willReturn('/en/example')
-            ->shouldBeCalled();
-
-        $this->routeGenerator->generate('/beispiel', 'de', null)
-            ->willReturn('/de/beispiel')
-            ->shouldBeCalled();
-
-        $result = $this->resolver->resolve($exampleDimension);
-        self::assertInstanceOf(ContentView::class, $result);
-
-        /** @var SettingsData $content */
-        $content = $result->getContent();
-
-        self::assertSame([
-            'de' => [
-                'locale' => 'de',
-                'url' => '/de/beispiel',
-                'alternate' => true,
-            ],
-            'en' => [
-                'locale' => 'en',
-                'url' => '/en/example',
-                'alternate' => true,
-            ],
-        ], $content['localizations'] ?? null);
     }
 
     public function testResolveWebspace(): void

--- a/packages/content/tests/Unit/Mocks/DimensionContentMockWrapperTrait.php
+++ b/packages/content/tests/Unit/Mocks/DimensionContentMockWrapperTrait.php
@@ -57,7 +57,7 @@ trait DimensionContentMockWrapperTrait
 
     public function removeAvailableLocale(string $availableLocale): void
     {
-        $this->instance->removeAvailableLocale();
+        $this->instance->removeAvailableLocale($availableLocale);
     }
 
     public function addAvailableLocale(string $availableLocale): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7672
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Temporary move localizations handling to content controller directly.

#### Why?

During SettingsResolver we don't know the current webspace, Resolving is also done during refresh of reference which is webspace unspecific so resolver should not access the webspace.

#### ToDo

 - [x] Test example with multiple available Languages