### PR TITLE
Remove deprecated `getRole` method in `Role` class

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -791,6 +791,7 @@ Removed deprecated functions and properties:
 - `Sulu\Component\Rest\ListBuilder\AbstractListBuilder::addField` (use `addSelectField()` instead)
 - `Sulu\Component\Rest\ListBuilder\AbstractListBuilder::hasField` (use `hasSelectField()` instead)
 - `Sulu\Component\Rest\ListBuilder\AbstractListBuilder::whereNot` (use `where()` instead)
+- `Sulu\Bundle\Security\Entity\Role::getRole` (use `getIdentifier` instead)
 
 Removed unused arguments:
 

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Role.php
@@ -88,18 +88,6 @@ class Role implements RoleInterface
         return $this->id;
     }
 
-    /**
-     * @deprecated since 2.1 and will be removed in 3.0. Use "getIdentifier" instead.
-     *
-     * @return string
-     */
-    public function getRole()
-    {
-        @trigger_deprecation('sulu/sulu', '2.1', 'The "%s" method is deprecated, use "%s" instead.', __METHOD__, 'getIdentifier');
-
-        return $this->getIdentifier();
-    }
-
     public function getIdentifier()
     {
         if ($this->anonymous) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | -
| Fixed tickets | -
| Related issues/PRs | #7547 
| License | MIT
| Documentation PR | sulu/sulu-rector#32

#### What's in this PR?
Removing deprecated method

#### Why?
Cleaning up is important :broom: 