### PR TITLE
Remove conflict to symfony polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -163,6 +163,7 @@
         "symfony/dotenv": "^5.4 || ^6.0",
         "symfony/monolog-bundle": "^3.5",
         "symfony/phpunit-bridge": "^5.4 || ^6.0",
+        "symfony/polyfill-php81": "^1.23",
         "symfony/runtime": "^5.4 || ^6.0",
         "symfony/stopwatch": "^5.4 || ^6.0",
         "symfony/var-dumper": "^5.4 || ^6.0",
@@ -189,7 +190,6 @@
         "swiftmailer/swiftmailer": "< 6.1.3",
         "symfony/doctrine-bridge": "< 5.4.0",
         "symfony/error-handler": "< 5.4.0",
-        "symfony/polyfill-php81": "<1.23",
         "symfony/swiftmailer-bundle": "< 3.1.4",
         "thecodingmachine/safe": "< 2.0.0"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no |
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove conflict to symfony polyfill.

#### Why?

Conflict the polyfill does mean conflicting sulu/skeleton as that replaces the polyfill on PHP 8.2:

https://github.com/sulu/skeleton/blob/67a5e95261746ce7d1b686aae2b32c7cfaad2c72/composer.json#L95