### PR TITLE
Change page selections list overlay to column_list

### DIFF
--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -494,7 +494,7 @@ final class SuluPageBundle extends AbstractBundle
                                 'resource_key' => 'pages',
                                 'types' => [
                                     'list_overlay' => [
-                                        'adapter' => 'table',
+                                        'adapter' => 'column_list',
                                         'list_key' => 'pages',
                                         'display_properties' => ['title', 'routePath'],
                                         'icon' => 'su-newspaper',
@@ -510,7 +510,7 @@ final class SuluPageBundle extends AbstractBundle
                                 'resource_key' => 'pages',
                                 'types' => [
                                     'list_overlay' => [
-                                        'adapter' => 'table',
+                                        'adapter' => 'column_list',
                                         'list_key' => 'pages',
                                         'display_properties' => ['title'],
                                         'empty_text' => 'sulu_page.no_page_selected',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Related Issues | #7672 
| License | MIT

#### What's in this PR?

Changes the list overlay adapter to column_list to select nested pages.

#### Why?

Otherwise only the homepage can be selected.