### PR TITLE
Fix composer dependency analyer when no imagick is installed

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -28,7 +28,7 @@ return $config
     ->ignoreErrorsOnExtension('ext-zip', [ErrorType::SHADOW_DEPENDENCY]) // not required to run Sulu
     ->ignoreErrorsOnPackage('guzzlehttp/guzzle', [ErrorType::SHADOW_DEPENDENCY]) // bc layer replaced later by symfony/http-client
     // UnknownClasses
-    ->ignoreUnknownClasses(\array_filter([
+    ->ignoreUnknownClasses([
         // bc layer for lowest
         'FOS\RestBundle\Controller\FOSRestController',
         'Swift_Events_SendEvent',
@@ -43,7 +43,7 @@ return $config
         'Symfony\Component\Security\Core\Event\AuthenticationFailureEvent',
         'Symfony\Component\Security\Core\Exception\UsernameNotFoundException',
         'Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface',
-    ]))
+    ])
     // DEV_DEPENDENCY_IN_PROD: optional dependency
     ->ignoreErrorsOnPackage('league/flysystem', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     ->ignoreErrorsOnPackage('league/flysystem-aws-s3-v3', [ErrorType::DEV_DEPENDENCY_IN_PROD])

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -14,10 +14,16 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
 $config = new Configuration();
 
+// optional fallback to gd or vips
+if (\extension_loaded('imagick')) {
+    $config->ignoreErrorsOnExtension('ext-imagick', [ErrorType::SHADOW_DEPENDENCY]);
+} else {
+    $config->ignoreUnknownClasses('Imagick');
+}
+
 return $config
     // SHADOW_DEPENDENCY
     ->ignoreErrorsOnExtension('ext-iconv', [ErrorType::SHADOW_DEPENDENCY]) // fallbacks to mbstring
-    ->ignoreErrorsOnExtension('ext-imagick', [ErrorType::SHADOW_DEPENDENCY]) // optional fallback to gd or vips
     ->ignoreErrorsOnExtension('ext-openssl', [ErrorType::SHADOW_DEPENDENCY]) // fallbacks to random_bytes
     ->ignoreErrorsOnExtension('ext-zip', [ErrorType::SHADOW_DEPENDENCY]) // not required to run Sulu
     ->ignoreErrorsOnPackage('guzzlehttp/guzzle', [ErrorType::SHADOW_DEPENDENCY]) // bc layer replaced later by symfony/http-client

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -15,20 +15,32 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 $config = new Configuration();
 
 $optionalIgnoreUnknownClasses = [];
+$optionalIgnoreShadowDependencyExtensions = [];
 
 // optional fallback to gd or vips
 if (\extension_loaded('imagick')) {
-    $config->ignoreErrorsOnExtension('ext-imagick', [ErrorType::SHADOW_DEPENDENCY]);
+    $optionalIgnoreShadowDependencyExtensions[] = 'ext-imagick';
 } else {
     $optionalIgnoreUnknownClasses[] = 'Imagick';
 }
 
 return $config
     // SHADOW_DEPENDENCY
-    ->ignoreErrorsOnExtension('ext-iconv', [ErrorType::SHADOW_DEPENDENCY]) // fallbacks to mbstring
-    ->ignoreErrorsOnExtension('ext-openssl', [ErrorType::SHADOW_DEPENDENCY]) // fallbacks to random_bytes
-    ->ignoreErrorsOnExtension('ext-zip', [ErrorType::SHADOW_DEPENDENCY]) // not required to run Sulu
-    ->ignoreErrorsOnPackage('guzzlehttp/guzzle', [ErrorType::SHADOW_DEPENDENCY]) // bc layer replaced later by symfony/http-client
+    ->ignoreErrorsOnExtensions(
+        [
+            ...$optionalIgnoreShadowDependencyExtensions,
+            'ext-iconv', // fallbacks to mbstring
+            'ext-openssl', // fallbacks to random_bytes
+            'ext-zip',  // not required to run Sulu
+        ],
+        [ErrorType::SHADOW_DEPENDENCY],
+    )
+    ->ignoreErrorsOnPackages(
+        [
+            'guzzlehttp/guzzle', // bc layer replaced later by symfony/http-client
+        ],
+        [ErrorType::SHADOW_DEPENDENCY]
+    )
     // UnknownClasses
     ->ignoreUnknownClasses([
         ...$optionalIgnoreUnknownClasses,
@@ -48,28 +60,38 @@ return $config
         'Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface',
     ])
     // DEV_DEPENDENCY_IN_PROD: optional dependency
-    ->ignoreErrorsOnPackage('league/flysystem', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('league/flysystem-aws-s3-v3', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('league/flysystem-azure-blob-storage', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('microsoft/azure-storage-blob', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('php-ffmpeg/php-ffmpeg', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('rokka/imagine-vips', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('scheb/2fa-backup-code', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('scheb/2fa-bundle', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('scheb/2fa-email', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('scheb/2fa-google-authenticator', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('scheb/2fa-totp', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('scheb/2fa-trusted-device', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('superbalist/flysystem-google-storage', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('symfony/stopwatch', [ErrorType::DEV_DEPENDENCY_IN_PROD])
-    ->ignoreErrorsOnPackage('symfony/monolog-bundle', [ErrorType::DEV_DEPENDENCY_IN_PROD]) // false positive only used in SuluTestKernel
+    ->ignoreErrorsOnPackages(
+        [
+            'league/flysystem',
+            'league/flysystem-aws-s3-v3',
+            'league/flysystem-azure-blob-storage',
+            'microsoft/azure-storage-blob',
+            'php-ffmpeg/php-ffmpeg',
+            'rokka/imagine-vips',
+            'scheb/2fa-backup-code',
+            'scheb/2fa-bundle',
+            'scheb/2fa-email',
+            'scheb/2fa-google-authenticator',
+            'scheb/2fa-totp',
+            'scheb/2fa-trusted-device',
+            'superbalist/flysystem-google-storage',
+            'symfony/stopwatch',
+            'symfony/monolog-bundle', // false positive only used in SuluTestKernel
+        ],
+        [ErrorType::DEV_DEPENDENCY_IN_PROD],
+    )
     // UNUSED_DEPENDENCY
-    ->ignoreErrorsOnPackage('doctrine/annotations', [ErrorType::UNUSED_DEPENDENCY])
-    ->ignoreErrorsOnPackage('guzzlehttp/promises', [ErrorType::UNUSED_DEPENDENCY]) // required for faster fos http cache clearing
-    ->ignoreErrorsOnPackage('nyholm/psr7', [ErrorType::UNUSED_DEPENDENCY]) // required for faster fos http cache clearing
-    ->ignoreErrorsOnPackage('symfony/asset', [ErrorType::UNUSED_DEPENDENCY]) // false positive we use assets
-    ->ignoreErrorsOnPackage('symfony/cache', [ErrorType::UNUSED_DEPENDENCY]) // we use caches mostly via psr interfaces
-    ->ignoreErrorsOnPackage('symfony/css-selector', [ErrorType::UNUSED_DEPENDENCY]) // we use caches mostly via psr interfaces
-    ->ignoreErrorsOnPackage('symfony/proxy-manager-bridge', [ErrorType::UNUSED_DEPENDENCY]) // can only be removed when min symfony version is 6.2
-    ->ignoreErrorsOnPackage('symfony/yaml', [ErrorType::UNUSED_DEPENDENCY]) // we use yaml configurations
+    ->ignoreErrorsOnPackages(
+        [
+            'doctrine/annotations',
+            'guzzlehttp/promises', // required for faster fos http cache clearing
+            'nyholm/psr7', // required for faster fos http cache clearing
+            'symfony/asset', // false positive we use assets
+            'symfony/cache', // we use caches mostly via psr interfaces
+            'symfony/css-selector', // kept for future usage
+            'symfony/proxy-manager-bridge', // can only be removed when min symfony version is 6.2
+            'symfony/yaml', // we use yaml configurations
+        ],
+        [ErrorType::UNUSED_DEPENDENCY],
+    )
 ;

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -43,7 +43,6 @@ return $config
         'Symfony\Component\Security\Core\Event\AuthenticationFailureEvent',
         'Symfony\Component\Security\Core\Exception\UsernameNotFoundException',
         'Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface',
-        !\class_exists('Imagick') ? 'Imagick' : null, // optional fallback to gd or vips
     ]))
     // DEV_DEPENDENCY_IN_PROD: optional dependency
     ->ignoreErrorsOnPackage('league/flysystem', [ErrorType::DEV_DEPENDENCY_IN_PROD])

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -14,11 +14,13 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
 $config = new Configuration();
 
+$optionalIgnoreUnknownClasses = [];
+
 // optional fallback to gd or vips
 if (\extension_loaded('imagick')) {
     $config->ignoreErrorsOnExtension('ext-imagick', [ErrorType::SHADOW_DEPENDENCY]);
 } else {
-    $config->ignoreUnknownClasses('Imagick');
+    $optionalIgnoreUnknownClasses[] = 'Imagick';
 }
 
 return $config
@@ -29,6 +31,7 @@ return $config
     ->ignoreErrorsOnPackage('guzzlehttp/guzzle', [ErrorType::SHADOW_DEPENDENCY]) // bc layer replaced later by symfony/http-client
     // UnknownClasses
     ->ignoreUnknownClasses([
+        ...$optionalIgnoreUnknownClasses,
         // bc layer for lowest
         'FOS\RestBundle\Controller\FOSRestController',
         'Swift_Events_SendEvent',

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -31,7 +31,7 @@ return $config
             ...$optionalIgnoreShadowDependencyExtensions,
             'ext-iconv', // fallbacks to mbstring
             'ext-openssl', // fallbacks to random_bytes
-            'ext-zip',  // not required to run Sulu
+            'ext-zip', // not required to run Sulu
         ],
         [ErrorType::SHADOW_DEPENDENCY],
     )

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -22,7 +22,7 @@ return $config
     ->ignoreErrorsOnExtension('ext-zip', [ErrorType::SHADOW_DEPENDENCY]) // not required to run Sulu
     ->ignoreErrorsOnPackage('guzzlehttp/guzzle', [ErrorType::SHADOW_DEPENDENCY]) // bc layer replaced later by symfony/http-client
     // UnknownClasses
-    ->ignoreUnknownClasses([
+    ->ignoreUnknownClasses(\array_filter([
         // bc layer for lowest
         'FOS\RestBundle\Controller\FOSRestController',
         'Swift_Events_SendEvent',
@@ -37,7 +37,8 @@ return $config
         'Symfony\Component\Security\Core\Event\AuthenticationFailureEvent',
         'Symfony\Component\Security\Core\Exception\UsernameNotFoundException',
         'Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface',
-    ])
+        !\class_exists('Imagick') ? 'Imagick' : null, // optional fallback to gd or vips
+    ]))
     // DEV_DEPENDENCY_IN_PROD: optional dependency
     ->ignoreErrorsOnPackage('league/flysystem', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     ->ignoreErrorsOnPackage('league/flysystem-aws-s3-v3', [ErrorType::DEV_DEPENDENCY_IN_PROD])


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix composer dependency analyer when no imagick is installed

#### Why?

Contributers may have not imagick installed:

<img width="720" height="225" alt="grafik" src="https://github.com/user-attachments/assets/55c985f4-dc25-4cc5-9c09-5677e0294586" />
