### PR TITLE
Add possibility to remove p tags from text_editor

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
@@ -71,8 +71,8 @@ export default class CKEditor5 extends React.Component<Props> {
                 value,
                 disabled,
                 options: {
-                    strip_p_tags: {
-                        value: stripPTags = false,
+                    enter_mode: {
+                        value: enterModeValue = 'p',
                     } = {},
                 } = {},
             } = this.props;
@@ -88,7 +88,7 @@ export default class CKEditor5 extends React.Component<Props> {
             const editorData = this.getEditorData();
             if (editorData !== value && !(value === '' && editorData === undefined)) {
                 let finalValue = value;
-                if (finalValue && stripPTags) {
+                if (finalValue && enterModeValue === 'br') {
                     finalValue = addPTags(finalValue);
                 }
                 this.editorInstance.setData(finalValue);
@@ -101,8 +101,8 @@ export default class CKEditor5 extends React.Component<Props> {
             formats,
             locale,
             options: {
-                strip_p_tags: {
-                    value: stripPTags = false,
+                enter_mode: {
+                    value: enterModeValue = 'p',
                 } = {},
             } = {},
         } = this.props;
@@ -218,7 +218,7 @@ export default class CKEditor5 extends React.Component<Props> {
             .then((editor) => {
                 this.editorInstance = editor;
                 let value = this.props.value;
-                if (value && stripPTags) {
+                if (value && enterModeValue === 'br') {
                     value = addPTags(value);
                 }
                 this.editorInstance.setData(value);
@@ -276,14 +276,14 @@ export default class CKEditor5 extends React.Component<Props> {
     getEditorData() {
         const {
             options: {
-                strip_p_tags: {
-                    value: stripPTags = false,
+                enter_mode: {
+                    value: enterModeValue = 'p',
                 } = {},
             } = {},
         } = this.props;
 
         const editorData = this.editorInstance.getData();
-        return editorData === '' ? undefined : (stripPTags ? removePTags(editorData) : editorData);
+        return editorData === '' ? undefined : (enterModeValue === 'br' ? removePTags(editorData) : editorData);
     }
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/CKEditor5.js
@@ -17,6 +17,7 @@ import CodePlugin from '@ckeditor/ckeditor5-basic-styles/src/code';
 import TablePlugin from '@ckeditor/ckeditor5-table/src/table';
 import TableToolbarPlugin from '@ckeditor/ckeditor5-table/src/tabletoolbar';
 import {translate} from '../../utils/Translator';
+import {addPTags, removePTags} from './utils';
 import ExternalLinkPlugin from './plugins/ExternalLinkPlugin';
 import InternalLinkPlugin from './plugins/InternalLinkPlugin';
 import configRegistry from './registries/configRegistry';
@@ -24,6 +25,7 @@ import pluginRegistry from './registries/pluginRegistry';
 import type {IObservableValue} from 'mobx/lib/mobx';
 import type {ElementRef} from 'react';
 import './ckeditor5.scss';
+import type {SchemaOptions} from '../Form/types';
 
 type Props = {|
     disabled: boolean,
@@ -32,6 +34,7 @@ type Props = {|
     onBlur?: () => void,
     onChange: (value: ?string) => void,
     onFocus?: (event: { target: EventTarget }) => void,
+    options?: SchemaOptions,
     value: ?string,
 |};
 
@@ -48,6 +51,7 @@ export default class CKEditor5 extends React.Component<Props> {
     static defaultProps = {
         disabled: false,
         formats: ['h2', 'h3', 'h4', 'h5', 'h6'],
+        options: {},
         value: '',
     };
 
@@ -63,7 +67,15 @@ export default class CKEditor5 extends React.Component<Props> {
 
     componentDidUpdate() {
         if (this.editorInstance) {
-            const {value, disabled} = this.props;
+            const {
+                value,
+                disabled,
+                options: {
+                    strip_p_tags: {
+                        value: stripPTags = false,
+                    } = {},
+                } = {},
+            } = this.props;
 
             if (disabled) {
                 this.editorInstance.ui.element.classList.add('disabled');
@@ -75,13 +87,25 @@ export default class CKEditor5 extends React.Component<Props> {
 
             const editorData = this.getEditorData();
             if (editorData !== value && !(value === '' && editorData === undefined)) {
-                this.editorInstance.setData(value);
+                let finalValue = value;
+                if (finalValue && stripPTags) {
+                    finalValue = addPTags(finalValue);
+                }
+                this.editorInstance.setData(finalValue);
             }
         }
     }
 
     componentDidMount() {
-        const {formats, locale} = this.props;
+        const {
+            formats,
+            locale,
+            options: {
+                strip_p_tags: {
+                    value: stripPTags = false,
+                } = {},
+            } = {},
+        } = this.props;
 
         const defaultConfig = {
             toolbar: [
@@ -193,8 +217,11 @@ export default class CKEditor5 extends React.Component<Props> {
             })
             .then((editor) => {
                 this.editorInstance = editor;
-
-                this.editorInstance.setData(this.props.value);
+                let value = this.props.value;
+                if (value && stripPTags) {
+                    value = addPTags(value);
+                }
+                this.editorInstance.setData(value);
 
                 const {disabled, onBlur, onChange, onFocus} = this.props;
                 const {
@@ -247,8 +274,16 @@ export default class CKEditor5 extends React.Component<Props> {
     }
 
     getEditorData() {
+        const {
+            options: {
+                strip_p_tags: {
+                    value: stripPTags = false,
+                } = {},
+            } = {},
+        } = this.props;
+
         const editorData = this.editorInstance.getData();
-        return editorData === '' ? undefined : editorData;
+        return editorData === '' ? undefined : (stripPTags ? removePTags(editorData) : editorData);
     }
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/utils.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/utils.test.js
@@ -1,0 +1,82 @@
+// @flow
+import {removePTags, addPTags} from '../utils';
+
+test('Test remove p tags', () => {
+    const html = '<p>This is a paragraph.</p>';
+    const expected = '<!--p-->This is a paragraph.<!--/p-->';
+    expect(removePTags(html)).toBe(expected);
+});
+
+test('Test remove p tags complex', () => {
+    const html = [
+        '<h2>Headline</h2>',
+        '<p>paragraph with Link',
+        '<a target="_self" href="https://www.sulu.io">',
+        'https://www.sulu.io',
+        '</a>',
+        ' test 213</p>',
+    ].join('');
+    const expected = [
+        '<h2>Headline</h2>',
+        '<!--p-->paragraph with Link',
+        '<a target="_self" href="https://www.sulu.io">',
+        'https://www.sulu.io',
+        '</a>',
+        ' test 213<!--/p-->',
+    ].join('');
+    expect(removePTags(html)).toBe(expected);
+});
+
+test('Test remove multiple p tages', () => {
+    const html = '<p>Test line 1</p><p>Test line 2</p><p>Test line 3</p>';
+    const expected = [
+        '<!--p-->Test line 1<!--/p-->',
+        '<br></br>',
+        '<!--p-->Test line 2<!--/p-->',
+        '<br></br>',
+        '<!--p-->Test line 3<!--/p-->',
+    ].join('');
+    expect(removePTags(html)).toBe(expected);
+});
+
+test('Test readd p tags', () => {
+    const string = '<!--p-->This is a paragraph.<!--/p-->';
+    const html = '<p>This is a paragraph.</p>';
+    expect(addPTags(string)).toBe(html);
+});
+
+test('Test readd p tags complex', () => {
+    const string = [
+        '<h2>Headline</h2>',
+        '<!--p-->paragraph with Link',
+        '<a target="_self" href="https://www.sulu.io">',
+        'https://www.sulu.io',
+        '</a>',
+        ' test 213<!--/p-->',
+    ].join('');
+    const html = [
+        '<h2>Headline</h2>',
+        '<p>paragraph with Link',
+        '<a target="_self" href="https://www.sulu.io">',
+        'https://www.sulu.io',
+        '</a>',
+        ' test 213</p>',
+    ].join('');
+    expect(addPTags(string)).toBe(html);
+});
+
+test('Test readd multiple p tages', () => {
+    const string = [
+        '<!--p-->Test line 1<!--/p-->',
+        '<br></br>',
+        '<!--p-->Test line 2<!--/p-->',
+        '<br></br>',
+        '<!--p-->Test line 3<!--/p-->',
+    ].join('');
+    const html = [
+        '<p>Test line 1</p>',
+        '<p>Test line 2</p>',
+        '<p>Test line 3</p>',
+    ].join('');
+    expect(addPTags(string)).toBe(html);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/utils.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/utils.test.js
@@ -3,7 +3,7 @@ import {removePTags, addPTags} from '../utils';
 
 test('Test remove p tags', () => {
     const html = '<p>This is a paragraph.</p>';
-    const expected = '<!--p-->This is a paragraph.<!--/p-->';
+    const expected = 'This is a paragraph.';
     expect(removePTags(html)).toBe(expected);
 });
 
@@ -40,7 +40,7 @@ test('Test remove multiple p tages', () => {
 });
 
 test('Test readd p tags', () => {
-    const string = '<!--p-->This is a paragraph.<!--/p-->';
+    const string = 'This is a paragraph.';
     const html = '<p>This is a paragraph.</p>';
     expect(addPTags(string)).toBe(html);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/utils.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/utils.js
@@ -40,4 +40,26 @@ function findViewLinkItemInSelection(editor: Object, linkTag: string) {
     );
 }
 
-export {addLinkConversion, findModelItemInSelection, findViewLinkItemInSelection};
+function removePTags(htmlString: string): string {
+    const string = htmlString.replace(/<p>/g, '<!--p-->').replace(/<\/p>/g, '<!--/p--><br></br>');
+    return replaceLast(string, '<br></br>', '');
+}
+
+function addPTags(htmlString: string): string {
+    return htmlString
+        .replace(/<!--p-->/g, '<p>')
+        .replace(/<!--\/p--><br><\/br>/g, '</p>')
+        .replace(/<!--\/p-->/g, '</p>');
+}
+
+function replaceLast(str, search, replace) {
+    const lastIndex = str.lastIndexOf(search);
+
+    if (lastIndex === -1) {
+        return str;
+    }
+
+    return str.slice(0, lastIndex) + replace + str.slice(lastIndex + search.length);
+}
+
+export {addLinkConversion, findModelItemInSelection, findViewLinkItemInSelection, removePTags, addPTags};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/utils.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/utils.js
@@ -41,11 +41,21 @@ function findViewLinkItemInSelection(editor: Object, linkTag: string) {
 }
 
 function removePTags(htmlString: string): string {
+    // Checks if this is a single paragraph
+    const match = htmlString.match(/^<p>([^<>]*)<\/p>$/);
+    if (match) {
+        return match[1];
+    }
+
     const string = htmlString.replace(/<p>/g, '<!--p-->').replace(/<\/p>/g, '<!--/p--><br></br>');
     return replaceLast(string, '<br></br>', '');
 }
 
 function addPTags(htmlString: string): string {
+    if (htmlString.indexOf('<!--p-->') === -1) {
+        return `<p>${htmlString}</p>`;
+    }
+
     return htmlString
         .replace(/<!--p-->/g, '<p>')
         .replace(/<!--\/p--><br><\/br>/g, '</p>')

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/adapters/CKEditor5.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/adapters/CKEditor5.js
@@ -42,6 +42,7 @@ export default class CKEditor5 extends React.Component<TextEditorProps> {
                 onBlur={onBlur}
                 onChange={onChange}
                 onFocus={onFocus}
+                options={options || {}}
                 value={value}
             />
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Related issues/PRs | #5214
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add possibility to script p tags from the `text_editor`. 

#### Why?

To fix FormBundle issue and add possibility to use text_editor without p tags.


#### Example Usage

```xml
    <property name="title" type="text_editor" mandatory="true">
        <meta>
            <title>sulu_form.title</title>
        </meta>

        <params>
            <param name="enter_mode" value="br"/>
        </params>
    </property>
```

