### PR TITLE
Allow indexing global blocks content

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -30,6 +30,7 @@ use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Extension\ExtensionManagerInterface;
 use Sulu\Component\Content\Metadata\BlockMetadata;
+use Sulu\Component\Content\Metadata\ComponentMetadata;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\ItemMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
@@ -283,8 +284,8 @@ EOT;
             $propertyMapping = new ComplexMetadata();
 
             foreach ($property->getComponents() as $component) {
-                /** @var \Sulu\Component\Content\Metadata\PropertyMetadata $componentProperty */
-                foreach ($component->getChildren() as $componentProperty) {
+                $children = $this->getComponentChildren($component);
+                foreach ($children as $componentProperty) {
                     $this->mapProperty(
                         $componentProperty,
                         $propertyMapping,
@@ -392,6 +393,28 @@ EOT;
                 ]
             );
         }
+    }
+
+    /**
+     * @return ItemMetadata[]
+     */
+    private function getComponentChildren(ComponentMetadata $component): array
+    {
+        if ($component->hasTag('sulu.global_block')) {
+            return $component->getChildren();
+        }
+
+        $tag = $component->getTag('sulu.global_block');
+        /** @var string[] $attributes */
+        $attributes = $tag['attributes'] ?? [];
+        $refType = $attributes['global_block'] ?? '';
+        $result = $this->structureFactory->getStructureMetadata('block', $refType);
+
+        if (!$result instanceof StructureMetadata) {
+            return $component->getChildren();
+        }
+
+        return $result->getChildren();
     }
 
     private function createIndexNameField(Metadata $documentMetadata, $indexName, $decorate)

--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -400,7 +400,7 @@ EOT;
      */
     private function getComponentChildren(ComponentMetadata $component): array
     {
-        if ($component->hasTag('sulu.global_block')) {
+        if (!$component->hasTag('sulu.global_block')) {
             return $component->getChildren();
         }
 


### PR DESCRIPTION
#7503

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7503
| Related issues/PRs | #7503
| License | MIT

#### What's in this PR?

Global content blocks can now be indexed by the search bundle

#### Why?

Because it did not so ;-)

I am a little bit lost about the tests. There does not seem to be a correspondig test for this class. I am not too familiar with prophesize & co as some other providers did seem to use it. If you point me in the right direction, I could provide some tests.