### PR TITLE
Fix Link Provider configuration for Pages tree view

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
@@ -42,9 +42,9 @@ final class PageLinkProvider implements LinkProviderInterface
         return LinkConfigurationBuilder::create()
             ->setTitle($this->translator->trans('sulu_page.pages', [], 'admin'))
             ->setResourceKey(PageInterface::RESOURCE_KEY)
-            ->setListAdapter('table')
-            ->setDisplayProperties(['id'])
-            ->setOverlayTitle($this->translator->trans('sulu_page.selection_overlay_title', [], 'admin'))
+            ->setListAdapter('column_list')
+            ->setDisplayProperties(['title'])
+            ->setOverlayTitle($this->translator->trans('sulu_page.single_selection_overlay_title', [], 'admin'))
             ->setEmptyText($this->translator->trans('sulu_page.no_page_selected', [], 'admin'))
             ->setIcon('su-document');
     }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Content\Application\ContentManager\ContentManagerInterface;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class PageLinkProviderTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    private PageLinkProvider $pageLinkProvider;
+    private ObjectProphecy $contentManager;
+    private ObjectProphecy $pageRepository;
+    private ObjectProphecy $referenceStore;
+    private ObjectProphecy $translator;
+
+    protected function setUp(): void
+    {
+        $this->contentManager = $this->prophesize(ContentManagerInterface::class);
+        $this->pageRepository = $this->prophesize(PageRepositoryInterface::class);
+        $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+        $this->translator->trans(Argument::cetera())->willReturnArgument(0);
+
+        $this->pageLinkProvider = new PageLinkProvider(
+            $this->contentManager->reveal(),
+            $this->pageRepository->reveal(),
+            $this->referenceStore->reveal(),
+            $this->translator->reveal()
+        );
+    }
+
+    public function testGetConfigurationBuilder(): void
+    {
+        $linkConfigurationBuilder = $this->pageLinkProvider->getConfigurationBuilder();
+        $linkConfiguration = $linkConfigurationBuilder->getLinkConfiguration();
+
+        $this->assertSame(
+            PageInterface::RESOURCE_KEY,
+            self::getPrivateProperty($linkConfiguration, 'resourceKey'),
+        );
+
+        $this->assertSame(
+            'column_list',
+            self::getPrivateProperty($linkConfiguration, 'listAdapter'),
+        );
+
+        $this->assertSame([
+            'title',
+        ], self::getPrivateProperty($linkConfiguration, 'displayProperties'));
+    }
+}

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
@@ -28,11 +28,27 @@ class PageLinkProviderTest extends TestCase
     use ProphecyTrait;
     use SetGetPrivatePropertyTrait;
 
-    private PageLinkProvider $pageLinkProvider;
+    /**
+     * @var ObjectProphecy<ContentManagerInterface>
+     */
     private ObjectProphecy $contentManager;
+
+    /**
+     * @var ObjectProphecy<PageRepositoryInterface>
+     */
     private ObjectProphecy $pageRepository;
+
+    /**
+     * @var ObjectProphecy<ReferenceStoreInterface>
+     */
     private ObjectProphecy $referenceStore;
+
+    /**
+     * @var ObjectProphecy<TranslatorInterface>
+     */
     private ObjectProphecy $translator;
+
+    private PageLinkProvider $pageLinkProvider;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix Link Provider configuration for Pages

#### Why?

@Prokyonn stumbled over this in https://github.com/sulu/sulu/pull/8249/ that we currently not show the tree overlay. Cherry picked this out and added a test.