### PR TITLE
Remove requirement to symfony/form and prepended csrf protection configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,6 @@
         "symfony/expression-language": "^6.4 || ^7.1",
         "symfony/filesystem": "^6.4 || ^7.1",
         "symfony/finder": "^6.4 || ^7.1",
-        "symfony/form": "^6.4 || ^7.1",
         "symfony/framework-bundle": "^6.4 || ^7.1",
         "symfony/html-sanitizer": "^6.4 || ^7.1",
         "symfony/http-client": "^6.4 || ^7.1",

--- a/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/DependencyInjection/SuluSecurityExtension.php
@@ -176,7 +176,6 @@ class SuluSecurityExtension extends Extension implements PrependExtensionInterfa
             $container->prependExtensionConfig(
                 'framework',
                 [
-                    'csrf_protection' => true,
                     'session' => [
                         'cookie_path' => '/admin',
                     ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove requirement to symfony/form.

#### Why?

The extension mapping was based on symfony forms as the phpcr related stuff is removed we not longer require symfony form in sulu core.