### PR TITLE
Fix locale for SmartContentItemController

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/SmartContentItemController.php
@@ -51,7 +51,8 @@ class SmartContentItemController extends AbstractRestController
      */
     public function getItemsAction(Request $request)
     {
-        $locale = $request->getLocale();
+        /** @var string $locale */
+        $locale = $request->query->get('locale') ?? $request->getLocale();
 
         /** @var array{
          *     locale: string,

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/SmartContent/MediaSmartContentProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/SmartContent/MediaSmartContentProvider.php
@@ -219,7 +219,7 @@ readonly class MediaSmartContentProvider implements SmartContentProviderInterfac
             );
 
         $queryBuilder
-            ->leftJoin(
+            ->innerJoin(
                 'fileVersion.meta',
                 'fileVersionMeta',
                 Join::WITH,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/8164
| Related issues/PRs | https://github.com/sulu/sulu/issues/8164
| License | MIT

#### What's in this PR?

Adjusts the controller to use the correctly selected locale from the Sulu admin.

#### Why?

It did use the wrong locale
