### PR TITLE
Remove unused `TagManager::resolve*` functions

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -916,6 +916,8 @@ Removed deprecated functions and properties:
 - `Sulu\Bundle\AdminBundle\Metadata\MetadataProvierRegistry::addMetadataProiver` (use dependency injection via tagged service instead)
 - `Sulu\Bundle\TagBundle\Entity\TagRepository::findAllTags` (use `findAll` instead)
 - `Sulu\Bundle\TagBundle\Tag\TagManager::findAll` (use repository instead)
+- `Sulu\Bundle\TagBundle\Tag\TagManagerInterface::resolveTagIds` (use the Repository)
+- `Sulu\Bundle\TagBundle\Tag\TagManagerInterface::resolveTagNames` (use the Repository)
 
 Removed unused arguments:
 

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManager.php
@@ -181,42 +181,4 @@ class TagManager implements TagManagerInterface
 
         return $destTag;
     }
-
-    /**
-     * Resolves tag ids to names.
-     *
-     * @return array
-     */
-    public function resolveTagIds($tagIds)
-    {
-        $resolvedTags = [];
-
-        foreach ($tagIds as $tagId) {
-            $tag = $this->findById($tagId);
-            if (null !== $tag) {
-                $resolvedTags[] = $tag->getName();
-            }
-        }
-
-        return $resolvedTags;
-    }
-
-    /**
-     * Resolves tag names to ids.
-     *
-     * @return array
-     */
-    public function resolveTagNames($tagNames)
-    {
-        $resolvedTags = [];
-
-        foreach ($tagNames as $tagName) {
-            $tag = $this->findByName($tagName);
-            if (null !== $tag) {
-                $resolvedTags[] = $tag->getId();
-            }
-        }
-
-        return $resolvedTags;
-    }
 }

--- a/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
+++ b/src/Sulu/Bundle/TagBundle/Tag/TagManagerInterface.php
@@ -73,18 +73,4 @@ interface TagManagerInterface
      * @throws Exception\TagNotFoundException
      */
     public function merge($srcTagIds, $destTagId);
-
-    /**
-     * Resolves tag ids to names.
-     *
-     * @return array
-     */
-    public function resolveTagIds($tagIds);
-
-    /**
-     * Resolves tag names to ids.
-     *
-     * @return array
-     */
-    public function resolveTagNames($tagNames);
 }

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Tag/TagManagerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Tag/TagManagerTest.php
@@ -84,31 +84,13 @@ class TagManagerTest extends TestCase
         );
     }
 
-    public function testResolveTagNames(): void
+    public function testFindById(): void
     {
-        $tagNames = ['Tag1', 'Tag2', 'Tag3', 'InvalidTag'];
+        $tag = new Tag();
+        $this->tagRepository->findTagById(10)->shouldBeCalled()->willReturn($tag);
 
-        $this->tagRepository->findTagByName('Tag1')->shouldBeCalled()->willReturn((new Tag())->setId(1));
-        $this->tagRepository->findTagByName('Tag2')->shouldBeCalled()->willReturn((new Tag())->setId(2));
-        $this->tagRepository->findTagByName('Tag3')->shouldBeCalled()->willReturn((new Tag())->setId(3));
-        $this->tagRepository->findTagByName('InvalidTag')->shouldBeCalled()->willReturn(null);
+        $actualTag = $this->tagManager->findById(10);
 
-        $tagIds = $this->tagManager->resolveTagNames($tagNames);
-
-        $this->assertEquals([1, 2, 3], $tagIds);
-    }
-
-    public function testResolveTagIds(): void
-    {
-        $this->tagRepository->findTagById(1)->shouldBeCalled()->willReturn((new Tag())->setName('Tag1'));
-        $this->tagRepository->findTagById(2)->shouldBeCalled()->willReturn((new Tag())->setName('Tag2'));
-        $this->tagRepository->findTagById(3)->shouldBeCalled()->willReturn((new Tag())->setName('Tag3'));
-        $this->tagRepository->findTagById(99)->shouldBeCalled()->willReturn(null);
-
-        $tagIds = [1, 2, 3, 99];
-
-        $tagNames = $this->tagManager->resolveTagIds($tagIds);
-
-        $this->assertEquals(['Tag1', 'Tag2', 'Tag3'], $tagNames);
+        $this->assertEquals($tag, $actualTag);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing unsed TagManager functions.

#### Why?
In the new doctrine implementation of the Tag/entity resolving we don't need those functions anymore.

The implementation is sub-optimal anyways. :D No querries in a loop.