### PR TITLE
Add new SuluSearchBundle to 3.0 based on CMSIG / SEAL — Search Engine Abstraction Layer

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,10 @@ APP_SECRET=a448d1dfcaa563fce56c2fd9981f662b
 #TRUSTED_HOSTS=localhost,example.com
 ###< symfony/framework-bundle ###
 
+###> cmsig/seal-symfony-bundle ###
+SEAL_DSN=loupe://%kernel.project_dir%/var/indexes
+###< cmsig/seal-symfony-bundle ###
+
 ###> symfony/lock ###
 # Choose one of the stores below
 # postgresql+advisory://db_user:db_password@localhost/db_name

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,8 @@
         "ext-json": "*",
         "ext-simplexml": "*",
         "composer-runtime-api": "^2.0",
+        "cmsig/seal": "^0.12.2",
+        "cmsig/seal-symfony-bundle": "^0.12.2",
         "composer/semver": "^3.4",
         "contao/imagine-svg": "^1.0",
         "doctrine/annotations": "^1.14 || ^2.0",
@@ -43,8 +45,6 @@
         "doctrine/orm": "^2.15",
         "doctrine/persistence": "^3.1",
         "dragonmantank/cron-expression": "^1.1 || ^2.0 || ^3.0",
-        "league/flysystem": "^3.0",
-        "league/flysystem-bundle": "^3.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "friendsofsymfony/http-cache": "^3.0",
         "friendsofsymfony/http-cache-bundle": "^3.0",
@@ -56,6 +56,8 @@
         "imagine/imagine": "^1.0",
         "jms/serializer": "^3.19",
         "jms/serializer-bundle": "^4.0.1 || ^5.0",
+        "league/flysystem": "^3.0",
+        "league/flysystem-bundle": "^3.0",
         "massive/build-bundle": "^0.5.7",
         "matomo/device-detector": "^3.9 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.3",
@@ -109,6 +111,8 @@
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
+        "cmsig/seal-loupe-adapter": "^0.12.2",
+        "cmsig/seal-memory-adapter": "^0.12.2",
         "coduo/php-matcher": "^6.0.14",
         "jangregor/phpstan-prophecy": "^2.0",
         "league/flysystem-memory": "^3.0",
@@ -137,8 +141,8 @@
         "symfony/browser-kit": "^6.4 || ^7.1",
         "symfony/debug-bundle": "^6.4 || ^7.1",
         "symfony/dotenv": "^6.4 || ^7.1",
-        "symfony/error-handler": "^6.4 || ^7.1",
         "symfony/emoji": "^7.1",
+        "symfony/error-handler": "^6.4 || ^7.1",
         "symfony/monolog-bundle": "^3.7",
         "symfony/phpunit-bridge": "^6.4 || ^7.1",
         "symfony/runtime": "^6.4 || ^7.1",
@@ -198,6 +202,7 @@
             "Sulu\\Snippet\\": "packages/snippet/src",
             "Sulu\\Page\\": "packages/page/src",
             "Sulu\\Route\\": "packages/route/src",
+            "Sulu\\Search\\": "packages/search/src",
             "Sulu\\Content\\": "packages/content/src"
         },
         "exclude-from-classmap": [
@@ -212,6 +217,7 @@
             "Sulu\\Snippet\\Tests\\": "packages/snippet/tests",
             "Sulu\\Page\\Tests\\": "packages/page/tests",
             "Sulu\\Route\\Tests\\": "packages/route/tests",
+            "Sulu\\Search\\Tests\\": "packages/search/tests",
             "Sulu\\Content\\Tests\\": "packages/content/tests"
         }
     },

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -53,5 +53,6 @@ return [
     Sulu\Messenger\Infrastructure\Symfony\HttpKernel\SuluMessengerBundle::class => ['all' => true],
     Sulu\Article\Infrastructure\Symfony\HttpKernel\SuluArticleBundle::class => ['all' => true],
     Sulu\Snippet\Infrastructure\Symfony\HttpKernel\SuluSnippetBundle::class => ['all' => true],
+    Sulu\Search\Infrastructure\Symfony\HttpKernel\SuluSearchBundle::class => ['all' => true],
     Sulu\Page\Infrastructure\Symfony\HttpKernel\SuluPageBundle::class => ['all' => true],
 ];

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -46,6 +46,7 @@ return [
     FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true],
     Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle::class => ['all' => true, 'website' => true],
     Scheb\TwoFactorBundle\SchebTwoFactorBundle::class => ['all' => true],
+    CmsIg\Seal\Integration\Symfony\SealBundle::class => ['all' => true],
     Sulu\Content\Tests\Application\ExampleTestBundle\ExampleTestBundle::class => ['all' => true],
     Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle::class => ['all' => true],
     Sulu\Route\Infrastructure\Symfony\HttpKernel\SuluRouteBundle::class => ['all' => true],

--- a/config/packages/cmsig_seal.yaml
+++ b/config/packages/cmsig_seal.yaml
@@ -1,0 +1,7 @@
+cmsig_seal:
+    schemas:
+        default:
+            dir: '%kernel.project_dir%/config/schemas'
+    engines:
+        default:
+            adapter: 'loupe://%kernel.project_dir%/var/indexes'

--- a/config/packages/cmsig_seal.yaml
+++ b/config/packages/cmsig_seal.yaml
@@ -1,7 +1,13 @@
 cmsig_seal:
-    schemas:
-        default:
-            dir: '%kernel.project_dir%/config/schemas'
+    # schemas:
+    #    default:
+    #        dir: '%kernel.project_dir%/config/schemas'
+    #        engine: default
     engines:
         default:
-            adapter: 'loupe://%kernel.project_dir%/var/indexes'
+            adapter: '%env(resolve:SEAL_DSN)%'
+
+when@test:
+    cmsig_seal:
+        # "TEST_TOKEN" is typically set by ParaTest
+        index_name_prefix: 'test_%env(default::TEST_TOKEN)%'

--- a/packages/search/.gitattributes
+++ b/packages/search/.gitattributes
@@ -1,0 +1,9 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+composer.lock export-ignore
+/Tests export-ignore
+/tests export-ignore
+phpunit.xml.dist export-ignore
+.php-cs-fixer.dist.php export-ignore
+phpstan.neon export-ignore
+rector.php export-ignore

--- a/packages/search/.gitignore
+++ b/packages/search/.gitignore
@@ -1,0 +1,41 @@
+# IDEs
+.idea/*
+*.iml
+*~
+
+# System files
+.DS_Store
+
+# Composer
+/vendor/
+/composer.phar
+/composer.lock
+/auth.json
+
+# PHPUnit
+/phpunit.xml
+/.phpunit.result.cache
+/.phpunit.cache/
+
+# PHP CS Fixer
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
+
+# PHPStan
+/phpstan.neon
+
+# symfony
+.env.local
+.env.*.local
+/tests/Application/var
+
+# PHPUnit
+/phpunit.xml
+.phpunit.result.cache
+
+# Backup entities generated with doctrine:generate:entities command
+*/Entity/*~
+
+# Frontend Caches
+node_modules/
+npm-debug.log

--- a/packages/search/config/schemas/admin.php
+++ b/packages/search/config/schemas/admin.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use CmsIg\Seal\Schema\Field;
+use CmsIg\Seal\Schema\Index;
+
+return new Index('admin', [
+    'id' => new Field\IdentifierField('id'),
+    'resourceKey' => new Field\TextField('resourceKey', searchable: false, filterable: true),
+    'resourceId' => new Field\TextField('resourceId', searchable: false),
+    'locale' => new Field\TextField('locale', searchable: false, filterable: true),
+    'title' => new Field\TextField('title'),
+    'description' => new Field\TextField('description'),
+    'content' => new Field\TextField('content', multiple: true),
+    'changedAt' => new Field\DateTimeField('changedAt'),
+    'createdAt' => new Field\DateTimeField('createdAt'),
+]);

--- a/packages/search/config/schemas/admin.php
+++ b/packages/search/config/schemas/admin.php
@@ -18,8 +18,6 @@ return new Index('admin', [
     'resourceId' => new Field\TextField('resourceId', searchable: false),
     'locale' => new Field\TextField('locale', searchable: false, filterable: true),
     'title' => new Field\TextField('title'),
-    'description' => new Field\TextField('description'),
-    'content' => new Field\TextField('content', multiple: true),
     'changedAt' => new Field\DateTimeField('changedAt'),
     'createdAt' => new Field\DateTimeField('createdAt'),
 ]);

--- a/packages/search/phpunit.xml.dist
+++ b/packages/search/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true"
+         bootstrap="tests/test-bootstrap.php"
+>
+    <testsuites>
+        <!-- Run Unit Tests before Functional Tests for better Developer Experience -->
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+
+        <testsuite name="Functional">
+            <directory>tests/Functional</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src/</directory>
+        </include>
+    </source>
+
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <ini name="date.timezone" value="UTC" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="APP_ENV" value="test" force="true"/>
+        <server name="KERNEL_CLASS" value="Sulu\Article\Tests\Application\Kernel"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    </php>
+</phpunit>

--- a/packages/search/src/Application/MessageHandler/ReindexMessageHandler.php
+++ b/packages/search/src/Application/MessageHandler/ReindexMessageHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Search\Application\MessageHandler;
+
+use CmsIg\Seal\EngineInterface;
+use CmsIg\Seal\Reindex\ReindexConfig;
+use CmsIg\Seal\Reindex\ReindexProviderInterface;
+
+/**
+ * @internal To call this service always use the message bus with the ReindexConfig as a message.
+ *           Direct calls are not supported we may move the service at any time.
+ */
+final readonly class ReindexMessageHandler
+{
+    /**
+     * @param iterable<ReindexProviderInterface> $reindexProviders
+     */
+    public function __construct(
+        private EngineInterface $engine,
+        private iterable $reindexProviders,
+    ) {
+    }
+
+    public function __invoke(ReindexConfig $reindexConfig): void
+    {
+        $this->engine->reindex(
+            $this->reindexProviders,
+            $reindexConfig,
+        );
+    }
+}

--- a/packages/search/src/Infrastructure/Symfony/HttpKernel/SuluSearchBundle.php
+++ b/packages/search/src/Infrastructure/Symfony/HttpKernel/SuluSearchBundle.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace Sulu\Search\Infrastructure\Symfony\HttpKernel;
 
+use Sulu\Page\Application\MessageHandler\CreatePageMessageHandler;
+use Sulu\Search\Application\MessageHandler\ReindexMessageHandler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use Symfony\Component\DependencyInjection\Reference;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 
 use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
 /**
  * @experimental
@@ -35,6 +39,15 @@ final class SuluSearchBundle extends AbstractBundle
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $services = $container->services();
+
+        // Message Handler services
+        $services->set('sulu_search.reindex_message_handler')
+            ->class(ReindexMessageHandler::class)
+            ->args([
+                new Reference('cmsig_seal.engine'),
+                tagged_iterator('cmsig_seal.reindex_provider'),
+            ])
+            ->tag('messenger.message_handler');
     }
 
     /**

--- a/packages/search/src/Infrastructure/Symfony/HttpKernel/SuluSearchBundle.php
+++ b/packages/search/src/Infrastructure/Symfony/HttpKernel/SuluSearchBundle.php
@@ -13,16 +13,15 @@ declare(strict_types=1);
 
 namespace Sulu\Search\Infrastructure\Symfony\HttpKernel;
 
-use Sulu\Page\Application\MessageHandler\CreatePageMessageHandler;
 use Sulu\Search\Application\MessageHandler\ReindexMessageHandler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-use Symfony\Component\DependencyInjection\Reference;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
-
-use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
 /**
  * @experimental
@@ -44,7 +43,7 @@ final class SuluSearchBundle extends AbstractBundle
         $services->set('sulu_search.reindex_message_handler')
             ->class(ReindexMessageHandler::class)
             ->args([
-                new Reference('cmsig_seal.engine'),
+                new Reference('cmsig_seal.engine.default'),
                 tagged_iterator('cmsig_seal.reindex_provider'),
             ])
             ->tag('messenger.message_handler');

--- a/packages/search/src/Infrastructure/Symfony/HttpKernel/SuluSearchBundle.php
+++ b/packages/search/src/Infrastructure/Symfony/HttpKernel/SuluSearchBundle.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Search\Infrastructure\Symfony\HttpKernel;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
+
+/**
+ * @experimental
+ *
+ * @codeCoverageIgnore
+ */
+final class SuluSearchBundle extends AbstractBundle
+{
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
+     */
+    public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $services = $container->services();
+    }
+
+    /**
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
+     */
+    public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        if ($builder->hasExtension('cmsig_seal')) {
+            $builder->prependExtensionConfig(
+                'cmsig_seal',
+                [
+                    'schemas' => [
+                        'sulu_search' => [
+                            'dir' => \dirname(__DIR__, 4) . '/config/schemas',
+                            'engine' => 'default',
+                        ],
+                    ],
+                ],
+            );
+        }
+    }
+
+    /**
+     * @internal this method is not part of the public API and should only be called by the Symfony framework classes
+     */
+    public function getPath(): string
+    {
+        return \dirname(__DIR__, 4); // target the root of the library where config, src, ... is located
+    }
+}

--- a/packages/search/tests/Application/.env
+++ b/packages/search/tests/Application/.env
@@ -1,0 +1,2 @@
+APP_ENV=test
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4

--- a/packages/search/tests/Application/Kernel.php
+++ b/packages/search/tests/Application/Kernel.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Search\Tests\Application;
+
+use Sulu\Article\Infrastructure\Symfony\HttpKernel\SuluArticleBundle;
+use Sulu\Bundle\TestBundle\Kernel\SuluTestKernel;
+use Sulu\Component\HttpKernel\SuluKernel;
+use Sulu\Content\Tests\Application\ExampleTestBundle\ExampleTestBundle;
+use Sulu\Snippet\Infrastructure\Symfony\HttpKernel\SuluSnippetBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+/**
+ * AppKernel for functional tests.
+ */
+class Kernel extends SuluTestKernel
+{
+    /**
+     * @var string|null
+     */
+    private $config = 'default';
+
+    public function __construct(string $environment, bool $debug, string $suluContext = SuluKernel::CONTEXT_ADMIN)
+    {
+        $environmentParts = \explode('_', $environment, 2);
+        $environment = $environmentParts[0];
+        $this->config = $environmentParts[1] ?? $this->config;
+
+        parent::__construct($environment, $debug, $suluContext);
+    }
+
+    public function registerBundles(): iterable
+    {
+        $bundles = [...parent::registerBundles()];
+
+        $bundles[] = new SuluArticleBundle();
+        $bundles[] = new ExampleTestBundle(); // TODO currently required for test content bundle, everybody should setup database by its own
+        $bundles[] = new SuluSnippetBundle();
+
+        return $bundles;
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        parent::registerContainerConfiguration($loader);
+
+        $loader->load(__DIR__ . '/config/config.yml');
+
+        if (\file_exists(__DIR__ . '/config/config_' . $this->config . '.yml')) {
+            $loader->load(__DIR__ . '/config/config_' . $this->config . '.yml');
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getKernelParameters(): array
+    {
+        $parameters = parent::getKernelParameters();
+
+        return $parameters;
+    }
+
+    public function getCacheDir(): string
+    {
+        return parent::getCacheDir() . '/' . $this->config;
+    }
+
+    public function getCommonCacheDir(): string
+    {
+        return parent::getCommonCacheDir() . '/' . $this->config;
+    }
+}

--- a/packages/search/tests/Application/bin/adminconsole
+++ b/packages/search/tests/Application/bin/adminconsole
@@ -1,0 +1,5 @@
+#!/usr/bin/env php
+<?php
+
+$suluContext = 'admin';
+include __DIR__ . DIRECTORY_SEPARATOR. 'console.php';

--- a/packages/search/tests/Application/bin/console.php
+++ b/packages/search/tests/Application/bin/console.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Sulu\Article\Tests\Application\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Debug\Debug;
+
+if (false === \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+    echo 'Warning: The console should be invoked via the CLI version of PHP, not the ' . \PHP_SAPI . ' SAPI' . \PHP_EOL;
+}
+
+require __DIR__ . '/../../../../../vendor/autoload.php';
+
+if (!\class_exists(Application::class)) {
+    throw new RuntimeException('You need to add "symfony/framework-bundle" as a Composer dependency.');
+}
+
+$input = new ArgvInput();
+if (null !== $env = $input->getParameterOption(['--env', '-e'], null, true)) {
+    \assert(\is_string($env));
+    \putenv('APP_ENV=' . $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = $env);
+}
+
+if ($input->hasParameterOption('--no-debug', true)) {
+    \putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
+}
+
+require \dirname(__DIR__) . '/config/bootstrap.php';
+
+if ($_SERVER['APP_DEBUG']) {
+    \umask(0000);
+
+    if (\class_exists(Debug::class)) {
+        Debug::enable();
+    }
+}
+
+\assert(\is_string($_SERVER['APP_ENV']));
+\assert(!isset($suluContext) || \is_string($suluContext));
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], $suluContext ?? Kernel::CONTEXT_ADMIN);
+$application = new Application($kernel);
+$application->run($input);

--- a/packages/search/tests/Application/bin/websiteconsole
+++ b/packages/search/tests/Application/bin/websiteconsole
@@ -1,0 +1,5 @@
+#!/usr/bin/env php
+<?php
+
+$suluContext = 'website';
+include __DIR__ . DIRECTORY_SEPARATOR. 'console.php';

--- a/packages/search/tests/Application/config/bootstrap.php
+++ b/packages/search/tests/Application/config/bootstrap.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Symfony\Component\Dotenv\Dotenv;
+
+$file = __DIR__ . '/../../../../../vendor/autoload.php';
+
+if (!\file_exists($file)) {
+    throw new RuntimeException('Install dependencies to run test suite.');
+}
+
+require $file;
+
+// Load cached env vars if the .env.local.php file exists
+// Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
+if (\is_array($env = @include \dirname(__DIR__) . '/.env.local.php')) {
+    $_ENV += $env;
+} elseif (!\class_exists(Dotenv::class)) {
+    throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
+} else {
+    $path = \dirname(__DIR__) . '/.env';
+    $dotenv = new Dotenv();
+    $dotenv->loadEnv($path);
+}
+
+$_SERVER += $_ENV;
+$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
+$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || \filter_var($_SERVER['APP_DEBUG'], \FILTER_VALIDATE_BOOLEAN) ? '1' : '0'; // @phpstan-ignore cast.int

--- a/packages/search/tests/Application/config/config.yml
+++ b/packages/search/tests/Application/config/config.yml
@@ -1,0 +1,12 @@
+sulu_article: {}
+
+framework:
+    # symfony recipe default configuration:
+    workflows: null
+    messenger:
+        transports:
+        routing:
+
+twig:
+    paths:
+        - '%kernel.project_dir%/templates'

--- a/packages/search/tests/Application/config/routing.yml
+++ b/packages/search/tests/Application/config/routing.yml
@@ -1,0 +1,6 @@
+sulu_article_api:
+    resource: "@SuluArticleBundle/config/routing_admin_api.yaml"
+    prefix: /admin/api
+
+sulu_website_frontend:
+    resource: "@SuluWebsiteBundle/Resources/config/routing_website.yaml"

--- a/packages/search/tests/Application/config/templates/articles/article.xml
+++ b/packages/search/tests/Application/config/templates/articles/article.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>article</key>
+
+    <view>views/articles/article</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Article</title>
+        <title lang="de">Artikel</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+            <tag name="sulu.search.field" role="title"/>
+        </property>
+
+        <property name="url" type="route">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+            <tag name="sulu.search.field" role="url"/>
+        </property>
+
+        <property name="description" type="text_area">
+            <meta>
+                <title lang="en">Description</title>
+                <title lang="de">Beschreibung</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="description"/>
+        </property>
+
+        <property name="image" type="single_media_selection">
+            <meta>
+                <title lang="en">Image</title>
+                <title lang="de">Bild</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="image"/>
+        </property>
+    </properties>
+</template>

--- a/packages/search/tests/Application/config/templates/pages/default.xml
+++ b/packages/search/tests/Application/config/templates/pages/default.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default</key>
+
+    <view>::default</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="tags" type="tag_selection"/>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="article" type="text_area" mandatory="false" />
+    </properties>
+</template>

--- a/packages/search/tests/Application/config/templates/pages/overview.xml
+++ b/packages/search/tests/Application/config/templates/pages/overview.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>overview</key>
+
+    <view>::overview</view>
+    <controller>SuluWebsiteBundle:Default:index</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="tags" type="tag_selection"/>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="article" type="text_line" minOccurs="1" maxOccurs="10"/>
+
+        <block name="block" default-type="type1">
+            <types>
+                <type name="type1">
+                    <properties>
+                        <property name="title" type="text_line"/>
+                        <property name="article" type="text_line" minOccurs="2"/>
+                    </properties>
+                </type>
+            </types>
+        </block>
+    </properties>
+</template>

--- a/packages/search/tests/Application/config/webspaces/blog.xml
+++ b/packages/search/tests/Application/config/webspaces/blog.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>Blog CMF</name>
+    <key>blog</key>
+
+    <security>
+        <system>Blog</system>
+    </security>
+
+    <localizations>
+        <localization language="de" default="true"/>
+        <localization language="en"/>
+    </localizations>
+
+    <theme>default</theme>
+
+    <default-templates>
+        <default-template type="homepage">default</default-template>
+        <default-template type="page">default</default-template>
+    </default-templates>
+
+    <templates>
+        <template type="search">search/search</template>
+    </templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>Blog CMF AT</name>
+            <key>blogcmf_at</key>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url>{host}/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="stage">
+                    <urls>
+                        <url>{host}/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="test">
+                    <urls>
+                        <url>blog.io/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url>blog.io/{localization}</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>

--- a/packages/search/tests/Application/config/webspaces/sulu.io.xml
+++ b/packages/search/tests/Application/config/webspaces/sulu.io.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu-io</key>
+
+    <security>
+        <system>Website</system>
+    </security>
+
+    <localizations>
+        <localization language="de" default="true"/>
+        <localization language="en"/>
+    </localizations>
+
+    <theme>default</theme>
+
+    <default-templates>
+        <default-template type="homepage">default</default-template>
+        <default-template type="page">default</default-template>
+    </default-templates>
+
+    <templates>
+        <template type="search">search/search</template>
+    </templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>Sulu CMF AT</name>
+            <key>sulucmf_at</key>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="de">{host}</url>
+                        <url language="en">{host}/en</url>
+                    </urls>
+                </environment>
+                <environment type="test">
+                    <urls>
+                        <url>sulu.io/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url>sulu.io/{localization}</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>

--- a/packages/search/tests/Application/templates/views/articles/article.html.twig
+++ b/packages/search/tests/Application/templates/views/articles/article.html.twig
@@ -1,0 +1,7 @@
+{% extends 'views/base.html.twig' %}
+
+{% block content %}
+    <h1>{{ content.title }}</h1>
+
+    {{ content.description|raw }}
+{% endblock %}

--- a/packages/search/tests/Application/templates/views/base.html.twig
+++ b/packages/search/tests/Application/templates/views/base.html.twig
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace({'_': '-'}) }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <title>{{ content.title }}</title>
+</head>
+<body>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/packages/search/tests/Unit/Application/MessageHandler/ReindexMessageHandlerTest.php
+++ b/packages/search/tests/Unit/Application/MessageHandler/ReindexMessageHandlerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Search\Tests\Unit\Application\MessageHandler;
+
+use CmsIg\Seal\Adapter\Memory\MemoryAdapter;
+use CmsIg\Seal\Engine;
+use CmsIg\Seal\Reindex\ReindexConfig;
+use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+use Sulu\Search\Application\MessageHandler\ReindexMessageHandler;
+
+class ReindexMessageHandlerTest extends TestCase
+{
+    private Engine $engine;
+
+    /**
+     * @var \ArrayObject<ReindexProviderInterface>
+     */
+    private \ArrayObject $reindexProviders;
+
+    private ReindexMessageHandler $reindexMessageHandler;
+
+    public function setUp(): void
+    {
+        $this->engine = new Engine(
+            new MemoryAdapter(),
+            new Schema([
+                'admin' => require (\dirname(__DIR__, 4) . '/config/schemas/admin.php'),
+            ]),
+        );
+        $this->engine->createSchema();
+        $this->reindexProviders = new \ArrayObject();
+
+        $this->reindexMessageHandler = new ReindexMessageHandler(
+            $this->engine,
+            $this->reindexProviders,
+        );
+    }
+
+    public function testInvoke(): void
+    {
+        $message = $this->createMessage('admin', [
+            'example::f6a4bfa6-6737-4ffb-b03a-f9fe45352537::de',
+            'example::f85a9552-c33a-4707-b1c2-8b79b32edabf::de',
+        ]);
+
+        $this->reindexProviders->append($this->createMinimalReindexProviderInterface());
+
+        $this->reindexMessageHandler->__invoke($message);
+
+        $this->assertSame(2, $this->engine->countDocuments('admin'));
+    }
+
+    /**
+     * @param array<string> $identifiers
+     */
+    private function createMessage(string $index, array $identifiers): ReindexConfig
+    {
+        return ReindexConfig::create()
+            ->withIndex($index)
+            ->withIdentifiers($identifiers);
+    }
+
+    private function createMinimalReindexProviderInterface(): ReindexProviderInterface
+    {
+        return new class() implements ReindexProviderInterface {
+            public function total(): ?int
+            {
+                return null;
+            }
+
+            public function provide(ReindexConfig $reindexConfig): \Generator
+            {
+                foreach ($reindexConfig->getIdentifiers() as $identifier) {
+                    yield [
+                        'id' => $identifier,
+                        'title' => 'Test ' . $identifier,
+                    ];
+                }
+            }
+
+            public static function getIndex(): string
+            {
+                return 'admin';
+            }
+        };
+    }
+}

--- a/packages/search/tests/Unit/Application/MessageHandler/ReindexMessageHandlerTest.php
+++ b/packages/search/tests/Unit/Application/MessageHandler/ReindexMessageHandlerTest.php
@@ -15,16 +15,18 @@ use CmsIg\Seal\Adapter\Memory\MemoryAdapter;
 use CmsIg\Seal\Engine;
 use CmsIg\Seal\Reindex\ReindexConfig;
 use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use CmsIg\Seal\Schema\Index;
 use CmsIg\Seal\Schema\Schema;
 use PHPUnit\Framework\TestCase;
 use Sulu\Search\Application\MessageHandler\ReindexMessageHandler;
+use Webmozart\Assert\Assert;
 
 class ReindexMessageHandlerTest extends TestCase
 {
     private Engine $engine;
 
     /**
-     * @var \ArrayObject<ReindexProviderInterface>
+     * @var \ArrayObject<int|string, ReindexProviderInterface>
      */
     private \ArrayObject $reindexProviders;
 
@@ -32,10 +34,13 @@ class ReindexMessageHandlerTest extends TestCase
 
     public function setUp(): void
     {
+        $adminIndex = require \dirname(__DIR__, 4) . '/config/schemas/admin.php';
+        Assert::isInstanceOf($adminIndex, Index::class);
+
         $this->engine = new Engine(
             new MemoryAdapter(),
             new Schema([
-                'admin' => require (\dirname(__DIR__, 4) . '/config/schemas/admin.php'),
+                'admin' => $adminIndex,
             ]),
         );
         $this->engine->createSchema();

--- a/packages/search/tests/phpstan/console-application.php
+++ b/packages/search/tests/phpstan/console-application.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Sulu\Article\Tests\Application\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+require \dirname(__DIR__) . '/Application/config/bootstrap.php';
+$kernel = new Kernel(
+    $_SERVER['APP_ENV'], // @phpstan-ignore argument.type
+    (bool) $_SERVER['APP_DEBUG'],
+    Kernel::CONTEXT_ADMIN,
+);
+
+return new Application($kernel);

--- a/packages/search/tests/phpstan/object-manager.php
+++ b/packages/search/tests/phpstan/object-manager.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+use Sulu\Article\Tests\Application\Kernel;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+require \dirname(__DIR__) . '/Application/config/bootstrap.php';
+
+$kernel = new Kernel(
+    $_SERVER['APP_ENV'], // @phpstan-ignore argument.type
+    (bool) $_SERVER['APP_DEBUG'],
+    Kernel::CONTEXT_ADMIN,
+);
+$kernel->boot();
+
+/** @var ContainerInterface $container */
+$container = $kernel->getContainer();
+
+return $container->get('doctrine')->getManager();

--- a/packages/search/tests/test-bootstrap.php
+++ b/packages/search/tests/test-bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+require __DIR__ . '/Application/config/bootstrap.php';

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -45,6 +45,7 @@ class SuluTestKernel extends SuluKernel
             new \FOS\RestBundle\FOSRestBundle(),
             new \FOS\JsRoutingBundle\FOSJsRoutingBundle(),
             new \League\FlysystemBundle\FlysystemBundle(),
+            new \CmsIg\Seal\Integration\Symfony\SealBundle(),
 
             // Sulu
             new \Sulu\Messenger\Infrastructure\Symfony\HttpKernel\SuluMessengerBundle(),
@@ -69,6 +70,7 @@ class SuluTestKernel extends SuluKernel
             new \Sulu\Bundle\ReferenceBundle\SuluReferenceBundle(),
             new \Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle(),
             new \Sulu\Page\Infrastructure\Symfony\HttpKernel\SuluPageBundle(),
+            new \Sulu\Search\Infrastructure\Symfony\HttpKernel\SuluSearchBundle(),
         ];
 
         if (\class_exists(\Symfony\Bundle\MonologBundle\MonologBundle::class)) {

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -30,6 +30,8 @@ flysystem:
                 directory: '%kernel.project_dir%/var/uploads'
 
 cmsig_seal:
+    # "TEST_TOKEN" is typically set by ParaTest
+    index_name_prefix: 'test_%env(default::TEST_TOKEN)%'
     engines:
         default:
             adapter: 'memory://'

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -28,3 +28,8 @@ flysystem:
             adapter: 'local'
             options:
                 directory: '%kernel.project_dir%/var/uploads'
+
+cmsig_seal:
+    engines:
+        default:
+            adapter: 'memory://'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7672
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add a new Search bundle which is based on SEAL the Search Engine Abstraction Layer for PHP.

https://github.com/PHP-CMSIG/search

This init the bundle but does not provide yet any reindex providers.

#### Why?

We are replacing the old Sulu massive search implemenation with a modern Search integration supporting different kind of search engines.

#### Example?

Creating ReindexProvider will look like this, we are using a message bus here so reindexing can be done also async:

```php
class SearchProcessManager
{
    public function onPageChanged(PageCreatedEvent|PageModifiedEvent|PageRemovedEvent $event): void
    {
        $this->messageBus->dispatch(
            ReindexConfig::create()
                ->withIndex('admin')
                ->withIdentifiers([
                    PageInterface::RESROUCE_KEY . '::' . $page->getResourceId() . '::' . $page->getLocale(),
                ])
        );
    }
}
```

```php
class PageReindexProvider implements ReindexProviderInterface {
     public function total(): ?int
     {
         return null;
     }

     public function provide(ReindexConfig $reindexConfig): \Generator
     {
         $pages = $this->loadPages($reindexConfig->getIdentifiers());
         foreach ($pages) as $page) {
             yield [
                 'id' => $identifier,
                 'title' => 'Test ' . $identifier,
             ];
         }
     }
      
     /**
      * @param $identifiers No identifiers mean indexing all pages.
      */
     private function loadPages(array $identifiers = []): \Generator
     {
          // use generator and toIterable and do not fetch all pages into memory here
          // admin index only need to keep title in mind not any content
     }

     public static function getIndex(): string
     {
         return 'admin';
     }
};
```