### PR TITLE
Fix flacky FormMetadataProviderTest

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -116,8 +116,9 @@ class FormMetadataProviderTest extends KernelTestCase
             ['tags' => ['test2' => ['test' => 'test-value2']]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
-        $this->assertCount(1, $typedForm->getForms());
-        $this->assertEquals(['default'], \array_keys($typedForm->getForms()));
+        $forms = $typedForm->getForms();
+        \ksort($forms);
+        $this->assertSame(['default'], \array_keys($forms));
 
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',
@@ -125,8 +126,9 @@ class FormMetadataProviderTest extends KernelTestCase
             ['tags' => ['test' => false]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
-        $this->assertCount(2, $typedForm->getForms());
-        $this->assertEquals(['overview', 'grouped'], \array_keys($typedForm->getForms()));
+        $forms = $typedForm->getForms();
+        \ksort($forms);
+        $this->assertSame(['grouped', 'overview'], \array_keys($forms));
 
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',
@@ -134,8 +136,9 @@ class FormMetadataProviderTest extends KernelTestCase
             ['tags' => ['test' => true]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
-        $this->assertCount(1, $typedForm->getForms());
-        $this->assertEquals(['default'], \array_keys($typedForm->getForms()));
+        $forms = $typedForm->getForms();
+        \ksort($forms);
+        $this->assertSame(['default'], \array_keys($forms));
 
         $typedForm = $this->formMetadataProvider->getMetadata(
             'page',
@@ -143,7 +146,8 @@ class FormMetadataProviderTest extends KernelTestCase
             ['tags' => ['test3' => ['value' => 'test-value']]]
         );
         $this->assertInstanceOf(TypedFormMetadata::class, $typedForm);
-        $this->assertCount(1, $typedForm->getForms());
-        $this->assertEquals(['default'], \array_keys($typedForm->getForms()));
+        $forms = $typedForm->getForms();
+        \ksort($forms);
+        $this->assertSame(['default'], \array_keys($forms));
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix flacky FormMetadataProviderTest which make the pipeline file from time to time.

#### Why?

Was introduced in https://github.com/sulu/sulu/pull/8124