### PR TITLE
Add search listener and search provider for categories for SEAL

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
+++ b/src/Sulu/Bundle/CategoryBundle/Category/CategoryManager.php
@@ -275,8 +275,12 @@ class CategoryManager implements CategoryManagerInterface
             $this->trashManager->store(CategoryInterface::RESOURCE_KEY, $entity);
         }
 
+        $translationLocales = [];
+
         /** @var CategoryTranslationInterface $translation */
         foreach ($entity->getTranslations() as $translation) {
+            $translationLocales[] = $translation->getLocale();
+
             foreach ($translation->getKeywords() as $keyword) {
                 $this->keywordManager->delete($keyword, $entity);
             }
@@ -287,7 +291,7 @@ class CategoryManager implements CategoryManagerInterface
         $categoryName = $defaultTranslation ? $defaultTranslation->getTranslation() : null;
 
         $this->em->remove($entity);
-        $this->domainEventCollector->collect(new CategoryRemovedEvent($id, $categoryName, $defaultLocale));
+        $this->domainEventCollector->collect(new CategoryRemovedEvent($id, $categoryName, $defaultLocale, $translationLocales));
         $this->em->flush();
 
         // throw a category.delete event

--- a/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryRemovedEvent.php
+++ b/src/Sulu/Bundle/CategoryBundle/Domain/Event/CategoryRemovedEvent.php
@@ -17,10 +17,14 @@ use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 
 class CategoryRemovedEvent extends DomainEvent
 {
+    /**
+     * @param string[]|null $allLocales
+     */
     public function __construct(
         private int $categoryId,
         private ?string $categoryTitle,
-        private ?string $categoryTitleLocale
+        private ?string $categoryTitleLocale,
+        private ?array $allLocales,
     ) {
         parent::__construct();
     }
@@ -53,5 +57,13 @@ class CategoryRemovedEvent extends DomainEvent
     public function getResourceSecurityContext(): ?string
     {
         return CategoryAdmin::SECURITY_CONTEXT;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getAllLocales(): ?array
+    {
+        return $this->allLocales;
     }
 }

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/CategoryIndexListener.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/CategoryIndexListener.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryCreatedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryModifiedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryRemovedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryRestoredEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryTranslationAddedEvent;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @internal this class is internal no backwards compatibility promise is given for this class
+ *           use Symfony Dependency Injection to override or create your own Listener instead
+ */
+final class CategoryIndexListener
+{
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function onCategoryChanged(CategoryCreatedEvent|CategoryModifiedEvent|CategoryRemovedEvent|CategoryTranslationAddedEvent|CategoryRestoredEvent $event): void
+    {
+        $locale = $event->getResourceLocale();
+        $identifiers = [];
+
+        if ($event instanceof CategoryRemovedEvent) {
+            $locales = $event->getAllLocales();
+
+            if (!$locales) {
+                return;
+            }
+
+            foreach ($locales as $locale) {
+                $identifiers[] = CategoryInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+            }
+        } elseif ($event instanceof CategoryRestoredEvent) {
+            $category = $event->getCategory();
+
+            foreach ($category->getTranslations() as $translation) {
+                if (!$translation->getLocale()) {
+                    continue;
+                }
+
+                $identifiers[] = CategoryInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $translation->getLocale();
+            }
+        } elseif ($locale) {
+            $identifiers[] = CategoryInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+        }
+
+        if (!$identifiers) {
+            return;
+        }
+
+        $this->messageBus->dispatch(
+            ReindexConfig::create()
+                ->withIndex('admin')
+                ->withIdentifiers($identifiers),
+        );
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/CategoryReindexProvider.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/CategoryReindexProvider.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface;
+
+/**
+ * @phpstan-type Category array{
+ *     id: int,
+ *     changed: \DateTimeImmutable,
+ *     created: \DateTimeImmutable,
+ *     translation: string,
+ *     locale: string,
+ * }
+ *
+ * @internal this class is internal no backwards compatibility promise is given for this class
+ *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
+ */
+final class CategoryReindexProvider
+{
+    /**
+     * @var EntityRepository<CategoryInterface>
+     */
+    protected EntityRepository $categoryRepository;
+
+    /**
+     * @var EntityRepository<CategoryTranslationInterface>
+     */
+    protected EntityRepository $categoryTranslationRepository;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+    ) {
+        $repository = $entityManager->getRepository(CategoryInterface::class);
+        $translationRepository = $entityManager->getRepository(CategoryTranslationInterface::class);
+
+        $this->categoryRepository = $repository;
+        $this->categoryTranslationRepository = $translationRepository;
+    }
+
+    public function total(): int
+    {
+        return $this->categoryRepository->count([]);
+    }
+
+    public function provide(ReindexConfig $reindexConfig): \Generator
+    {
+        $categories = $this->loadCategories($reindexConfig->getIdentifiers());
+
+        /** @var Category $category */
+        foreach ($categories as $category) {
+            yield [
+                'id' => CategoryInterface::RESOURCE_KEY . '::' . ((string) $category['id']) . '::' . $category['locale'],
+                'resourceKey' => CategoryInterface::RESOURCE_KEY,
+                'resourceId' => (string) $category['id'],
+                'changedAt' => $category['changed']->format('c'),
+                'createdAt' => $category['created']->format('c'),
+                'title' => $category['translation'],
+                'locale' => $category['locale'],
+            ];
+        }
+    }
+
+    /**
+     * @param string[] $identifiers
+     *
+     * @return iterable<Category>
+     */
+    private function loadCategories(array $identifiers = []): iterable
+    {
+        $qb = $this->categoryTranslationRepository->createQueryBuilder('translation')
+            ->select('category.id')
+            ->addSelect('category.created')
+            ->addSelect('category.changed')
+            ->addSelect('translation.translation')
+            ->addSelect('translation.locale')
+            ->leftJoin('translation.category', 'category');
+
+        if (0 < \count($identifiers)) {
+            $conditions = [];
+            $parameters = [];
+
+            foreach ($identifiers as $index => $identifier) {
+                $id = \explode('::', $identifier)[1];
+                $locale = \explode('::', $identifier)[2];
+
+                $conditions[] = "(category.id = :id{$index} AND translation.locale = :locale{$index})";
+                $parameters["id{$index}"] = $id;
+                $parameters["locale{$index}"] = $locale;
+            }
+
+            $qb->where(\implode(' OR ', $conditions));
+            $qb->setParameters($parameters);
+        }
+
+        /** @var iterable<Category> */
+        return $qb->getQuery()->toIterable();
+    }
+
+    public static function getIndex(): string
+    {
+        return 'admin';
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -78,5 +78,25 @@
 
             <tag name="sulu.context" context="admin"/>
         </service>
+
+        <service
+                id="sulu_category.category_index_listener"
+                class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\CategoryIndexListener"
+        >
+            <argument type="service" id="sulu_message_bus"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\CategoryBundle\Domain\Event\CategoryCreatedEvent" method="onCategoryChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\CategoryBundle\Domain\Event\CategoryModifiedEvent" method="onCategoryChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\CategoryBundle\Domain\Event\CategoryRemovedEvent" method="onCategoryChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\CategoryBundle\Domain\Event\CategoryTranslationAddedEvent" method="onCategoryChanged"/>
+            <tag name="kernel.event_listener" event="Sulu\Bundle\CategoryBundle\Domain\Event\CategoryRestoredEvent" method="onCategoryChanged"/>
+        </service>
+
+        <service
+                id="sulu_category.category_reindex_provider"
+                class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\CategoryReindexProvider"
+        >
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+            <tag name="cmsig_seal.reindex_provider"/>
+        </service>
     </services>
 </container>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Infrastructure/Sulu/Search/CategoryReindexProviderTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Infrastructure/Sulu/Search/CategoryReindexProviderTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Tests\Functional\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\CategoryBundle\Entity\Category;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\CategoryReindexProvider;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class CategoryReindexProviderTest extends SuluTestCase
+{
+    use SetGetPrivatePropertyTrait;
+
+    private EntityManagerInterface $entityManager;
+    private CategoryReindexProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->getEntityManager();
+        $this->provider = new CategoryReindexProvider($this->entityManager);
+        $this->purgeDatabase();
+    }
+
+    public function testGetIndex(): void
+    {
+        $this->assertSame('admin', CategoryReindexProvider::getIndex());
+    }
+
+    public function testTotal(): void
+    {
+        $this->createCategory();
+
+        $this->entityManager->flush();
+
+        $this->assertSame(1, $this->provider->total());
+    }
+
+    public function testProvideAll(): void
+    {
+        $category1 = $this->createCategory(null, 'en');
+        $category1Translation = $this->createCategoryTranslation($category1, 'en', 'Category EN 1');
+        $category2 = $this->createCategory(null, 'en');
+        $category2Translation1 = $this->createCategoryTranslation($category2, 'en', 'Category EN 2');
+        $category2Translation2 = $this->createCategoryTranslation($category2, 'de', 'Category DE 2');
+
+        $this->entityManager->flush();
+
+        $changedDateString1 = '2023-06-01 15:30:00';
+        $changedDateString2 = '2024-06-01 15:30:00';
+
+        $connection = self::getEntityManager()->getConnection();
+        $sql = 'UPDATE ca_categories SET changed = :changed WHERE id = :id';
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString1,
+            'id' => $category1->getId(),
+        ]);
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString2,
+            'id' => $category2->getId(),
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('admin');
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(3, $results);
+
+        $this->assertSame(
+            [
+                [
+                    'id' => CategoryInterface::RESOURCE_KEY . '::' . $category1->getId() . '::' . $category1Translation->getLocale(),
+                    'resourceKey' => CategoryInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $category1->getId(),
+                    'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
+                    'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
+                    'title' => $category1Translation->getTranslation(),
+                    'locale' => $category1Translation->getLocale(),
+                ],
+                [
+                    'id' => CategoryInterface::RESOURCE_KEY . '::' . $category2->getId() . '::' . $category2Translation1->getLocale(),
+                    'resourceKey' => CategoryInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $category2->getId(),
+                    'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                    'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
+                    'title' => $category2Translation1->getTranslation(),
+                    'locale' => $category2Translation1->getLocale(),
+                ],
+                [
+                    'id' => CategoryInterface::RESOURCE_KEY . '::' . $category2->getId() . '::' . $category2Translation2->getLocale(),
+                    'resourceKey' => CategoryInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $category2->getId(),
+                    'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                    'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
+                    'title' => $category2Translation2->getTranslation(),
+                    'locale' => $category2Translation2->getLocale(),
+                ],
+            ],
+            [...$results],
+        );
+    }
+
+    public function testProvideWithSpecificIdentifiers(): void
+    {
+        $category1 = $this->createCategory(null, 'en');
+        $category1Translation = $this->createCategoryTranslation($category1, 'en', 'Category EN 1');
+        $category2 = $this->createCategory(null, 'en');
+        $category2Translation1 = $this->createCategoryTranslation($category2, 'en', 'Category EN 2');
+        $category2Translation2 = $this->createCategoryTranslation($category2, 'de', 'Category DE 2');
+        $category3 = $this->createCategory(null, 'en');
+        $category3Translation1 = $this->createCategoryTranslation($category3, 'en', 'Category EN 3');
+
+        $this->entityManager->flush();
+
+        $changedDateString1 = '2023-06-01 15:30:00';
+        $changedDateString2 = '2024-06-01 15:30:00';
+
+        $connection = self::getEntityManager()->getConnection();
+        $sql = 'UPDATE ca_categories SET changed = :changed WHERE id = :id';
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString1,
+            'id' => $category1->getId(),
+        ]);
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString2,
+            'id' => $category2->getId(),
+        ]);
+
+        $identifiers = [
+            CategoryInterface::RESOURCE_KEY . '::' . $category1->getId() . '::' . $category1Translation->getLocale(),
+            CategoryInterface::RESOURCE_KEY . '::' . $category2->getId() . '::' . $category2Translation2->getLocale(),
+        ];
+
+        $config = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers($identifiers);
+
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(2, $results);
+
+        $resultTitles = \array_column($results, 'title');
+        $this->assertContains('Category EN 1', $resultTitles);
+        $this->assertContains('Category DE 2', $resultTitles);
+        $this->assertNotContains('Category EN 2', $resultTitles);
+        $this->assertNotContains('Category EN 3', $resultTitles);
+    }
+
+    private function createCategory(
+        ?string $key = null,
+        string $defaultLocale = 'en',
+        ?CategoryInterface $parentCategory = null,
+    ): Category {
+        $category = new Category();
+        $category->setKey($key);
+        $category->setDefaultLocale($defaultLocale);
+        $category->setCreated(new \DateTimeImmutable('2000-01-01 12:00:00'));
+
+        if ($parentCategory) {
+            $category->setParent($parentCategory);
+            $parentCategory->addChild($category);
+        }
+
+        $this->entityManager->persist($category);
+
+        return $category;
+    }
+
+    private function createCategoryTranslation(CategoryInterface $category, string $locale, string $title): CategoryTranslation
+    {
+        $categoryTrans = new CategoryTranslation();
+        $categoryTrans->setLocale($locale);
+        $categoryTrans->setTranslation($title);
+        $categoryTrans->setCategory($category);
+        $category->addTranslation($categoryTrans);
+
+        $this->entityManager->persist($categoryTrans);
+
+        return $categoryTrans;
+    }
+}

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/CategoryManagerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Category/CategoryManagerTest.php
@@ -151,6 +151,7 @@ class CategoryManagerTest extends TestCase
 
         $translation = $this->prophesize(CategoryTranslationInterface::class);
         $translation->getTranslation()->willReturn('category-translation');
+        $translation->getLocale()->willReturn('de');
         $translation->getKeywords()->willReturn([$keyword1->reveal(), $keyword2->reveal()]);
 
         $category = $this->prophesize(CategoryInterface::class);
@@ -208,6 +209,7 @@ class CategoryManagerTest extends TestCase
 
         $translation = $this->prophesize(CategoryTranslationInterface::class);
         $translation->getTranslation()->willReturn('category-translation');
+        $translation->getLocale()->willReturn('de');
         $translation->getKeywords()->willReturn([$keyword1->reveal(), $keyword2->reveal()]);
 
         $category = $this->prophesize(CategoryInterface::class);

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Search/CategoryIndexListenerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Search/CategoryIndexListenerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryCreatedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryModifiedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryRemovedEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryRestoredEvent;
+use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryTranslationAddedEvent;
+use Sulu\Bundle\CategoryBundle\Entity\Category;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\CategoryIndexListener;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[CoversClass(CategoryIndexListener::class)]
+class CategoryIndexListenerTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<MessageBusInterface>
+     */
+    private ObjectProphecy $messageBus;
+    private CategoryIndexListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->messageBus = $this->prophesize(MessageBusInterface::class);
+        $this->listener = new CategoryIndexListener($this->messageBus->reveal());
+    }
+
+    public function testOnCategoryChangedWithCategoryCreatedEvent(): void
+    {
+        $category = new Category();
+        $category->setId(123);
+        $event = new CategoryCreatedEvent($category, 'en', []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::123::en']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onCategoryChanged($event);
+    }
+
+    public function testOnCategoryChangedWithCategoryModifiedEvent(): void
+    {
+        $category = new Category();
+        $category->setId(456);
+        $event = new CategoryModifiedEvent($category, 'en', []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::456::en']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onCategoryChanged($event);
+    }
+
+    public function testOnCategoryChangedWithCategoryRemovedEvent(): void
+    {
+        $category = new Category();
+        $category->setId(789);
+        $event = new CategoryRemovedEvent($category->getId(), 'Uncool category', 'en', ['en', 'de']);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::789::en', CategoryInterface::RESOURCE_KEY . '::789::de']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onCategoryChanged($event);
+    }
+
+    public function testOnCategoryChangedWithCategoryTranslationAddedEvent(): void
+    {
+        $category = new Category();
+        $category->setId(111);
+        $category->setDefaultLocale('en');
+        $event = new CategoryTranslationAddedEvent($category, 'de', []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::111::de']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onCategoryChanged($event);
+    }
+
+    public function testOnCategoryChangedWithCategoryRestoredEvent(): void
+    {
+        $category = new Category();
+        $category->setId(111);
+        $category->setDefaultLocale('en');
+        $categoryTranslation = new CategoryTranslation();
+        $categoryTranslation->setLocale('en');
+        $category->addTranslation($categoryTranslation);
+        $event = new CategoryRestoredEvent($category, []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::111::en']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onCategoryChanged($event);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7672
| License | MIT

#### What's in this PR?

Added ReindexProvider and IndexListener for Categories for SEAL.

#### Why?

Because MassiveSearchBundle was removed