### PR TITLE
Add missing navigation twig extensions

### DIFF
--- a/packages/page/src/Domain/Repository/NavigationRepositoryInterface.php
+++ b/packages/page/src/Domain/Repository/NavigationRepositoryInterface.php
@@ -38,4 +38,44 @@ interface NavigationRepositoryInterface
         int $depth = 1,
         array $properties = []
     ): array;
+
+    /**
+     * @param array<string, mixed> $properties
+     *
+     * @return array<string, mixed>[]
+     */
+    public function getNavigationFlatByUuid(
+        string $uuid,
+        string $locale,
+        string $webspaceKey,
+        int $depth = 1,
+        ?string $navigationContext = null,
+        array $properties = []
+    ): array;
+
+    /**
+     * @param array<string, mixed> $properties
+     *
+     * @return array<string, mixed>[]
+     */
+    public function getNavigationTreeByUuid(
+        string $uuid,
+        string $locale,
+        string $webspaceKey,
+        int $depth = 1,
+        ?string $navigationContext = null,
+        array $properties = []
+    ): array;
+
+    /**
+     * @param array<string, mixed> $properties
+     *
+     * @return array<string, mixed>[]
+     */
+    public function getBreadcrumb(
+        string $uuid,
+        string $locale,
+        string $webspaceKey,
+        array $properties = []
+    ): array;
 }

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -97,16 +97,7 @@ class NavigationRepository implements NavigationRepositoryInterface
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
-        $loadExcerpt = (bool) ($properties['excerpt'] ?? false);
-
-        $result = [];
-        /** @var PageInterface $page */
-        foreach ($pages as $page) {
-            $content = $this->resolvePageContent($page, $locale);
-            $result[] = $this->normalizePageContent($content, $loadExcerpt);
-        }
-
-        return $result;
+        return $this->resolveAndNormalizePages($pages, $locale, $this->shouldLoadExcerpt($properties));
     }
 
     public function getNavigationFlatByUuid(
@@ -117,44 +108,12 @@ class NavigationRepository implements NavigationRepositoryInterface
         ?string $navigationContext = null,
         array $properties = []
     ): array {
-        $parentPage = $this->entityRepository->find($uuid);
-
-        if (null === $parentPage) {
-            return [];
-        }
-
-        $filters = [
-            'locale' => $locale,
-            'webspaceKey' => $webspaceKey,
-            'stage' => DimensionContentInterface::STAGE_LIVE,
-        ];
-
-        if (null !== $navigationContext) {
-            $filters['navigationContexts'] = [$navigationContext];
-        }
-
-        // Get children within depth range relative to parent
-        $queryBuilder = $this->createQueryBuilder($filters);
-        $queryBuilder
-            ->andWhere('page.lft > :parentLft')
-            ->andWhere('page.rgt < :parentRgt')
-            ->andWhere('page.depth <= :maxDepth')
-            ->setParameter('parentLft', $parentPage->getLft())
-            ->setParameter('parentRgt', $parentPage->getRgt())
-            ->setParameter('maxDepth', $parentPage->getDepth() + $depth);
+        $filters = $this->buildChildrenFilters($uuid, $locale, $webspaceKey, $depth, $navigationContext);
 
         /** @var iterable<PageInterface> $pages */
-        $pages = $queryBuilder->getQuery()->getResult();
+        $pages = $this->createQueryBuilder($filters)->getQuery()->getResult();
 
-        $loadExcerpt = (bool) ($properties['excerpt'] ?? false);
-
-        $result = [];
-        foreach ($pages as $page) {
-            $content = $this->resolvePageContent($page, $locale);
-            $result[] = $this->normalizePageContent($content, $loadExcerpt);
-        }
-
-        return $result;
+        return $this->resolveAndNormalizePages($pages, $locale, $this->shouldLoadExcerpt($properties));
     }
 
     public function getNavigationTreeByUuid(
@@ -165,41 +124,10 @@ class NavigationRepository implements NavigationRepositoryInterface
         ?string $navigationContext = null,
         array $properties = []
     ): array {
-        $parentPage = $this->entityRepository->find($uuid);
+        $filters = $this->buildChildrenFilters($uuid, $locale, $webspaceKey, $depth, $navigationContext);
+        $pages = $this->findByAsTree($filters);
 
-        if (null === $parentPage) {
-            return [];
-        }
-
-        $filters = [
-            'locale' => $locale,
-            'webspaceKey' => $webspaceKey,
-            'stage' => DimensionContentInterface::STAGE_LIVE,
-        ];
-
-        if (null !== $navigationContext) {
-            $filters['navigationContexts'] = [$navigationContext];
-        }
-
-        // Get children within depth range relative to parent
-        $queryBuilder = $this->createQueryBuilder($filters);
-        $queryBuilder
-            ->andWhere('page.lft > :parentLft')
-            ->andWhere('page.rgt < :parentRgt')
-            ->andWhere('page.depth <= :maxDepth')
-            ->setParameter('parentLft', $parentPage->getLft())
-            ->setParameter('parentRgt', $parentPage->getRgt())
-            ->setParameter('maxDepth', $parentPage->getDepth() + $depth);
-
-        $query = $queryBuilder->getQuery();
-        $query->setHint(Query::HINT_INCLUDE_META_COLUMNS, true);
-
-        /** @var iterable<PageInterface> $pages */
-        $pages = $query->getResult('sulu_page_tree');
-
-        $loadExcerpt = (bool) ($properties['excerpt'] ?? false);
-
-        return $this->normalizePageTree($pages, $loadExcerpt, $locale, 1, $depth);
+        return $this->normalizePageTree($pages, $this->shouldLoadExcerpt($properties), $locale, 1, $depth);
     }
 
     public function getBreadcrumb(
@@ -208,29 +136,101 @@ class NavigationRepository implements NavigationRepositoryInterface
         string $webspaceKey,
         array $properties = []
     ): array {
-        $page = $this->entityRepository->find($uuid);
+        $page = $this->createQueryBuilder(['uuid' => $uuid])->getQuery()->getOneOrNullResult();
 
         if (null === $page) {
             return [];
         }
 
-        $loadExcerpt = (bool) ($properties['excerpt'] ?? false);
+        // Query all ancestors in a single query using nested set values
+        /** @var PageInterface[] $ancestors */
+        $ancestors = $this->createQueryBuilder([
+            'ancestorsOf' => $uuid,
+            'webspaceKey' => $webspaceKey,
+        ])->getQuery()->getResult();
 
-        // Build breadcrumb by traversing up the tree
-        $breadcrumb = [];
-        $currentPage = $page;
+        // Combine ancestors with current page (ancestors are already ordered by lft ASC)
+        /** @var PageInterface[] $pages */
+        $pages = [...$ancestors, $page];
 
-        while (null !== $currentPage) {
-            $content = $this->resolvePageContent($currentPage, $locale);
-            $normalized = $this->normalizePageContent($content, $loadExcerpt);
+        return $this->resolveAndNormalizePages($pages, $locale, $this->shouldLoadExcerpt($properties));
+    }
 
-            // Prepend to maintain root -> current order
-            \array_unshift($breadcrumb, $normalized);
+    /**
+     * @param array<string, mixed> $properties
+     */
+    private function shouldLoadExcerpt(array $properties): bool
+    {
+        return (bool) ($properties['excerpt'] ?? false);
+    }
 
-            $currentPage = $currentPage->getParent();
+    /**
+     * @return array{
+     *     locale: string,
+     *     webspaceKey: string,
+     *     stage: string,
+     *     childrenOf: string,
+     *     childrenDepth: int,
+     *     navigationContexts?: array<string>
+     * }
+     */
+    private function buildChildrenFilters(
+        string $uuid,
+        string $locale,
+        string $webspaceKey,
+        int $depth,
+        ?string $navigationContext
+    ): array {
+        $filters = [
+            'locale' => $locale,
+            'webspaceKey' => $webspaceKey,
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+            'childrenOf' => $uuid,
+            'childrenDepth' => $depth,
+        ];
+
+        if (null !== $navigationContext) {
+            $filters['navigationContexts'] = [$navigationContext];
         }
 
-        return $breadcrumb;
+        return $filters;
+    }
+
+    /**
+     * @param iterable<PageInterface> $pages
+     *
+     * @return array<string, mixed>[]
+     */
+    private function resolveAndNormalizePages(
+        iterable $pages,
+        string $locale,
+        bool $loadExcerpt
+    ): array {
+        $result = [];
+        foreach ($pages as $page) {
+            $content = $this->resolvePageContent($page, $locale);
+            $result[] = $this->normalizePageContent($content, $loadExcerpt);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string[] $fields
+     *
+     * @return array<string, int|string>|null
+     */
+    private function fetchNestedSetValues(string $uuid, array $fields): ?array
+    {
+        $qb = $this->entityRepository->createQueryBuilder('page');
+        $qb->select(...\array_map(fn ($f) => "page.{$f}", $fields))
+            ->where('page.uuid = :uuid')
+            ->setParameter('uuid', $uuid);
+
+        /** @var array<string, int|string>|null $result */
+        $result = $qb->getQuery()->getOneOrNullResult();
+
+        return $result;
     }
 
     /**
@@ -248,12 +248,10 @@ class NavigationRepository implements NavigationRepositoryInterface
      */
     private function findBy(array $filters = []): \Generator
     {
-        $queryBuilder = $this->createQueryBuilder($filters);
+        $query = $this->createQueryBuilder($filters)->getQuery();
 
-        /** @var iterable<PageInterface> $pages */
-        $pages = $queryBuilder->getQuery()->getResult();
-
-        foreach ($pages as $page) {
+        /** @var PageInterface $page */
+        foreach ($query->toIterable() as $page) {
             yield $page;
         }
     }
@@ -286,8 +284,6 @@ class NavigationRepository implements NavigationRepositoryInterface
         foreach ($pages as $page) {
             yield $page;
         }
-
-        return $pages;
     }
 
     /**
@@ -369,11 +365,64 @@ class NavigationRepository implements NavigationRepositoryInterface
      *     limit?: int,
      *     navigationContexts?: string[],
      *     depth?: int,
+     *     uuid?: string,
+     *     ancestorsOf?: string,
+     *     childrenOf?: string,
+     *     childrenDepth?: int,
      * } $filters
      */
     private function createQueryBuilder(array $filters): QueryBuilder
     {
         $queryBuilder = $this->entityRepository->createQueryBuilder('page');
+
+        $uuid = $filters['uuid'] ?? null;
+        if (null !== $uuid) {
+            Assert::string($uuid); // @phpstan-ignore staticMethod.alreadyNarrowedType
+            $queryBuilder->andWhere('page.uuid = :uuid')
+                ->setParameter('uuid', $uuid);
+        }
+
+        $ancestorsOf = $filters['ancestorsOf'] ?? null;
+        if (null !== $ancestorsOf) {
+            Assert::string($ancestorsOf); // @phpstan-ignore staticMethod.alreadyNarrowedType
+
+            $result = $this->fetchNestedSetValues($ancestorsOf, ['lft', 'rgt']);
+
+            if (null !== $result) {
+                $queryBuilder
+                    ->andWhere('page.lft < :ancestorLft')
+                    ->andWhere('page.rgt > :ancestorRgt')
+                    ->setParameter('ancestorLft', $result['lft'])
+                    ->setParameter('ancestorRgt', $result['rgt']);
+            }
+        }
+
+        $childrenOf = $filters['childrenOf'] ?? null;
+        if (null !== $childrenOf) {
+            Assert::string($childrenOf); // @phpstan-ignore staticMethod.alreadyNarrowedType
+
+            $result = $this->fetchNestedSetValues($childrenOf, ['lft', 'rgt', 'depth']);
+
+            if (null !== $result) {
+                $queryBuilder
+                    ->andWhere('page.lft > :parentLft')
+                    ->andWhere('page.rgt < :parentRgt')
+                    ->setParameter('parentLft', $result['lft'])
+                    ->setParameter('parentRgt', $result['rgt']);
+
+                $childrenDepth = $filters['childrenDepth'] ?? null;
+                if (null !== $childrenDepth) {
+                    Assert::integer($childrenDepth); // @phpstan-ignore staticMethod.alreadyNarrowedType
+                    Assert::integer($result['depth']);
+                    $queryBuilder
+                        ->andWhere('page.depth <= :maxDepth')
+                        ->setParameter('maxDepth', $result['depth'] + $childrenDepth);
+                }
+            } else {
+                // Parent UUID doesn't exist, make query return no results
+                $queryBuilder->andWhere('1 = 0');
+            }
+        }
 
         $webspace = $filters['webspaceKey'] ?? null;
         if (null !== $webspace) {

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -109,6 +109,130 @@ class NavigationRepository implements NavigationRepositoryInterface
         return $result;
     }
 
+    public function getNavigationFlatByUuid(
+        string $uuid,
+        string $locale,
+        string $webspaceKey,
+        int $depth = 1,
+        ?string $navigationContext = null,
+        array $properties = []
+    ): array {
+        $parentPage = $this->entityRepository->find($uuid);
+
+        if (null === $parentPage) {
+            return [];
+        }
+
+        $filters = [
+            'locale' => $locale,
+            'webspaceKey' => $webspaceKey,
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+        ];
+
+        if (null !== $navigationContext) {
+            $filters['navigationContexts'] = [$navigationContext];
+        }
+
+        // Get children within depth range relative to parent
+        $queryBuilder = $this->createQueryBuilder($filters);
+        $queryBuilder
+            ->andWhere('page.lft > :parentLft')
+            ->andWhere('page.rgt < :parentRgt')
+            ->andWhere('page.depth <= :maxDepth')
+            ->setParameter('parentLft', $parentPage->getLft())
+            ->setParameter('parentRgt', $parentPage->getRgt())
+            ->setParameter('maxDepth', $parentPage->getDepth() + $depth);
+
+        /** @var iterable<PageInterface> $pages */
+        $pages = $queryBuilder->getQuery()->getResult();
+
+        $loadExcerpt = (bool) ($properties['excerpt'] ?? false);
+
+        $result = [];
+        foreach ($pages as $page) {
+            $content = $this->resolvePageContent($page, $locale);
+            $result[] = $this->normalizePageContent($content, $loadExcerpt);
+        }
+
+        return $result;
+    }
+
+    public function getNavigationTreeByUuid(
+        string $uuid,
+        string $locale,
+        string $webspaceKey,
+        int $depth = 1,
+        ?string $navigationContext = null,
+        array $properties = []
+    ): array {
+        $parentPage = $this->entityRepository->find($uuid);
+
+        if (null === $parentPage) {
+            return [];
+        }
+
+        $filters = [
+            'locale' => $locale,
+            'webspaceKey' => $webspaceKey,
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+        ];
+
+        if (null !== $navigationContext) {
+            $filters['navigationContexts'] = [$navigationContext];
+        }
+
+        // Get children within depth range relative to parent
+        $queryBuilder = $this->createQueryBuilder($filters);
+        $queryBuilder
+            ->andWhere('page.lft > :parentLft')
+            ->andWhere('page.rgt < :parentRgt')
+            ->andWhere('page.depth <= :maxDepth')
+            ->setParameter('parentLft', $parentPage->getLft())
+            ->setParameter('parentRgt', $parentPage->getRgt())
+            ->setParameter('maxDepth', $parentPage->getDepth() + $depth);
+
+        $query = $queryBuilder->getQuery();
+        $query->setHint(Query::HINT_INCLUDE_META_COLUMNS, true);
+
+        /** @var iterable<PageInterface> $pages */
+        $pages = $query->getResult('sulu_page_tree');
+
+        $loadExcerpt = (bool) ($properties['excerpt'] ?? false);
+
+        return $this->normalizePageTree($pages, $loadExcerpt, $locale, 1, $depth);
+    }
+
+    public function getBreadcrumb(
+        string $uuid,
+        string $locale,
+        string $webspaceKey,
+        array $properties = []
+    ): array {
+        $page = $this->entityRepository->find($uuid);
+
+        if (null === $page) {
+            return [];
+        }
+
+        $loadExcerpt = (bool) ($properties['excerpt'] ?? false);
+
+        // Build breadcrumb by traversing up the tree
+        $breadcrumb = [];
+        $currentPage = $page;
+
+        while (null !== $currentPage) {
+            $content = $this->resolvePageContent($currentPage, $locale);
+            $normalized = $this->normalizePageContent($content, $loadExcerpt);
+
+            // Prepend to maintain root -> current order
+            \array_unshift($breadcrumb, $normalized);
+
+            $currentPage = $currentPage->getParent();
+        }
+
+        return $breadcrumb;
+    }
+
     /**
      * @param array{
      *      locale?: string|null,

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -35,10 +35,10 @@ class NavigationTwigExtension extends AbstractExtension
         return [
             new TwigFunction('sulu_navigation_root_flat', [$this, 'flatRootNavigationFunction']),
             new TwigFunction('sulu_navigation_root_tree', [$this, 'treeRootNavigationFunction']),
-            //            new TwigFunction('sulu_navigation_flat', [$this, 'flatNavigationFunction']),
-            //            new TwigFunction('sulu_navigation_tree', [$this, 'treeNavigationFunction']),
-            //            new TwigFunction('sulu_breadcrumb', [$this, 'breadcrumbFunction']),
-            //            new TwigFunction('sulu_navigation_is_active', [$this, 'navigationIsActiveFunction']),
+            new TwigFunction('sulu_navigation_flat', [$this, 'flatNavigationFunction']),
+            new TwigFunction('sulu_navigation_tree', [$this, 'treeNavigationFunction']),
+            new TwigFunction('sulu_breadcrumb', [$this, 'breadcrumbFunction']),
+            new TwigFunction('sulu_navigation_is_active', [$this, 'navigationIsActiveFunction']),
         ];
     }
 
@@ -74,5 +74,118 @@ class NavigationTwigExtension extends AbstractExtension
             $depth,
             ['excerpt' => $loadExcerpt]
         );
+    }
+
+    /**
+     * @return array<string, mixed>[]
+     */
+    public function flatNavigationFunction(
+        string $uuid,
+        ?string $context = null,
+        int $depth = 1,
+        bool $loadExcerpt = false,
+        ?int $level = null
+    ): array {
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+
+        // Handle level parameter: get breadcrumb and use UUID at specified level
+        if (null !== $level) {
+            $breadcrumb = $this->navigationRepository->getBreadcrumb(
+                $uuid,
+                $locale,
+                $webspaceKey,
+                []
+            );
+
+            if (!isset($breadcrumb[$level])) {
+                return [];
+            }
+
+            $levelUuid = $breadcrumb[$level]['uuid'] ?? $breadcrumb[$level]['id'] ?? null;
+            if (!\is_string($levelUuid) || '' === $levelUuid) {
+                return [];
+            }
+
+            $uuid = $levelUuid;
+        }
+
+        return $this->navigationRepository->getNavigationFlatByUuid(
+            $uuid,
+            $locale,
+            $webspaceKey,
+            $depth,
+            $context,
+            ['excerpt' => $loadExcerpt]
+        );
+    }
+
+    /**
+     * @return array<string, mixed>[]
+     */
+    public function treeNavigationFunction(
+        string $uuid,
+        ?string $context = null,
+        int $depth = 1,
+        bool $loadExcerpt = false,
+        ?int $level = null
+    ): array {
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+
+        // Handle level parameter: get breadcrumb and use UUID at specified level
+        if (null !== $level) {
+            $breadcrumb = $this->navigationRepository->getBreadcrumb(
+                $uuid,
+                $locale,
+                $webspaceKey,
+                []
+            );
+
+            if (!isset($breadcrumb[$level])) {
+                return [];
+            }
+
+            $levelUuid = $breadcrumb[$level]['uuid'] ?? $breadcrumb[$level]['id'] ?? null;
+            if (!\is_string($levelUuid) || '' === $levelUuid) {
+                return [];
+            }
+
+            $uuid = $levelUuid;
+        }
+
+        return $this->navigationRepository->getNavigationTreeByUuid(
+            $uuid,
+            $locale,
+            $webspaceKey,
+            $depth,
+            $context,
+            ['excerpt' => $loadExcerpt]
+        );
+    }
+
+    /**
+     * @return array<string, mixed>[]
+     */
+    public function breadcrumbFunction(string $uuid): array
+    {
+        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
+        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+
+        return $this->navigationRepository->getBreadcrumb(
+            $uuid,
+            $locale,
+            $webspaceKey,
+            []
+        );
+    }
+
+    public function navigationIsActiveFunction(string $requestPath, string $itemPath): bool
+    {
+        if ($requestPath === $itemPath) {
+            return true;
+        }
+
+        return (bool) \preg_match(\sprintf('/%s([\/]|$)/', \preg_quote($itemPath, '/')), $requestPath);
     }
 }

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Doctrine\Repository;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+
+class NavigationRepositoryTest extends SuluTestCase
+{
+    use CreatePageTrait;
+
+    private NavigationRepositoryInterface $navigationRepository;
+
+    private Page $parent;
+    private Page $child1;
+    private Page $child2;
+    private Page $grandchild1;
+
+    protected function setUp(): void
+    {
+        self::purgeDatabase();
+
+        $this->navigationRepository = self::getContainer()->get('sulu_page.navigation_repository');
+
+        $messageBus = self::getContainer()->get('sulu_message_bus');
+
+        // Create hierarchical page structure:
+        // parent (main)
+        //   ├── child1 (main)
+        //   │   └── grandchild1 (main)
+        //   └── child2 (footer)
+
+        // Create parent page
+        $envelope = $messageBus->dispatch(
+            new \Symfony\Component\Messenger\Envelope(
+                new \Sulu\Page\Application\Message\CreatePageMessage(
+                    webspaceKey: 'sulu-io',
+                    parentId: \Sulu\Page\Application\MessageHandler\CreatePageMessageHandler::HOMEPAGE_PARENT_ID,
+                    data: [
+                        'locale' => 'en',
+                        'template' => 'default',
+                        'title' => 'Parent Page',
+                        'url' => '/parent',
+                        'navigationContexts' => ['main'],
+                    ]
+                ),
+                [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
+            )
+        );
+        $this->parent = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+
+        // Publish parent
+        $messageBus->dispatch(
+            new \Symfony\Component\Messenger\Envelope(
+                new \Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage(
+                    identifier: ['uuid' => $this->parent->getUuid()],
+                    locale: 'en',
+                    transitionName: \Sulu\Content\Domain\Model\WorkflowInterface::WORKFLOW_TRANSITION_PUBLISH
+                ),
+                [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
+            )
+        );
+
+        // Create child1 under parent
+        $envelope = $messageBus->dispatch(
+            new \Symfony\Component\Messenger\Envelope(
+                new \Sulu\Page\Application\Message\CreatePageMessage(
+                    webspaceKey: 'sulu-io',
+                    parentId: $this->parent->getUuid(),
+                    data: [
+                        'locale' => 'en',
+                        'template' => 'default',
+                        'title' => 'Child 1',
+                        'url' => '/child1',
+                        'navigationContexts' => ['main'],
+                    ]
+                ),
+                [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
+            )
+        );
+        $this->child1 = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+
+        // Publish child1
+        $messageBus->dispatch(
+            new \Symfony\Component\Messenger\Envelope(
+                new \Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage(
+                    identifier: ['uuid' => $this->child1->getUuid()],
+                    locale: 'en',
+                    transitionName: \Sulu\Content\Domain\Model\WorkflowInterface::WORKFLOW_TRANSITION_PUBLISH
+                ),
+                [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
+            )
+        );
+
+        // Create child2 under parent
+        $envelope = $messageBus->dispatch(
+            new \Symfony\Component\Messenger\Envelope(
+                new \Sulu\Page\Application\Message\CreatePageMessage(
+                    webspaceKey: 'sulu-io',
+                    parentId: $this->parent->getUuid(),
+                    data: [
+                        'locale' => 'en',
+                        'template' => 'default',
+                        'title' => 'Child 2',
+                        'url' => '/child2',
+                        'navigationContexts' => ['footer'],
+                    ]
+                ),
+                [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
+            )
+        );
+        $this->child2 = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+
+        // Publish child2
+        $messageBus->dispatch(
+            new \Symfony\Component\Messenger\Envelope(
+                new \Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage(
+                    identifier: ['uuid' => $this->child2->getUuid()],
+                    locale: 'en',
+                    transitionName: \Sulu\Content\Domain\Model\WorkflowInterface::WORKFLOW_TRANSITION_PUBLISH
+                ),
+                [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
+            )
+        );
+
+        // Create grandchild1 under child1
+        $envelope = $messageBus->dispatch(
+            new \Symfony\Component\Messenger\Envelope(
+                new \Sulu\Page\Application\Message\CreatePageMessage(
+                    webspaceKey: 'sulu-io',
+                    parentId: $this->child1->getUuid(),
+                    data: [
+                        'locale' => 'en',
+                        'template' => 'default',
+                        'title' => 'Grandchild 1',
+                        'url' => '/grandchild1',
+                        'navigationContexts' => ['main'],
+                    ]
+                ),
+                [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
+            )
+        );
+        $this->grandchild1 = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+
+        // Publish grandchild1
+        $messageBus->dispatch(
+            new \Symfony\Component\Messenger\Envelope(
+                new \Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage(
+                    identifier: ['uuid' => $this->grandchild1->getUuid()],
+                    locale: 'en',
+                    transitionName: \Sulu\Content\Domain\Model\WorkflowInterface::WORKFLOW_TRANSITION_PUBLISH
+                ),
+                [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
+            )
+        );
+
+        self::getEntityManager()->flush();
+    }
+
+    public function testGetNavigationFlatByUuid(): void
+    {
+        $result = $this->navigationRepository->getNavigationFlatByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            1
+        );
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertSame('Child 1', $result[0]['title']);
+        $this->assertSame('Child 2', $result[1]['title']);
+    }
+
+    public function testGetNavigationFlatByUuidWithDepth(): void
+    {
+        // Depth 1 should return only direct children
+        $result1 = $this->navigationRepository->getNavigationFlatByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            1
+        );
+
+        $this->assertCount(2, $result1);
+
+        // Depth 2 should return children and grandchildren
+        $result2 = $this->navigationRepository->getNavigationFlatByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            2
+        );
+
+        $this->assertCount(3, $result2);
+        $titles = \array_column($result2, 'title');
+        $this->assertContains('Child 1', $titles);
+        $this->assertContains('Child 2', $titles);
+        $this->assertContains('Grandchild 1', $titles);
+    }
+
+    public function testGetNavigationFlatByUuidWithNavigationContext(): void
+    {
+        // Filter by 'main' context
+        $result = $this->navigationRepository->getNavigationFlatByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            1,
+            'main'
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Child 1', $result[0]['title']);
+
+        // Filter by 'footer' context
+        $resultFooter = $this->navigationRepository->getNavigationFlatByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            1,
+            'footer'
+        );
+
+        $this->assertCount(1, $resultFooter);
+        $this->assertSame('Child 2', $resultFooter[0]['title']);
+    }
+
+    public function testGetNavigationFlatByUuidReturnsEmptyForInvalidUuid(): void
+    {
+        $result = $this->navigationRepository->getNavigationFlatByUuid(
+            'non-existent-uuid',
+            'en',
+            'sulu-io',
+            1
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetNavigationTreeByUuid(): void
+    {
+        $result = $this->navigationRepository->getNavigationTreeByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            1
+        );
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertSame('Child 1', $result[0]['title']);
+        $this->assertArrayHasKey('children', $result[0]);
+        $this->assertSame('Child 2', $result[1]['title']);
+        $this->assertArrayHasKey('children', $result[1]);
+    }
+
+    public function testGetNavigationTreeByUuidWithDepth(): void
+    {
+        // Depth 1 should return children but no grandchildren
+        $result1 = $this->navigationRepository->getNavigationTreeByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            1
+        );
+
+        $this->assertCount(2, $result1);
+        $this->assertEmpty($result1[0]['children']);
+        $this->assertEmpty($result1[1]['children']);
+
+        // Depth 2 should include grandchildren in tree
+        $result2 = $this->navigationRepository->getNavigationTreeByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            2
+        );
+
+        $this->assertCount(2, $result2);
+        $this->assertCount(1, $result2[0]['children']);
+        $this->assertSame('Grandchild 1', $result2[0]['children'][0]['title']);
+    }
+
+    public function testGetNavigationTreeByUuidWithNavigationContext(): void
+    {
+        // Filter by 'main' context
+        $result = $this->navigationRepository->getNavigationTreeByUuid(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io',
+            2,
+            'main'
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Child 1', $result[0]['title']);
+        $this->assertCount(1, $result[0]['children']);
+        $this->assertSame('Grandchild 1', $result[0]['children'][0]['title']);
+    }
+
+    public function testGetNavigationTreeByUuidReturnsEmptyForInvalidUuid(): void
+    {
+        $result = $this->navigationRepository->getNavigationTreeByUuid(
+            'non-existent-uuid',
+            'en',
+            'sulu-io',
+            1
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetBreadcrumb(): void
+    {
+        $result = $this->navigationRepository->getBreadcrumb(
+            $this->grandchild1->getUuid(),
+            'en',
+            'sulu-io'
+        );
+
+        $this->assertIsArray($result);
+        $this->assertCount(3, $result);
+
+        // Verify root -> current order
+        $this->assertSame('Parent Page', $result[0]['title']);
+        $this->assertSame('Child 1', $result[1]['title']);
+        $this->assertSame('Grandchild 1', $result[2]['title']);
+    }
+
+    public function testGetBreadcrumbOrder(): void
+    {
+        // Test with child1 - should have 2 items
+        $result = $this->navigationRepository->getBreadcrumb(
+            $this->child1->getUuid(),
+            'en',
+            'sulu-io'
+        );
+
+        $this->assertCount(2, $result);
+        $this->assertSame('Parent Page', $result[0]['title']);
+        $this->assertSame('Child 1', $result[1]['title']);
+
+        // Test with parent - should have 1 item
+        $resultParent = $this->navigationRepository->getBreadcrumb(
+            $this->parent->getUuid(),
+            'en',
+            'sulu-io'
+        );
+
+        $this->assertCount(1, $resultParent);
+        $this->assertSame('Parent Page', $resultParent[0]['title']);
+    }
+
+    public function testGetBreadcrumbReturnsEmptyForInvalidUuid(): void
+    {
+        $result = $this->navigationRepository->getBreadcrumb(
+            'non-existent-uuid',
+            'en',
+            'sulu-io'
+        );
+
+        $this->assertSame([], $result);
+    }
+}

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -60,7 +60,9 @@ class NavigationRepositoryTest extends SuluTestCase
                 [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
             )
         );
-        $this->parent = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+        $result = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+        \assert($result instanceof \Sulu\Page\Domain\Model\Page);
+        $this->parent = $result;
 
         // Publish parent
         $messageBus->dispatch(
@@ -91,7 +93,9 @@ class NavigationRepositoryTest extends SuluTestCase
                 [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
             )
         );
-        $this->child1 = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+        $result = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+        \assert($result instanceof \Sulu\Page\Domain\Model\Page);
+        $this->child1 = $result;
 
         // Publish child1
         $messageBus->dispatch(
@@ -122,7 +126,9 @@ class NavigationRepositoryTest extends SuluTestCase
                 [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
             )
         );
-        $this->child2 = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+        $result = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+        \assert($result instanceof \Sulu\Page\Domain\Model\Page);
+        $this->child2 = $result;
 
         // Publish child2
         $messageBus->dispatch(
@@ -153,7 +159,9 @@ class NavigationRepositoryTest extends SuluTestCase
                 [new \Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp()]
             )
         );
-        $this->grandchild1 = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+        $result = $envelope->all(\Symfony\Component\Messenger\Stamp\HandledStamp::class)[0]->getResult();
+        \assert($result instanceof \Sulu\Page\Domain\Model\Page);
+        $this->grandchild1 = $result;
 
         // Publish grandchild1
         $messageBus->dispatch(
@@ -179,7 +187,6 @@ class NavigationRepositoryTest extends SuluTestCase
             1
         );
 
-        $this->assertIsArray($result);
         $this->assertCount(2, $result);
         $this->assertSame('Child 1', $result[0]['title']);
         $this->assertSame('Child 2', $result[1]['title']);
@@ -260,7 +267,6 @@ class NavigationRepositoryTest extends SuluTestCase
             1
         );
 
-        $this->assertIsArray($result);
         $this->assertCount(2, $result);
         $this->assertSame('Child 1', $result[0]['title']);
         $this->assertArrayHasKey('children', $result[0]);
@@ -291,7 +297,9 @@ class NavigationRepositoryTest extends SuluTestCase
         );
 
         $this->assertCount(2, $result2);
+        \assert(\is_array($result2[0]['children']));
         $this->assertCount(1, $result2[0]['children']);
+        \assert(\is_array($result2[0]['children'][0]));
         $this->assertSame('Grandchild 1', $result2[0]['children'][0]['title']);
     }
 
@@ -308,7 +316,9 @@ class NavigationRepositoryTest extends SuluTestCase
 
         $this->assertCount(1, $result);
         $this->assertSame('Child 1', $result[0]['title']);
+        \assert(\is_array($result[0]['children']));
         $this->assertCount(1, $result[0]['children']);
+        \assert(\is_array($result[0]['children'][0]));
         $this->assertSame('Grandchild 1', $result[0]['children'][0]['title']);
     }
 
@@ -332,7 +342,6 @@ class NavigationRepositoryTest extends SuluTestCase
             'sulu-io'
         );
 
-        $this->assertIsArray($result);
         $this->assertCount(3, $result);
 
         // Verify root -> current order

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Symfony\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
+use Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension;
+
+class NavigationTwigExtensionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @return array<array{bool, string, string}>
+     */
+    public static function activeElementProvider(): array
+    {
+        return [
+            [false, '/', '/news/item'],
+            [true, '/news/item', '/news/item'],
+            [true, '/news/item', '/news'],
+            [false, '/news/item', '/'],
+            [false, '/news/item-1', '/news/item'],
+            [false, '/news', '/news/item'],
+            [false, '/news', '/product/item'],
+            [false, '/news', '/news-1'],
+            [false, '/news', '/news-1/item'],
+            [true, '/', '/'],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('activeElementProvider')]
+    public function testNavigationIsActiveFunction(bool $expected, string $requestPath, string $itemPath): void
+    {
+        $extension = new NavigationTwigExtension(
+            $this->prophesize(NavigationRepositoryInterface::class)->reveal(),
+            $this->prophesize(RequestAnalyzerInterface::class)->reveal()
+        );
+
+        $this->assertEquals($expected, $extension->navigationIsActiveFunction($requestPath, $itemPath));
+    }
+
+    public function testFlatRootNavigationFunction(): void
+    {
+        $navigationRepository = $this->prophesize(NavigationRepositoryInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $extension = new NavigationTwigExtension(
+            $navigationRepository->reveal(),
+            $requestAnalyzer->reveal()
+        );
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu-io');
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $localization = new Localization('en');
+        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+
+        $navigationRepository->getNavigationFlat('main', 'en', 'sulu-io', 1, ['loadExcerpt' => false])
+            ->willReturn([['title' => 'Page 1']])
+            ->shouldBeCalled();
+
+        $result = $extension->flatRootNavigationFunction('main', 1, false);
+
+        $this->assertEquals([['title' => 'Page 1']], $result);
+    }
+
+    public function testTreeRootNavigationFunction(): void
+    {
+        $navigationRepository = $this->prophesize(NavigationRepositoryInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $extension = new NavigationTwigExtension(
+            $navigationRepository->reveal(),
+            $requestAnalyzer->reveal()
+        );
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu-io');
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $localization = new Localization('en');
+        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+
+        $navigationRepository->getNavigationTree('main', 'en', 'sulu-io', 2, ['excerpt' => true])
+            ->willReturn([['title' => 'Page 1', 'children' => []]])
+            ->shouldBeCalled();
+
+        $result = $extension->treeRootNavigationFunction('main', 2, true);
+
+        $this->assertEquals([['title' => 'Page 1', 'children' => []]], $result);
+    }
+
+    public function testFlatNavigationFunction(): void
+    {
+        $navigationRepository = $this->prophesize(NavigationRepositoryInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $extension = new NavigationTwigExtension(
+            $navigationRepository->reveal(),
+            $requestAnalyzer->reveal()
+        );
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu-io');
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $localization = new Localization('en');
+        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+
+        $navigationRepository->getNavigationFlatByUuid('parent-uuid', 'en', 'sulu-io', 2, 'main', ['excerpt' => true])
+            ->willReturn([['title' => 'Child 1'], ['title' => 'Child 2']])
+            ->shouldBeCalled();
+
+        $result = $extension->flatNavigationFunction('parent-uuid', 'main', 2, true);
+
+        $this->assertEquals([['title' => 'Child 1'], ['title' => 'Child 2']], $result);
+    }
+
+    public function testTreeNavigationFunction(): void
+    {
+        $navigationRepository = $this->prophesize(NavigationRepositoryInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $extension = new NavigationTwigExtension(
+            $navigationRepository->reveal(),
+            $requestAnalyzer->reveal()
+        );
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu-io');
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $localization = new Localization('en');
+        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+
+        $navigationRepository->getNavigationTreeByUuid('parent-uuid', 'en', 'sulu-io', 2, null, ['excerpt' => false])
+            ->willReturn([['title' => 'Child 1', 'children' => [['title' => 'Grandchild 1']]]])
+            ->shouldBeCalled();
+
+        $result = $extension->treeNavigationFunction('parent-uuid', null, 2, false);
+
+        $this->assertEquals([['title' => 'Child 1', 'children' => [['title' => 'Grandchild 1']]]], $result);
+    }
+
+    public function testBreadcrumbFunction(): void
+    {
+        $navigationRepository = $this->prophesize(NavigationRepositoryInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $extension = new NavigationTwigExtension(
+            $navigationRepository->reveal(),
+            $requestAnalyzer->reveal()
+        );
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu-io');
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $localization = new Localization('en');
+        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', [])
+            ->willReturn([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'child-uuid', 'title' => 'Child']])
+            ->shouldBeCalled();
+
+        $result = $extension->breadcrumbFunction('child-uuid');
+
+        $this->assertEquals([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'child-uuid', 'title' => 'Child']], $result);
+    }
+
+    public function testFlatNavigationFunctionWithLevel(): void
+    {
+        $navigationRepository = $this->prophesize(NavigationRepositoryInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $extension = new NavigationTwigExtension(
+            $navigationRepository->reveal(),
+            $requestAnalyzer->reveal()
+        );
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu-io');
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $localization = new Localization('en');
+        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+
+        $breadcrumb = [
+            ['uuid' => 'grandparent-uuid', 'title' => 'Grandparent'],
+            ['uuid' => 'parent-uuid', 'title' => 'Parent'],
+            ['uuid' => 'child-uuid', 'title' => 'Child'],
+        ];
+
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', [])
+            ->willReturn($breadcrumb)
+            ->shouldBeCalled();
+
+        $navigationRepository->getNavigationFlatByUuid('grandparent-uuid', 'en', 'sulu-io', 1, null, ['excerpt' => false])
+            ->willReturn([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'uncle-uuid', 'title' => 'Uncle']])
+            ->shouldBeCalled();
+
+        $result = $extension->flatNavigationFunction('child-uuid', null, 1, false, 0);
+
+        $this->assertEquals([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'uncle-uuid', 'title' => 'Uncle']], $result);
+    }
+
+    public function testFlatNavigationFunctionWithInvalidLevel(): void
+    {
+        $navigationRepository = $this->prophesize(NavigationRepositoryInterface::class);
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $extension = new NavigationTwigExtension(
+            $navigationRepository->reveal(),
+            $requestAnalyzer->reveal()
+        );
+
+        $webspace = new Webspace();
+        $webspace->setKey('sulu-io');
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $localization = new Localization('en');
+        $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+
+        $breadcrumb = [
+            ['uuid' => 'parent-uuid', 'title' => 'Parent'],
+        ];
+
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', [])
+            ->willReturn($breadcrumb)
+            ->shouldBeCalled();
+
+        $result = $extension->flatNavigationFunction('child-uuid', null, 1, false, 5);
+
+        $this->assertEquals([], $result);
+    }
+}


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes # <!-- add issue number if exists -->
  | Related issues/PRs | # <!-- add if exists -->
  | License | MIT

  #### What's in this PR?

  This PR reintegrates missing navigation Twig extensions from Sulu 2.6 into Sulu 3.0, providing backward compatibility for templates migrating from 2.6 to 3.0.

  **Added Twig Functions:**
  - `sulu_navigation_flat($uuid, $context, $depth, $loadExcerpt, $level)` - Get flat navigation from specific page
  - `sulu_navigation_tree($uuid, $context, $depth, $loadExcerpt, $level)` - Get hierarchical navigation from specific page
  - `sulu_breadcrumb($uuid)` - Get breadcrumb trail from page to root
  - `sulu_navigation_is_active($requestPath, $itemPath)` - Check if navigation item is active

  #### Why?

  Sulu 2.6 provided navigation Twig extensions (`sulu_navigation_flat`, `sulu_navigation_tree`, `sulu_breadcrumb`, `sulu_navigation_is_active`) that were missing in Sulu 3.0.

  #### Example Usage

  ```twig
  {# Get flat navigation children of a specific page #}
  {% set children = sulu_navigation_flat(page.uuid, 'main', 2, true) %}

  {# Get hierarchical navigation tree #}
  {% set tree = sulu_navigation_tree(page.uuid, 'main', 3, false) %}

  {# Get breadcrumb trail #}
  {% set breadcrumb = sulu_breadcrumb(page.uuid) %}
  {% for item in breadcrumb %}
      <a href="{{ item.url }}">{{ item.title }}</a>
  {% endfor %}

  {# Check if navigation item is active #}
  {% if sulu_navigation_is_active(app.request.requestUri, item.url) %}
      <li class="active">{{ item.title }}</li>
  {% endif %}

  {# Get navigation at specific level (e.g., siblings of grandparent) #}
  {% set siblings = sulu_navigation_flat(page.uuid, 'main', 1, false, 0) %}