### PR TITLE
Replace all usage of resource_locator field type by route field type

### DIFF
--- a/packages/article/tests/Application/config/templates/pages/default.xml
+++ b/packages/article/tests/Application/config/templates/pages/default.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/article/tests/Application/config/templates/pages/overview.xml
+++ b/packages/article/tests/Application/config/templates/pages/overview.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -151,7 +151,7 @@ class RoutableDataMapper implements DataMapperInterface
     {
         foreach ($metadata->getFlatFieldMetadata() as $property) {
             // TODO add support for page_tree_route field type: https://github.com/sulu/SuluContentBundle/issues/242
-            if ('route' === $property->getType() || 'resource_locator' === $property->getType()) {
+            if ('route' === $property->getType()) {
                 return $property;
             }
         }

--- a/packages/content/src/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTrait.php
+++ b/packages/content/src/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTrait.php
@@ -56,7 +56,7 @@ trait ResolveContentDimensionUrlTrait
         }
 
         foreach ($metadata->getItems() as $property) {
-            if ('route' === $property->getType() || 'resource_locator' === $property->getType()) {
+            if ('route' === $property->getType()) {
                 /** @var string|null */
                 return $dimensionContent->getTemplateData()[$property->getName()] ?? null;
             }

--- a/packages/content/tests/Application/config/templates/examples/blocks-with-custom-settings.xml
+++ b/packages/content/tests/Application/config/templates/examples/blocks-with-custom-settings.xml
@@ -23,7 +23,7 @@
             <tag name="sulu.search.field" role="title"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/packages/content/tests/Application/config/templates/examples/full-content.xml
+++ b/packages/content/tests/Application/config/templates/examples/full-content.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/packages/content/tests/Application/config/templates/pages/default.xml
+++ b/packages/content/tests/Application/config/templates/pages/default.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/packages/content/tests/Application/config/templates/pages/default_with_page_selection.xml
+++ b/packages/content/tests/Application/config/templates/pages/default_with_page_selection.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/packages/custom-url/tests/Application/config/templates/pages/default.xml
+++ b/packages/custom-url/tests/Application/config/templates/pages/default.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/custom-url/tests/Application/config/templates/pages/overview.xml
+++ b/packages/custom-url/tests/Application/config/templates/pages/overview.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/route/tests/Application/config/templates/pages/default.xml
+++ b/packages/route/tests/Application/config/templates/pages/default.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/route/tests/Application/config/templates/pages/overview.xml
+++ b/packages/route/tests/Application/config/templates/pages/overview.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/search/tests/Application/config/templates/pages/default.xml
+++ b/packages/search/tests/Application/config/templates/pages/default.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/search/tests/Application/config/templates/pages/overview.xml
+++ b/packages/search/tests/Application/config/templates/pages/overview.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/snippet/tests/Application/config/templates/pages/default.xml
+++ b/packages/snippet/tests/Application/config/templates/pages/default.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/packages/snippet/tests/Application/config/templates/pages/overview.xml
+++ b/packages/snippet/tests/Application/config/templates/pages/overview.xml
@@ -16,7 +16,7 @@
 
         <property name="tags" type="tag_selection"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Application/config/templates/pages/default.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
@@ -45,7 +45,7 @@
             <tag name="sulu.rlp.part" priority="100"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/grouped.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/grouped.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part" priority="100"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/overview.xml
@@ -18,7 +18,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" />
         </property>
         <property name="article" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -27,7 +27,7 @@
         "url": {
             "disabledCondition": null,
             "visibleCondition": null,
-            "type": "resource_locator",
+            "type": "route",
             "colSpan": 12,
             "options": [],
             "types": [],

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
@@ -42,7 +42,7 @@
         "url": {
             "disabledCondition": null,
             "visibleCondition": null,
-            "type": "resource_locator",
+            "type": "route",
             "colSpan": 12,
             "options": [],
             "types": [],

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/templates/pages/default.xml
@@ -24,7 +24,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
             </meta>

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/config/templates/pages/overview.xml
@@ -13,9 +13,8 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.rlp.part" />
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" />
         </property>
     </properties>
 </template>
-

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/default.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Application/config/templates/pages/overview.xml
@@ -14,7 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" />
         </property>
         <property name="article" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/default.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Application/config/templates/pages/overview.xml
@@ -14,7 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" />
         </property>
         <property name="article" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/CoreBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Application/config/templates/pages/default.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part" priority="100"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/CoreBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Application/config/templates/pages/overview.xml
@@ -14,7 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" />
         </property>
         <property name="article" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/default.xml
@@ -25,7 +25,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
             </meta>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/images.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/images.xml
@@ -25,7 +25,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
             </meta>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Application/config/templates/pages/overview.xml
@@ -25,7 +25,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
             </meta>

--- a/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/default.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Tests/Application/config/templates/pages/overview.xml
@@ -14,7 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" />
         </property>
         <property name="article" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Application/config/templates/pages/default.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <property name="title" type="text_line"/>
-        <property name="url" type="resource_locator">
+        <property name="url" type="route">
             <tag name="sulu.rlp"/>
         </property>
     </properties>

--- a/src/Sulu/Bundle/ReferenceBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/ReferenceBundle/Tests/Application/config/templates/pages/default.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/default.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Application/config/templates/pages/overview.xml
@@ -14,7 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" />
         </property>
         <property name="article" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/default.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/TagBundle/Tests/Application/config/templates/pages/overview.xml
@@ -14,7 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" />
         </property>
         <property name="article" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/TestBundle/Resources/structures/pages/default.xml
+++ b/src/Sulu/Bundle/TestBundle/Resources/structures/pages/default.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>

--- a/src/Sulu/Bundle/TrashBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Application/config/templates/pages/default.xml
@@ -27,7 +27,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/default.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
@@ -40,4 +40,3 @@
         <property name="localized_blog" type="text_area" mandatory="false" />
     </properties>
 </template>
-

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/overview.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/overview.xml
@@ -14,7 +14,7 @@
             <tag name="sulu.rlp.part" />
         </property>
         <property name="tags" type="text_line" minOccurs="2" maxOccurs="10"/>
-        <property name="url" type="resource_locator" mandatory="false">
+        <property name="url" type="route" mandatory="false">
             <tag name="sulu.rlp" />
         </property>
         <property name="article" type="text_area" mandatory="false"/>

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/simple.xml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/templates/pages/simple.xml
@@ -26,7 +26,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="de">Adresse</title>
                 <title lang="en">Resourcelocator</title>
@@ -40,4 +40,3 @@
         <property name="localized_blog" type="text_area" mandatory="false" />
     </properties>
 </template>
-

--- a/tests/Resources/DataFixtures/Page/template.xml
+++ b/tests/Resources/DataFixtures/Page/template.xml
@@ -51,7 +51,7 @@
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_block.xml
+++ b/tests/Resources/DataFixtures/Page/template_block.xml
@@ -14,7 +14,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10"/>
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
         <property name="article" type="text_editor" mandatory="true"/>

--- a/tests/Resources/DataFixtures/Page/template_block_type_without_meta.xml
+++ b/tests/Resources/DataFixtures/Page/template_block_type_without_meta.xml
@@ -14,7 +14,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10"/>
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
         <block name="block1" default-type="default" minOccurs="2" maxOccurs="10" mandatory="true">

--- a/tests/Resources/DataFixtures/Page/template_block_types.xml
+++ b/tests/Resources/DataFixtures/Page/template_block_types.xml
@@ -14,7 +14,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10"/>
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
         <block name="block1" default-type="default" minOccurs="2" maxOccurs="10" mandatory="true">

--- a/tests/Resources/DataFixtures/Page/template_block_with_sections.xml
+++ b/tests/Resources/DataFixtures/Page/template_block_with_sections.xml
@@ -14,7 +14,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10"/>
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_duplicated_priority.xml
+++ b/tests/Resources/DataFixtures/Page/template_duplicated_priority.xml
@@ -13,7 +13,7 @@
         <property name="title" type="text_line" mandatory="true">
             <tag name="sulu.node.title" priority="10" />
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1" />
         </property>
         <property name="article" type="text_area" mandatory="false">

--- a/tests/Resources/DataFixtures/Page/template_expression.xml
+++ b/tests/Resources/DataFixtures/Page/template_expression.xml
@@ -28,7 +28,7 @@
 
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_invalid_expression.xml
+++ b/tests/Resources/DataFixtures/Page/template_invalid_expression.xml
@@ -28,7 +28,7 @@
 
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_lifetime_0.xml
+++ b/tests/Resources/DataFixtures/Page/template_lifetime_0.xml
@@ -37,7 +37,7 @@
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_load_internal.xml
+++ b/tests/Resources/DataFixtures/Page/template_load_internal.xml
@@ -39,7 +39,7 @@
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_meta_params.xml
+++ b/tests/Resources/DataFixtures/Page/template_meta_params.xml
@@ -22,7 +22,7 @@
             </params>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_missing_title.xml
+++ b/tests/Resources/DataFixtures/Page/template_missing_title.xml
@@ -13,7 +13,7 @@
     <properties>
         <property name="article" type="text_editor"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_nesting_params.xml
+++ b/tests/Resources/DataFixtures/Page/template_nesting_params.xml
@@ -23,7 +23,7 @@
             </params>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_reserved.xml
+++ b/tests/Resources/DataFixtures/Page/template_reserved.xml
@@ -13,7 +13,7 @@
         <property name="title" type="text_line" mandatory="true"/>
         <property name="changed" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_sections.xml
+++ b/tests/Resources/DataFixtures/Page/template_sections.xml
@@ -33,7 +33,7 @@
                 <info_text lang="en">Info-EN</info_text>
             </meta>
             <properties>
-                <property name="url" type="resource_locator" mandatory="true" cssClass="test"
+                <property name="url" type="route" mandatory="true" cssClass="test"
                           colspan="6">
                     <tag name="sulu.rlp" priority="1"/>
                 </property>

--- a/tests/Resources/DataFixtures/Page/template_title_in_section.xml
+++ b/tests/Resources/DataFixtures/Page/template_title_in_section.xml
@@ -17,7 +17,7 @@
             </properties>
         </section>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_with_global_blocks.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_global_blocks.xml
@@ -12,7 +12,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_with_global_blocks_invalid_no_ref_or_name.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_global_blocks_invalid_no_ref_or_name.xml
@@ -12,7 +12,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_with_global_blocks_invalid_ref_and_name.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_global_blocks_invalid_ref_and_name.xml
@@ -12,7 +12,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_with_invalid_ignore.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_invalid_ignore.xml
@@ -17,7 +17,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_with_localizations.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_localizations.xml
@@ -30,7 +30,7 @@
             <tag name="some.random.tag" one="1" two="2" three="three" />
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
     </properties>

--- a/tests/Resources/DataFixtures/Page/template_with_nested_blocks.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_nested_blocks.xml
@@ -17,7 +17,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true" />
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_with_schema.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_schema.xml
@@ -48,7 +48,7 @@
             <tag name="sulu.rlp.part"/>
         </property>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <meta>
                 <title lang="en">Resourcelocator</title>
                 <title lang="de">Adresse</title>

--- a/tests/Resources/DataFixtures/Page/template_with_xinclude_properties.xml
+++ b/tests/Resources/DataFixtures/Page/template_with_xinclude_properties.xml
@@ -4,7 +4,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
         <property name="title" type="text_line" mandatory="true"/>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 </properties>

--- a/tests/Resources/DataFixtures/Page/template_without_invalid_ignore.xml
+++ b/tests/Resources/DataFixtures/Page/template_without_invalid_ignore.xml
@@ -17,7 +17,7 @@
     <properties>
         <property name="title" type="text_line" mandatory="true"/>
 
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 

--- a/tests/Resources/DataFixtures/Page/template_without_title.xml
+++ b/tests/Resources/DataFixtures/Page/template_without_title.xml
@@ -10,7 +10,7 @@
     <cacheLifetime>2400</cacheLifetime>
 
     <properties>
-        <property name="url" type="resource_locator" mandatory="true">
+        <property name="url" type="route" mandatory="true">
             <tag name="sulu.rlp" priority="1"/>
         </property>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | required for https://github.com/sulu/sulu/pull/8265
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Replace all usage of resource_locator field type by route field type.

#### Why?

There is no longer 2 types, and it make more sense if we call it route bundle that the route bundle field type is called `route` and not `resource_locator`.