### PR TITLE
Use UNDERSCORE instead of DASH to maintain BC for locale strings

### DIFF
--- a/packages/content/src/UserInterface/Controller/Website/ContentController.php
+++ b/packages/content/src/UserInterface/Controller/Website/ContentController.php
@@ -203,7 +203,7 @@ class ContentController extends AbstractController
             ?->getAllLocalizations() ?? [];
 
         foreach ($webspaceLocales as $webspaceLocale) {
-            $locale = $webspaceLocale->getLocale(Localization::DASH);
+            $locale = $webspaceLocale->getLocale(Localization::UNDERSCORE);
             if (\array_key_exists($locale, $localizations)) {
                 continue;
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8217

#### What's in this PR?

Revert the use the previous format for locales stored in the database (en_gb) rather than the URL-friendly dashed version (en-gb).

#### Why?

Any database from a Sulu 2.6 install will use `en_gb` as the locale format.

This change in 3.0 breaks that and will require sweeping database migrations on huge sections of the DB data.

Therefore the simplest solution is to revert back to use UNDERSCORE as this will remove the need to carry out any extra database migrations when upgrading to 3.0.
