### PR TITLE
Remove form key for article/snippet trashHandler

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
+++ b/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
@@ -167,7 +167,7 @@ final class ArticleTrashItemHandler implements
     public function getConfiguration(): RestoreConfiguration
     {
         return new RestoreConfiguration(
-            'restore_article',
+            null,
             ArticleAdmin::EDIT_TABS_VIEW,
             ['id' => 'id'],
             null, // TODO serialization group?

--- a/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
@@ -167,7 +167,7 @@ final class SnippetTrashItemHandler implements
     public function getConfiguration(): RestoreConfiguration
     {
         return new RestoreConfiguration(
-            'restore_snippet',
+            null,
             SnippetAdmin::EDIT_TABS_VIEW,
             ['id' => 'id'],
             null, // TODO serialization group?


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove form key from article and snippet TrashHandler.

#### Why?

Because otherwise there will be an error
<img width="3046" height="1354" alt="image" src="https://github.com/user-attachments/assets/9176aab8-266b-463c-a140-f60884459780" />

