### PR TITLE
Fix refresh route with route field type

### DIFF
--- a/packages/route/assets/js/containers/Form/fields/ResourceLocator.js
+++ b/packages/route/assets/js/containers/Form/fields/ResourceLocator.js
@@ -143,7 +143,7 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
                 parts: this.parts,
                 resourceKey: formInspector.resourceKey,
                 locale: formInspector.locale ? formInspector.locale.get() : userStore.contentLocale,
-                id: formInspector.id,
+                resourceId: formInspector.id,
                 routeSchema,
                 ...requestOptions,
             }

--- a/packages/route/assets/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/packages/route/assets/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -877,7 +877,7 @@ test('Should request new URL with correct options and disable button when refres
     expect(Requester.post).toBeCalledWith(
         '/admin/api/resource-locators',
         {
-            id: 5,
+            resourceId: 5,
             locale: 'en',
             parts: {title: 'title-value', subtitle: 'subtitle-value'},
             resourceKey: 'test',

--- a/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
+++ b/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
@@ -151,7 +151,7 @@ class RouteRepository implements RouteRepositoryInterface
             $queryBuilder
                 ->andWhere($expr->not($expr->andX(
                     $expr->eq('route.resourceKey', ':excludeResourceKey'),
-                    $expr->eq('route.resourceId', ':excludeResourceId')
+                    $expr->eq('route.resourceId', ':excludeResourceId'),
                 )))
                 ->setParameter('excludeResourceKey', $excludeResource['resourceKey'])
                 ->setParameter('excludeResourceId', $excludeResource['resourceId']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The refresh did not keep the current id correctly in mind.

#### Why?

Fix after merging https://github.com/sulu/sulu/pull/8265 and https://github.com/sulu/sulu/pull/8234 together.