### PR TITLE
Return always a LinkConfigurationBuilder in all LinkProviders

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,4 +1,3 @@
-
 ## 3.0.0
 
 The upgrade from Sulu 2.6 to Sulu 3.0 is a major upgrade and will require some migration steps.
@@ -834,17 +833,22 @@ The following methods have been updated with a return type hint:
 - `NavigationItem::key()`: returns `int`
 - `NavigationItem::valid()`: returns `bool`
 - `NavigationItem::rewind()`: returns `void`
-- `AddressType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `ContactType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `EmailType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `FaxType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `PhoneType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `Position::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `SocialMediaProfileType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `UrlType::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `PropertyParameter::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `Localization::jsonSerialize()` returns `array` (see its typehint for the exact shape)
-- `WebspaceCollection::getIterator()` returns `\Traversable`
+- `AddressType::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `ContactType::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `EmailType::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `FaxType::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `PhoneType::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `Position::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `SocialMediaProfileType::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `UrlType::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `PropertyParameter::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `Localization::jsonSerialize()`: returns `array` (see its typehint for the exact shape)
+- `WebspaceCollection::getIterator():` returns `\Traversable`
+- `LinkProviderInterface::getConfiguration()`: replaced by `LinkProviderInterface::getConfigurationBuilder(): LinkConfigurationBuilder`
+- `LinkProviderInterface::preload()`: returns `iterable`
+- `LinkProviderPoolInterface::getProvider()`: returns `LinkProviderInterface`
+- `LinkProviderPoolInterface::hasProvider()`: returns `bool`
+- `LinkProviderPoolInterface::getConfiguration()`: returns `array`
 
 The corresponding traits `TimestampableTrait` and `UserBlameTrait` have been updated with these return type hints.
 

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
@@ -15,7 +15,6 @@ namespace Sulu\Article\Infrastructure\Sulu\Content;
 
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
-use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
@@ -24,7 +23,11 @@ use Sulu\Content\Application\ContentManager\ContentManagerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ArticleLinkProvider implements LinkProviderInterface
+/**
+ * @interal This class is an integration to the SuluMarkupBundle and can be changed any time.
+ *          Use Symfony dependency injection service decoration and change the behaviour if you need.
+ */
+final class ArticleLinkProvider implements LinkProviderInterface
 {
     public function __construct(
         private readonly ContentManagerInterface $contentManager,
@@ -34,7 +37,7 @@ class ArticleLinkProvider implements LinkProviderInterface
     ) {
     }
 
-    public function getConfiguration(): LinkConfiguration
+    public function getConfigurationBuilder(): LinkConfigurationBuilder
     {
         return LinkConfigurationBuilder::create()
             ->setTitle($this->translator->trans('sulu_article.articles', [], 'admin'))
@@ -43,11 +46,10 @@ class ArticleLinkProvider implements LinkProviderInterface
             ->setDisplayProperties(['id'])
             ->setOverlayTitle($this->translator->trans('sulu_article.selection_overlay_title', [], 'admin'))
             ->setEmptyText($this->translator->trans('sulu_article.no_article_selected', [], 'admin'))
-            ->setIcon('su-document')
-            ->getLinkConfiguration();
+            ->setIcon('su-document');
     }
 
-    public function preload(array $hrefs, $locale, $published = true)
+    public function preload(array $hrefs, string $locale, bool $published = true): iterable
     {
         $dimensionAttributes = [
             'locale' => $locale,

--- a/packages/content/tests/Application/ExampleTestBundle/Link/ExampleLinkProvider.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Link/ExampleLinkProvider.php
@@ -23,7 +23,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Repository\ExampleRepository;
 
-class ExampleLinkProvider implements LinkProviderInterface
+final class ExampleLinkProvider implements LinkProviderInterface
 {
     public function __construct(
         private readonly ContentManagerInterface $contentManager,
@@ -32,7 +32,7 @@ class ExampleLinkProvider implements LinkProviderInterface
     ) {
     }
 
-    public function getConfiguration(): LinkConfiguration
+    public function getConfigurationBuilder(): LinkConfiguration
     {
         return LinkConfigurationBuilder::create()
             ->setTitle('Example')
@@ -45,7 +45,7 @@ class ExampleLinkProvider implements LinkProviderInterface
             ->getLinkConfiguration();
     }
 
-    public function preload(array $hrefs, $locale, $published = true)
+    public function preload(array $hrefs, string $locale, bool $published = true): iterable
     {
         $dimensionAttributes = [
             'locale' => $locale,

--- a/packages/content/tests/Application/ExampleTestBundle/Link/ExampleLinkProvider.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Link/ExampleLinkProvider.php
@@ -32,7 +32,7 @@ final class ExampleLinkProvider implements LinkProviderInterface
     ) {
     }
 
-    public function getConfigurationBuilder(): LinkConfiguration
+    public function getConfigurationBuilder(): LinkConfigurationBuilder
     {
         return LinkConfigurationBuilder::create()
             ->setTitle('Example')
@@ -41,8 +41,7 @@ final class ExampleLinkProvider implements LinkProviderInterface
             ->setDisplayProperties(['id'])
             ->setOverlayTitle('Select Example')
             ->setEmptyText('No example selected')
-            ->setIcon('su-document')
-            ->getLinkConfiguration();
+            ->setIcon('su-document');
     }
 
     public function preload(array $hrefs, string $locale, bool $published = true): iterable

--- a/packages/content/tests/Application/ExampleTestBundle/Link/ExampleLinkProvider.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Link/ExampleLinkProvider.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Application\ExampleTestBundle\Link;
 
-use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;

--- a/packages/content/tests/Functional/Infrastructure/Sulu/Link/ContentLinkProviderTest.php
+++ b/packages/content/tests/Functional/Infrastructure/Sulu/Link/ContentLinkProviderTest.php
@@ -124,13 +124,13 @@ class ContentLinkProviderTest extends WebsiteTestCase
 
     public function testPreloadDE(): void
     {
-        $links = $this->exampleLinkProvider->preload(self::$exampleIds, 'de');
+        $links = [...$this->exampleLinkProvider->preload(self::$exampleIds, 'de')];
         $this->assertArraySnapshot('links_de.json', $this->mapLinks($links));
     }
 
     public function testPreloadEN(): void
     {
-        $links = $this->exampleLinkProvider->preload(self::$exampleIds, 'en');
+        $links = [...$this->exampleLinkProvider->preload(self::$exampleIds, 'en')];
         $this->assertArraySnapshot('links_en.json', $this->mapLinks($links));
     }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Infrastructure\Sulu\Content;
 
-use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;

--- a/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
@@ -24,7 +24,11 @@ use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class PageLinkProvider implements LinkProviderInterface
+/**
+ * @interal This class is an integration to the SuluMarkupBundle and can be changed any time.
+ *          Use Symfony dependency injection service decoration and change the behaviour if you need.
+ */
+final class PageLinkProvider implements LinkProviderInterface
 {
     public function __construct(
         private readonly ContentManagerInterface $contentManager,
@@ -34,7 +38,7 @@ class PageLinkProvider implements LinkProviderInterface
     ) {
     }
 
-    public function getConfiguration(): LinkConfiguration
+    public function getConfigurationBuilder(): LinkConfigurationBuilder
     {
         return LinkConfigurationBuilder::create()
             ->setTitle($this->translator->trans('sulu_page.pages', [], 'admin'))
@@ -43,11 +47,10 @@ class PageLinkProvider implements LinkProviderInterface
             ->setDisplayProperties(['id'])
             ->setOverlayTitle($this->translator->trans('sulu_page.selection_overlay_title', [], 'admin'))
             ->setEmptyText($this->translator->trans('sulu_page.no_page_selected', [], 'admin'))
-            ->setIcon('su-document')
-            ->getLinkConfiguration();
+            ->setIcon('su-document');
     }
 
-    public function preload(array $hrefs, $locale, $published = true)
+    public function preload(array $hrefs, string $locale, bool $published = true): iterable
     {
         $dimensionAttributes = [
             'locale' => $locale,

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -32,6 +32,7 @@ use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPool;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
@@ -123,10 +124,7 @@ class AdminControllerTest extends TestCase
      */
     private $smartContentProviders;
 
-    /**
-     * @var ObjectProphecy<LinkProviderPoolInterface>
-     */
-    private $linkProviderPool;
+    private LinkProviderPoolInterface $linkProviderPool;
 
     /**
      * @var ObjectProphecy<LocalizationManagerInterface>
@@ -196,7 +194,7 @@ class AdminControllerTest extends TestCase
         $this->fieldTypeOptionRegistry = $this->prophesize(FieldTypeOptionRegistryInterface::class);
         $this->contactManager = $this->prophesize(ContactManagerInterface::class);
         $this->smartContentProviders = new \ArrayIterator([]);
-        $this->linkProviderPool = $this->prophesize(LinkProviderPoolInterface::class);
+        $this->linkProviderPool = new LinkProviderPool([]);
         $this->localizationManager = $this->prophesize(LocalizationManagerInterface::class);
 
         $this->localizationManager->getLocalizations()->willReturn([]);
@@ -217,7 +215,7 @@ class AdminControllerTest extends TestCase
             $this->fieldTypeOptionRegistry->reveal(),
             $this->contactManager->reveal(),
             $this->smartContentProviders,
-            $this->linkProviderPool->reveal(),
+            $this->linkProviderPool,
             $this->localizationManager->reveal(),
             $this->environment,
             $this->suluVersion,

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/ExternalLinkProvider.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/ExternalLinkProvider.php
@@ -14,21 +14,19 @@ namespace Sulu\Bundle\MarkupBundle\Markup\Link;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @internal
+ * @interal This class is an integration to the SuluMarkupBundle and can be changed any time.
+ *          Use Symfony dependency injection service decoration and change the behaviour if you need.
  */
-class ExternalLinkProvider implements LinkProviderInterface
+final class ExternalLinkProvider implements LinkProviderInterface
 {
     public function __construct(
         private TranslatorInterface $translator,
     ) {
     }
 
-    public function getConfiguration()
+    public function getConfigurationBuilder(): LinkConfigurationBuilder
     {
-        /** @var LinkConfigurationBuilder $linkConfigurationBuilder */
-        $linkConfigurationBuilder = LinkConfigurationBuilder::create();
-
-        return $linkConfigurationBuilder
+        return LinkConfigurationBuilder::create()
             ->setTitle($this->translator->trans('sulu_admin.external_link', [], 'admin'))
             ->setResourceKey('')
             ->setListAdapter('')
@@ -38,7 +36,7 @@ class ExternalLinkProvider implements LinkProviderInterface
             ->setIcon('');
     }
 
-    public function preload(array $hrefs, $locale, $published = true)
+    public function preload(array $hrefs, string $locale, bool $published = true): iterable
     {
         if (0 === \count($hrefs)) {
             return [];

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderInterface.php
@@ -16,6 +16,8 @@ interface LinkProviderInterface
     public function getConfigurationBuilder(): LinkConfigurationBuilder;
 
     /**
+     * @param string[] $hrefs
+     *
      * @return LinkItem[]
      */
     public function preload(array $hrefs, string $locale, bool $published = true): iterable;

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderInterface.php
@@ -11,26 +11,12 @@
 
 namespace Sulu\Bundle\MarkupBundle\Markup\Link;
 
-/**
- * Provides links.
- */
 interface LinkProviderInterface
 {
-    /**
-     * Return configuration for content-type.
-     *
-     * @return LinkConfiguration|LinkConfigurationBuilder|null
-     */
-    public function getConfiguration();
+    public function getConfigurationBuilder(): LinkConfigurationBuilder;
 
     /**
-     * Load given items identified by the given hrefs.
-     *
-     * @param string[] $hrefs
-     * @param string $locale
-     * @param bool $published
-     *
      * @return LinkItem[]
      */
-    public function preload(array $hrefs, $locale, $published = true);
+    public function preload(array $hrefs, string $locale, bool $published = true): iterable;
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
@@ -11,25 +11,16 @@
 
 namespace Sulu\Bundle\MarkupBundle\Markup\Link;
 
-/**
- * Contains all providers.
- */
-class LinkProviderPool implements LinkProviderPoolInterface
+final class LinkProviderPool implements LinkProviderPoolInterface
 {
     /**
-     * @var LinkProviderInterface[]
+     * @param array<string, LinkProviderInterface> $providers
      */
-    private $providers;
-
-    /**
-     * @param LinkProviderInterface[] $providers
-     */
-    public function __construct(array $providers)
+    public function __construct(private readonly array $providers)
     {
-        $this->providers = $providers;
     }
 
-    public function getProvider($name): LinkProviderInterface
+    public function getProvider(string $name): LinkProviderInterface
     {
         if (!$this->hasProvider($name)) {
             throw new ProviderNotFoundException($name, \array_keys($this->providers));
@@ -38,7 +29,7 @@ class LinkProviderPool implements LinkProviderPoolInterface
         return $this->providers[$name];
     }
 
-    public function hasProvider($name): bool
+    public function hasProvider(string $name): bool
     {
         return \array_key_exists($name, $this->providers);
     }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPool.php
@@ -29,7 +29,7 @@ class LinkProviderPool implements LinkProviderPoolInterface
         $this->providers = $providers;
     }
 
-    public function getProvider($name)
+    public function getProvider($name): LinkProviderInterface
     {
         if (!$this->hasProvider($name)) {
             throw new ProviderNotFoundException($name, \array_keys($this->providers));
@@ -38,29 +38,18 @@ class LinkProviderPool implements LinkProviderPoolInterface
         return $this->providers[$name];
     }
 
-    public function hasProvider($name)
+    public function hasProvider($name): bool
     {
         return \array_key_exists($name, $this->providers);
     }
 
-    public function getConfiguration()
+    public function getConfiguration(): array
     {
         $configuration = [];
         foreach ($this->providers as $name => $provider) {
-            /** @var LinkConfiguration|LinkConfigurationBuilder|null $providerConfiguration */
-            $providerConfiguration = $provider->getConfiguration();
-
-            if ($providerConfiguration instanceof LinkConfiguration) {
-                @trigger_deprecation(
-                    'sulu/sulu',
-                    '2.6',
-                    'The LinkProvider should return a LinkConfigurationBuilder and not a LinkConfiguration. The LinkConfiguration will not be supported in 3.0.'
-                );
-            }
-
-            $configuration[$name] = $providerConfiguration instanceof LinkConfigurationBuilder ? $providerConfiguration->getLinkConfiguration() : $providerConfiguration;
+            $configuration[$name] = $provider->getConfigurationBuilder()->getLinkConfiguration();
         }
 
-        return \array_filter($configuration);
+        return $configuration;
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPoolInterface.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkProviderPoolInterface.php
@@ -11,35 +11,14 @@
 
 namespace Sulu\Bundle\MarkupBundle\Markup\Link;
 
-/**
- * Interface for link-provider-pool.
- */
 interface LinkProviderPoolInterface
 {
-    /**
-     * Returns provider by name.
-     *
-     * @param string $name
-     *
-     * @return LinkProviderInterface
-     *
-     * @throws ProviderNotFoundException
-     */
-    public function getProvider($name);
+    public function getProvider(string $name): LinkProviderInterface;
+
+    public function hasProvider(string $name): bool;
 
     /**
-     * Returns true if provider exists.
-     *
-     * @param string $name
-     *
-     * @return bool
+     * @return array<string, LinkConfiguration>
      */
-    public function hasProvider($name);
-
-    /**
-     * Returns configuration for content-type.
-     *
-     * @return LinkConfiguration[]
-     */
-    public function getConfiguration();
+    public function getConfiguration(): array;
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/ExternalLinkProviderTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/ExternalLinkProviderTest.php
@@ -50,7 +50,7 @@ class ExternalLinkProviderTest extends TestCase
         $this->translator->trans('sulu_admin.external_link', [], 'admin')->willReturn('External Link');
 
         /** @var LinkConfigurationBuilder $configurationBuilder */
-        $configurationBuilder = $this->externalLinkProvider->getConfiguration();
+        $configurationBuilder = $this->externalLinkProvider->getConfigurationBuilder();
         $this->assertEquals(
             new LinkConfiguration(
                 'External Link',

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/LinkProviderPoolTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/LinkProviderPoolTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfiguration;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPool;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
@@ -39,7 +40,6 @@ class LinkProviderPoolTest extends TestCase
         $this->providerProphecies = [
             'content' => $this->prophesize(LinkProviderInterface::class),
             'media' => $this->prophesize(LinkProviderInterface::class),
-            'page' => $this->prophesize(LinkProviderInterface::class),
         ];
 
         $this->pool = new LinkProviderPool(
@@ -77,30 +77,31 @@ class LinkProviderPoolTest extends TestCase
     public function testGetConfiguration(): void
     {
         $configuration = [
-            'content' => new LinkConfiguration(
-                'Content',
-                'content',
-                'column_list',
-                ['title'],
-                'Title',
-                'Empty',
-                'su-document'
-            ),
-            'media' => new LinkConfiguration(
-                'Media',
-                'media',
-                'table',
-                ['title'],
-                'Title',
-                'Empty',
-                'su-document'
-            ),
+            'content' => LinkConfigurationBuilder::create()
+                ->setTitle('Content')
+                ->setResourceKey('content')
+                ->setListAdapter('column_list')
+                ->setDisplayProperties(['title'])
+                ->setOverlayTitle('Title')
+                ->setEmptyText('Empty')
+                ->setIcon('su-document'),
+            'media' => LinkConfigurationBuilder::create()
+                ->setTitle('Media')
+                ->setResourceKey('media')
+                ->setListAdapter('table')
+                ->setDisplayProperties(['title'])
+                ->setOverlayTitle('Title')
+                ->setEmptyText('Empty')
+                ->setIcon('su-image'),
         ];
 
         $this->providerProphecies['content']->getConfigurationBuilder()->willReturn($configuration['content']);
         $this->providerProphecies['media']->getConfigurationBuilder()->willReturn($configuration['media']);
-        $this->providerProphecies['page']->getConfigurationBuilder()->willReturn(null);
 
-        $this->assertEquals($configuration, $this->pool->getConfiguration());
+        $configurations = $this->pool->getConfiguration();
+        $this->assertCount(2, $configurations);
+        foreach ($configurations as $configuration) {
+            $this->assertInstanceOf(LinkConfiguration::class, $configuration); // @phpstan-ignore-line method.alreadyNarrowedType
+        }
     }
 }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/LinkProviderPoolTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/Link/LinkProviderPoolTest.php
@@ -97,9 +97,9 @@ class LinkProviderPoolTest extends TestCase
             ),
         ];
 
-        $this->providerProphecies['content']->getConfiguration()->willReturn($configuration['content']);
-        $this->providerProphecies['media']->getConfiguration()->willReturn($configuration['media']);
-        $this->providerProphecies['page']->getConfiguration()->willReturn(null);
+        $this->providerProphecies['content']->getConfigurationBuilder()->willReturn($configuration['content']);
+        $this->providerProphecies['media']->getConfigurationBuilder()->willReturn($configuration['media']);
+        $this->providerProphecies['page']->getConfigurationBuilder()->willReturn(null);
 
         $this->assertEquals($configuration, $this->pool->getConfiguration());
     }

--- a/src/Sulu/Bundle/MediaBundle/Markup/Link/MediaLinkProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Markup/Link/MediaLinkProvider.php
@@ -18,7 +18,11 @@ use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class MediaLinkProvider implements LinkProviderInterface
+/**
+ * @interal This class is an integration to the SuluMarkupBundle and can be changed any time.
+ *          Use Symfony dependency injection service decoration and change the behaviour if you need.
+ */
+final class MediaLinkProvider implements LinkProviderInterface
 {
     public function __construct(
         private MediaRepositoryInterface $mediaRepository,
@@ -27,11 +31,9 @@ class MediaLinkProvider implements LinkProviderInterface
     ) {
     }
 
-    public function getConfiguration()
+    public function getConfigurationBuilder(): LinkConfigurationBuilder
     {
-        $linkConfigurationBuilder = LinkConfigurationBuilder::create();
-
-        return $linkConfigurationBuilder
+        return LinkConfigurationBuilder::create()
             ->setTitle($this->translator->trans('sulu_media.media', [], 'admin'))
             ->setResourceKey('media')
             ->setDisplayProperties(['title'])
@@ -41,7 +43,7 @@ class MediaLinkProvider implements LinkProviderInterface
             ->setIcon('');
     }
 
-    public function preload(array $hrefs, $locale, $published = true)
+    public function preload(array $hrefs, string $locale, bool $published = true): iterable
     {
         $medias = $this->mediaRepository->findMediaDisplayInfo($hrefs, $locale);
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Markup/Link/MediaLinkProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Markup/Link/MediaLinkProviderTest.php
@@ -90,7 +90,7 @@ class MediaLinkProviderTest extends TestCase
         $this->mediaManager->getUrl(3, 'test1.jpg', 3)->willReturn('/test1.jpg?version=3');
         $this->mediaManager->getUrl(6, 'test2.jpg', 1)->willReturn('/test2.jpg?version=1');
 
-        $mediaLinks = $this->mediaLinkProvider->preload([3, 6], 'de', false);
+        $mediaLinks = [...$this->mediaLinkProvider->preload([3, 6], 'de', false)];
 
         $this->assertEquals(3, $mediaLinks[0]->getId());
         $this->assertEquals('Test1', $mediaLinks[0]->getTitle());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Markup/Link/MediaLinkProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Markup/Link/MediaLinkProviderTest.php
@@ -63,7 +63,7 @@ class MediaLinkProviderTest extends TestCase
     public function testGetConfiguration(): void
     {
         /** @var LinkConfigurationBuilder $configurationBuilder */
-        $configurationBuilder = $this->mediaLinkProvider->getConfiguration();
+        $configurationBuilder = $this->mediaLinkProvider->getConfigurationBuilder();
 
         $this->assertEquals(
             new LinkConfiguration(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7672
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Return always a LinkConfigurationBuilder in all LinkProviders.

#### Why?

So a service can be decorated and extended with new builder data.


#### Example?

The underlaying services are internal as the constructors may change to extend a link provider use service deocration like this:

```php
use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
use Symfony\Component\DependencyInjection\Attribute\AsDecorator;

#[AsDecorator(decorates: 'sulu_article.link_provider')]
class CustomArticleLinkProvider implements LinkProviderInterface
{
    public function __construct(
         private readonly LinkProviderInterface $inner,
    ) {}

    public function getConfigurationBuilder(): LinkConfigurationBuilder
    {
         return $this->inner->getConfigurationBuilder()
              // call builder here
              ;
    }

    public function preload(array $hrefs, string $locale, bool $published = true): iterable
    {
         return $this->inner->preload($hrefs, $locale, $published);
    }
}
```