### PR TITLE
Fix media smart content filters default behaviour

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/Visitor/MediaSmartContentFiltersVisitor.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/Visitor/MediaSmartContentFiltersVisitor.php
@@ -12,9 +12,14 @@
 namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\Visitor;
 
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\Visitor\SmartContentFiltersVisitorInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+/**
+ * @internal This class should not be instantiated by a project.
+ *           Create your own smart content filters visitor to change its behaviour.
+ */
 class MediaSmartContentFiltersVisitor implements SmartContentFiltersVisitorInterface
 {
     public function __construct(
@@ -27,23 +32,28 @@ class MediaSmartContentFiltersVisitor implements SmartContentFiltersVisitorInter
     {
         $request = $this->requestStack->getCurrentRequest();
         if (null === $request) {
-            return [];
+            return $filters;
         }
 
         if ($parameters['mimetype_parameter'] ?? null) {
             $mimetypeParameter = $parameters['mimetype_parameter'];
             if (\is_string($mimetypeParameter)) {
-                $filters['mimetype'] = $mimetypeParameter;
-            }
-        }
-        if ($parameters['type_parameter'] ?? null) {
-            $typeParameter = $parameters['type_parameter'];
-            if (\is_string($typeParameter)) {
-                $filters['type'] = $typeParameter;
+                $filters['mimetype'] = $request->query->getString($mimetypeParameter);
             }
         }
 
-        $filters['webspaceKey'] = $this->requestAnalyzer->getWebspace()->getKey();
+        if ($parameters['type_parameter'] ?? null) {
+            $typeParameter = $parameters['type_parameter'];
+            if (\is_string($typeParameter)) {
+                $filters['type'] = $request->query->getString($typeParameter);
+            }
+        }
+
+        $webspace = $this->requestAnalyzer->getWebspace();
+
+        if ($webspace instanceof Webspace) { // @phpstan-ignore-line instanceof.alwaysTrue
+            $filters['webspaceKey'] = $webspace->getKey();
+        }
 
         return $filters;
     }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/Visitor/MediaSmartContentFiltersVisitorTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/Visitor/MediaSmartContentFiltersVisitorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Infrastructure\Sulu\Content\Visitor;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\Visitor\MediaSmartContentFiltersVisitor;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzer;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class MediaSmartContentFiltersVisitorTest extends TestCase
+{
+    private RequestStack $requestStack;
+    private RequestAnalyzerInterface $requestAnalyzer;
+    private MediaSmartContentFiltersVisitor $mediaSmartContentFiltersVisitor;
+
+    protected function setUp(): void
+    {
+        $this->requestStack = new RequestStack();
+        $this->requestAnalyzer = new RequestAnalyzer($this->requestStack, []);
+
+        $this->mediaSmartContentFiltersVisitor = new MediaSmartContentFiltersVisitor(
+            $this->requestAnalyzer,
+            $this->requestStack,
+        );
+    }
+
+    public function testVisitEmpty(): void
+    {
+        $this->assertSame([], $this->mediaSmartContentFiltersVisitor->visit([], [], []));
+    }
+
+    public function testVisitEmptyWithRequest(): void
+    {
+        $request = new Request();
+        $this->requestStack->push($request);
+
+        $this->assertSame([], $this->mediaSmartContentFiltersVisitor->visit([], [], []));
+    }
+
+    public function testVisitKeepFilters(): void
+    {
+        $this->assertSame(['keep' => 'this'], $this->mediaSmartContentFiltersVisitor->visit([], ['keep' => 'this'], []));
+    }
+
+    public function testMimeType(): void
+    {
+        $parameters['mimetype_parameter'] = 'mime_type';
+        $request = new Request();
+        $request->query->set('mime_type', 'application/pdf');
+        $this->requestStack->push($request);
+
+        $this->assertSame(['mimetype' => 'application/pdf'], $this->mediaSmartContentFiltersVisitor->visit([], [], $parameters));
+    }
+
+    public function testType(): void
+    {
+        $parameters['type_parameter'] = 'media_type';
+        $request = new Request();
+        $request->query->set('media_type', 'image');
+        $this->requestStack->push($request);
+
+        $this->assertSame(['type' => 'image'], $this->mediaSmartContentFiltersVisitor->visit([], [], $parameters));
+    }
+
+    public function testWebspaceKey(): void
+    {
+        $request = new Request();
+        $this->requestStack->push($request);
+
+        $webspace = new Webspace();
+        $webspace->setKey('website');
+        $suluAttribute = new RequestAttributes([
+            'webspace' => $webspace,
+        ]);
+        $request->attributes->set(RequestAnalyzer::SULU_ATTRIBUTE, $suluAttribute);
+
+        $this->assertSame(['webspaceKey' => 'website'], $this->mediaSmartContentFiltersVisitor->visit([], [], []));
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Return current filters instead of unset them.

#### Why?

@Prokyonn stumbled over this in https://github.com/sulu/sulu/pull/8249. As it's not related directly to #8249 merging this as an own PR.