### PR TITLE
Block ids pregenerate

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -98,13 +98,13 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     }
 
     componentDidUpdate(prevProps: Props<T, U>) {
-        const {value} = this.props;
+        const {generateBlockIds, value} = this.props;
 
         // Only call ensureBlockIds if:
-        // 1. The value reference changed (not the one we just set)
-        // 2. There are actually blocks without IDs
-        // 3. We're not currently generating IDs
-        if (prevProps.value !== value && !this.isGeneratingIds) {
+        // 1. generateBlockIds function is provided
+        // 2. The value reference changed
+        // 3. There are actually blocks without IDs
+        if (generateBlockIds && prevProps.value !== value) {
             const hasBlocksWithoutIds = value && value.some((block) => !block._id);
             if (hasBlocksWithoutIds) {
                 this.ensureBlockIds();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -50,6 +50,7 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     @observable expandedBlocks: Array<boolean> = [];
     @observable selectedBlocks: Array<boolean> = [];
     @observable mode: BlockMode = 'sortable';
+    @observable isGeneratingIds: boolean = false;
 
     fillArraysDisposer: ?() => *;
     setPasteableBlocksDisposer: ?() => *;
@@ -91,12 +92,71 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
         if (props.movable === false) {
             this.mode = 'static';
         }
+
+        // Ensure IDs are generated for initial value
+        this.ensureBlockIds();
+    }
+
+    componentDidUpdate(prevProps: Props<T, U>) {
+        const {value} = this.props;
+
+        // Only call ensureBlockIds if:
+        // 1. The value reference changed (not the one we just set)
+        // 2. There are actually blocks without IDs
+        // 3. We're not currently generating IDs
+        if (prevProps.value !== value && !this.isGeneratingIds) {
+            const hasBlocksWithoutIds = value && value.some((block) => !block._id);
+            if (hasBlocksWithoutIds) {
+                this.ensureBlockIds();
+            }
+        }
     }
 
     componentWillUnmount() {
         this.fillArraysDisposer?.();
         this.setPasteableBlocksDisposer?.();
     }
+
+    @action ensureBlockIds = async() => {
+        const {generateBlockIds, onChange, value} = this.props;
+
+        // Prevent multiple simultaneous ID generation operations
+        if (this.isGeneratingIds || !value || !generateBlockIds) {
+            return;
+        }
+
+        // Find all blocks without IDs
+        const blocksWithoutIds = value.filter((block) => !block._id);
+
+        if (blocksWithoutIds.length === 0) {
+            return;
+        }
+
+        this.isGeneratingIds = true;
+
+        try {
+            // Generate IDs for all blocks without IDs
+            const generatedIds = await generateBlockIds(blocksWithoutIds.length);
+
+            // Ensure generated IDs is a valid array
+            if (!generatedIds || !Array.isArray(generatedIds) || generatedIds.length !== blocksWithoutIds.length) {
+                return;
+            }
+
+            // Update the value with the generated IDs
+            let generatedIdIndex = 0;
+            const updatedValue = value.map((block) => {
+                if (!block._id) {
+                    return {...block, _id: generatedIds[generatedIdIndex++]};
+                }
+                return block;
+            });
+
+            onChange(updatedValue);
+        } finally {
+            this.isGeneratingIds = false;
+        }
+    };
 
     fillArrays = () => {
         const {collapsable, defaultType, onChange, minOccurs, value} = this.props;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -1677,3 +1677,31 @@ test('Should pre-generate IDs only for blocks without IDs (mixed case)', async()
         },
     ]);
 });
+
+test('Should not generate IDs when generateBlockIds is not provided', async() => {
+    const changeSpy = jest.fn();
+
+    mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={[
+                {
+                    type: 'type1',
+                    content: 'Block 1',
+                },
+                {
+                    type: 'type2',
+                    content: 'Block 2',
+                },
+            ]}
+        />
+    );
+
+    // Wait for potential async operations
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Should not try to generate IDs or call onChange since generateBlockIds is not provided
+    expect(changeSpy).not.toHaveBeenCalled();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -1549,3 +1549,131 @@ test('Should remove ID from clipboard when cutting blocks', () => {
         {content: 'Test 1', type: 'editor'}, // _id should be removed for cut blocks too
     ]);
 });
+
+test('Should pre-generate IDs for blocks without IDs when loaded from server', async() => {
+    const mockId1 = '12345678';
+    const mockId2 = '87654321';
+    const generateBlockIdsSpy = jest.fn().mockReturnValue(Promise.resolve([mockId1, mockId2]));
+    const changeSpy = jest.fn();
+
+    const value = [
+        {
+            type: 'type1',
+            content: 'Block 1',
+        },
+        {
+            type: 'type2',
+            content: 'Block 2',
+        },
+    ];
+
+    mount(
+        <BlockCollection
+            defaultType="editor"
+            generateBlockIds={generateBlockIdsSpy}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    // Wait for async ID generation
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(generateBlockIdsSpy).toHaveBeenCalledWith(2);
+    expect(changeSpy).toHaveBeenCalledWith([
+        {
+            type: 'type1',
+            content: 'Block 1',
+            _id: mockId1,
+        },
+        {
+            type: 'type2',
+            content: 'Block 2',
+            _id: mockId2,
+        },
+    ]);
+});
+
+test('Should not pre-generate IDs for blocks that already have IDs', async() => {
+    const existingId1 = 'existing1';
+    const existingId2 = 'existing2';
+    const generateBlockIdsSpy = jest.fn();
+    const changeSpy = jest.fn();
+
+    const value = [
+        {
+            type: 'type1',
+            content: 'Block 1',
+            _id: existingId1,
+        },
+        {
+            type: 'type2',
+            content: 'Block 2',
+            _id: existingId2,
+        },
+    ];
+
+    mount(
+        <BlockCollection
+            defaultType="editor"
+            generateBlockIds={generateBlockIdsSpy}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    // Wait for potential async operations
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Should not generate IDs since all blocks already have them
+    expect(generateBlockIdsSpy).not.toHaveBeenCalled();
+    expect(changeSpy).not.toHaveBeenCalled();
+});
+
+test('Should pre-generate IDs only for blocks without IDs (mixed case)', async() => {
+    const existingId = 'existing1';
+    const newId = '12345678';
+    const generateBlockIdsSpy = jest.fn().mockReturnValue(Promise.resolve([newId]));
+    const changeSpy = jest.fn();
+
+    const value = [
+        {
+            type: 'type1',
+            content: 'Block 1',
+            _id: existingId,
+        },
+        {
+            type: 'type2',
+            content: 'Block 2',
+        },
+    ];
+
+    mount(
+        <BlockCollection
+            defaultType="editor"
+            generateBlockIds={generateBlockIdsSpy}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    // Wait for async ID generation
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(generateBlockIdsSpy).toHaveBeenCalledWith(1);
+    expect(changeSpy).toHaveBeenCalledWith([
+        {
+            type: 'type1',
+            content: 'Block 1',
+            _id: existingId,
+        },
+        {
+            type: 'type2',
+            content: 'Block 2',
+            _id: newId,
+        },
+    ]);
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #7672 
| Related issues/PRs | https://github.com/sulu/sulu/pull/8262
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add the pregeneration of block-ids if the server respond blocks with missing id.

#### Why?

When blocks are created e.g. in fixtures the user could forget the id and so the UI adds them later.