### PR TITLE
Prepare extendability for SEO and Excerpt Content Tab

### DIFF
--- a/packages/content/config/forms/content_excerpt.xml
+++ b/packages/content/config/forms/content_excerpt.xml
@@ -6,43 +6,43 @@
     <key>content_excerpt</key>
 
     <properties>
-        <property name="excerptTitle" type="text_line">
+        <property name="excerpt/title" type="text_line">
             <meta>
                 <title>sulu_admin.title</title>
             </meta>
         </property>
 
-        <property name="excerptMore" type="text_line">
+        <property name="excerpt/more" type="text_line">
             <meta>
                 <title>sulu_page.text_for_more_link</title>
             </meta>
         </property>
 
-        <property name="excerptDescription" type="text_editor">
+        <property name="excerpt/description" type="text_editor">
             <meta>
                 <title>sulu_admin.description</title>
             </meta>
         </property>
 
-        <property name="excerptCategories" type="category_selection">
+        <property name="excerpt/categories" type="category_selection">
             <meta>
                 <title>sulu_category.categories</title>
             </meta>
         </property>
 
-        <property name="excerptTags" type="tag_selection">
+        <property name="excerpt/tags" type="tag_selection">
             <meta>
                 <title>sulu_tag.tags</title>
             </meta>
         </property>
 
-        <property name="excerptIcon" type="single_media_selection">
+        <property name="excerpt/icon" type="single_media_selection">
             <meta>
                 <title>sulu_page.icons</title>
             </meta>
         </property>
 
-        <property name="excerptImage" type="single_media_selection">
+        <property name="excerpt/image" type="single_media_selection">
             <meta>
                 <title>sulu_page.images</title>
             </meta>

--- a/packages/content/config/forms/content_seo.xml
+++ b/packages/content/config/forms/content_seo.xml
@@ -12,7 +12,7 @@
             </meta>
         </property>
 
-        <property name="seoTitle" type="text_line">
+        <property name="seo/title" type="text_line">
             <meta>
                 <title>sulu_page.meta_title</title>
                 <info_text>sulu_page.meta_title_info_text</info_text>
@@ -23,7 +23,7 @@
             </params>
         </property>
 
-        <property name="seoDescription" type="text_area">
+        <property name="seo/description" type="text_area">
             <meta>
                 <title>sulu_page.meta_description</title>
                 <info_text>sulu_page.meta_description_info_text</info_text>
@@ -34,7 +34,7 @@
             </params>
         </property>
 
-        <property name="seoKeywords" type="text_line">
+        <property name="seo/keywords" type="text_line">
             <meta>
                 <title>sulu_page.meta_keywords</title>
                 <info_text>sulu_page.meta_keywords_info_text</info_text>
@@ -46,13 +46,13 @@
             </params>
         </property>
 
-        <property name="seoCanonicalUrl" type="text_line">
+        <property name="seo/canonicalUrl" type="text_line">
             <meta>
                 <title>sulu_page.canonical_url</title>
             </meta>
         </property>
 
-        <property name="seoNoIndex" type="checkbox">
+        <property name="seo/noIndex" type="checkbox">
             <params>
                 <param name="label">
                     <meta>
@@ -64,7 +64,7 @@
             </params>
         </property>
 
-        <property name="seoNoFollow" type="checkbox">
+        <property name="seo/noFollow" type="checkbox">
             <params>
                 <param name="label">
                     <meta>
@@ -76,7 +76,7 @@
             </params>
         </property>
 
-        <property name="seoHideInSitemap" type="checkbox">
+        <property name="seo/hideInSitemap" type="checkbox">
             <params>
                 <param name="label">
                     <meta>

--- a/packages/content/src/Domain/Model/ExcerptInterface.php
+++ b/packages/content/src/Domain/Model/ExcerptInterface.php
@@ -18,17 +18,15 @@ use Sulu\Bundle\TagBundle\Tag\TagInterface;
 
 interface ExcerptInterface
 {
-    public function getExcerptTitle(): ?string;
+    /**
+     * @return array<string, mixed>
+     */
+    public function getExcerptData(): array;
 
-    public function setExcerptTitle(?string $excerptTitle): void;
-
-    public function getExcerptMore(): ?string;
-
-    public function setExcerptMore(?string $excerptMore): void;
-
-    public function getExcerptDescription(): ?string;
-
-    public function setExcerptDescription(?string $excerptDescription): void;
+    /**
+     * @param array<string, mixed> $excerptData
+     */
+    public function setExcerptData(array $excerptData): void;
 
     /**
      * @return CategoryInterface[]
@@ -59,24 +57,4 @@ interface ExcerptInterface
      * @param TagInterface[] $excerptTags
      */
     public function setExcerptTags(array $excerptTags): void;
-
-    /**
-     * @return array{id: int}|null
-     */
-    public function getExcerptImage(): ?array;
-
-    /**
-     * @param array{id?: int}|null $excerptImage
-     */
-    public function setExcerptImage(?array $excerptImage): void;
-
-    /**
-     * @return array{id: int}|null
-     */
-    public function getExcerptIcon(): ?array;
-
-    /**
-     * @param array{id?: int}|null $excerptIcon
-     */
-    public function setExcerptIcon(?array $excerptIcon): void;
 }

--- a/packages/content/src/Domain/Model/ExcerptTrait.php
+++ b/packages/content/src/Domain/Model/ExcerptTrait.php
@@ -20,19 +20,9 @@ use Sulu\Bundle\TagBundle\Tag\TagInterface;
 trait ExcerptTrait
 {
     /**
-     * @var string|null
+     * @var array<string, mixed>
      */
-    private $excerptTitle;
-
-    /**
-     * @var string|null
-     */
-    private $excerptDescription;
-
-    /**
-     * @var string|null
-     */
-    private $excerptMore;
+    private $excerptData = [];
 
     /**
      * @var ArrayCollection<int, CategoryInterface>
@@ -44,44 +34,17 @@ trait ExcerptTrait
      */
     private $excerptTags;
 
+    public function getExcerptData(): array
+    {
+        return $this->excerptData;
+    }
+
     /**
-     * @var int|null
+     * @param array<string, mixed> $excerptData
      */
-    private $excerptImageId;
-
-    /**
-     * @var int|null
-     */
-    private $excerptIconId;
-
-    public function getExcerptTitle(): ?string
+    public function setExcerptData(array $excerptData): void
     {
-        return $this->excerptTitle;
-    }
-
-    public function setExcerptTitle(?string $excerptTitle): void
-    {
-        $this->excerptTitle = $excerptTitle;
-    }
-
-    public function getExcerptDescription(): ?string
-    {
-        return $this->excerptDescription;
-    }
-
-    public function setExcerptDescription(?string $excerptDescription): void
-    {
-        $this->excerptDescription = $excerptDescription;
-    }
-
-    public function getExcerptMore(): ?string
-    {
-        return $this->excerptMore;
-    }
-
-    public function setExcerptMore(?string $excerptMore): void
-    {
-        $this->excerptMore = $excerptMore;
+        $this->excerptData = $excerptData;
     }
 
     /**
@@ -156,50 +119,6 @@ trait ExcerptTrait
         foreach ($excerptTags as $excerptTag) {
             $this->excerptTags->add($excerptTag);
         }
-    }
-
-    /**
-     * @return array{id: int}|null
-     */
-    public function getExcerptImage(): ?array
-    {
-        if (!$this->excerptImageId) {
-            return null;
-        }
-
-        return [
-            'id' => $this->excerptImageId,
-        ];
-    }
-
-    /**
-     * @param array{id?: int}|null $excerptImage
-     */
-    public function setExcerptImage(?array $excerptImage): void
-    {
-        $this->excerptImageId = $excerptImage['id'] ?? null;
-    }
-
-    /**
-     * @return array{id: int}|null
-     */
-    public function getExcerptIcon(): ?array
-    {
-        if (!$this->excerptIconId) {
-            return null;
-        }
-
-        return [
-            'id' => $this->excerptIconId,
-        ];
-    }
-
-    /**
-     * @param array{id?: int}|null $excerptIcon
-     */
-    public function setExcerptIcon(?array $excerptIcon): void
-    {
-        $this->excerptIconId = $excerptIcon['id'] ?? null;
     }
 
     private function initializeTags(): void

--- a/packages/content/src/Domain/Model/SeoInterface.php
+++ b/packages/content/src/Domain/Model/SeoInterface.php
@@ -15,21 +15,15 @@ namespace Sulu\Content\Domain\Model;
 
 interface SeoInterface
 {
-    public function getSeoTitle(): ?string;
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSeoData(): array;
 
-    public function setSeoTitle(?string $seoTitle): void;
-
-    public function getSeoDescription(): ?string;
-
-    public function setSeoDescription(?string $seoDescription): void;
-
-    public function getSeoKeywords(): ?string;
-
-    public function setSeoKeywords(?string $seoKeywords): void;
-
-    public function getSeoCanonicalUrl(): ?string;
-
-    public function setSeoCanonicalUrl(?string $seoCanonicalUrl): void;
+    /**
+     * @param array<string, mixed> $seoData
+     */
+    public function setSeoData(array $seoData): void;
 
     public function getSeoNoIndex(): bool;
 

--- a/packages/content/src/Domain/Model/SeoTrait.php
+++ b/packages/content/src/Domain/Model/SeoTrait.php
@@ -16,24 +16,9 @@ namespace Sulu\Content\Domain\Model;
 trait SeoTrait
 {
     /**
-     * @var string|null
+     * @var array<string, mixed>
      */
-    private $seoTitle;
-
-    /**
-     * @var string|null
-     */
-    private $seoDescription;
-
-    /**
-     * @var string|null
-     */
-    private $seoKeywords;
-
-    /**
-     * @var string|null
-     */
-    private $seoCanonicalUrl;
+    private $seoData = [];
 
     /**
      * @var bool
@@ -50,44 +35,17 @@ trait SeoTrait
      */
     private $seoHideInSitemap = false;
 
-    public function getSeoTitle(): ?string
+    public function getSeoData(): array
     {
-        return $this->seoTitle;
+        return $this->seoData;
     }
 
-    public function setSeoTitle(?string $seoTitle): void
+    /**
+     * @param array<string, mixed> $seoData
+     */
+    public function setSeoData(array $seoData): void
     {
-        $this->seoTitle = $seoTitle;
-    }
-
-    public function getSeoDescription(): ?string
-    {
-        return $this->seoDescription;
-    }
-
-    public function setSeoDescription(?string $seoDescription): void
-    {
-        $this->seoDescription = $seoDescription;
-    }
-
-    public function getSeoKeywords(): ?string
-    {
-        return $this->seoKeywords;
-    }
-
-    public function setSeoKeywords(?string $seoKeywords): void
-    {
-        $this->seoKeywords = $seoKeywords;
-    }
-
-    public function getSeoCanonicalUrl(): ?string
-    {
-        return $this->seoCanonicalUrl;
-    }
-
-    public function setSeoCanonicalUrl(?string $seoCanonicalUrl): void
-    {
-        $this->seoCanonicalUrl = $seoCanonicalUrl;
+        $this->seoData = $seoData;
     }
 
     public function getSeoNoIndex(): bool


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Prepare extendability for SEO and Excerpt Content Tab. This is a draft introduce the concept.

#### Why?

In 2.6 the excerpt was easy to extend via XML we require same and should also make SEO tab extendable.

Adding new field to SEO and Excerpt should be as easy as creating just a new `content_excerpt.xml` with:

```xml
<?xml version="1.0" ?>
<form xmlns="http://schemas.sulu.io/template/template"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
>
    <key>content_excerpt</key>

    <properties>
        <property name="excerpt/custom" type="text_line">
            <meta>
                <title>sulu_admin.custom</title>
            </meta>
        </property>
    </properties>
</form>
```