### PR TITLE
 Fix category tree search #8130 

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4157,7 +4157,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$_embedded on mixed\\.$#"
-			count: 28
+			count: 29
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
@@ -4212,7 +4212,7 @@ parameters:
 
 		-
 			message: "#^Cannot access property \\$total on mixed\\.$#"
-			count: 10
+			count: 11
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
@@ -4272,7 +4272,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
-			count: 46
+			count: 45
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
@@ -24389,6 +24389,11 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\PreviewBundle\\\\Tests\\\\Functional\\\\Preview\\\\Renderer\\\\PreviewRendererTest\\:\\:\\$previewRenderer \\(Sulu\\\\Bundle\\\\PreviewBundle\\\\Preview\\\\Renderer\\\\PreviewRenderer\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Tests/Functional/Preview/Renderer/PreviewRendererTest.php
+
+		-
+			message: "#^Call to an undefined static method Gedmo\\\\Sluggable\\\\Util\\\\Urlizer\\:\\:urlize\\(\\)\\.$#"
+			count: 1
+			path: src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerTest.php
 
 		-
 			message: "#^Cannot access offset 'lastVisit' on mixed\\.$#"

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -260,7 +260,8 @@ class CategoryController extends AbstractRestController implements ClassResource
             }
         }
 
-        if (!empty($expandedIds) && $request->get('search', false)) {
+        $search = $request->get('search');
+        if (!empty($expandedIds) && empty($search)) {
             $categoriesByParentId = [];
             foreach ($categories as &$category) {
                 $categoryParentId = $category['parent'];

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -237,14 +237,16 @@ class CategoryController extends AbstractRestController implements ClassResource
             );
         }
 
-        if (!$request->get('search')) {
+        $search = $request->get('search');
+
+        if (!$search) {
             // expand collected parents if search is not set
             if (\count($parentExpressions) >= 2) {
                 $listBuilder->addExpression($listBuilder->createOrExpression($parentExpressions));
             } elseif (\count($parentExpressions) >= 1) {
                 $listBuilder->addExpression($parentExpressions[0]);
             }
-        } elseif ($request->get('search') && $parentId && !$expandedIds) {
+        } elseif ($search && $parentId && !$expandedIds) {
             // filter for parentId when search is active and no expandedIds are set
             $listBuilder->addExpression($parentExpressions[0]);
         }
@@ -260,8 +262,7 @@ class CategoryController extends AbstractRestController implements ClassResource
             }
         }
 
-        $search = $request->get('search');
-        if (!empty($expandedIds) && empty($search)) {
+        if (!empty($expandedIds) && !$search) {
             $categoriesByParentId = [];
             foreach ($categories as &$category) {
                 $categoryParentId = $category['parent'];

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -260,7 +260,7 @@ class CategoryController extends AbstractRestController implements ClassResource
             }
         }
 
-        if (!empty($expandedIds)) {
+        if (!empty($expandedIds) && $request->get('search', false)) {
             $categoriesByParentId = [];
             foreach ($categories as &$category) {
                 $categoryParentId = $category['parent'];

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -518,6 +518,35 @@ class CategoryControllerTest extends SuluTestCase
         $this->assertTrue($categories[0]->hasChildren);
     }
 
+    public function testCGetFlatWithSearchAndExpandedIds(): void
+    {
+        $category1 = $this->createCategory('first-category-key', 'en');
+        $this->createCategoryTranslation($category1, 'en', 'First Category');
+        $category3 = $this->createCategory(null, 'en', $category1);
+        $this->createCategoryTranslation($category3, 'en', 'Third Category');
+        $category4 = $this->createCategory(null, 'en', $category3);
+        $this->createCategoryTranslation($category4, 'en', 'Fourth Category');
+
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/categories?locale=en&flat=true&search=Third&searchFields=name&expandedIds=' . $category1->getId()
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $response = \json_decode($this->client->getResponse()->getContent());
+        $categories = $response->_embedded->categories;
+
+        $this->assertCount(1, $categories);
+        $this->assertEquals(1, $response->total);
+
+        $this->assertEquals('Third Category', $categories[0]->name);
+        $this->assertTrue($categories[0]->hasChildren);
+    }
+
     public function testCGetWithNoLocale(): void
     {
         $this->client->jsonRequest(

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -65,7 +65,7 @@ class CategoryControllerTest extends SuluTestCase
         );
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
-        $response = \json_decode($this->client->getResponse()->getContent());
+        $response = \json_decode($this->client->getResponse()->getContent() ?: '');
 
         $this->assertEquals('First Category', $response->name);
         $this->assertEquals('first-category-key', $response->key);
@@ -1684,7 +1684,7 @@ class CategoryControllerTest extends SuluTestCase
         );
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
-        $response = \json_decode($this->client->getResponse()->getContent(), true);
+        $response = \json_decode($this->client->getResponse()->getContent() ?: '', true);
         $this->assertArrayNotHasKey('parent', $response);
     }
 


### PR DESCRIPTION
All By @MarkusHolstein, I was not able to do changes on the PR directly and CI seems to be kind of broken.

Original PR: https://github.com/sulu/sulu/pull/8130

Content:

---

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | Replaces #8045
| License | MIT

#### What's in this PR?

When searching for a category string, nearly always the expandedIds parameter is set in the query string to the controller.
As in a full tree view in the category administration, there is no $parentId in the request parameters, thus $categoriesByParentId[$parentId] delivers null, which leads to iterator_to_array(): Argument https://github.com/sulu/sulu/pull/1 ($iterator) must be of type Traversable|array, null given at src/Sulu/Component/Rest/ListBuilder/CollectionRepresentation.php:35, though categories were found, but not with parent "null"
This fixes this behaviour. and allows to search a full tree.

#### Why?

The server responds with a 500 Exception.
Replaces #8045 as suggested.

#### Example Usage

Call url https://sulu.rocks/admin/api/categories?page=1&locale=en&expandedIds=3&limit=10&fields=name,id&search=Test3&flat=true
