### PR TITLE
Add block settings resolving

### DIFF
--- a/packages/content/config/forms/content_block_settings.xml
+++ b/packages/content/config/forms/content_block_settings.xml
@@ -10,13 +10,13 @@
             <params>
                 <param name="description">
                     <meta>
-                        <title>sulu_page.hide_block_description</title>
+                        <title>sulu_content.hide_block_description</title>
                     </meta>
                 </param>
                 <param name="icon" value="su-hide" />
                 <param name="label">
                     <meta>
-                        <title>sulu_page.hide_block_label</title>
+                        <title>sulu_content.hide_block_label</title>
                     </meta>
                 </param>
                 <param name="skin" value="heading" />
@@ -32,13 +32,13 @@
                     <params>
                         <param name="description">
                             <meta>
-                                <title>sulu_page.schedules_description</title>
+                                <title>sulu_content.schedules_description</title>
                             </meta>
                         </param>
                         <param name="icon" value="su-clock" />
                         <param name="label">
                             <meta>
-                                <title>sulu_page.schedules_label</title>
+                                <title>sulu_content.schedules_label</title>
                             </meta>
                         </param>
                         <param name="skin" value="heading" />
@@ -52,7 +52,7 @@
                     <params>
                         <param name="add_button_text">
                             <meta>
-                                <title>sulu_page.add_schedule</title>
+                                <title>sulu_content.add_schedule</title>
                             </meta>
                         </param>
                         <param name="collapsable" value="false" />

--- a/packages/content/config/forms/content_block_settings.xml
+++ b/packages/content/config/forms/content_block_settings.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
 >
-    <key>page_block_settings</key>
+    <key>content_block_settings</key>
 
     <properties>
         <property name="hidden" type="checkbox">
@@ -151,70 +151,6 @@
                         </type>
                     </types>
                 </block>
-            </properties>
-        </section>
-
-        <section name="segments" visibleCondition="__webspace ? __webspace.segments|length &gt; 0 : true">
-            <properties>
-                <property
-                    name="segment_enabled"
-                    type="checkbox"
-                    visibleCondition="__webspace ? __webspace.segments|length &gt; 0 : true"
-                >
-                    <params>
-                        <param name="description">
-                            <meta>
-                                <title>sulu_page.segment_description</title>
-                            </meta>
-                        </param>
-                        <param name="icon" value="su-focus" />
-                        <param name="label">
-                            <meta>
-                                <title>sulu_page.segment_label</title>
-                            </meta>
-                        </param>
-                        <param name="skin" value="heading" />
-                        <param name="type" value="toggler" />
-                    </params>
-
-                    <tag name="sulu.block_setting_icon" icon="su-focus" />
-                </property>
-
-                <property name="segments" type="segment_select" visibleCondition="segment_enabled == true" />
-            </properties>
-        </section>
-
-        <section name="target_groups" visibleCondition="__bundles|includes('sulu_audience_targeting')">
-            <properties>
-                <property
-                    name="target_groups_enabled"
-                    type="checkbox"
-                    visibleCondition="__bundles|includes('sulu_audience_targeting')"
-                >
-                    <params>
-                        <param name="description">
-                            <meta>
-                                <title>sulu_page.target_groups_description</title>
-                            </meta>
-                        </param>
-                        <param name="icon" value="su-user" />
-                        <param name="label">
-                            <meta>
-                                <title>sulu_page.target_groups_label</title>
-                            </meta>
-                        </param>
-                        <param name="skin" value="heading" />
-                        <param name="type" value="toggler" />
-                    </params>
-
-                    <tag name="sulu.block_setting_icon" icon="su-user" />
-                </property>
-
-                <property
-                    name="target_groups"
-                    type="target_group_selection"
-                    visibleCondition="target_groups_enabled == true"
-                />
             </properties>
         </section>
     </properties>

--- a/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
@@ -112,22 +112,16 @@ class BlockPropertyResolver implements PropertyResolverMetadataAwareInterface
                 $formMetadata = $globalBlocksMetadata[$globalBlockType];
             }
 
-            // Resolve block content fields
             $resolvedBlock = \array_merge(
                 ['type' => $type],
                 $this->metadataResolver->resolveItems($formMetadata->getItems(), $block, $locale)
             );
 
-            // Resolve block settings if present
             $settingsFormKeyOption = $metadata->findOption('settings_form_key');
             if ($settingsFormKeyOption) {
                 $settingsFormKey = $settingsFormKeyOption->getValue();
                 if (\is_string($settingsFormKey) && isset($block['settings'])) {
-                    $resolvedBlock['settings'] = $this->resolveBlockSettings(
-                        $block,
-                        $settingsFormKey,
-                        $locale
-                    );
+                    $resolvedBlock['settings'] = $this->resolveBlockSettings($block, $settingsFormKey, $locale);
                 }
             }
 
@@ -156,36 +150,25 @@ class BlockPropertyResolver implements PropertyResolverMetadataAwareInterface
 
     /**
      * @param array<string, mixed> $block
-     *
-     * @return array<mixed>
      */
-    private function resolveBlockSettings(array $block, string $settingsFormKey, string $locale): array
+    private function resolveBlockSettings(array $block, string $settingsFormKey, string $locale): ContentView
     {
-        // Check if block has settings
         if (!isset($block['settings']) || !\is_array($block['settings'])) {
-            return [];
+            return ContentView::create([], []);
         }
 
         $settingsData = $block['settings'];
-
-        // Load the settings form metadata using the form key from options
-        $typedFormMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')
+        $formMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')
             ->getMetadata($settingsFormKey, $locale, []);
 
-        if (!$typedFormMetadata instanceof TypedFormMetadata) {
-            // Return unresolved settings if metadata is missing
-            return $settingsData;
-        }
-
-        $formMetadata = $typedFormMetadata->getForms()['default'] ?? null;
-
         if (!$formMetadata instanceof FormMetadata) {
-            // Return unresolved settings if form metadata is missing
-            return $settingsData;
+            return ContentView::create($settingsData, []);
         }
 
-        // Resolve the settings using the metadata
-        return $this->metadataResolver->resolveItems($formMetadata->getItems(), $settingsData, $locale);
+        return ContentView::create(
+            $this->metadataResolver->resolveItems($formMetadata->getItems(), $settingsData, $locale),
+            []
+        );
     }
 
     public static function getType(): string

--- a/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/BlockPropertyResolver.php
@@ -112,15 +112,26 @@ class BlockPropertyResolver implements PropertyResolverMetadataAwareInterface
                 $formMetadata = $globalBlocksMetadata[$globalBlockType];
             }
 
-            $contentViews[$key] = ContentView::create(
-                \array_merge(
-                    ['type' => $type],
-                    $this->metadataResolver->resolveItems($formMetadata->getItems(), $block, $locale)
-                ),
-                [
-                    ...$returnedParams,
-                ]
+            // Resolve block content fields
+            $resolvedBlock = \array_merge(
+                ['type' => $type],
+                $this->metadataResolver->resolveItems($formMetadata->getItems(), $block, $locale)
             );
+
+            // Resolve block settings if present
+            $settingsFormKeyOption = $metadata->findOption('settings_form_key');
+            if ($settingsFormKeyOption) {
+                $settingsFormKey = $settingsFormKeyOption->getValue();
+                if (\is_string($settingsFormKey) && isset($block['settings'])) {
+                    $resolvedBlock['settings'] = $this->resolveBlockSettings(
+                        $block,
+                        $settingsFormKey,
+                        $locale
+                    );
+                }
+            }
+
+            $contentViews[$key] = ContentView::create($resolvedBlock, [...$returnedParams]);
         }
 
         $minOccurs = $metadata->getMinOccurs();
@@ -141,6 +152,40 @@ class BlockPropertyResolver implements PropertyResolverMetadataAwareInterface
         $result = $tag?->getAttribute('global_block');
 
         return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     *
+     * @return array<mixed>
+     */
+    private function resolveBlockSettings(array $block, string $settingsFormKey, string $locale): array
+    {
+        // Check if block has settings
+        if (!isset($block['settings']) || !\is_array($block['settings'])) {
+            return [];
+        }
+
+        $settingsData = $block['settings'];
+
+        // Load the settings form metadata using the form key from options
+        $typedFormMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')
+            ->getMetadata($settingsFormKey, $locale, []);
+
+        if (!$typedFormMetadata instanceof TypedFormMetadata) {
+            // Return unresolved settings if metadata is missing
+            return $settingsData;
+        }
+
+        $formMetadata = $typedFormMetadata->getForms()['default'] ?? null;
+
+        if (!$formMetadata instanceof FormMetadata) {
+            // Return unresolved settings if form metadata is missing
+            return $settingsData;
+        }
+
+        // Resolve the settings using the metadata
+        return $this->metadataResolver->resolveItems($formMetadata->getItems(), $settingsData, $locale);
     }
 
     public static function getType(): string

--- a/packages/content/tests/Application/config/config_admin.yml
+++ b/packages/content/tests/Application/config/config_admin.yml
@@ -9,3 +9,8 @@ services:
         class: Sulu\Content\Tests\Application\PreviewKernelFactory
         arguments:
             - '%kernel.environment%'
+
+sulu_admin:
+    forms:
+        directories:
+            - '%kernel.project_dir%/config/forms'

--- a/packages/content/tests/Application/config/forms/custom_block_settings.xml
+++ b/packages/content/tests/Application/config/forms/custom_block_settings.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>custom_block_settings</key>
+
+    <properties>
+        <property name="hidden" type="checkbox">
+            <params>
+                <param name="description">
+                    <meta>
+                        <title>Hide this block</title>
+                    </meta>
+                </param>
+                <param name="icon" value="su-hide" />
+                <param name="label">
+                    <meta>
+                        <title>Hidden</title>
+                    </meta>
+                </param>
+                <param name="skin" value="heading" />
+                <param name="type" value="toggler" />
+            </params>
+
+            <tag name="sulu.block_setting_icon" icon="su-hide" />
+        </property>
+
+        <property name="custom_note" type="text_line">
+            <meta>
+                <title>Custom Note</title>
+            </meta>
+        </property>
+
+        <property name="examples" type="example_selection">
+            <meta>
+                <title>Related Examples</title>
+            </meta>
+        </property>
+    </properties>
+</form>

--- a/packages/content/tests/Application/config/templates/examples/blocks-with-custom-settings.xml
+++ b/packages/content/tests/Application/config/templates/examples/blocks-with-custom-settings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>blocks-with-custom-settings</key>
+
+    <view>@ExampleTest/examples/default</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+
+    <meta>
+        <title lang="en">Custom Settings Template</title>
+        <title lang="de">Template mit benutzerdefinierten Einstellungen</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="title"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <block name="blocks_with_custom_settings_form_key" default-type="editor" minOccurs="0">
+            <meta>
+                <title lang="en">Content with Custom Settings</title>
+                <title lang="de">Inhalte mit benutzerdefinierten Einstellungen</title>
+            </meta>
+
+            <params>
+                <param name="settings_form_key" value="custom_block_settings" />
+            </params>
+
+            <types>
+                <type name="editor">
+                    <meta>
+                        <title lang="en">Editor</title>
+                        <title lang="de">Editor</title>
+                    </meta>
+                    <properties>
+                        <property name="text_editor" type="text_editor">
+                            <meta>
+                                <title lang="en">Text Editor</title>
+                                <title lang="de">Texteditor</title>
+                            </meta>
+                        </property>
+                    </properties>
+                </type>
+            </types>
+        </block>
+    </properties>
+</template>

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -809,11 +809,11 @@ class ContentResolverTest extends SuluTestCase
         self::assertIsArray($settings['schedules']);
         self::assertCount(1, $settings['schedules']);
 
-        /** @var array<string, mixed> $schedule */
+        /** @var array{type: string, start: \DateTimeInterface, end: \DateTimeInterface} $schedule */
         $schedule = $settings['schedules'][0];
         self::assertSame('fixed', $schedule['type']);
-        self::assertSame('2025-09-17T00:00:00', $schedule['start']);
-        self::assertSame('2025-09-25T00:00:00', $schedule['end']);
+        self::assertSame((new \DateTimeImmutable('2025-09-17T00:00:00'))->getTimestamp(), $schedule['start']->getTimestamp());
+        self::assertSame((new \DateTimeImmutable('2025-09-25T00:00:00'))->getTimestamp(), $schedule['end']->getTimestamp());
 
         self::assertNull($settings['segment_enabled']);
         self::assertNull($settings['segments']);
@@ -825,6 +825,111 @@ class ContentResolverTest extends SuluTestCase
         $blockWithoutSettings = $blocks[1];
         self::assertSame('editor', $blockWithoutSettings['type']);
         self::assertSame('<p>Editor block without settings</p>', $blockWithoutSettings['text_editor']);
+        self::assertArrayNotHasKey('settings', $blockWithoutSettings);
+    }
+
+    public function testResolveContentBlocksWithCustomSettings(): void
+    {
+        $example1 = static::createExample(
+            [
+                'en' => [
+                    'live' => [
+                        'template' => 'default',
+                        'title' => 'Referenced Example 1',
+                        'url' => '/referenced-example-1',
+                        'description' => 'This example will be referenced in block settings',
+                    ],
+                ],
+            ]
+        );
+
+        $example2 = static::createExample(
+            [
+                'en' => [
+                    'live' => [
+                        'template' => 'default',
+                        'title' => 'Referenced Example 2',
+                        'url' => '/referenced-example-2',
+                        'description' => 'Another example for multi-selection testing',
+                    ],
+                ],
+            ]
+        );
+
+        static::getEntityManager()->flush();
+
+        $exampleWithCustomSettings = static::createExample(
+            [
+                'en' => [
+                    'live' => [
+                        'template' => 'blocks-with-custom-settings',
+                        'title' => 'Content with Custom Block Settings',
+                        'url' => '/custom-settings-test',
+                        'blocks_with_custom_settings_form_key' => [
+                            [
+                                'type' => 'editor',
+                                'text_editor' => '<p>Block with custom settings and entity references</p>',
+                                'settings' => [
+                                    'hidden' => false,
+                                    'custom_note' => 'This is a test note',
+                                    'examples' => [$example1->getId(), $example2->getId()],
+                                ],
+                            ],
+                            [
+                                'type' => 'editor',
+                                'text_editor' => '<p>Block without any settings</p>',
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($exampleWithCustomSettings, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        $content = $result['content'];
+
+        self::assertArrayHasKey('blocks_with_custom_settings_form_key', $content);
+        $blocks = $content['blocks_with_custom_settings_form_key'];
+        self::assertIsArray($blocks);
+        self::assertCount(2, $blocks);
+
+        // Test first block with custom settings
+        /** @var array<string, mixed> $blockWithCustomSettings */
+        $blockWithCustomSettings = $blocks[0];
+        self::assertSame('editor', $blockWithCustomSettings['type']);
+        self::assertSame('<p>Block with custom settings and entity references</p>', $blockWithCustomSettings['text_editor']);
+
+        self::assertArrayHasKey('settings', $blockWithCustomSettings);
+        $settings = $blockWithCustomSettings['settings'];
+        self::assertIsArray($settings);
+
+        self::assertFalse($settings['hidden']);
+        self::assertSame('This is a test note', $settings['custom_note']);
+
+        self::assertArrayHasKey('examples', $settings);
+        $examples = $settings['examples'];
+        self::assertIsArray($examples);
+        self::assertCount(2, $examples);
+
+        /** @var array<string, mixed> $resolvedExample1 */
+        $resolvedExample1 = $examples[0];
+        self::assertSame('Referenced Example 1', $resolvedExample1['title']);
+        self::assertSame('This example will be referenced in block settings', $resolvedExample1['description']);
+
+        /** @var array<string, mixed> $resolvedExample2 */
+        $resolvedExample2 = $examples[1];
+        self::assertSame('Referenced Example 2', $resolvedExample2['title']);
+        self::assertSame('Another example for multi-selection testing', $resolvedExample2['description']);
+
+        // Test second block without settings
+        /** @var array<string, mixed> $blockWithoutSettings */
+        $blockWithoutSettings = $blocks[1];
+        self::assertSame('editor', $blockWithoutSettings['type']);
+        self::assertSame('<p>Block without any settings</p>', $blockWithoutSettings['text_editor']);
         self::assertArrayNotHasKey('settings', $blockWithoutSettings);
     }
 

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -738,6 +738,96 @@ class ContentResolverTest extends SuluTestCase
         self::assertNull($viewViewBlock2['media']['displayOption']);
     }
 
+    public function testResolveContentBlocksWithSettings(): void
+    {
+        $example1 = static::createExample(
+            [
+                'en' => [
+                    'live' => [
+                        'template' => 'full-content',
+                        'title' => 'Lorem Ipsum',
+                        'url' => '/lorem-ipsum',
+                        'blocks' => [
+                            [
+                                'type' => 'editor',
+                                'text_editor' => '<p>Editor block with settings</p>',
+                                'settings' => [
+                                    'hidden' => false,
+                                    'schedules_enabled' => false,
+                                    'schedules' => [
+                                        [
+                                            'type' => 'fixed',
+                                            'start' => '2025-09-17T00:00:00',
+                                            'end' => '2025-09-25T00:00:00',
+                                        ],
+                                    ],
+                                    'segment_enabled' => null,
+                                    'segments' => null,
+                                    'target_groups_enabled' => null,
+                                    'target_groups' => null,
+                                ],
+                            ],
+                            [
+                                'type' => 'editor',
+                                'text_editor' => '<p>Editor block without settings</p>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'create_route' => true,
+            ]
+        );
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($example1, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        $content = $result['content'];
+
+        self::assertArrayHasKey('blocks', $content);
+        $blocks = $content['blocks'];
+        self::assertIsArray($blocks);
+        self::assertCount(2, $blocks);
+
+        // First block with settings
+        /** @var array<string, mixed> $blockWithSettings */
+        $blockWithSettings = $blocks[0];
+        self::assertSame('editor', $blockWithSettings['type']);
+        self::assertSame('<p>Editor block with settings</p>', $blockWithSettings['text_editor']);
+
+        // Assert settings are resolved
+        self::assertArrayHasKey('settings', $blockWithSettings);
+        $settings = $blockWithSettings['settings'];
+        self::assertIsArray($settings);
+        self::assertFalse($settings['hidden']);
+        self::assertFalse($settings['schedules_enabled']);
+
+        self::assertArrayHasKey('schedules', $settings);
+        self::assertIsArray($settings['schedules']);
+        self::assertCount(1, $settings['schedules']);
+
+        /** @var array<string, mixed> $schedule */
+        $schedule = $settings['schedules'][0];
+        self::assertSame('fixed', $schedule['type']);
+        self::assertSame('2025-09-17T00:00:00', $schedule['start']);
+        self::assertSame('2025-09-25T00:00:00', $schedule['end']);
+
+        self::assertNull($settings['segment_enabled']);
+        self::assertNull($settings['segments']);
+        self::assertNull($settings['target_groups_enabled']);
+        self::assertNull($settings['target_groups']);
+
+        // Second block without settings
+        /** @var array<string, mixed> $blockWithoutSettings */
+        $blockWithoutSettings = $blocks[1];
+        self::assertSame('editor', $blockWithoutSettings['type']);
+        self::assertSame('<p>Editor block without settings</p>', $blockWithoutSettings['text_editor']);
+        self::assertArrayNotHasKey('settings', $blockWithoutSettings);
+    }
+
     public function testResolveImageMap(): void
     {
         $collection1 = self::createCollection(['title' => 'collection-1', 'locale' => 'en']);

--- a/packages/content/translations/admin.de.json
+++ b/packages/content/translations/admin.de.json
@@ -15,5 +15,10 @@
     "sulu_content.webspace": "Webspace",
     "sulu_content.main_webspace": "Hauptwebspace",
     "sulu_content.additional_webspaces": "Weitere Webspaces",
-    "sulu_content.page_settings": "Seiteneinstellungen"
+    "sulu_content.page_settings": "Seiteneinstellungen",
+    "sulu_content.hide_block_label": "Nicht auf publizierter Website darstellen",
+    "sulu_content.hide_block_description": "Dieser Block wird nicht veröffentlicht, kann aber weiterhin im Admin bearbeitet werden.",
+    "sulu_content.schedules_label": "Zeitfenster zuweisen",
+    "sulu_content.schedules_description": "Der Block wird nur angezeigt, wenn mindestens einer der Bedingungen erfüllt wird.",
+    "sulu_content.add_schedule": "Zeitfenster hinzufügen"
 }

--- a/packages/content/translations/admin.en.json
+++ b/packages/content/translations/admin.en.json
@@ -15,5 +15,10 @@
     "sulu_content.webspace": "Webspace",
     "sulu_content.main_webspace": "Main Webspace",
     "sulu_content.additional_webspaces": "Additional Webspaces",
-    "sulu_content.page_settings": "Page settings"
+    "sulu_content.page_settings": "Page settings",
+    "sulu_content.hide_block_label": "Don't display on public website",
+    "sulu_content.hide_block_description": "This block will not be published, but remains editable in the admin.",
+    "sulu_content.schedules_label": "Assign time schedule",
+    "sulu_content.schedules_description": "The block will only be visible if at least one condition is valid.",
+    "sulu_content.add_schedule": "Add schedule"
 }

--- a/packages/page/config/forms/content_block_settings.xml
+++ b/packages/page/config/forms/content_block_settings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>content_block_settings</key>
+
+    <properties>
+        <section name="segments" visibleCondition="__webspace ? __webspace.segments|length &gt; 0 : true">
+            <properties>
+                <property
+                    name="segment_enabled"
+                    type="checkbox"
+                    visibleCondition="__webspace ? __webspace.segments|length &gt; 0 : true"
+                >
+                    <params>
+                        <param name="description">
+                            <meta>
+                                <title>sulu_page.segment_description</title>
+                            </meta>
+                        </param>
+                        <param name="icon" value="su-focus" />
+                        <param name="label">
+                            <meta>
+                                <title>sulu_page.segment_label</title>
+                            </meta>
+                        </param>
+                        <param name="skin" value="heading" />
+                        <param name="type" value="toggler" />
+                    </params>
+
+                    <tag name="sulu.block_setting_icon" icon="su-focus" />
+                </property>
+
+                <property name="segments" type="segment_select" visibleCondition="segment_enabled == true" />
+            </properties>
+        </section>
+    </properties>
+</form>

--- a/packages/page/config/forms/page_block_settings.xml
+++ b/packages/page/config/forms/page_block_settings.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>page_block_settings</key>
+
+    <properties>
+        <property name="hidden" type="checkbox">
+            <params>
+                <param name="description">
+                    <meta>
+                        <title>sulu_page.hide_block_description</title>
+                    </meta>
+                </param>
+                <param name="icon" value="su-hide" />
+                <param name="label">
+                    <meta>
+                        <title>sulu_page.hide_block_label</title>
+                    </meta>
+                </param>
+                <param name="skin" value="heading" />
+                <param name="type" value="toggler" />
+            </params>
+
+            <tag name="sulu.block_setting_icon" icon="su-hide" />
+        </property>
+
+        <section name="schedules">
+            <properties>
+                <property name="schedules_enabled" type="checkbox">
+                    <params>
+                        <param name="description">
+                            <meta>
+                                <title>sulu_page.schedules_description</title>
+                            </meta>
+                        </param>
+                        <param name="icon" value="su-clock" />
+                        <param name="label">
+                            <meta>
+                                <title>sulu_page.schedules_label</title>
+                            </meta>
+                        </param>
+                        <param name="skin" value="heading" />
+                        <param name="type" value="toggler" />
+                    </params>
+
+                    <tag name="sulu.block_setting_icon" icon="su-clock" />
+                </property>
+
+                <block name="schedules" default-type="fixed" minOccurs="1" visibleCondition="schedules_enabled == true">
+                    <params>
+                        <param name="add_button_text">
+                            <meta>
+                                <title>sulu_page.add_schedule</title>
+                            </meta>
+                        </param>
+                        <param name="collapsable" value="false" />
+                        <param name="movable" value="false" />
+                    </params>
+                    <types>
+                        <type name="weekly">
+                            <meta>
+                                <title>sulu_admin.weekly</title>
+                            </meta>
+                            <properties>
+                                <property name="days" type="select" mandatory="true">
+                                    <meta>
+                                        <title>sulu_admin.weekdays</title>
+                                    </meta>
+
+                                    <params>
+                                        <param name="default_values" type="collection">
+                                            <param name="monday" />
+                                            <param name="tuesday" />
+                                            <param name="wednesday" />
+                                            <param name="thursday" />
+                                            <param name="friday" />
+                                            <param name="saturday" />
+                                            <param name="sunday" />
+                                        </param>
+                                        <param name="values" type="collection">
+                                            <param name="monday">
+                                                <meta>
+                                                    <title>sulu_admin.monday</title>
+                                                </meta>
+                                            </param>
+                                            <param name="tuesday">
+                                                <meta>
+                                                    <title>sulu_admin.tuesday</title>
+                                                </meta>
+                                            </param>
+                                            <param name="wednesday">
+                                                <meta>
+                                                    <title>sulu_admin.wednesday</title>
+                                                </meta>
+                                            </param>
+                                            <param name="thursday">
+                                                <meta>
+                                                    <title>sulu_admin.thursday</title>
+                                                </meta>
+                                            </param>
+                                            <param name="friday">
+                                                <meta>
+                                                    <title>sulu_admin.friday</title>
+                                                </meta>
+                                            </param>
+                                            <param name="saturday">
+                                                <meta>
+                                                    <title>sulu_admin.saturday</title>
+                                                </meta>
+                                            </param>
+                                            <param name="sunday">
+                                                <meta>
+                                                    <title>sulu_admin.sunday</title>
+                                                </meta>
+                                            </param>
+                                        </param>
+                                    </params>
+                                </property>
+
+                                <property name="start" type="time" colspan="6" mandatory="true">
+                                    <meta>
+                                        <title>sulu_admin.start</title>
+                                    </meta>
+                                </property>
+
+                                <property name="end" type="time" colspan="6" mandatory="true">
+                                    <meta>
+                                        <title>sulu_admin.end</title>
+                                    </meta>
+                                </property>
+                            </properties>
+                        </type>
+                        <type name="fixed">
+                            <meta>
+                                <title>sulu_admin.fixed</title>
+                            </meta>
+                            <properties>
+                                <property name="start" type="datetime" colspan="6">
+                                    <meta>
+                                        <title>sulu_admin.start</title>
+                                    </meta>
+                                </property>
+                                <property name="end" type="datetime" colspan="6">
+                                    <meta>
+                                        <title>sulu_admin.end</title>
+                                    </meta>
+                                </property>
+                            </properties>
+                        </type>
+                    </types>
+                </block>
+            </properties>
+        </section>
+
+        <section name="segments" visibleCondition="__webspace ? __webspace.segments|length &gt; 0 : true">
+            <properties>
+                <property
+                    name="segment_enabled"
+                    type="checkbox"
+                    visibleCondition="__webspace ? __webspace.segments|length &gt; 0 : true"
+                >
+                    <params>
+                        <param name="description">
+                            <meta>
+                                <title>sulu_page.segment_description</title>
+                            </meta>
+                        </param>
+                        <param name="icon" value="su-focus" />
+                        <param name="label">
+                            <meta>
+                                <title>sulu_page.segment_label</title>
+                            </meta>
+                        </param>
+                        <param name="skin" value="heading" />
+                        <param name="type" value="toggler" />
+                    </params>
+
+                    <tag name="sulu.block_setting_icon" icon="su-focus" />
+                </property>
+
+                <property name="segments" type="segment_select" visibleCondition="segment_enabled == true" />
+            </properties>
+        </section>
+
+        <section name="target_groups" visibleCondition="__bundles|includes('sulu_audience_targeting')">
+            <properties>
+                <property
+                    name="target_groups_enabled"
+                    type="checkbox"
+                    visibleCondition="__bundles|includes('sulu_audience_targeting')"
+                >
+                    <params>
+                        <param name="description">
+                            <meta>
+                                <title>sulu_page.target_groups_description</title>
+                            </meta>
+                        </param>
+                        <param name="icon" value="su-user" />
+                        <param name="label">
+                            <meta>
+                                <title>sulu_page.target_groups_label</title>
+                            </meta>
+                        </param>
+                        <param name="skin" value="heading" />
+                        <param name="type" value="toggler" />
+                    </params>
+
+                    <tag name="sulu.block_setting_icon" icon="su-user" />
+                </property>
+
+                <property
+                    name="target_groups"
+                    type="target_group_selection"
+                    visibleCondition="target_groups_enabled == true"
+                />
+            </properties>
+        </section>
+    </properties>
+</form>

--- a/packages/page/translations/admin.de.json
+++ b/packages/page/translations/admin.de.json
@@ -24,6 +24,8 @@
     "sulu_page.last_modified_or_authored": "Zuletzt geändert oder verfasst",
     "sulu_page.last_modified_enabled": "Aktualisierungsdatum aktivieren",
     "sulu_page.last_modified_date": "Datum der Aktualisierung",
+    "sulu_page.segment_label": "Segment zuweisen",
+    "sulu_page.segment_description": "Der Block wird automatisch nach dem gewählten Segment auf der Website gefiltert.",
     "sulu_activity.resource.pages": "Seite",
     "sulu_activity.resource.pages.translation": "Übersetzung",
     "sulu_activity.description.pages.created": "{userFullName} hat die Seite \"{resourceTitle}\" erstellt",

--- a/packages/page/translations/admin.en.json
+++ b/packages/page/translations/admin.en.json
@@ -24,6 +24,8 @@
     "sulu_page.last_modified_or_authored": "Last modified or authored",
     "sulu_page.last_modified_enabled": "Enable last modified date",
     "sulu_page.last_modified_date": "Last modified date",
+    "sulu_page.segment_label": "Assign segment",
+    "sulu_page.segment_description": "The block will be automatically filtered on the website by the chosen segment.",
     "sulu_activity.resource.pages": "Page",
     "sulu_activity.resource.pages.translation": "Translation",
     "sulu_activity.description.pages.created": "{userFullName} has created the page \"{resourceTitle}\"",

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitor.php
@@ -58,7 +58,7 @@ class BlockSettingsFormMetadataVisitor implements TypedFormMetadataVisitorInterf
 
             $optionMetadata = new OptionMetadata();
             $optionMetadata->setName('settings_form_key');
-            $optionMetadata->setValue('page_block_settings');
+            $optionMetadata->setValue('content_block_settings');
             $itemMetadata->addOption($optionMetadata);
         }
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -166,7 +166,7 @@ test('Render collapsed blocks with block previews', () => {
             {...fieldTypeDefaultProps}
             defaultType="editor"
             formInspector={formInspector}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
             value={value}
         />
@@ -1284,7 +1284,7 @@ test('Should open and close block settings overlay close button is clicked', () 
             {...fieldTypeDefaultProps}
             defaultType="editor"
             formInspector={formInspector}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
             value={value}
         />
@@ -1336,14 +1336,14 @@ test('Should open and close block settings overlay when confirm button is clicke
             defaultType="editor"
             formInspector={formInspector}
             onChange={changeSpy}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
             value={value}
         />
     );
 
-    expect(metadataStore.getSchema).toBeCalledWith('page_block_settings', undefined, undefined);
-    expect(metadataStore.getJsonSchema).toBeCalledWith('page_block_settings', undefined, undefined);
+    expect(metadataStore.getSchema).toBeCalledWith('content_block_settings', undefined, undefined);
+    expect(metadataStore.getJsonSchema).toBeCalledWith('content_block_settings', undefined, undefined);
     expect(fieldBlocks.exists('FormOverlay')).toEqual(false);
 
     fieldBlocks.find('Block').at(1).simulate('click');
@@ -1393,7 +1393,7 @@ test('Should destroy create new formstore when block settings overlay is opened 
             {...fieldTypeDefaultProps}
             defaultType="editor"
             formInspector={formInspector}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
             value={value}
         />
@@ -1453,14 +1453,14 @@ test('Should not close block settings overlay when confirm button is clicked wit
             defaultType="editor"
             formInspector={formInspector}
             onChange={changeSpy}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
             value={value}
         />
     );
 
-    expect(metadataStore.getSchema).toBeCalledWith('page_block_settings', undefined, undefined);
-    expect(metadataStore.getJsonSchema).toBeCalledWith('page_block_settings', undefined, undefined);
+    expect(metadataStore.getSchema).toBeCalledWith('content_block_settings', undefined, undefined);
+    expect(metadataStore.getJsonSchema).toBeCalledWith('content_block_settings', undefined, undefined);
     expect(fieldBlocks.exists('FormOverlay')).toEqual(false);
 
     fieldBlocks.find('Block').at(1).simulate('click');
@@ -1523,7 +1523,7 @@ test('Should display and update correct icons based on block settings data and s
             {...fieldTypeDefaultProps}
             defaultType="editor"
             formInspector={formInspector}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
             value={value}
         />
@@ -1597,7 +1597,7 @@ test('Should display correct icons based on visibleCondition', () => {
             {...fieldTypeDefaultProps}
             defaultType="editor"
             formInspector={formInspector}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
             value={value}
         />
@@ -1687,7 +1687,7 @@ test('Should recalculate visibleCondition only of changed blocks', () => {
             {...fieldTypeDefaultProps}
             defaultType="editor"
             formInspector={formInspector}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
             value={value}
         />
@@ -1747,7 +1747,7 @@ test('Should destroy the block settings form-store on unmount', () => {
             {...fieldTypeDefaultProps}
             defaultType="editor"
             formInspector={formInspector}
-            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'page_block_settings'}}}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
             types={types}
         />
     );

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -94,7 +94,7 @@
                         "settings_form_key": {
                             "name": "settings_form_key",
                             "type": null,
-                            "value": "page_block_settings"
+                            "value": "content_block_settings"
                         }
                     },
                     "types": {
@@ -211,7 +211,7 @@
                                         "settings_form_key": {
                                             "name": "settings_form_key",
                                             "type": null,
-                                            "value": "page_block_settings"
+                                            "value": "content_block_settings"
                                         }
                                     },
                                     "types": {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
@@ -118,7 +118,7 @@
                 "settings_form_key": {
                     "name": "settings_form_key",
                     "type": null,
-                    "value": "page_block_settings"
+                    "value": "content_block_settings"
                 }
             },
             "types": {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/BlockSettingsFormMetadataVisitorTest.php
@@ -44,7 +44,7 @@ class BlockSettingsFormMetadataVisitorTest extends TestCase
             [
                 'settings_form_key' => [
                     'name' => 'settings_form_key',
-                    'value' => 'page_block_settings',
+                    'value' => 'content_block_settings',
                 ],
             ],
             \array_map(function(OptionMetadata $optionMetadata): array {
@@ -115,7 +115,7 @@ class BlockSettingsFormMetadataVisitorTest extends TestCase
             [
                 'settings_form_key' => [
                     'name' => 'settings_form_key',
-                    'value' => 'page_block_settings',
+                    'value' => 'content_block_settings',
                 ],
             ],
             \array_map(function(OptionMetadata $optionMetadata): array {

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/forms/content_block_settings.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/forms/content_block_settings.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>content_block_settings</key>
+
+    <properties>
+        <section name="target_groups" visibleCondition="__bundles|includes('sulu_audience_targeting')">
+            <properties>
+                <property
+                    name="target_groups_enabled"
+                    type="checkbox"
+                    visibleCondition="__bundles|includes('sulu_audience_targeting')"
+                >
+                    <params>
+                        <param name="description">
+                            <meta>
+                                <title>sulu_page.target_groups_description</title>
+                            </meta>
+                        </param>
+                        <param name="icon" value="su-user" />
+                        <param name="label">
+                            <meta>
+                                <title>sulu_page.target_groups_label</title>
+                            </meta>
+                        </param>
+                        <param name="skin" value="heading" />
+                        <param name="type" value="toggler" />
+                    </params>
+
+                    <tag name="sulu.block_setting_icon" icon="su-user" />
+                </property>
+
+                <property
+                    name="target_groups"
+                    type="target_group_selection"
+                    visibleCondition="target_groups_enabled == true"
+                />
+            </properties>
+        </section>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/forms/content_block_settings.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/config/forms/content_block_settings.xml
@@ -16,13 +16,13 @@
                     <params>
                         <param name="description">
                             <meta>
-                                <title>sulu_page.target_groups_description</title>
+                                <title>sulu_audience_targeting.target_groups_description</title>
                             </meta>
                         </param>
                         <param name="icon" value="su-user" />
                         <param name="label">
                             <meta>
-                                <title>sulu_page.target_groups_label</title>
+                                <title>sulu_audience_targeting.target_groups_label</title>
                             </meta>
                         </param>
                         <param name="skin" value="heading" />

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/admin.de.json
@@ -23,5 +23,7 @@
     "sulu_audience_targeting.query_string_value": "Wert",
     "sulu_audience_targeting.smartphone": "Smartphone",
     "sulu_audience_targeting.tablet": "Tablet",
-    "sulu_audience_targeting.desktop": "Desktop"
+    "sulu_audience_targeting.desktop": "Desktop",
+    "sulu_audience_targeting.target_groups_label": "Zielgruppen zuweisen",
+    "sulu_audience_targeting.target_groups_description": "Der Block wird nur den ausgewählten Zielgruppen angezeigt."
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/translations/admin.en.json
@@ -23,5 +23,7 @@
     "sulu_audience_targeting.query_string_value": "Value",
     "sulu_audience_targeting.smartphone": "Smartphone",
     "sulu_audience_targeting.tablet": "Tablet",
-    "sulu_audience_targeting.desktop": "Desktop"
+    "sulu_audience_targeting.desktop": "Desktop",
+    "sulu_audience_targeting.target_groups_label": "Assign target groups",
+    "sulu_audience_targeting.target_groups_description": "The block will only be visible for the selected target groups."
 }

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/request_analyzer.xml
@@ -58,7 +58,6 @@
         </service>
         <service id="sulu_core.request_processor.date_time"
                  class="Sulu\Component\Webspace\Analyzer\Attributes\DateTimeRequestProcessor">
-            <tag name="sulu.context" context="website"/>
             <tag name="sulu.request_attributes" priority="0"/>
         </service>
     </services>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT

#### What's in this PR?

Restores the settings in Sulu 3.0 as you knew it from 2.6
Additionally adds proper resolving of the settings form.

#### Why?

Missing feature in Sulu 3.0.
