### PR TITLE
Fix remove draft and Rename copy locale

### DIFF
--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -297,7 +297,7 @@ final class ArticleController
             return null;
         }
 
-        if ('copy-locale' === $action) {
+        if ('copy_locale' === $action) {
             $message = new CopyLocaleArticleMessage(
                 ['uuid' => $uuid],
                 (string) $request->query->get('src'),

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -282,7 +282,7 @@ class ArticleControllerTest extends SuluTestCase
     #[Depends('testPost')]
     public function testPostTriggerCopyLocale(string $id): void
     {
-        $this->client->request('POST', '/admin/api/articles/' . $id . '?locale=de&action=copy-locale&src=en&dest=de');
+        $this->client->request('POST', '/admin/api/articles/' . $id . '?locale=de&action=copy_locale&src=en&dest=de');
 
         $response = $this->client->getResponse();
 

--- a/packages/content/tests/Application/ExampleTestBundle/Controller/ExampleController.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Controller/ExampleController.php
@@ -219,7 +219,7 @@ class ExampleController extends AbstractRestController
                 $this->entityManager->flush();
 
                 return $this->handleView($this->view($this->normalize($example, $dimensionContent)));
-            case 'remove-draft':
+            case 'remove_draft':
                 $dimensionContent = $this->contentManager->applyTransition(
                     $example,
                     $dimensionAttributes,

--- a/packages/content/tests/Application/ExampleTestBundle/Controller/ExampleController.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Controller/ExampleController.php
@@ -192,7 +192,7 @@ class ExampleController extends AbstractRestController
         $action = $request->query->get('action');
 
         switch ($action) {
-            case 'copy-locale':
+            case 'copy_locale':
                 $dimensionContent = $this->contentManager->copy(
                     $example,
                     [

--- a/packages/content/tests/Functional/Integration/ExampleControllerTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerTest.php
@@ -403,7 +403,7 @@ class ExampleControllerTest extends SuluTestCase
     #[Depends('testPost')]
     public function testPostTriggerCopyLocale(int $id): void
     {
-        $this->client->request('POST', '/admin/api/examples/' . $id . '?locale=de&action=copy-locale&src=en&dest=de');
+        $this->client->request('POST', '/admin/api/examples/' . $id . '?locale=de&action=copy_locale&src=en&dest=de');
 
         $response = $this->client->getResponse();
 

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -258,7 +258,7 @@ final class PageController
             return null;
         }
 
-        if ('copy-locale' === $action) {
+        if ('copy_locale' === $action) {
             $message = new CopyLocalePageMessage(
                 ['uuid' => $uuid],
                 (string) $request->query->get('src'),

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -491,7 +491,7 @@ class PageControllerTest extends SuluTestCase
     #[Depends('testPost')]
     public function testPostTriggerCopyLocale(string $id): void
     {
-        $this->client->request('POST', '/admin/api/pages/' . $id . '?locale=de&action=copy-locale&src=en&dest=de');
+        $this->client->request('POST', '/admin/api/pages/' . $id . '?locale=de&action=copy_locale&src=en&dest=de');
 
         $response = $this->client->getResponse();
 

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -268,7 +268,7 @@ final class SnippetController
             return null;
         }
 
-        if ('copy-locale' === $action) {
+        if ('copy_locale' === $action) {
             $message = new CopyLocaleSnippetMessage(
                 ['uuid' => $uuid],
                 (string) $request->query->get('src'),

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -200,7 +200,7 @@ class SnippetControllerTest extends SuluTestCase
     #[Depends('testPost')]
     public function testPostTriggerCopyLocale(string $id): void
     {
-        $this->client->request('POST', '/admin/api/snippets/' . $id . '?locale=de&action=copy-locale&src=en&dest=de');
+        $this->client->request('POST', '/admin/api/snippets/' . $id . '?locale=de&action=copy_locale&src=en&dest=de');
 
         $response = $this->client->getResponse();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/ResourceStore.js
@@ -276,7 +276,7 @@ export default class ResourceStore {
                 {},
                 {
                     ...options,
-                    action: 'copy-locale',
+                    action: 'copy_locale',
                     dest: locale,
                     id: this.id,
                     locale,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/ResourceStore/tests/ResourceStore.test.js
@@ -610,7 +610,7 @@ test('Copy the content from different locale', () => {
     resourceStore.copyFromLocale('de');
 
     expect(ResourceRequester.post)
-        .toBeCalledWith('pages', {}, {action: 'copy-locale', id: 4, locale: 'en', dest: 'en', src: 'de'});
+        .toBeCalledWith('pages', {}, {action: 'copy_locale', id: 4, locale: 'en', dest: 'en', src: 'de'});
 
     return promise.then(() => {
         expect(resourceStore.data).toEqual(germanContent);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
@@ -309,7 +309,7 @@ test('Close dialog and show success message when onClose from CopyLocaleDialog i
         expect(ResourceRequester.post).toBeCalledWith(
             'snippets',
             undefined,
-            {action: 'copy-locale', dest: ['de', 'fr'], id: 3, locale, webspace: 'sulu_io'}
+            {action: 'copy_locale', dest: ['de', 'fr'], id: 3, locale, webspace: 'sulu_io'}
         );
 
         postPromise.then(() => {
@@ -378,7 +378,7 @@ test('Close dialog and show success message when onClose from CopyLocaleDialog i
         expect(ResourceRequester.post).toBeCalledWith(
             'snippets',
             undefined,
-            {action: 'copy-locale', dest: ['de', 'fr'], id: 3, locale, webspace: 'sulu_io', title: 'Test 123'}
+            {action: 'copy_locale', dest: ['de', 'fr'], id: 3, locale, webspace: 'sulu_io', title: 'Test 123'}
         );
 
         postPromise.then(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
@@ -234,7 +234,7 @@ test('Delete draft when dialog is confirmed', () => {
     expect(ResourceRequester.post).toBeCalledWith(
         'snippets',
         undefined,
-        {action: 'remove-draft', id: 3, locale: deleteDraftToolbarAction.resourceFormStore.locale, webspace: 'sulu_io'}
+        {action: 'remove_draft', id: 3, locale: deleteDraftToolbarAction.resourceFormStore.locale, webspace: 'sulu_io'}
     );
 
     return deleteDraftPromise.then(() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
@@ -145,7 +145,7 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
             {
                 id,
                 locale,
-                action: 'copy-locale',
+                action: 'copy_locale',
                 webspace,
                 ...options,
             }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
@@ -115,7 +115,7 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
             resourceKey,
             undefined,
             {
-                action: 'remove-draft',
+                action: 'remove_draft',
                 locale,
                 id,
                 webspace,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes
| Related issues/PRs | #7672
| License | MIT
| Documentation PR |

#### What's in this PR?

Replaces `remove-draft` and `copy-locale` with `remove_draft` and `copy_locale`

#### Why?

Because the workflow transition is called `remove_draft`, the functionality is currently broken. And to keep conistent, we also change copy locale action.