### PR TITLE
Add search listener and search provider for Pages for SEAL

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Search/ArticleIndexListener.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/ArticleIndexListener.php
@@ -21,6 +21,7 @@ use Sulu\Article\Domain\Event\ArticleRestoredEvent;
 use Sulu\Article\Domain\Event\ArticleTranslationAddedEvent;
 use Sulu\Article\Domain\Event\ArticleTranslationCopiedEvent;
 use Sulu\Article\Domain\Event\ArticleTranslationRemovedEvent;
+use Sulu\Article\Domain\Event\ArticleTranslationRestoredEvent;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -35,7 +36,7 @@ final class ArticleIndexListener
     ) {
     }
 
-    public function onArticleChanged(ArticleCreatedEvent|ArticleModifiedEvent|ArticleRemovedEvent|ArticleRestoredEvent|ArticleTranslationAddedEvent|ArticleTranslationRemovedEvent|ArticleTranslationCopiedEvent $event): void
+    public function onArticleChanged(ArticleCreatedEvent|ArticleModifiedEvent|ArticleRemovedEvent|ArticleRestoredEvent|ArticleTranslationRestoredEvent|ArticleTranslationAddedEvent|ArticleTranslationRemovedEvent|ArticleTranslationCopiedEvent $event): void
     {
         $locale = $event->getResourceLocale();
         $identifiers = [];

--- a/packages/article/src/Infrastructure/Sulu/Search/ArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/ArticleReindexProvider.php
@@ -55,9 +55,10 @@ final class ArticleReindexProvider implements ReindexProviderInterface
         $this->dimensionContentRepository = $dimensionContentRepository;
     }
 
-    public function total(): int
+    public function total(): ?int
     {
-        return $this->articleRepository->count([]);
+        // Todo: Add correct count for multiple locales.
+        return null;
     }
 
     public function provide(ReindexConfig $reindexConfig): \Generator

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -34,6 +34,7 @@ use Sulu\Article\Domain\Event\ArticleRestoredEvent;
 use Sulu\Article\Domain\Event\ArticleTranslationAddedEvent;
 use Sulu\Article\Domain\Event\ArticleTranslationCopiedEvent;
 use Sulu\Article\Domain\Event\ArticleTranslationRemovedEvent;
+use Sulu\Article\Domain\Event\ArticleTranslationRestoredEvent;
 use Sulu\Article\Domain\Model\Article;
 use Sulu\Article\Domain\Model\ArticleDimensionContent;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
@@ -433,6 +434,7 @@ final class SuluArticleBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => ArticleModifiedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleRemovedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleRestoredEvent::class, 'method' => 'onArticleChanged'])
+            ->tag('kernel.event_listener', ['event' => ArticleTranslationRestoredEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleTranslationAddedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleTranslationRemovedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleTranslationCopiedEvent::class, 'method' => 'onArticleChanged']);

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/ArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/ArticleReindexProviderTest.php
@@ -55,17 +55,7 @@ class ArticleReindexProviderTest extends SuluTestCase
 
     public function testTotal(): void
     {
-        $article = static::createArticle([
-            'en' => [
-                'live' => [
-                    'template' => 'article',
-                    'title' => 'Test Article',
-                    'url' => '/test-article',
-                ],
-            ],
-        ]);
-
-        $this->assertSame(1, $this->provider->total());
+        $this->assertNull($this->provider->total());
     }
 
     public function testProvideAll(): void

--- a/packages/page/src/Domain/Event/PageRemovedEvent.php
+++ b/packages/page/src/Domain/Event/PageRemovedEvent.php
@@ -20,7 +20,9 @@ use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 class PageRemovedEvent extends DomainEvent
 {
     /**
-     * @param array<string, mixed> $context
+     * @param array{
+     *     locales?: string[]
+     * } $context
      */
     public function __construct(
         private string $pageId,
@@ -64,5 +66,13 @@ class PageRemovedEvent extends DomainEvent
     public function getResourceSecurityContext(): ?string
     {
         return PageAdmin::getPageSecurityContext(static::getResourceWebspaceKey());
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getAllLocales(): ?array
+    {
+        return $this->context['locales'] ?? null;
     }
 }

--- a/packages/page/src/Infrastructure/Sulu/Search/PageIndexListener.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/PageIndexListener.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use Sulu\Content\Domain\Model\DimensionContentCollection;
+use Sulu\Page\Domain\Event\PageCreatedEvent;
+use Sulu\Page\Domain\Event\PageModifiedEvent;
+use Sulu\Page\Domain\Event\PageRemovedEvent;
+use Sulu\Page\Domain\Event\PageRestoredEvent;
+use Sulu\Page\Domain\Event\PageTranslationAddedEvent;
+use Sulu\Page\Domain\Event\PageTranslationRemovedEvent;
+use Sulu\Page\Domain\Event\PageTranslationRestoredEvent;
+use Sulu\Page\Domain\Model\PageDimensionContent;
+use Sulu\Page\Domain\Model\PageInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @internal this class is internal no backwards compatibility promise is given for this class
+ *           use Symfony Dependency Injection to override or create your own Listener instead
+ */
+final class PageIndexListener
+{
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+    ) {
+    }
+
+    // Todo: Check if translation removed and translation restored event is needed.
+    public function onPageChanged(PageCreatedEvent|PageModifiedEvent|PageRemovedEvent|PageRestoredEvent|PageTranslationRestoredEvent|PageTranslationAddedEvent|PageTranslationRemovedEvent $event): void
+    {
+        $locale = $event->getResourceLocale();
+        $identifiers = [];
+
+        if ($event instanceof PageRemovedEvent) {
+            $locales = $event->getAllLocales();
+
+            if (!$locales) {
+                return;
+            }
+
+            foreach ($locales as $locale) {
+                $identifiers[] = PageInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+            }
+        } elseif ($event instanceof PageRestoredEvent) {
+            $page = $event->getPage();
+            $dimensionContentCollection = new DimensionContentCollection($page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+            $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);
+
+            if (!$unlocalizedDimensionContent?->getAvailableLocales()) {
+                return;
+            }
+
+            foreach ($unlocalizedDimensionContent->getAvailableLocales() as $locale) {
+                $identifiers[] = PageInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+            }
+        } elseif ($locale) {
+            $identifiers[] = PageInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+        }
+
+        if (!$identifiers) {
+            return;
+        }
+
+        $this->messageBus->dispatch(
+            ReindexConfig::create()
+                ->withIndex('admin')
+                ->withIdentifiers($identifiers),
+        );
+    }
+}

--- a/packages/page/src/Infrastructure/Sulu/Search/PageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/PageReindexProvider.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use CmsIg\Seal\Reindex\ReindexProviderInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Domain\Model\PageInterface;
+
+/**
+ * @phpstan-type Page array{
+ *     pageId: int,
+ *     changed: \DateTimeImmutable,
+ *     created: \DateTimeImmutable,
+ *     title: string,
+ *     locale: string,
+ * }
+ *
+ * @internal this class is internal no backwards compatibility promise is given for this class
+ *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
+ */
+final class PageReindexProvider implements ReindexProviderInterface
+{
+    /**
+     * @var EntityRepository<PageInterface>
+     */
+    protected EntityRepository $pageRepository;
+
+    /**
+     * @var EntityRepository<PageDimensionContentInterface>
+     */
+    protected EntityRepository $dimensionContentRepository;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+    ) {
+        $repository = $entityManager->getRepository(PageInterface::class);
+        $dimensionContentRepository = $entityManager->getRepository(PageDimensionContentInterface::class);
+
+        $this->pageRepository = $repository;
+        $this->dimensionContentRepository = $dimensionContentRepository;
+    }
+
+    public function total(): ?int
+    {
+        // Todo: Add correct count because of multiple locales.
+        return null;
+    }
+
+    public function provide(ReindexConfig $reindexConfig): \Generator
+    {
+        $pages = $this->loadPages($reindexConfig->getIdentifiers());
+
+        /** @var Page $page */
+        foreach ($pages as $page) {
+            yield [
+                'id' => PageInterface::RESOURCE_KEY . '::' . ((string) $page['pageId']) . '::' . $page['locale'],
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => (string) $page['pageId'],
+                'changedAt' => $page['changed']->format('c'),
+                'createdAt' => $page['created']->format('c'),
+                'title' => $page['title'],
+                'locale' => $page['locale'],
+            ];
+        }
+    }
+
+    /**
+     * @param string[] $identifiers
+     *
+     * @return iterable<Page>
+     */
+    private function loadPages(array $identifiers = []): iterable
+    {
+        $qb = $this->dimensionContentRepository->createQueryBuilder('dimensionContent')
+            ->select('IDENTITY(dimensionContent.page) AS pageId')
+            ->addSelect('dimensionContent.created')
+            ->addSelect('dimensionContent.changed')
+            ->addSelect('dimensionContent.title')
+            ->addSelect('dimensionContent.locale')
+            ->where('dimensionContent.stage = :stage')
+            ->andWhere('dimensionContent.locale IS NOT NULL')
+            ->andWhere('dimensionContent.version = :version');
+
+        $parameters = [
+            'stage' => DimensionContentInterface::STAGE_DRAFT,
+            'version' => DimensionContentInterface::CURRENT_VERSION,
+        ];
+
+        if (0 < \count($identifiers)) {
+            $conditions = [];
+
+            foreach ($identifiers as $index => $identifier) {
+                $resourceKey = \explode('::', $identifier)[0];
+
+                if (PageInterface::RESOURCE_KEY !== $resourceKey) {
+                    continue;
+                }
+
+                $id = \explode('::', $identifier)[1] ?? '';
+                $locale = \explode('::', $identifier)[2] ?? '';
+
+                $conditions[] = "(dimensionContent.page = :id{$index} AND dimensionContent.locale = :locale{$index})";
+                $parameters["id{$index}"] = $id;
+                $parameters["locale{$index}"] = $locale;
+            }
+
+            if (!$conditions) {
+                return [];
+            }
+
+            $qb->andWhere(\implode(' OR ', $conditions));
+        }
+
+        $qb->setParameters($parameters);
+
+        /** @var iterable<Page> */
+        return $qb->getQuery()->toIterable();
+    }
+
+    public static function getIndex(): string
+    {
+        return 'admin';
+    }
+}

--- a/packages/page/src/Infrastructure/Sulu/Search/PageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/PageReindexProvider.php
@@ -57,7 +57,7 @@ final class PageReindexProvider implements ReindexProviderInterface
 
     public function total(): ?int
     {
-        // Todo: Add correct count because of multiple locales.
+        // Todo: Add correct count for multiple locales.
         return null;
     }
 

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -653,6 +653,30 @@ final class SuluPageBundle extends AbstractBundle
                 ],
             );
         }
+
+        if ($builder->hasExtension('sulu_search')) {
+            $builder->prependExtensionConfig(
+                'sulu_search',
+                [
+                    'admin' => [
+                        'resources' => [
+                            PageInterface::RESOURCE_KEY => [
+                                'name' => 'sulu_page.pages',
+                                'icon' => 'su-document',
+                                'route' => [
+                                    'name' => PageAdmin::EDIT_FORM_VIEW,
+                                    'resultToRoute' => [
+                                        'id' => 'id',
+                                        'locale' => 'locale',
+                                    ],
+                                ],
+                                'securityContext' => PageAdmin::SECURITY_CONTEXT_GROUP, // Todo: Add correct permissions for webspaces.
+                            ],
+                        ],
+                    ],
+                ],
+            );
+        }
     }
 
     /**

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -29,6 +29,13 @@ use Sulu\Page\Application\MessageHandler\OrderPageMessageHandler;
 use Sulu\Page\Application\MessageHandler\RemovePageMessageHandler;
 use Sulu\Page\Application\MessageHandler\RemovePageTranslationMessageHandler;
 use Sulu\Page\Application\MessageHandler\RestorePageVersionMessageHandler;
+use Sulu\Page\Domain\Event\PageCreatedEvent;
+use Sulu\Page\Domain\Event\PageModifiedEvent;
+use Sulu\Page\Domain\Event\PageRemovedEvent;
+use Sulu\Page\Domain\Event\PageRestoredEvent;
+use Sulu\Page\Domain\Event\PageTranslationAddedEvent;
+use Sulu\Page\Domain\Event\PageTranslationRemovedEvent;
+use Sulu\Page\Domain\Event\PageTranslationRestoredEvent;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
@@ -82,8 +89,8 @@ use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
  */
 final class SuluPageBundle extends AbstractBundle
 {
-    use PersistenceExtensionTrait;
     use PersistenceBundleTrait;
+    use PersistenceExtensionTrait;
 
     public function __construct()
     {
@@ -368,7 +375,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_content.content_data_mapper'),
                 '%sulu.model.page.class%',
-                null, //TODO add security context for preview
+                null, // TODO add security context for preview
             ])
             ->tag('sulu.context', ['context' => 'admin'])
             ->tag('sulu_preview.object_provider', ['provider-key' => 'pages']);
@@ -506,6 +513,26 @@ final class SuluPageBundle extends AbstractBundle
                 ->tag('sulu_trash.restore_trash_item_handler')
                 ->tag('sulu_trash.restore_configuration_provider');
         }
+
+        $services->set('sulu_page.page_index_listener')
+            ->class('Sulu\Page\Infrastructure\Sulu\Search\PageIndexListener')
+            ->args([
+                new Reference('sulu_message_bus'),
+            ])
+            ->tag('kernel.event_listener', ['event' => PageCreatedEvent::class, 'method' => 'onPageChanged'])
+            ->tag('kernel.event_listener', ['event' => PageModifiedEvent::class, 'method' => 'onPageChanged'])
+            ->tag('kernel.event_listener', ['event' => PageRemovedEvent::class, 'method' => 'onPageChanged'])
+            ->tag('kernel.event_listener', ['event' => PageRestoredEvent::class, 'method' => 'onPageChanged'])
+            ->tag('kernel.event_listener', ['event' => PageTranslationRestoredEvent::class, 'method' => 'onPageChanged'])
+            ->tag('kernel.event_listener', ['event' => PageTranslationAddedEvent::class, 'method' => 'onPageChanged'])
+            ->tag('kernel.event_listener', ['event' => PageTranslationRemovedEvent::class, 'method' => 'onPageChanged']);
+
+        $services->set('sulu_page.page_reindex_provider')
+            ->class('Sulu\Page\Infrastructure\Sulu\Search\PageReindexProvider')
+            ->args([
+                new Reference('doctrine.orm.entity_manager'),
+            ])
+            ->tag('cmsig_seal.reindex_provider');
     }
 
     /**
@@ -623,7 +650,7 @@ final class SuluPageBundle extends AbstractBundle
                             ],
                         ],
                     ],
-                ]
+                ],
             );
         }
     }

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/PageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/PageReindexProviderTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Infrastructure\Sulu\Search\PageReindexProvider;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+
+class PageReindexProviderTest extends SuluTestCase
+{
+    use CreatePageTrait;
+    use SetGetPrivatePropertyTrait;
+
+    private EntityManagerInterface $entityManager;
+    private PageReindexProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->getEntityManager();
+        $this->provider = new PageReindexProvider($this->entityManager);
+        $this->purgeDatabase();
+    }
+
+    public function testGetIndex(): void
+    {
+        $this->assertSame('admin', PageReindexProvider::getIndex());
+    }
+
+    public function testTotal(): void
+    {
+        $this->assertNull($this->provider->total());
+    }
+
+    public function testProvideAll(): void
+    {
+        $page1 = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Test Page',
+                    'url' => '/test-page',
+                ],
+            ],
+        ]);
+        $page2 = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Test Page 2',
+                    'url' => '/test-page-2',
+                ],
+            ],
+            'de' => [
+                'draft' => [
+                    'template' => 'default',
+                    'title' => 'Test Schnipsel 2',
+                    'url' => '/test-schnipsel-2',
+                ],
+            ],
+        ]);
+
+        $createdAt = '2020-06-01 15:30:00';
+        $changedDateString1 = '2023-06-01 15:30:00';
+        $changedDateString2 = '2024-11-29 15:30:00';
+
+        $connection = self::getEntityManager()->getConnection();
+        $sql = 'UPDATE pa_page_dimension_contents SET changed = :changed, created = :created WHERE pageUuid = :uuid';
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString1,
+            'created' => $createdAt,
+            'uuid' => $page1->getUuid(),
+        ]);
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString2,
+            'created' => $createdAt,
+            'uuid' => $page2->getUuid(),
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('admin');
+        /** @var array<array{id: string}> $results */
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(3, $results);
+
+        $expectedResult = [
+            [
+                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::de',
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $page2->getUuid(),
+                'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
+                'title' => 'Test Schnipsel 2',
+                'locale' => 'de',
+            ],
+            [
+                'id' => PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::en',
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $page1->getUuid(),
+                'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
+                'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
+                'title' => 'Test Page',
+                'locale' => 'en',
+            ],
+            [
+                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $page2->getUuid(),
+                'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
+                'title' => 'Test Page 2',
+                'locale' => 'en',
+            ],
+        ];
+
+        \usort($expectedResult, fn ($a, $b) => \strcmp($a['id'], $b['id']));
+        \usort($results, fn ($a, $b) => \strcmp($a['id'], $b['id']));
+
+        $this->assertSame(
+            $expectedResult,
+            $results,
+        );
+    }
+
+    public function testProvideWithSpecificIdentifiers(): void
+    {
+        $page1 = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Cool Page 1',
+                    'url' => '/cool-page-1',
+                ],
+            ],
+            'de' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Cool Page DE 1',
+                    'url' => '/cool-seite-de-1',
+                ],
+            ],
+        ]);
+        $page2 = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Not so cool Page 2',
+                    'url' => '/not-so-cool-page-2',
+                ],
+            ],
+            'de' => [
+                'draft' => [
+                    'template' => 'default',
+                    'title' => 'Not so cool Page DE 2',
+                    'url' => '/not-so-cool-seite-de-2',
+                ],
+            ],
+        ]);
+
+        $createdAt = '2020-06-01 15:30:00';
+        $changedDateString1 = '2023-06-01 15:30:00';
+        $changedDateString2 = '2024-06-01 15:30:00';
+
+        $connection = self::getEntityManager()->getConnection();
+        $sql = 'UPDATE pa_page_dimension_contents SET changed = :changed, created = :created WHERE pageUuid = :uuid';
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString1,
+            'created' => $createdAt,
+            'uuid' => $page1->getUuid(),
+        ]);
+
+        $connection->executeStatement($sql, [
+            'changed' => $changedDateString2,
+            'created' => $createdAt,
+            'uuid' => $page2->getUuid(),
+        ]);
+
+        $identifiers = [
+            PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::de',
+            PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
+        ];
+
+        $config = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers($identifiers);
+
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(2, $results);
+
+        $resultTitles = \array_column($results, 'title');
+        $this->assertContains('Cool Page DE 1', $resultTitles);
+        $this->assertContains('Not so cool Page 2', $resultTitles);
+        $this->assertNotContains('Cool Page 1', $resultTitles);
+        $this->assertNotContains('Not so cool Page DE 2', $resultTitles);
+    }
+}

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/PageIndexListenerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/PageIndexListenerTest.php
@@ -100,7 +100,7 @@ class PageIndexListenerTest extends TestCase
     public function testOnPageChangedWithPageRestored(): void
     {
         $page = new Page('222');
-        $event = new PageRestoredEvent($page, 'de', []);
+        $event = new PageRestoredEvent($page, 'pageTitle', ['locales' => ['de']], []);
         $dimensionContent = $page->createDimensionContent();
         $dimensionContent->setLocale(null);
         $dimensionContent->addAvailableLocale('de');

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/PageIndexListenerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/PageIndexListenerTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Search;
+
+use CmsIg\Seal\Reindex\ReindexConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Page\Domain\Event\PageCreatedEvent;
+use Sulu\Page\Domain\Event\PageModifiedEvent;
+use Sulu\Page\Domain\Event\PageRemovedEvent;
+use Sulu\Page\Domain\Event\PageRestoredEvent;
+use Sulu\Page\Domain\Event\PageTranslationAddedEvent;
+use Sulu\Page\Domain\Event\PageTranslationRemovedEvent;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Infrastructure\Sulu\Search\PageIndexListener;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[CoversClass(PageIndexListener::class)]
+class PageIndexListenerTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<MessageBusInterface>
+     */
+    private ObjectProphecy $messageBus;
+    private PageIndexListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->messageBus = $this->prophesize(MessageBusInterface::class);
+        $this->listener = new PageIndexListener($this->messageBus->reveal());
+    }
+
+    public function testOnPageChangedWithPageCreatedEvent(): void
+    {
+        $page = new Page('123');
+        $event = new PageCreatedEvent($page, 'en', []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::123::en']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onPageChanged($event);
+    }
+
+    public function testOnPageChangedWithPageModifiedEvent(): void
+    {
+        $page = new Page('456');
+        $event = new PageModifiedEvent($page, 'en', []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::456::en']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onPageChanged($event);
+    }
+
+    public function testOnPageChangedWithPageRemovedEvent(): void
+    {
+        $page = new Page('789');
+        $event = new PageRemovedEvent($page->getId(), 'webspace', 'Title', ['locales' => ['en', 'de']]);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::789::en', PageInterface::RESOURCE_KEY . '::789::de']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onPageChanged($event);
+    }
+
+    public function testOnPageChangedWithPageRestored(): void
+    {
+        $page = new Page('222');
+        $event = new PageRestoredEvent($page, 'de', []);
+        $dimensionContent = $page->createDimensionContent();
+        $dimensionContent->setLocale(null);
+        $dimensionContent->addAvailableLocale('de');
+        $page->addDimensionContent($dimensionContent);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::222::de']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onPageChanged($event);
+    }
+
+    public function testOnPageChangedWithPageTranslationAddedEvent(): void
+    {
+        $page = new Page('333');
+        $event = new PageTranslationAddedEvent($page, 'de', []);
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::333::de']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onPageChanged($event);
+    }
+
+    public function testOnPageChangedWithPageTranslationRemovedEvent(): void
+    {
+        $page = new Page('444');
+        $event = new PageTranslationRemovedEvent($page, 'de');
+
+        $expectedConfig = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::444::de']);
+
+        $this->messageBus->dispatch($expectedConfig)
+            ->willReturn(new Envelope($expectedConfig))
+            ->shouldBeCalledOnce();
+
+        $this->listener->onPageChanged($event);
+    }
+}

--- a/packages/snippet/src/Infrastructure/Sulu/Search/SnippetIndexListener.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/SnippetIndexListener.php
@@ -20,6 +20,7 @@ use Sulu\Snippet\Domain\Event\SnippetRemovedEvent;
 use Sulu\Snippet\Domain\Event\SnippetRestoredEvent;
 use Sulu\Snippet\Domain\Event\SnippetTranslationAddedEvent;
 use Sulu\Snippet\Domain\Event\SnippetTranslationRemovedEvent;
+use Sulu\Snippet\Domain\Event\SnippetTranslationRestoredEvent;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -34,8 +35,7 @@ final class SnippetIndexListener
     ) {
     }
 
-    // Todo: Check if translation removed and translation restored event is needed.
-    public function onSnippetChanged(SnippetCreatedEvent|SnippetModifiedEvent|SnippetRemovedEvent|SnippetRestoredEvent|SnippetTranslationAddedEvent|SnippetTranslationRemovedEvent $event): void
+    public function onSnippetChanged(SnippetCreatedEvent|SnippetModifiedEvent|SnippetRemovedEvent|SnippetRestoredEvent|SnippetTranslationRestoredEvent|SnippetTranslationAddedEvent|SnippetTranslationRemovedEvent $event): void
     {
         $locale = $event->getResourceLocale();
         $identifiers = [];

--- a/packages/snippet/src/Infrastructure/Sulu/Search/SnippetReindexProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/SnippetReindexProvider.php
@@ -55,9 +55,10 @@ final class SnippetReindexProvider implements ReindexProviderInterface
         $this->dimensionContentRepository = $dimensionContentRepository;
     }
 
-    public function total(): int
+    public function total(): ?int
     {
-        return $this->snippetRepository->count([]);
+        // Todo: Add correct count for multiple locales.
+        return null;
     }
 
     public function provide(ReindexConfig $reindexConfig): \Generator

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -33,6 +33,7 @@ use Sulu\Snippet\Domain\Event\SnippetRemovedEvent;
 use Sulu\Snippet\Domain\Event\SnippetRestoredEvent;
 use Sulu\Snippet\Domain\Event\SnippetTranslationAddedEvent;
 use Sulu\Snippet\Domain\Event\SnippetTranslationRemovedEvent;
+use Sulu\Snippet\Domain\Event\SnippetTranslationRestoredEvent;
 use Sulu\Snippet\Domain\Model\Snippet;
 use Sulu\Snippet\Domain\Model\SnippetArea;
 use Sulu\Snippet\Domain\Model\SnippetAreaInterface;
@@ -380,6 +381,7 @@ final class SuluSnippetBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => SnippetModifiedEvent::class, 'method' => 'onSnippetChanged'])
             ->tag('kernel.event_listener', ['event' => SnippetRemovedEvent::class, 'method' => 'onSnippetChanged'])
             ->tag('kernel.event_listener', ['event' => SnippetRestoredEvent::class, 'method' => 'onSnippetChanged'])
+            ->tag('kernel.event_listener', ['event' => SnippetTranslationRestoredEvent::class, 'method' => 'onSnippetChanged'])
             ->tag('kernel.event_listener', ['event' => SnippetTranslationAddedEvent::class, 'method' => 'onSnippetChanged'])
             ->tag('kernel.event_listener', ['event' => SnippetTranslationRemovedEvent::class, 'method' => 'onSnippetChanged']);
 

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Search/SnippetReindexProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Search/SnippetReindexProviderTest.php
@@ -43,16 +43,7 @@ class SnippetReindexProviderTest extends SuluTestCase
 
     public function testTotal(): void
     {
-        $this->createSnippet([
-            'en' => [
-                'live' => [
-                    'template' => 'snippet',
-                    'title' => 'Test Snippet',
-                ],
-            ],
-        ]);
-
-        $this->assertSame(1, $this->provider->total());
+        $this->assertNull($this->provider->total());
     }
 
     public function testProvideAll(): void

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/CategoryReindexProvider.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/CategoryReindexProvider.php
@@ -54,9 +54,10 @@ final class CategoryReindexProvider implements ReindexProviderInterface
         $this->categoryTranslationRepository = $translationRepository;
     }
 
-    public function total(): int
+    public function total(): ?int
     {
-        return $this->categoryRepository->count([]);
+        // Todo: Add correct count for multiple locales.
+        return null;
     }
 
     public function provide(ReindexConfig $reindexConfig): \Generator

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Infrastructure/Sulu/Search/CategoryReindexProviderTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Infrastructure/Sulu/Search/CategoryReindexProviderTest.php
@@ -43,11 +43,7 @@ class CategoryReindexProviderTest extends SuluTestCase
 
     public function testTotal(): void
     {
-        $this->createCategory();
-
-        $this->entityManager->flush();
-
-        $this->assertSame(1, $this->provider->total());
+        $this->assertNull($this->provider->total());
     }
 
     public function testProvideAll(): void

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/MediaReindexProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/MediaReindexProvider.php
@@ -47,9 +47,10 @@ final class MediaReindexProvider implements ReindexProviderInterface
         $this->mediaRepository = $repository;
     }
 
-    public function total(): int
+    public function total(): ?int
     {
-        return $this->mediaRepository->count([]);
+        // Todo: Add correct count for multiple locales.
+        return null;
     }
 
     public function provide(ReindexConfig $reindexConfig): \Generator

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/MediaReindexProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/MediaReindexProviderTest.php
@@ -59,11 +59,7 @@ class MediaReindexProviderTest extends SuluTestCase
 
     public function testTotal(): void
     {
-        $this->createMedia('test123');
-
-        $this->entityManager->flush();
-
-        $this->assertSame(1, $this->provider->total());
+        $this->assertNull($this->provider->total());
     }
 
     public function testProvideAll(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no 
| Related issues/PRs | #7672
| License | MIT

#### What's in this PR?

Added ReindexProvider and IndexListener for Pages and add translationRestoredEvents to article- and snippetIndexListener
