### PR TITLE
Fix ArticleRouteDefaultsProviderTest

### DIFF
--- a/packages/article/tests/Unit/Infrastructure/Sulu/Route/ArticleRouteDefaultsProviderTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Route/ArticleRouteDefaultsProviderTest.php
@@ -35,6 +35,7 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Route\Application\Routing\Matcher\RouteDefaultsProviderInterface;
 use Sulu\Route\Domain\Model\Route;
+use Symfony\Component\DependencyInjection\Container;
 
 class ArticleRouteDefaultsProviderTest extends TestCase
 {
@@ -58,9 +59,10 @@ class ArticleRouteDefaultsProviderTest extends TestCase
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
         $this->cacheLifetimeResolver = new CacheLifetimeResolver();
-        $this->metadataProviderRegistry = new MetadataProviderRegistry();
         $this->formMetadataProvider = $this->prophesize(FormMetadataProvider::class);
-        $this->metadataProviderRegistry->addMetadataProvider('form', $this->formMetadataProvider->reveal());
+        $container = new Container();
+        $container->set('form', $this->formMetadataProvider->reveal());
+        $this->metadataProviderRegistry = new MetadataProviderRegistry($container);
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->webspaceResolver = $this->prophesize(WebspaceResolver::class);
     }


### PR DESCRIPTION
  | Q                  | A        |
  |--------------------|----------|
  | Bug fix?           | yes      |
  | New feature?       | no       |
  | BC breaks?         | no       |
  | Deprecations?      | no       |
  | Fixed tickets      | fixes #  |
  | Related issues/PRs | #8232    |
  | License            | MIT      |
  | Documentation PR   | N/A      |

  What's in this PR?

  This PR fixes the ArticleRouteDefaultsProviderTest to work with the new MetadataProviderRegistry API introduced in #8232.

  Why?

  Commit 3a1f4f2b9a removed the deprecated AddMetadataPass and refactored MetadataProviderRegistry to use constructor injection with a PSR-11 container instead of the mutable addMetadataProvider() method.