### PR TITLE
Remove not longer required compiler pass RouteDefaultsOptionsCompilerPass in WebsiteBundle

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
+++ b/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\WebsiteBundle;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\WebsiteBundle\DependencyInjection\Compiler\DeregisterDefaultRouteListenerCompilerPass;
 use Sulu\Bundle\WebsiteBundle\Entity\AnalyticsInterface;
-use Sulu\Route\Infrastructure\Symfony\DependencyInjection\RouteDefaultsOptionsCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -29,7 +28,6 @@ final class SuluWebsiteBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new RouteDefaultsOptionsCompilerPass()); // TODO remove in 3.0 as already registered by new RouteBundle
         $container->addCompilerPass(new DeregisterDefaultRouteListenerCompilerPass());
 
         $this->buildPersistence(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove not longer required compiler pass.

#### Why?

Was registered in website and new route bundle as new route bundle was not always activated.