### PR TITLE
Add support of refresh URL of child pages

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Content/Normalizer/PageNormalizer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/Normalizer/PageNormalizer.php
@@ -32,6 +32,7 @@ class PageNormalizer implements NormalizerInterface
         $page = $object->getResource();
 
         $normalizedData['webspace'] = $page->getWebspaceKey();
+        $normalizedData['parentUuid'] = $page->getParent()?->getUuid();
 
         return $normalizedData;
     }

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -147,7 +147,7 @@ class PageControllerTest extends SuluTestCase
         self::purgeDatabase();
 
         $targetGroupIds = $this->createTargetGroups();
-        $homepage = $this->createHomepage('123-123-123', 'sulu-io');
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
 
         $excerptData = [
             'excerptTitle' => 'Excerpt Title',
@@ -328,7 +328,7 @@ class PageControllerTest extends SuluTestCase
         self::purgeDatabase();
 
         $targetGroupIds = $this->createTargetGroups();
-        $homepage = $this->createHomepage('123-123-123', 'sulu-io');
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
 
         $excerptData = [
             'excerptTitle' => 'Excerpt Title',
@@ -387,7 +387,7 @@ class PageControllerTest extends SuluTestCase
     public function testPostPublishBlogWebspace(): void
     {
         $targetGroupIds = $this->createTargetGroups();
-        $homepage = $this->createHomepage('321-321-321', 'blog');
+        $homepage = $this->createHomepage('0199ee13-6eae-7e0e-b559-ed579da52916', 'blog');
 
         $excerptData = [
             'excerptTitle' => 'Excerpt Title',
@@ -637,7 +637,7 @@ class PageControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', '123-123-123'),
+            \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', '0199ee04-c220-784e-a6fa-ac985870f2d5'),
             [],
             [],
             [],
@@ -690,7 +690,7 @@ class PageControllerTest extends SuluTestCase
     #[Depends('testCopy')]
     public function testMove(string $id): void
     {
-        $this->client->request('POST', '/admin/api/pages/' . $id . '?locale=en&action=move&destination=123-123-123');
+        $this->client->request('POST', '/admin/api/pages/' . $id . '?locale=en&action=move&destination=0199ee04-c220-784e-a6fa-ac985870f2d5');
 
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('page_post_move.json', $response);

--- a/packages/page/tests/Functional/Integration/responses/page_cget.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget.json
@@ -1,7 +1,7 @@
 {
     "_embedded" : {
         "pages" : [ {
-            "id" : "123-123-123",
+            "id" : "0199ee04-c220-784e-a6fa-ac985870f2d5",
             "title" : null,
             "author" : null,
             "created" : null,

--- a/packages/page/tests/Functional/Integration/responses/page_cget_after_copy.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget_after_copy.json
@@ -2,7 +2,7 @@
     "_embedded": {
         "pages": [
             {
-                "id": "123-123-123",
+                "id": "0199ee04-c220-784e-a6fa-ac985870f2d5",
                 "version": null,
                 "title": null,
                 "author": null,

--- a/packages/page/tests/Functional/Integration/responses/page_cget_after_move.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget_after_move.json
@@ -2,7 +2,7 @@
     "_embedded": {
         "pages": [
             {
-                "id": "123-123-123",
+                "id": "0199ee04-c220-784e-a6fa-ac985870f2d5",
                 "title": null,
                 "author": null,
                 "created" : null,

--- a/packages/page/tests/Functional/Integration/responses/page_cget_exclude_ghost_shadow.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget_exclude_ghost_shadow.json
@@ -2,7 +2,7 @@
     "_embedded": {
         "pages": [
             {
-                "id": "123-123-123",
+                "id": "0199ee04-c220-784e-a6fa-ac985870f2d5",
                 "version" : null,
                 "title": null,
                 "author": null,

--- a/packages/page/tests/Functional/Integration/responses/page_cget_ghost_shadow.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget_ghost_shadow.json
@@ -2,7 +2,7 @@
     "_embedded": {
         "pages": [
             {
-                "id": "123-123-123",
+                "id": "0199ee04-c220-784e-a6fa-ac985870f2d5",
                 "version" : null,
                 "title": null,
                 "author": null,

--- a/packages/page/tests/Functional/Integration/responses/page_get.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get.json
@@ -36,6 +36,7 @@
     "lastModifiedEnabled": true,
     "locale": "en",
     "navigationContexts": [],
+    "parentUuid" : "@uuid@",
     "published": null,
     "publishedState": false,
     "seoCanonicalUrl": "https://sulu.io/",

--- a/packages/page/tests/Functional/Integration/responses/page_get_after_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get_after_restore.json
@@ -24,6 +24,7 @@
     "lastModifiedEnabled" : true,
     "locale" : "en",
     "navigationContexts" : [ "main" ],
+    "parentUuid" : "@uuid@",
     "published" : "@dateTime@",
     "publishedState" : false,
     "seoCanonicalUrl" : "https://sulu.io/",

--- a/packages/page/tests/Functional/Integration/responses/page_get_ghost_locale.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get_ghost_locale.json
@@ -22,6 +22,7 @@
     "lastModifiedEnabled": false,
     "locale": null,
     "navigationContexts": [],
+    "parentUuid" : "@uuid@",
     "published": null,
     "publishedState": false,
     "seoCanonicalUrl": null,

--- a/packages/page/tests/Functional/Integration/responses/page_post.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post.json
@@ -36,6 +36,7 @@
     "lastModifiedEnabled": true,
     "locale": "en",
     "navigationContexts": [],
+    "parentUuid" : "@uuid@",
     "published": null,
     "publishedState": false,
     "seoCanonicalUrl": "https://sulu.io/",

--- a/packages/page/tests/Functional/Integration/responses/page_post_copy.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_copy.json
@@ -24,6 +24,7 @@
     "lastModifiedEnabled" : true,
     "locale" : "en",
     "navigationContexts" : [ "main" ],
+    "parentUuid" : "@uuid@",
     "published" : null,
     "publishedState" : false,
     "seoCanonicalUrl" : "https://sulu.io/",

--- a/packages/page/tests/Functional/Integration/responses/page_post_move.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_move.json
@@ -24,6 +24,7 @@
     "lastModifiedEnabled" : true,
     "locale" : "en",
     "navigationContexts" : [ "main" ],
+    "parentUuid" : "@uuid@",
     "published" : null,
     "publishedState" : false,
     "seoCanonicalUrl" : "https://sulu.io/",

--- a/packages/page/tests/Functional/Integration/responses/page_post_order.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_order.json
@@ -28,6 +28,7 @@
     "lastModifiedEnabled": false,
     "locale": "en",
     "navigationContexts": [],
+    "parentUuid" : "@uuid@",
     "published": null,
     "publishedState": false,
     "seoCanonicalUrl": null,

--- a/packages/page/tests/Functional/Integration/responses/page_post_publish.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_publish.json
@@ -37,6 +37,7 @@
     "locale": "en",
     "navigationContexts": ["main"],
     "published": "@string@.isDateTime()",
+    "parentUuid": "@uuid@",
     "publishedState": true,
     "seoCanonicalUrl": "https://sulu.io/",
     "seoDescription": "Seo Description",

--- a/packages/page/tests/Functional/Integration/responses/page_post_publish_blog.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_publish_blog.json
@@ -36,6 +36,7 @@
     "lastModifiedEnabled": true,
     "locale": "en",
     "navigationContexts": ["main"],
+    "parentUuid" : "@uuid@",
     "published": "@datetime@",
     "publishedState": true,
     "seoCanonicalUrl": "https://sulu.io/",

--- a/packages/page/tests/Functional/Integration/responses/page_post_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_restore.json
@@ -32,6 +32,7 @@
     "lastModifiedEnabled": true,
     "locale": "en",
     "navigationContexts": [],
+    "parentUuid" : "@uuid@",
     "published": null,
     "publishedState": false,
     "seoCanonicalUrl": "https://sulu.io/2",

--- a/packages/page/tests/Functional/Integration/responses/page_post_trigger_copy_locale.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_trigger_copy_locale.json
@@ -38,6 +38,7 @@
     "lastModifiedEnabled": true,
     "locale": "de",
     "navigationContexts": [],
+    "parentUuid" : "@uuid@",
     "published": null,
     "publishedState": false,
     "seoCanonicalUrl": "https://sulu.io/",

--- a/packages/page/tests/Functional/Integration/responses/page_post_trigger_unpublish.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_trigger_unpublish.json
@@ -33,6 +33,7 @@
     "lastModifiedEnabled": true,
     "locale": "en",
     "navigationContexts": ["main"],
+    "parentUuid" : "@uuid@",
     "published": null,
     "publishedState": false,
     "seoCanonicalUrl": "https:\/\/sulu.io\/",

--- a/packages/page/tests/Functional/Integration/responses/page_put.json
+++ b/packages/page/tests/Functional/Integration/responses/page_put.json
@@ -38,6 +38,7 @@
     "lastModifiedEnabled": true,
     "locale": "en",
     "navigationContexts": [],
+    "parentUuid" : "@uuid@",
     "published": null,
     "publishedState": false,
     "seoCanonicalUrl": "https://sulu.io/2",

--- a/packages/route/assets/js/index.js
+++ b/packages/route/assets/js/index.js
@@ -25,6 +25,10 @@ initializer.addUpdateConfigHook('sulu_route', (config: Object, initialized: bool
 
                 return Promise.resolve(mode);
             },
+            resourceStorePropertiesToRequest: { // maybe move to schemaOptions and prepend via MetadataListener
+                parentUuid: 'parentId',
+                parentId: 'parentId',
+            },
             generationUrl: config.generateUrl,
             options: {history: true},
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #7672
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add support of refresh URL of child pages.

#### Why?

The resource locator endpoint requires to the uuid of the parent to support refresh, that is handled via `resourceStorePropertiesToRequest`. 