### PR TITLE
Fix missing search routes

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -30,6 +30,10 @@ sulu_route_api:
     resource: "@SuluRouteBundle/config/routing_admin_api.yaml"
     prefix: /admin/api
 
+sulu_search_api:
+    resource: "@SuluSearchBundle/config/routing_admin_api.yaml"
+    prefix: /admin/api
+
 sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing.yaml"
     prefix: /admin/media


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix missing search routes.

#### Why?

When not starting sulu via skeleton the routes where missing. This already done in the skeleton beta2: https://github.com/sulu/skeleton/compare/3.0.0-beta1...3.0.0-beta2