### PR TITLE
Remove deprecated `findAllTags` and replace with Repository method

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -914,6 +914,8 @@ Removed deprecated functions and properties:
 - `Sulu\Bundle\Security\Entity\Role::getRole` (use `getIdentifier` instead)
 - `Sulu\Bundle\AdminBundle\Admin\AdminPool::addAdmin` (use dependency injection via tagged service instead)
 - `Sulu\Bundle\AdminBundle\Metadata\MetadataProvierRegistry::addMetadataProiver` (use dependency injection via tagged service instead)
+- `Sulu\Bundle\TagBundle\Entity\TagRepository::findAllTags` (use `findAll` instead)
+- `Sulu\Bundle\TagBundle\Tag\TagManager::findAll` (use repository instead)
 
 Removed unused arguments:
 

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -25,7 +25,6 @@ use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -194,19 +193,8 @@ class AdminController
         $locale = $user->getLocale();
 
         $metadataOptions = $request->query->all();
-
-        try {
-            $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)
-                ->getMetadata($key, $locale, $metadataOptions);
-        } catch (ServiceNotFoundException $exception) {
-            $view = View::create(
-                ['message' => \sprintf('"%s" not found', $exception->getSourceId())],
-                Response::HTTP_NOT_FOUND
-            );
-            $view->setFormat('json');
-
-            return $this->viewHandler->handle($view);
-        }
+        $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)
+            ->getMetadata($key, $locale, $metadataOptions);
 
         $context = new Context();
         $context->addGroup('Default');

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -25,6 +25,7 @@ use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\ContactBundle\Contact\ContactManagerInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -193,8 +194,19 @@ class AdminController
         $locale = $user->getLocale();
 
         $metadataOptions = $request->query->all();
-        $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)
-            ->getMetadata($key, $locale, $metadataOptions);
+
+        try {
+            $metadata = $this->metadataProviderRegistry->getMetadataProvider($type)
+                ->getMetadata($key, $locale, $metadataOptions);
+        } catch (ServiceNotFoundException $exception) {
+            $view = View::create(
+                ['message' => \sprintf('"%s" not found', $exception->getSourceId())],
+                Response::HTTP_NOT_FOUND
+            );
+            $view->setFormat('json');
+
+            return $this->viewHandler->handle($view);
+        }
 
         $context = new Context();
         $context->addGroup('Default');

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\TagBundle\Tag\Exception\TagAlreadyExistsException;
 use Sulu\Bundle\TagBundle\Tag\Exception\TagNotFoundException;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
+use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\Exception\MissingArgumentException;
@@ -51,6 +52,7 @@ class TagController extends AbstractRestController implements SecuredControllerI
         private FieldDescriptorFactoryInterface $fieldDescriptorFactory,
         private DoctrineListBuilderFactoryInterface $listBuilderFactory,
         private TagManagerInterface $tagManager,
+        private TagRepositoryInterface $tagRepository,
         private EntityManagerInterface $entityManager,
         private UrlGeneratorInterface $router,
         private string $tagClass
@@ -107,7 +109,7 @@ class TagController extends AbstractRestController implements SecuredControllerI
             );
             $view = $this->view($list, 200);
         } else {
-            $list = new CollectionRepresentation($this->tagManager->findAll(), TagInterface::RESOURCE_KEY);
+            $list = new CollectionRepresentation($this->tagRepository->findAll(), TagInterface::RESOURCE_KEY);
 
             $context = new Context();
             $context->setGroups(['partialTag']);

--- a/src/Sulu/Bundle/TagBundle/Entity/TagRepository.php
+++ b/src/Sulu/Bundle/TagBundle/Entity/TagRepository.php
@@ -50,12 +50,4 @@ class TagRepository extends EntityRepository implements TagRepositoryInterface
             return null;
         }
     }
-
-    /**
-     * @deprecated use the Repository findAll method
-     */
-    public function findAllTags()
-    {
-        return $this->findAll();
-    }
 }

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -41,6 +41,7 @@
             <argument type="service" id="sulu_core.list_builder.field_descriptor_factory"/>
             <argument type="service" id="sulu_core.doctrine_list_builder_factory"/>
             <argument type="service" id="sulu_tag.tag_manager"/>
+            <argument type="service" id="sulu.repository.tag" />
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <argument type="service" id="router"/>
             <argument>%sulu.model.tag.class%</argument>

--- a/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/TagBundle/Resources/config/services.xml
@@ -24,7 +24,7 @@
         </service>
 
         <service id="sulu_tag.twig_extension" class="Sulu\Bundle\TagBundle\Twig\TagTwigExtension">
-            <argument type="service" id="sulu_tag.tag_manager"/>
+            <argument type="service" id="sulu.repository.tag"/>
             <argument type="service" id="sulu_tag.tag_request_handler"/>
             <argument type="service" id="sulu_core.array_serializer"/>
             <argument type="service" id="sulu_core.cache.memoize"/>

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
@@ -41,18 +41,6 @@ class TagManager implements TagManagerInterface
     }
 
     /**
-     * Loads all the tags managed in this system.
-     *
-     * @deprecated use the Repository findAll method
-     *
-     * @return TagInterface[]
-     */
-    public function findAll()
-    {
-        return $this->tagRepository->findAllTags();
-    }
-
-    /**
      * Loads the tag with the given id.
      *
      * @param $id number The id of the tag

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\TagBundle\Tag;
 
-use Sulu\Bundle\TagBundle\Tag\Exception\TagNotFoundException;
-
 /**
  * Defines the operations of the TagManager.
  * The TagManager is responsible for the centralized management of our tags.

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
@@ -11,6 +11,8 @@
 
 namespace Sulu\Bundle\TagBundle\Tag;
 
+use Sulu\Bundle\TagBundle\Tag\Exception\TagNotFoundException;
+
 /**
  * Defines the operations of the TagManager.
  * The TagManager is responsible for the centralized management of our tags.
@@ -47,6 +49,8 @@ interface TagManagerInterface
      *
      * @param array $data The data of the tag to save
      * @param number|null $id The id for saving the tag (optional)
+     *
+     * @throws Exception\TagNotFoundException
      */
     public function save($data, $id = null);
 
@@ -54,6 +58,8 @@ interface TagManagerInterface
      * Deletes the given Tag.
      *
      * @param number $id The tag to delete
+     *
+     * @throws Exception\TagNotFoundException
      */
     public function delete($id);
 

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
@@ -18,15 +18,6 @@ namespace Sulu\Bundle\TagBundle\Tag;
 interface TagManagerInterface
 {
     /**
-     * Loads all the tags managed in this system.
-     *
-     * @deprecated use the Repository findAll method
-     *
-     * @return TagInterface[]
-     */
-    public function findAll();
-
-    /**
      * Loads the tag with the given id.
      *
      * @param $id number The id of the tag

--- a/src/Sulu/Bundle/TagBundle/Tag/TagRepositoryInterface.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagRepositoryInterface.php
@@ -37,13 +37,4 @@ interface TagRepositoryInterface extends RepositoryInterface
      * @return TagInterface|null
      */
     public function findTagByName($name);
-
-    /**
-     * Searches for all tags.
-     *
-     * @deprecated use the Repository findAll method
-     *
-     * @return array<TagInterface>
-     */
-    public function findAllTags();
 }

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
@@ -16,8 +16,9 @@ use JMS\Serializer\SerializationContext;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\TagBundle\Entity\Tag;
-use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
+use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Sulu\Bundle\TagBundle\Twig\TagTwigExtension;
 use Sulu\Component\Cache\Memoize;
 use Sulu\Component\Cache\MemoizeInterface;
@@ -32,6 +33,16 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class TagTwigExtensionTest extends TestCase
 {
     use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<TagRepositoryInterface>
+     */
+    private ObjectProphecy $tagRepository;
+
+    public function setUp(): void
+    {
+        $this->tagRepository = $this->prophesize(TagRepositoryInterface::class);
+    }
 
     /**
      * Returns memoize cache instance.
@@ -64,8 +75,7 @@ class TagTwigExtensionTest extends TestCase
             $tags[] = $tag;
         }
 
-        $tagManager = $this->prophesize(TagManagerInterface::class);
-        $tagManager->findAll()->shouldBeCalled()->willReturn($tags);
+        $this->tagRepository->findAll()->shouldBeCalled()->willReturn($tags);
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
         $serializer->serialize($tags, Argument::type(SerializationContext::class))
@@ -73,7 +83,7 @@ class TagTwigExtensionTest extends TestCase
         $tagRequestHandler = $this->prophesize(TagRequestHandlerInterface::class);
 
         $tagExtension = new TagTwigExtension(
-            $tagManager->reveal(),
+            $this->tagRepository->reveal(),
             $tagRequestHandler->reveal(),
             $serializer->reveal(),
             $this->getMemoizeCache()
@@ -104,7 +114,6 @@ class TagTwigExtensionTest extends TestCase
     {
         $tag = ['name' => 'Test'];
 
-        $tagManager = $this->prophesize(TagManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
         $request = $this->prophesize(Request::class);
 
@@ -118,7 +127,7 @@ class TagTwigExtensionTest extends TestCase
         $tagRequestHandler = new TagRequestHandler($requestStack->reveal());
 
         $tagExtension = new TagTwigExtension(
-            $tagManager->reveal(),
+            $this->tagRepository->reveal(),
             $tagRequestHandler,
             $serializer->reveal(),
             $this->getMemoizeCache()
@@ -151,7 +160,6 @@ class TagTwigExtensionTest extends TestCase
     {
         $tag = ['name' => 'Test'];
 
-        $tagManager = $this->prophesize(TagManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
         $request = $this->prophesize(Request::class);
 
@@ -165,7 +173,7 @@ class TagTwigExtensionTest extends TestCase
         $tagRequestHandler = new TagRequestHandler($requestStack->reveal());
 
         $tagExtension = new TagTwigExtension(
-            $tagManager->reveal(),
+            $this->tagRepository->reveal(),
             $tagRequestHandler,
             $serializer->reveal(),
             $this->getMemoizeCache()
@@ -195,7 +203,6 @@ class TagTwigExtensionTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('clearProvider')]
     public function testClearTagUrl($tagsParameter, $url, $tagsString): void
     {
-        $tagManager = $this->prophesize(TagManagerInterface::class);
         $requestStack = $this->prophesize(RequestStack::class);
         $request = $this->prophesize(Request::class);
 
@@ -209,7 +216,7 @@ class TagTwigExtensionTest extends TestCase
         $tagRequestHandler = new TagRequestHandler($requestStack->reveal());
 
         $tagExtension = new TagTwigExtension(
-            $tagManager->reveal(),
+            $this->tagRepository->reveal(),
             $tagRequestHandler,
             $serializer->reveal(),
             $this->getMemoizeCache()

--- a/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\TagBundle\Twig;
 
 use JMS\Serializer\SerializationContext;
-use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
 use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;

--- a/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
+++ b/src/Sulu/Bundle/TagBundle/Twig/TagTwigExtension.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\TagBundle\Twig;
 
 use JMS\Serializer\SerializationContext;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
+use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Sulu\Component\Cache\MemoizeInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Sulu\Component\Tag\Request\TagRequestHandlerInterface;
@@ -21,11 +22,8 @@ use Twig\TwigFunction;
 
 class TagTwigExtension extends AbstractExtension
 {
-    /**
-     * @deprecated Requiring the TagManagerInterface instead of the TagRepository
-     */
     public function __construct(
-        private TagManagerInterface $tagManager,
+        private TagRepositoryInterface $tagRepository,
         private TagRequestHandlerInterface $tagRequestHandler,
         private ArraySerializerInterface $serializer,
         private MemoizeInterface $memoizeCache,
@@ -54,7 +52,7 @@ class TagTwigExtension extends AbstractExtension
             'sulu_tags',
             \func_get_args(),
             function() {
-                $tags = $this->tagManager->findAll();
+                $tags = $this->tagRepository->findAll();
 
                 $context = SerializationContext::create();
                 $context->setSerializeNull(true);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/sulu/sulu/pull/8047
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Removing deprecated function

#### Why?
🧹 

#### Example Usage
```diff
-$this->tagManager->findAllTags();
+$this->tagRepository->findAll();
```