### PR TITLE
Fix regression in doctrine/orm 2.20.7 release

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7301,6 +7301,11 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
 
 		-
+			message: "#^Unable to resolve the template type TMaybeContained in call to method Doctrine\\\\Common\\\\Collections\\\\ReadableCollection\\<int,Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\MediaInterface\\>\\:\\:contains\\(\\)$#"
+			count: 1
+			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -13029,11 +13034,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\MediaBundle\\\\Command\\\\FormatCacheRegenerateCommand\\:\\:\\$filesystem is never read, only written\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Command/FormatCacheRegenerateCommand.php
-
-		-
-			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\ORM\\\\EntityManagerInterface\\:\\:getRepository\\(\\) expects class\\-string\\<SuluMediaBundle\\:Media\\>, string given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Command/MediaTypeUpdateCommand.php
 
 		-
 			message: "#^Method Sulu\\\\Bundle\\\\MediaBundle\\\\Content\\\\MediaSelectionContainer\\:\\:__construct\\(\\) has parameter \\$config with no type specified\\.$#"
@@ -24389,11 +24389,6 @@ parameters:
 			message: "#^Property Sulu\\\\Bundle\\\\PreviewBundle\\\\Tests\\\\Functional\\\\Preview\\\\Renderer\\\\PreviewRendererTest\\:\\:\\$previewRenderer \\(Sulu\\\\Bundle\\\\PreviewBundle\\\\Preview\\\\Renderer\\\\PreviewRenderer\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Tests/Functional/Preview/Renderer/PreviewRendererTest.php
-
-		-
-			message: "#^Call to an undefined static method Gedmo\\\\Sluggable\\\\Util\\\\Urlizer\\:\\:urlize\\(\\)\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerTest.php
 
 		-
 			message: "#^Cannot access offset 'lastVisit' on mixed\\.$#"

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\ContactBundle\Entity\AccountRepositoryInterface;
 use Sulu\Bundle\ContactBundle\Entity\Address as AddressEntity;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
+use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
 use Sulu\Bundle\TagBundle\Tag\TagManagerInterface;
@@ -253,7 +254,11 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
      */
     public function setMedias(Account $account, $mediaIds)
     {
-        $foundMedias = $this->mediaRepository->findById($mediaIds);
+        /** @var MediaInterface[] $foundMedias */
+        $foundMedias = [];
+        if (\count($mediaIds) > 0) {
+            $foundMedias = $this->mediaRepository->findById($mediaIds);
+        }
         $foundMediaIds = \array_map(
             function($mediaEntity) {
                 return $mediaEntity->getId();

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -632,7 +632,10 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
     private function setMedias(ContactInterface $contact, $mediaIds)
     {
         /** @var MediaInterface[] $foundMedias */
-        $foundMedias = $this->mediaRepository->findById($mediaIds);
+        $foundMedias = [];
+        if (\count($mediaIds) > 0) {
+            $foundMedias = $this->mediaRepository->findById($mediaIds);
+        }
         /** @var int[] $foundMediaIds */
         $foundMediaIds = \array_map(
             function($mediaEntity) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Do not call entity repository if media ids are empty.

#### Why?

Call of empty strings to doctrine orm methods ends in error now. See https://github.com/doctrine/orm/issues/12245

And errors in our CI: https://github.com/sulu/sulu/actions/runs/18717609941/job/53847239684