### PR TITLE
Add search listener and search provider for contacts for SEAL

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AccountReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AccountReindexProvider.php
@@ -26,8 +26,11 @@ use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
  *     created: \DateTimeImmutable,
  *     name: string
  * }
+ *
+ * @internal this class is internal no backwards compatibility promise is given for this class
+ *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-class AccountReindexProvider implements ReindexProviderInterface
+final class AccountReindexProvider implements ReindexProviderInterface
 {
     /**
      * @var EntityRepository<AccountInterface>
@@ -42,9 +45,9 @@ class AccountReindexProvider implements ReindexProviderInterface
         $this->accountRepository = $repository;
     }
 
-    public function total(): ?int
+    public function total(): int
     {
-        return null;
+        return $this->accountRepository->count([]);
     }
 
     public function provide(ReindexConfig $reindexConfig): \Generator

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactIndexListener.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactIndexListener.php
@@ -17,7 +17,11 @@ use CmsIg\Seal\Reindex\ReindexConfig;
 use Sulu\Bundle\ContactBundle\Domain\Event\AccountCreatedEvent;
 use Sulu\Bundle\ContactBundle\Domain\Event\AccountModifiedEvent;
 use Sulu\Bundle\ContactBundle\Domain\Event\AccountRemovedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\ContactCreatedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\ContactModifiedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\ContactRemovedEvent;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -37,6 +41,17 @@ class ContactIndexListener
                 ->withIndex('admin')
                 ->withIdentifiers([
                     AccountInterface::RESOURCE_KEY . '::' . $event->getResourceId(),
+                ]),
+        );
+    }
+
+    public function onContactChanged(ContactCreatedEvent|ContactModifiedEvent|ContactRemovedEvent $event): void
+    {
+        $this->messageBus->dispatch(
+            ReindexConfig::create()
+                ->withIndex('admin')
+                ->withIdentifiers([
+                    ContactInterface::RESOURCE_KEY . '::' . $event->getResourceId(),
                 ]),
         );
     }

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactIndexListener.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactIndexListener.php
@@ -17,24 +17,27 @@ use CmsIg\Seal\Reindex\ReindexConfig;
 use Sulu\Bundle\ContactBundle\Domain\Event\AccountCreatedEvent;
 use Sulu\Bundle\ContactBundle\Domain\Event\AccountModifiedEvent;
 use Sulu\Bundle\ContactBundle\Domain\Event\AccountRemovedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\AccountRestoredEvent;
 use Sulu\Bundle\ContactBundle\Domain\Event\ContactCreatedEvent;
 use Sulu\Bundle\ContactBundle\Domain\Event\ContactModifiedEvent;
 use Sulu\Bundle\ContactBundle\Domain\Event\ContactRemovedEvent;
+use Sulu\Bundle\ContactBundle\Domain\Event\ContactRestoredEvent;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * @internal
+ * @internal this class is internal no backwards compatibility promise is given for this class
+ *           use Symfony Dependency Injection to override or create your own Listener instead
  */
-class ContactIndexListener
+final class ContactIndexListener
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,
     ) {
     }
 
-    public function onAccountChanged(AccountCreatedEvent|AccountModifiedEvent|AccountRemovedEvent $event): void
+    public function onAccountChanged(AccountCreatedEvent|AccountModifiedEvent|AccountRemovedEvent|AccountRestoredEvent $event): void
     {
         $this->messageBus->dispatch(
             ReindexConfig::create()
@@ -45,7 +48,7 @@ class ContactIndexListener
         );
     }
 
-    public function onContactChanged(ContactCreatedEvent|ContactModifiedEvent|ContactRemovedEvent $event): void
+    public function onContactChanged(ContactCreatedEvent|ContactModifiedEvent|ContactRemovedEvent|ContactRestoredEvent $event): void
     {
         $this->messageBus->dispatch(
             ReindexConfig::create()

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactReindexProvider.php
@@ -27,8 +27,11 @@ use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
  *     firstName: string,
  *     lastName: string,
  * }
+ *
+ * @internal this class is internal no backwards compatibility promise is given for this class
+ *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-class ContactReindexProvider implements ReindexProviderInterface
+final class ContactReindexProvider implements ReindexProviderInterface
 {
     /**
      * @var EntityRepository<ContactInterface>
@@ -43,9 +46,9 @@ class ContactReindexProvider implements ReindexProviderInterface
         $this->contactRepository = $repository;
     }
 
-    public function total(): ?int
+    public function total(): int
     {
-        return null;
+        return $this->contactRepository->count([]);
     }
 
     public function provide(ReindexConfig $reindexConfig): \Generator

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/ContactReindexProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+
+/**
+ * @phpstan-type Contact array{
+ *     id: int,
+ *     changed: \DateTimeImmutable,
+ *     created: \DateTimeImmutable,
+ *     firstName: string,
+ *     lastName: string,
+ * }
+ */
+class ContactReindexProvider implements ReindexProviderInterface
+{
+    /**
+     * @var EntityRepository<ContactInterface>
+     */
+    protected EntityRepository $contactRepository;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+    ) {
+        $repository = $entityManager->getRepository(ContactInterface::class);
+
+        $this->contactRepository = $repository;
+    }
+
+    public function total(): ?int
+    {
+        return null;
+    }
+
+    public function provide(ReindexConfig $reindexConfig): \Generator
+    {
+        $contacts = $this->loadContacts($reindexConfig->getIdentifiers());
+
+        /** @var Contact $contact */
+        foreach ($contacts as $contact) {
+            yield [
+                'id' => ContactInterface::RESOURCE_KEY . '::' . ((string) $contact['id']),
+                'resourceKey' => ContactInterface::RESOURCE_KEY,
+                'resourceId' => (string) $contact['id'],
+                'changedAt' => $contact['changed']->format('c'),
+                'createdAt' => $contact['created']->format('c'),
+                'title' => $contact['firstName'] . ' ' . $contact['lastName'],
+            ];
+        }
+    }
+
+    /**
+     * @param string[] $identifiers
+     *
+     * @return iterable<Contact>
+     */
+    private function loadContacts(array $identifiers = []): iterable
+    {
+        $qb = $this->contactRepository->createQueryBuilder('contact')
+            ->select('contact.id')
+            ->addSelect('contact.firstName')
+            ->addSelect('contact.lastName')
+            ->addSelect('contact.created')
+            ->addSelect('contact.changed');
+
+        if (0 < \count($identifiers)) {
+            $qb->where('contact.id IN (:ids)')
+                ->setParameter('ids', \array_map(fn ($identifier) => (int) \str_replace(ContactInterface::RESOURCE_KEY . '::', '', $identifier), $identifiers));
+        }
+
+        /** @var iterable<Contact> */
+        return $qb->getQuery()->toIterable();
+    }
+
+    public static function getIndex(): string
+    {
+        return 'admin';
+    }
+}

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -219,9 +219,11 @@
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountCreatedEvent" method="onAccountChanged"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountModifiedEvent" method="onAccountChanged"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountRemovedEvent" method="onAccountChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountRestoredEvent" method="onAccountChanged"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\ContactCreatedEvent" method="onContactChanged"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\ContactModifiedEvent" method="onContactChanged"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\ContactRemovedEvent" method="onContactChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\ContactRestoredEvent" method="onContactChanged"/>
         </service>
 
         <service

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -219,11 +219,22 @@
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountCreatedEvent" method="onAccountChanged"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountModifiedEvent" method="onAccountChanged"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountRemovedEvent" method="onAccountChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\ContactCreatedEvent" method="onContactChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\ContactModifiedEvent" method="onContactChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\ContactRemovedEvent" method="onContactChanged"/>
         </service>
 
         <service
                 id="sulu_contact.account_reindex_provider"
                 class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AccountReindexProvider"
+        >
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <tag name="cmsig_seal.reindex_provider"/>
+        </service>
+
+        <service
+                id="sulu_contact.contact_reindex_provider"
+                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\ContactReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <tag name="cmsig_seal.reindex_provider"/>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AccountReindexProviderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AccountReindexProviderTest.php
@@ -39,7 +39,12 @@ class AccountReindexProviderTest extends SuluTestCase
 
     public function testTotal(): void
     {
-        $this->assertNull($this->provider->total());
+        $this->createAccount('Count 1');
+        $this->createAccount('Count 2');
+
+        $this->entityManager->flush();
+
+        $this->assertSame(2, $this->provider->total());
     }
 
     public function testProvideAll(): void

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/ContactReindexProviderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/ContactReindexProviderTest.php
@@ -42,7 +42,12 @@ class ContactReindexProviderTest extends SuluTestCase
 
     public function testTotal(): void
     {
-        $this->assertNull($this->provider->total());
+        $this->createContact();
+        $this->createContact();
+
+        $this->entityManager->flush();
+
+        $this->assertSame(2, $this->provider->total());
     }
 
     public function testProvideAll(): void

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/ContactReindexProviderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/ContactReindexProviderTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Tests\Functional\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\ContactReindexProvider;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class ContactReindexProviderTest extends SuluTestCase
+{
+    use SetGetPrivatePropertyTrait;
+
+    private EntityManagerInterface $entityManager;
+    private ContactReindexProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->getEntityManager();
+        $this->provider = new ContactReindexProvider($this->entityManager);
+        $this->purgeDatabase();
+    }
+
+    public function testGetIndex(): void
+    {
+        $this->assertSame('admin', ContactReindexProvider::getIndex());
+    }
+
+    public function testTotal(): void
+    {
+        $this->assertNull($this->provider->total());
+    }
+
+    public function testProvideAll(): void
+    {
+        $contact1 = $this->createContact();
+        $contact2 = $this->createContact();
+
+        $this->entityManager->flush();
+
+        $changedDateString1 = '2023-06-01 15:30:00';
+        $changedDateString2 = '2024-06-01 15:30:00';
+
+        $connection = self::getEntityManager()->getConnection();
+        $sql = 'UPDATE co_contacts SET changed = :changed WHERE id = :id';
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString1,
+            'id' => $contact1->getId(),
+        ]);
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString2,
+            'id' => $contact2->getId(),
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('admin');
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(2, $results);
+
+        $this->assertSame(
+            [
+                [
+                    'id' => ContactInterface::RESOURCE_KEY . '::' . $contact1->getId(),
+                    'resourceKey' => ContactInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $contact1->getId(),
+                    'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
+                    'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
+                    'title' => $contact1->getFullName(),
+                ],
+                [
+                    'id' => ContactInterface::RESOURCE_KEY . '::' . $contact2->getId(),
+                    'resourceKey' => ContactInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $contact2->getId(),
+                    'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                    'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
+                    'title' => $contact2->getFullName(),
+                ],
+            ],
+            [...$results],
+        );
+    }
+
+    public function testProvideWithSpecificIdentifiers(): void
+    {
+        $contact1 = $this->createContact();
+        $contact2 = $this->createContact('Fritz', 'Fantom');
+        $contact3 = $this->createContact('Thomas', 'Brezina');
+
+        $this->entityManager->flush();
+
+        $identifiers = [
+            ContactInterface::RESOURCE_KEY . '::' . $contact1->getId(),
+            ContactInterface::RESOURCE_KEY . '::' . $contact3->getId(),
+        ];
+
+        $config = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers($identifiers);
+
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(2, $results);
+
+        $resultTitles = \array_column($results, 'title');
+        $this->assertContains('Tom Turbo', $resultTitles);
+        $this->assertContains('Thomas Brezina', $resultTitles);
+        $this->assertNotContains('Fritz Fantom', $resultTitles);
+    }
+
+    private function createContact(string $firstName = 'Tom', string $lastName = 'Turbo'): Contact
+    {
+        $contact = new Contact();
+        $contact->setFirstName($firstName);
+        $contact->setLastName($lastName);
+        $contact->setCreated(new \DateTimeImmutable('2000-01-01 12:00:00'));
+
+        $this->entityManager->persist($contact);
+
+        return $contact;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #8224
| License | MIT

#### What's in this PR?

Added ReindexProvider and IndexListener for Contacts for SEAL.

#### Why?

Because MassiveSearchBundle was removed
