### PR TITLE
Fix preview link controller test after deprecated Urlizer with behat/transliterator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,6 @@
         "thecodingmachine/phpstan-strict-rules": "^1.0"
     },
     "conflict": {
-        "behat/transliterator": "< 1.3.0",
         "doctrine/lexer": ">= 3.0.0",
         "doctrine/doctrine-bundle": "2.13.1 || 2.13.x-dev || 2.14.x-dev",
         "doctrine/orm": "2.10.0 || 2.14.2 || 2.16.0 - 2.17.2",

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerTest.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Bundle\PreviewBundle\Tests\Functional\UserInterface\Controller;
 
-use Gedmo\Sluggable\Util\Urlizer;
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\PreviewBundle\Domain\Model\PreviewLinkInterface;
 use Sulu\Bundle\TestBundle\Kernel\SuluKernelBrowser;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use function Symfony\Component\String\u;
 
 class PreviewLinkControllerTest extends SuluTestCase
 {
@@ -183,7 +183,7 @@ class PreviewLinkControllerTest extends SuluTestCase
     {
         $page = new PageDocument();
         $page->setTitle($title);
-        $page->setResourceSegment('/' . Urlizer::urlize($title));
+        $page->setResourceSegment('/' . u($title)->ascii()->toString());
         $page->setParent($this->homePage);
         $page->setStructureType('default');
         $page->getStructure()->bind(

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerTest.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\PreviewBundle\Domain\Model\PreviewLinkInterface;
 use Sulu\Bundle\TestBundle\Kernel\SuluKernelBrowser;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
+
 use function Symfony\Component\String\u;
 
 class PreviewLinkControllerTest extends SuluTestCase


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use Symfony String component instead like they do it now in gedmo itself.

#### Why?

See https://github.com/doctrine-extensions/DoctrineExtensions/pull/2985