### PR TITLE
Remove parameter `sulu_media.adobe_creative_key`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -257,6 +257,7 @@ These unused parameters have been removed:
 - `sulu_security.group_repository.class`
 - `sulu_security.entity_group.class`
 - `sulu_security.entity.group`
+- `sulu_media.adobe_creative_key`
 
 The resource routes has been removed:
 

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -33,7 +33,6 @@ final class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('sulu_media');
         $rootNode = $treeBuilder->getRootNode();
         $rootNode->children()
-            ->scalarNode('adobe_creative_key')->defaultNull()->end()
             ->scalarNode('adapter')
                 ->defaultValue('auto')
             ->end()

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -278,12 +278,6 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
             $config['upload']['max_filesize']
         );
 
-        // Adobe creative sdk
-        $container->setParameter(
-            'sulu_media.adobe_creative_key',
-            $config['adobe_creative_key']
-        );
-
         // load services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing unused parameters

#### Why?
If we don't need it, remove it.