### PR TITLE
Add resolving of SnippetAreaDimensionContent for SnippetAreaTwigExtension

### DIFF
--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -237,6 +237,7 @@ final class SuluSnippetBundle extends AbstractBundle
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_core.webspace.request_analyzer'),
                 new Reference('sulu_snippet.snippet_reference_store'),
+                new Reference('sulu_content.content_resolver'),
             ])
             ->tag('twig.extension');
 

--- a/packages/snippet/src/Infrastructure/Symfony/Twig/SnippetAreaTwigExtension.php
+++ b/packages/snippet/src/Infrastructure/Symfony/Twig/SnippetAreaTwigExtension.php
@@ -16,6 +16,7 @@ namespace Sulu\Snippet\Infrastructure\Symfony\Twig;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
@@ -30,6 +31,7 @@ class SnippetAreaTwigExtension extends AbstractExtension
         private ContentAggregatorInterface $contentAggregator,
         private RequestAnalyzerInterface $requestAnalyzer,
         private ReferenceStoreInterface $referenceStore,
+        private ContentResolverInterface $contentResolver,
     ) {
     }
 
@@ -40,11 +42,17 @@ class SnippetAreaTwigExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * @param array<string, string>|null $properties
+     *
+     * @return array<string, mixed>|null
+     */
     public function loadSnippetByArea(
         string $areaKey,
         ?string $webspaceKey = null,
-        ?string $locale = null
-    ): ?SnippetDimensionContentInterface {
+        ?string $locale = null,
+        ?array $properties = null,
+    ): ?array {
         if (null === $webspaceKey) {
             $webspace = $this->requestAnalyzer->getWebspace();
             if (null === $webspace) { // @phpstan-ignore identical.alwaysFalse
@@ -71,8 +79,9 @@ class SnippetAreaTwigExtension extends AbstractExtension
         }
 
         $snippet = $snippetArea->getSnippet();
-        /** @var SnippetDimensionContentInterface $content */
-        $content = $this->contentAggregator->aggregate(
+
+        /** @var SnippetDimensionContentInterface $dimensionContent */
+        $dimensionContent = $this->contentAggregator->aggregate(
             $snippet,
             [
                 'locale' => $locale,
@@ -81,8 +90,10 @@ class SnippetAreaTwigExtension extends AbstractExtension
             ]
         );
 
+        $resolvedContent = $this->contentResolver->resolve($dimensionContent, $properties);
+
         $this->referenceStore->add($snippet->getUuid(), SnippetInterface::RESOURCE_KEY);
 
-        return $content;
+        return $resolvedContent;
     }
 }

--- a/packages/snippet/tests/Functional/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Tests\Functional\Infrastructure\Symfony\Twig;
+
+use Sulu\Bundle\MediaBundle\Api\Media;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Tests\Functional\Traits\CreateMediaTrait;
+use Sulu\Snippet\Infrastructure\Symfony\Twig\SnippetAreaTwigExtension;
+use Sulu\Snippet\Tests\Traits\CreateSnippetTrait;
+
+class SnippetAreaTwigExtensionTest extends SuluTestCase
+{
+    use CreateMediaTrait;
+    use CreateSnippetTrait;
+
+    private SnippetAreaTwigExtension $snippetAreaTwigExtension;
+
+    protected function setUp(): void
+    {
+        self::purgeDatabase();
+
+        $this->snippetAreaTwigExtension = self::getContainer()->get('sulu_snippet.snippet_area_twig_extension');
+    }
+
+    public function testLoadSnippetByAreaWithoutProperties(): void
+    {
+        $collection = self::createCollection(['title' => 'Test Collection', 'locale' => 'en']);
+        $mediaType = self::createMediaType(['name' => 'Image', 'description' => 'This is an image']);
+        $media = self::createMedia($collection, $mediaType, ['title' => 'Test Image', 'locale' => 'en']);
+
+        self::getEntityManager()->flush();
+
+        $snippet = static::createSnippet([
+            'en' => [
+                'draft' => [
+                    'template' => 'snippet',
+                    'title' => 'Test Snippet',
+                    'description' => 'This is a test snippet description',
+                    'image' => [
+                        'id' => $media->getId(),
+                    ],
+                ],
+            ],
+        ]);
+
+        static::publishSnippet($snippet, 'en');
+        static::createSnippetArea('hotel', 'sulu-io', $snippet);
+
+        self::getEntityManager()->flush();
+
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', 'sulu-io', 'en');
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('content', $result);
+
+        /** @var array<string, mixed> $content */
+        $content = $result['content'];
+        $this->assertArrayHasKey('title', $content);
+        $this->assertSame('Test Snippet', $content['title']);
+        $this->assertArrayHasKey('description', $content);
+        $this->assertSame('This is a test snippet description', $content['description']);
+        $this->assertArrayHasKey('image', $content);
+        $this->assertInstanceOf(Media::class, $content['image']);
+        $this->assertSame($media->getId(), $content['image']->getId());
+    }
+
+    public function testLoadSnippetByAreaWithProperties(): void
+    {
+        $collection = self::createCollection(['title' => 'Test Collection', 'locale' => 'en']);
+        $mediaType = self::createMediaType(['name' => 'Image', 'description' => 'This is an image']);
+        $media = self::createMedia($collection, $mediaType, ['title' => 'Test Image', 'locale' => 'en']);
+
+        self::getEntityManager()->flush();
+
+        $snippet = static::createSnippet([
+            'en' => [
+                'draft' => [
+                    'template' => 'snippet',
+                    'title' => 'Test Snippet with Properties',
+                    'description' => 'Description for properties test',
+                    'image' => [
+                        'id' => $media->getId(),
+                    ],
+                ],
+            ],
+        ]);
+
+        static::publishSnippet($snippet, 'en');
+        static::createSnippetArea('hotel', 'sulu-io', $snippet);
+
+        self::getEntityManager()->flush();
+
+        $properties = [
+            'title' => 'title',
+            'description' => 'description',
+        ];
+
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', 'sulu-io', 'en', $properties);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('title', $result);
+        $this->assertSame('Test Snippet with Properties', $result['title']);
+        $this->assertArrayHasKey('description', $result);
+        $this->assertSame('Description for properties test', $result['description']);
+
+        if (isset($result['content'])) {
+            $this->assertEmpty($result['content']);
+        }
+        $this->assertArrayNotHasKey('image', $result);
+    }
+
+    public function testLoadSnippetByAreaReturnsNullWhenAreaNotFound(): void
+    {
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('nonexistent', 'sulu-io', 'en');
+
+        $this->assertNull($result);
+    }
+
+    public function testLoadSnippetByAreaReturnsNullWhenNoSnippetAssigned(): void
+    {
+        $snippet = static::createSnippet([
+            'en' => [
+                'draft' => [
+                    'template' => 'snippet',
+                    'title' => 'Test Snippet',
+                ],
+            ],
+        ]);
+
+        static::publishSnippet($snippet, 'en');
+
+        self::getEntityManager()->flush();
+
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', 'sulu-io', 'en');
+
+        $this->assertNull($result);
+    }
+}

--- a/packages/snippet/tests/Traits/CreateSnippetTrait.php
+++ b/packages/snippet/tests/Traits/CreateSnippetTrait.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Tests\Traits;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Content\Application\ContentDataMapper\ContentDataMapper;
+use Sulu\Content\Domain\Model\DimensionContentCollection;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\WorkflowInterface;
+use Sulu\Snippet\Domain\Model\Snippet;
+use Sulu\Snippet\Domain\Model\SnippetArea;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContent;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
+use Webmozart\Assert\Assert;
+
+trait CreateSnippetTrait
+{
+    /**
+     * @param array<string, array{ draft?: array<string, mixed>, live?: array<string, mixed> }> $dataSet
+     */
+    protected static function createSnippet(array $dataSet = []): Snippet
+    {
+        $entityManager = static::getEntityManager();
+        $contentDataMapper = new ContentDataMapper([
+            static::getContainer()->get('sulu_content.template_data_mapper'),
+            static::getContainer()->get('sulu_content.excerpt_data_mapper'),
+            static::getContainer()->get('sulu_content.workflow_data_mapper'),
+        ]);
+
+        $snippet = new Snippet();
+
+        $draftUnlocalizedDimension = null;
+
+        if (\count($dataSet)) {
+            $draftUnlocalizedDimension = new SnippetDimensionContent($snippet);
+            $snippet->addDimensionContent($draftUnlocalizedDimension);
+            $entityManager->persist($draftUnlocalizedDimension);
+        }
+
+        $liveUnlocalizedDimension = null;
+        $createdPublishedUnlocalizedDimension = false;
+
+        foreach ($dataSet as $locale => $data) {
+            /** @var array<string, mixed> $draftData */
+            $draftData = $data['draft'] ?? $data['live'] ?? [];
+            $liveData = $data['live'] ?? null;
+
+            // Create localized draft dimension
+            $draftLocalizedDimension = new SnippetDimensionContent($snippet);
+            $draftLocalizedDimension->setLocale($locale);
+            $snippet->addDimensionContent($draftLocalizedDimension);
+            $entityManager->persist($draftLocalizedDimension);
+
+            // Map Draft Data
+            $draftDimensionContentCollection = new DimensionContentCollection(
+                [$draftUnlocalizedDimension, $draftLocalizedDimension],
+                ['stage' => DimensionContentInterface::STAGE_DRAFT, 'locale' => $locale],
+                SnippetDimensionContent::class
+            );
+            $contentDataMapper->map(
+                $draftDimensionContentCollection,
+                $draftDimensionContentCollection->getDimensionAttributes(),
+                $draftData
+            );
+            $draftLocalizedDimension->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_DRAFT);
+
+            if ($liveData) {
+                if (!$createdPublishedUnlocalizedDimension) {
+                    $liveUnlocalizedDimension = new SnippetDimensionContent($snippet);
+                    $liveUnlocalizedDimension->setStage(DimensionContentInterface::STAGE_LIVE);
+                    $snippet->addDimensionContent($liveUnlocalizedDimension);
+                    $entityManager->persist($liveUnlocalizedDimension);
+                    $createdPublishedUnlocalizedDimension = true;
+                }
+
+                // Create localized live dimension
+                $liveLocalizedDimension = new SnippetDimensionContent($snippet);
+                $liveLocalizedDimension->setStage(DimensionContentInterface::STAGE_LIVE);
+                $liveLocalizedDimension->setLocale($locale);
+                $snippet->addDimensionContent($liveLocalizedDimension);
+                $entityManager->persist($liveLocalizedDimension);
+
+                // Set published state
+                if (isset($data['draft'])) {
+                    $draftLocalizedDimension->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_DRAFT);
+                } else {
+                    $draftLocalizedDimension->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_PUBLISHED);
+                }
+
+                $draftLocalizedDimension->setWorkflowPublished(new \DateTimeImmutable());
+                $liveLocalizedDimension->setWorkflowPublished(new \DateTimeImmutable());
+
+                // Map live data
+                $liveDimensionContentCollection = new DimensionContentCollection(
+                    \array_filter([$liveUnlocalizedDimension, $liveLocalizedDimension]),
+                    ['stage' => DimensionContentInterface::STAGE_LIVE, 'locale' => $locale],
+                    SnippetDimensionContent::class
+                );
+                $liveData['published'] = \date('Y-m-d H:i:s');
+                $contentDataMapper->map(
+                    $liveDimensionContentCollection,
+                    $liveDimensionContentCollection->getDimensionAttributes(),
+                    $liveData
+                );
+            }
+        }
+
+        $entityManager->persist($snippet);
+
+        return $snippet;
+    }
+
+    protected static function publishSnippet(SnippetInterface $snippet, string $locale): void
+    {
+        $entityManager = static::getEntityManager();
+
+        $draftUnlocalizedDimension = null;
+        $draftLocalizedDimension = null;
+
+        foreach ($snippet->getDimensionContents() as $dimensionContent) {
+            Assert::isInstanceOf($dimensionContent, SnippetDimensionContent::class);
+
+            if (DimensionContentInterface::STAGE_DRAFT === $dimensionContent->getStage()) {
+                if (null === $dimensionContent->getLocale()) {
+                    $draftUnlocalizedDimension = $dimensionContent;
+                } elseif ($locale === $dimensionContent->getLocale()) {
+                    $draftLocalizedDimension = $dimensionContent;
+                }
+            }
+        }
+
+        Assert::notNull($draftLocalizedDimension);
+
+        // Create live dimensions if they don't exist
+        $liveUnlocalizedDimension = null;
+        $liveLocalizedDimension = null;
+
+        foreach ($snippet->getDimensionContents() as $dimensionContent) {
+            Assert::isInstanceOf($dimensionContent, SnippetDimensionContent::class);
+
+            if (DimensionContentInterface::STAGE_LIVE === $dimensionContent->getStage()) {
+                if (null === $dimensionContent->getLocale()) {
+                    $liveUnlocalizedDimension = $dimensionContent;
+                } elseif ($locale === $dimensionContent->getLocale()) {
+                    $liveLocalizedDimension = $dimensionContent;
+                }
+            }
+        }
+
+        if (!$liveUnlocalizedDimension) {
+            $liveUnlocalizedDimension = new SnippetDimensionContent($snippet);
+            $liveUnlocalizedDimension->setStage(DimensionContentInterface::STAGE_LIVE);
+            $snippet->addDimensionContent($liveUnlocalizedDimension);
+            $entityManager->persist($liveUnlocalizedDimension);
+        }
+
+        if (!$liveLocalizedDimension) {
+            $liveLocalizedDimension = new SnippetDimensionContent($snippet);
+            $liveLocalizedDimension->setStage(DimensionContentInterface::STAGE_LIVE);
+            $liveLocalizedDimension->setLocale($locale);
+            $snippet->addDimensionContent($liveLocalizedDimension);
+            $entityManager->persist($liveLocalizedDimension);
+        }
+
+        // Copy template data from draft to live
+        $liveLocalizedDimension->setTemplateKey($draftLocalizedDimension->getTemplateKey());
+        $liveLocalizedDimension->setTemplateData($draftLocalizedDimension->getTemplateData());
+
+        $draftLocalizedDimension->setWorkflowPlace(WorkflowInterface::WORKFLOW_PLACE_PUBLISHED);
+        $draftLocalizedDimension->setWorkflowPublished(new \DateTimeImmutable());
+        $liveLocalizedDimension->setWorkflowPublished(new \DateTimeImmutable());
+    }
+
+    protected static function createSnippetArea(string $areaKey, string $webspaceKey, SnippetInterface $snippet): SnippetArea
+    {
+        $entityManager = static::getEntityManager();
+
+        $snippetAreaRepository = static::getContainer()->get('sulu_snippet.snippet_area_repository');
+        $existingSnippetArea = $snippetAreaRepository->findOneBy([
+            'areaKey' => $areaKey,
+            'webspaceKey' => $webspaceKey,
+        ]);
+
+        if ($existingSnippetArea instanceof SnippetArea) {
+            $existingSnippetArea->setSnippet($snippet);
+
+            return $existingSnippetArea;
+        }
+
+        $snippetArea = new SnippetArea($areaKey, $webspaceKey);
+        $snippetArea->setSnippet($snippet);
+        $entityManager->persist($snippetArea);
+
+        return $snippetArea;
+    }
+
+    abstract protected static function getEntityManager(): EntityManagerInterface;
+}

--- a/packages/snippet/tests/Unit/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
@@ -23,6 +23,7 @@ use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Snippet\Domain\Exception\SnippetAreaNotFoundException;
 use Sulu\Snippet\Domain\Model\Snippet;
@@ -47,6 +48,9 @@ class SnippetAreaTwigExtensionTest extends TestCase
     /** @var ObjectProphecy<RequestAnalyzerInterface> */
     private ObjectProphecy $requestAnalyzer;
 
+    /** @var ObjectProphecy<ContentResolverInterface> */
+    private ObjectProphecy $contentResolver;
+
     private ReferenceStoreInterface $referenceStore;
 
     protected function setUp(): void
@@ -54,6 +58,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $this->snippetAreaRepository = $this->prophesize(SnippetAreaRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->contentResolver = $this->prophesize(ContentResolverInterface::class);
         $this->referenceStore = new ReferenceStore();
 
         $this->extension = new SnippetAreaTwigExtension(
@@ -61,6 +66,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             $this->contentAggregator->reveal(),
             $this->requestAnalyzer->reveal(),
             $this->referenceStore,
+            $this->contentResolver->reveal(),
         );
     }
 
@@ -87,6 +93,13 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $snippetArea = new SnippetArea($areaKey, $webspaceKey);
         $snippetArea->setSnippet($snippet);
 
+        $resolvedContent = [
+            'content' => [
+                'title' => 'Test Snippet',
+                'description' => 'Test Description',
+            ],
+        ];
+
         $this->snippetAreaRepository->findOneBy([
             'webspaceKey' => $webspaceKey,
             'areaKey' => $areaKey,
@@ -101,10 +114,11 @@ class SnippetAreaTwigExtensionTest extends TestCase
             ]
         )->willReturn($snippetDimensionContent);
 
+        $this->contentResolver->resolve($snippetDimensionContent, null)->willReturn($resolvedContent);
+
         $result = $this->extension->loadSnippetByArea($areaKey, $webspaceKey, $locale);
 
-        $this->assertSame($snippetDimensionContent, $result);
-        $this->assertSame('Test Snippet', $result->getTitle());
+        $this->assertSame($resolvedContent, $result);
 
         $this->assertSame(
             [SnippetInterface::RESOURCE_KEY . '-test-snippet-uuid' => SnippetInterface::RESOURCE_KEY . '-test-snippet-uuid'],
@@ -134,6 +148,12 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $snippetArea = new SnippetArea($areaKey, $webspaceKey);
         $snippetArea->setSnippet($snippet);
 
+        $resolvedContent = [
+            'content' => [
+                'title' => 'Footer Snippet',
+            ],
+        ];
+
         $this->snippetAreaRepository->findOneBy([
             'webspaceKey' => $webspaceKey,
             'areaKey' => $areaKey,
@@ -148,10 +168,11 @@ class SnippetAreaTwigExtensionTest extends TestCase
             ]
         )->willReturn($snippetDimensionContent);
 
+        $this->contentResolver->resolve($snippetDimensionContent, null)->willReturn($resolvedContent);
+
         $result = $this->extension->loadSnippetByArea($areaKey);
 
-        $this->assertSame($snippetDimensionContent, $result);
-        $this->assertSame('Footer Snippet', $result->getTitle());
+        $this->assertSame($resolvedContent, $result);
 
         $this->assertSame(
             [SnippetInterface::RESOURCE_KEY . '-footer-snippet-uuid' => SnippetInterface::RESOURCE_KEY . '-footer-snippet-uuid'],
@@ -231,5 +252,48 @@ class SnippetAreaTwigExtensionTest extends TestCase
 
         $this->expectException(SnippetAreaNotFoundException::class);
         $this->extension->loadSnippetByArea($areaKey, $webspaceKey, $locale);
+    }
+
+    public function testLoadSnippetByAreaWithProperties(): void
+    {
+        $areaKey = 'header';
+        $webspaceKey = 'example';
+        $locale = 'en';
+        $properties = [
+            'title' => 'title',
+            'description' => 'description',
+        ];
+
+        $snippet = new Snippet('test-snippet-uuid');
+        $snippetDimensionContent = new SnippetDimensionContent($snippet);
+        $snippetDimensionContent->setTemplateData(['title' => 'Test Snippet', 'description' => 'Test Description']);
+
+        $snippetArea = new SnippetArea($areaKey, $webspaceKey);
+        $snippetArea->setSnippet($snippet);
+
+        $resolvedContent = [
+            'title' => 'Test Snippet',
+            'description' => 'Test Description',
+        ];
+
+        $this->snippetAreaRepository->findOneBy([
+            'webspaceKey' => $webspaceKey,
+            'areaKey' => $areaKey,
+        ])->willReturn($snippetArea);
+
+        $this->contentAggregator->aggregate(
+            $snippet,
+            [
+                'locale' => $locale,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
+                'version' => DimensionContentInterface::CURRENT_VERSION,
+            ]
+        )->willReturn($snippetDimensionContent);
+
+        $this->contentResolver->resolve($snippetDimensionContent, $properties)->willReturn($resolvedContent);
+
+        $result = $this->extension->loadSnippetByArea($areaKey, $webspaceKey, $locale, $properties);
+
+        $this->assertSame($resolvedContent, $result);
     }
 }


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Related issues/PRs | #7964 
  | License | MIT

  #### What's in this PR?

  This PR extends the `SnippetAreaTwigExtension` to properly resolve snippet content using the `ContentResolver` and adds support for the `properties` parameter to control field extraction in Twig templates.

  #### Why?

  - Automatic resolution of nested content (media, etc.)
  - Properties parameter support for extracting only needed fields
  - Consistent content structure across the application

  #### Example Usage

  ```twig
  {# Load full snippet content #}
  {% set snippet = sulu_snippet_load_by_area('header', 'sulu-io', 'en') %}
  {{ snippet.content.title }}
  {{ snippet.content.description }}

  {# Extract only specific fields #}
  {% set snippet = sulu_snippet_load_by_area('header', 'sulu-io', 'en', {
      'snippetTitle': 'title',
      'snippetDescription': 'description'
  }) %}
  {{ snippet.snippetTitle }}
  {{ snippet.snippetDescription }}