### PR TITLE
Fix phpDoc of PreviewDefaultsProviderInterface after backmerge

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderRegistry.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Object/PreviewObjectProviderRegistry.php
@@ -20,12 +20,12 @@ use Sulu\Bundle\PreviewBundle\Preview\Provider\PreviewDefaultsProviderInterface;
 class PreviewObjectProviderRegistry implements PreviewObjectProviderRegistryInterface
 {
     /**
-     * @var array<string, PreviewObjectProviderInterface>
+     * @var array<string, PreviewDefaultsProviderInterface>
      */
     private $previewObjectProviders;
 
     /**
-     * @param iterable<string, PreviewObjectProviderInterface> $previewObjectProviders
+     * @param iterable<string, PreviewDefaultsProviderInterface> $previewObjectProviders
      */
     public function __construct(iterable $previewObjectProviders)
     {

--- a/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
+++ b/src/Sulu/Bundle/WebsiteBundle/SuluWebsiteBundle.php
@@ -14,8 +14,6 @@ namespace Sulu\Bundle\WebsiteBundle;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\WebsiteBundle\DependencyInjection\Compiler\DeregisterDefaultRouteListenerCompilerPass;
 use Sulu\Bundle\WebsiteBundle\Entity\AnalyticsInterface;
-use Sulu\Component\Route\RouteDefaultOptionsCompilerPass;
-use Sulu\Component\Util\SuluVersionPass;
 use Sulu\Route\Infrastructure\Symfony\DependencyInjection\RouteDefaultsOptionsCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use PreviewDefaultsProviderInterface instead of PreviewObjectProviderInterface.

#### Why?

The PreviewObjectProviderInterface was replaced by PreviewDefaultsProviderInterface in 3.0.