### PR TITLE
Improve performance of `MediaTypeUpdateCommand`

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
+++ b/src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
@@ -12,13 +12,12 @@
 namespace Sulu\Bundle\MediaBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Bundle\MediaBundle\Entity\File;
-use Sulu\Bundle\MediaBundle\Entity\FileVersion;
-use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManagerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class MediaTypeUpdateCommand extends Command
 {
@@ -38,43 +37,57 @@ class MediaTypeUpdateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $em = $this->entityManager;
-        $repo = $em->getRepository('SuluMediaBundle:Media');
-        $medias = $repo->findAll();
-        $counter = 0;
-        /** @var MediaInterface $media */
-        foreach ($medias as $media) {
-            /** @var File $file */
-            foreach ($media->getFiles() as $file) {
-                /** @var FileVersion $fileVersion */
-                foreach ($file->getFileVersions() as $fileVersion) {
-                    $mimeType = $fileVersion->getMimeType();
-                    if (null === $mimeType) {
-                        continue;
-                    }
-
-                    if ($fileVersion->getVersion() == $file->getVersion()) {
-                        $mediaTypeId = $this->mediaTypeManager->getMediaType($mimeType);
-                        if ($media->getType()->getId() != $mediaTypeId) {
-                            $oldType = $media->getType();
-                            $newType = $this->mediaTypeManager->get($mediaTypeId);
-                            $media->setType($newType);
-                            $em->persist($media);
-                            ++$counter;
-                            $output->writeln(\sprintf('Media with id <comment>%s</comment> change from type <comment>%s</comment> to <comment>%s</comment>', $media->getId(), $oldType->getName(), $newType->getName()));
-                        }
-                    }
-                }
+        /** @var array<int, array<int>> $updates */
+        $updates = [];
+        foreach ($this->getMimeTypesForAllMedia() as $mediaInfo) {
+            $mediaTypeId = $this->mediaTypeManager->getMediaType($mediaInfo['mimeType']);
+            if ($mediaInfo['type'] != $mediaTypeId) {
+                $updates[$mediaTypeId][] = $mediaInfo['id'];
             }
         }
 
-        if ($counter) {
-            $em->flush();
-            $output->writeln(\sprintf('<info>SUCCESS FULLY UPDATED (%s)</info>', $counter));
-        } else {
-            $output->writeln('<comment>Nothing to update</comment>');
+        $io = new SymfonyStyle($input, $output);
+        if ([] === $updates) {
+            $io->comment('Nothing to update');
+
+            return 0;
         }
 
+        $counter = 0;
+        foreach ($updates as $mediaTypeId => $mediaIds) {
+            $this->entityManager->createQueryBuilder()
+                ->update(Media::class, 'media')
+                ->set('media.type', ':type')
+                ->where('media.id IN (:ids)')
+                ->setParameter('ids', $mediaIds)
+                ->setParameter('type', $mediaTypeId)
+                ->getQuery()
+                ->execute()
+            ;
+
+            $counter += \count($mediaIds);
+        }
+        $io->success(\sprintf('Updated %s media types', $counter));
+
         return 0;
+    }
+
+    /**
+     * @return array<array{id: int, type: int, mimeType: string}>
+     */
+    private function getMimeTypesForAllMedia(): array
+    {
+        /** @var array<array{id: int, type: int, mimeType: string}> $data */
+        $data = $this->entityManager->createQueryBuilder()
+            ->addSelect('media.id', 'IDENTITY(media.type) as type', 'fileVersion.mimeType')
+            ->from('SuluMediaBundle:Media', 'media')
+            ->innerJoin('media.files', 'file')
+            ->innerJoin('file.fileVersions', 'fileVersion', 'WITH', 'fileVersion.version = file.version')
+            ->groupBy('media.id', 'media.type', 'fileVersion.mimeType')
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        return $data;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing the heavy entity loading in the UpdateMediaTypeCommand with a lighter array that updates a lot of elements at once.

#### Why?
When you have a lot of media this command can take a long time to run. From testing on a project with 9k media entries and 15k file versions the time the update took went from 5 seconds to under a second.