### PR TITLE
Add search listener and search provider for accounts for SEAL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.0",
-        "cmsig/seal": "^0.12.2",
+        "cmsig/seal": "^0.12.3",
         "cmsig/seal-symfony-bundle": "^0.12.2",
         "contao/imagine-svg": "^1.0",
         "doctrine/cache": "^1.12.1 || ^2.0",

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AccountReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AccountReindexProvider.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+
+/**
+ * @phpstan-type Account array{
+ *     id: int,
+ *     changed: \DateTimeImmutable,
+ *     created: \DateTimeImmutable,
+ *     name: string
+ * }
+ */
+class AccountReindexProvider implements ReindexProviderInterface
+{
+    /**
+     * @var EntityRepository<AccountInterface>
+     */
+    protected EntityRepository $accountRepository;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+    ) {
+        $repository = $entityManager->getRepository(AccountInterface::class);
+
+        $this->accountRepository = $repository;
+    }
+
+    public function total(): ?int
+    {
+        return null;
+    }
+
+    public function provide(ReindexConfig $reindexConfig): \Generator
+    {
+        $accounts = $this->loadAccounts($reindexConfig->getIdentifiers());
+
+        /** @var Account $account */
+        foreach ($accounts as $account) {
+            yield [
+                'id' => AccountInterface::RESOURCE_KEY . '::' . ((string) $account['id']),
+                'resourceKey' => AccountInterface::RESOURCE_KEY,
+                'resourceId' => (string) $account['id'],
+                'changedAt' => $account['changed']->format('c'),
+                'createdAt' => $account['created']->format('c'),
+                'title' => $account['name'],
+            ];
+        }
+    }
+
+    /**
+     * @param string[] $identifiers
+     *
+     * @return iterable<Account>
+     */
+    private function loadAccounts(array $identifiers = []): iterable
+    {
+        $qb = $this->accountRepository->createQueryBuilder('account')
+            ->select('account.id')
+            ->addSelect('account.name')
+            ->addSelect('account.created')
+            ->addSelect('account.changed');
+
+        if (0 < \count($identifiers)) {
+            $qb->where('account.id IN (:ids)')
+                ->setParameter('ids', \array_map(fn ($identifier) => (int) \str_replace(AccountInterface::RESOURCE_KEY . '::', '', $identifier), $identifiers));
+        }
+
+        /** @var iterable<Account> */
+        return $qb->getQuery()->toIterable();
+    }
+
+    public static function getIndex(): string
+    {
+        return 'admin';
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactIndexListener.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactIndexListener.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use Sulu\Bundle\ContactBundle\Domain\Event\AccountCreatedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\AccountModifiedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\AccountRemovedEvent;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @internal
+ */
+class ContactIndexListener
+{
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function onAccountChanged(AccountCreatedEvent|AccountModifiedEvent|AccountRemovedEvent $event): void
+    {
+        $this->messageBus->dispatch(
+            ReindexConfig::create()
+                ->withIndex('admin')
+                ->withIdentifiers([
+                    AccountInterface::RESOURCE_KEY . '::' . $event->getResourceId(),
+                ]),
+        );
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -210,5 +210,23 @@
         >
             <argument type="service" id="translator"/>
         </service>
+
+        <service
+                id="sulu_contact.contact_index_listener"
+                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\ContactIndexListener"
+        >
+            <argument type="service" id="sulu_message_bus"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountCreatedEvent" method="onAccountChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountModifiedEvent" method="onAccountChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountRemovedEvent" method="onAccountChanged"/>
+        </service>
+
+        <service
+                id="sulu_contact.account_reindex_provider"
+                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AccountReindexProvider"
+        >
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <tag name="cmsig_seal.reindex_provider"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AccountReindexProviderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AccountReindexProviderTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Functional\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ContactBundle\Entity\Account;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AccountReindexProvider;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class AccountReindexProviderTest extends SuluTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private AccountReindexProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->getEntityManager();
+        $this->provider = new AccountReindexProvider($this->entityManager);
+        $this->purgeDatabase();
+    }
+
+    public function testGetIndex(): void
+    {
+        $this->assertSame('admin', AccountReindexProvider::getIndex());
+    }
+
+    public function testTotal(): void
+    {
+        $this->assertNull($this->provider->total());
+    }
+
+    public function testProvideAll(): void
+    {
+        $account1 = $this->createAccount('Test Account 1');
+        $account2 = $this->createAccount('Test Account 2');
+
+        $this->entityManager->flush();
+
+        $changedDateString1 = '2023-06-01 15:30:00';
+        $changedDateString2 = '2024-06-01 15:30:00';
+
+        $connection = self::getEntityManager()->getConnection();
+        $sql = 'UPDATE co_accounts SET changed = :changed WHERE id = :id';
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString1,
+            'id' => $account1->getId(),
+        ]);
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString2,
+            'id' => $account2->getId(),
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('admin');
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(2, $results);
+
+        $this->assertSame(
+            [
+                [
+                    'id' => AccountInterface::RESOURCE_KEY . '::' . $account1->getId(),
+                    'resourceKey' => AccountInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $account1->getId(),
+                    'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
+                    'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
+                    'title' => $account1->getName(),
+                ],
+                [
+                    'id' => AccountInterface::RESOURCE_KEY . '::' . $account2->getId(),
+                    'resourceKey' => AccountInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $account2->getId(),
+                    'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                    'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
+                    'title' => $account2->getName(),
+                ],
+            ],
+            [...$results],
+        );
+    }
+
+    public function testProvideWithSpecificIdentifiers(): void
+    {
+        $account1 = $this->createAccount('Account One');
+        $account2 = $this->createAccount('Account Two');
+        $account3 = $this->createAccount('Account Three');
+
+        $this->entityManager->flush();
+
+        $identifiers = [
+            AccountInterface::RESOURCE_KEY . '::' . $account1->getId(),
+            AccountInterface::RESOURCE_KEY . '::' . $account3->getId(),
+        ];
+
+        $config = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers($identifiers);
+
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(2, $results);
+
+        $resultTitles = \array_column($results, 'title');
+        $this->assertContains('Account One', $resultTitles);
+        $this->assertContains('Account Three', $resultTitles);
+        $this->assertNotContains('Account Two', $resultTitles);
+    }
+
+    private function createAccount(string $name): Account
+    {
+        $account = new Account();
+        $account->setName($name);
+        $account->setCreated(new \DateTimeImmutable('2000-01-01 12:00:00'));
+
+        $this->entityManager->persist($account);
+
+        return $account;
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Search/ContactIndexListenerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Search/ContactIndexListenerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Unit\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\ContactBundle\Domain\Event\AccountCreatedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\AccountModifiedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\AccountRemovedEvent;
+use Sulu\Bundle\ContactBundle\Entity\Account;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\ContactIndexListener;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[CoversClass(ContactIndexListenerTest::class)]
+class ContactIndexListenerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<MessageBusInterface>
+     */
+    private ObjectProphecy $messageBus;
+    private ContactIndexListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->messageBus = $this->prophesize(MessageBusInterface::class);
+        $this->listener = new ContactIndexListener($this->messageBus->reveal());
+    }
+
+    public function testOnAccountChangedWithAccountCreatedEvent(): void
+    {
+        $account = new Account();
+        $account->setId(123);
+        $event = new AccountCreatedEvent($account, []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '::123']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onAccountChanged($event);
+    }
+
+    public function testOnAccountChangedWithAccountModifiedEvent(): void
+    {
+        $account = new Account();
+        $account->setId(456);
+        $event = new AccountModifiedEvent($account, []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '::456']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onAccountChanged($event);
+    }
+
+    public function testOnAccountChangedWithAccountRemovedEvent(): void
+    {
+        $account = new Account();
+        $account->setId(789);
+        $account->setName('Sulu GmbH');
+        $event = new AccountRemovedEvent($account->getId(), $account->getName());
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '::789']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onAccountChanged($event);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7672
| License | MIT

#### What's in this PR?

Added ReindexProvider and IndexListener for Accounts for SEAL.

#### Why?

Because MassiveSearchBundle was removed
