### PR TITLE
Fix requirement for symfony/error-handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/dom-crawler": "^5.4 || ^6.0 || ^7.0",
-        "symfony/error-handler": "^5.4 || ^6.0",
+        "symfony/error-handler": "^5.4 || ^6.0 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
         "symfony/event-dispatcher-contracts": "^2.1 || ^3.0",
         "symfony/expression-language": "^5.4 || ^6.0 || ^7.0",
@@ -187,7 +187,6 @@
         "scheb/2fa-trusted-device": "< 6.0 || >= 8.0",
         "swiftmailer/swiftmailer": "< 6.1.3",
         "symfony/doctrine-bridge": "< 5.4.0",
-        "symfony/error-handler": "< 5.4.0",
         "symfony/polyfill-php81": "<1.23",
         "symfony/swiftmailer-bundle": "< 3.1.4",
         "thecodingmachine/safe": "< 2.0.0"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -92089,13 +92089,13 @@ parameters:
 			path: src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
 
 		-
-			message: '#^Parameter \#1 \$values of static method Sulu\\Component\\Util\\SortUtils\:\:multisort\(\) expects array, ArrayObject\<int, Sulu\\Component\\Util\\Tests\\Unit\\FoobarTestClass\> given\.$#'
+			message: '#^Parameter \#1 \$values of static method Sulu\\Component\\Util\\SortUtils\:\:multisort\(\) expects array, ArrayObject\<int, \(object\{0\: string, 1\: string\}&stdClass\)\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
 
 		-
-			message: '#^Parameter \#1 \$values of static method Sulu\\Component\\Util\\SortUtils\:\:multisort\(\) expects array, ArrayObject\<int, object\{\}&stdClass\> given\.$#'
+			message: '#^Parameter \#1 \$values of static method Sulu\\Component\\Util\\SortUtils\:\:multisort\(\) expects array, ArrayObject\<int, Sulu\\Component\\Util\\Tests\\Unit\\FoobarTestClass\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/8191
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix requirement for symfony/error-handler.

#### Why?

Support Symfony 7.