### PR TITLE
Rename admin search providers and listeners

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleIndexListener.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleIndexListener.php
@@ -29,7 +29,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *           use Symfony Dependency Injection to override or create your own Listener instead
  */
-final class ArticleIndexListener
+final class AdminArticleIndexListener
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,

--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
@@ -11,19 +11,19 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Snippet\Infrastructure\Sulu\Search;
+namespace Sulu\Article\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
 use CmsIg\Seal\Reindex\ReindexProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
+use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
-use Sulu\Snippet\Domain\Model\SnippetInterface;
 
 /**
- * @phpstan-type Snippet array{
- *     snippetId: int,
+ * @phpstan-type Article array{
+ *     articleId: int,
  *     changed: \DateTimeImmutable,
  *     created: \DateTimeImmutable,
  *     title: string,
@@ -33,25 +33,25 @@ use Sulu\Snippet\Domain\Model\SnippetInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-final class SnippetReindexProvider implements ReindexProviderInterface
+final class AdminArticleReindexProvider implements ReindexProviderInterface
 {
     /**
-     * @var EntityRepository<SnippetInterface>
+     * @var EntityRepository<ArticleInterface>
      */
-    protected EntityRepository $snippetRepository;
+    protected EntityRepository $articleRepository;
 
     /**
-     * @var EntityRepository<SnippetDimensionContentInterface>
+     * @var EntityRepository<ArticleDimensionContentInterface>
      */
     protected EntityRepository $dimensionContentRepository;
 
     public function __construct(
         EntityManagerInterface $entityManager,
     ) {
-        $repository = $entityManager->getRepository(SnippetInterface::class);
-        $dimensionContentRepository = $entityManager->getRepository(SnippetDimensionContentInterface::class);
+        $repository = $entityManager->getRepository(ArticleInterface::class);
+        $dimensionContentRepository = $entityManager->getRepository(ArticleDimensionContentInterface::class);
 
-        $this->snippetRepository = $repository;
+        $this->articleRepository = $repository;
         $this->dimensionContentRepository = $dimensionContentRepository;
     }
 
@@ -63,18 +63,18 @@ final class SnippetReindexProvider implements ReindexProviderInterface
 
     public function provide(ReindexConfig $reindexConfig): \Generator
     {
-        $snippets = $this->loadSnippets($reindexConfig->getIdentifiers());
+        $articles = $this->loadArticles($reindexConfig->getIdentifiers());
 
-        /** @var Snippet $snippet */
-        foreach ($snippets as $snippet) {
+        /** @var Article $article */
+        foreach ($articles as $article) {
             yield [
-                'id' => SnippetInterface::RESOURCE_KEY . '::' . ((string) $snippet['snippetId']) . '::' . $snippet['locale'],
-                'resourceKey' => SnippetInterface::RESOURCE_KEY,
-                'resourceId' => (string) $snippet['snippetId'],
-                'changedAt' => $snippet['changed']->format('c'),
-                'createdAt' => $snippet['created']->format('c'),
-                'title' => $snippet['title'],
-                'locale' => $snippet['locale'],
+                'id' => ArticleInterface::RESOURCE_KEY . '::' . ((string) $article['articleId']) . '::' . $article['locale'],
+                'resourceKey' => ArticleInterface::RESOURCE_KEY,
+                'resourceId' => (string) $article['articleId'],
+                'changedAt' => $article['changed']->format('c'),
+                'createdAt' => $article['created']->format('c'),
+                'title' => $article['title'],
+                'locale' => $article['locale'],
             ];
         }
     }
@@ -82,12 +82,12 @@ final class SnippetReindexProvider implements ReindexProviderInterface
     /**
      * @param string[] $identifiers
      *
-     * @return iterable<Snippet>
+     * @return iterable<Article>
      */
-    private function loadSnippets(array $identifiers = []): iterable
+    private function loadArticles(array $identifiers = []): iterable
     {
         $qb = $this->dimensionContentRepository->createQueryBuilder('dimensionContent')
-            ->select('IDENTITY(dimensionContent.snippet) AS snippetId')
+            ->select('IDENTITY(dimensionContent.article) AS articleId')
             ->addSelect('dimensionContent.created')
             ->addSelect('dimensionContent.changed')
             ->addSelect('dimensionContent.title')
@@ -107,14 +107,14 @@ final class SnippetReindexProvider implements ReindexProviderInterface
             foreach ($identifiers as $index => $identifier) {
                 $resourceKey = \explode('::', $identifier)[0];
 
-                if (SnippetInterface::RESOURCE_KEY !== $resourceKey) {
+                if (ArticleInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
                 $id = \explode('::', $identifier)[1] ?? '';
                 $locale = \explode('::', $identifier)[2] ?? '';
 
-                $conditions[] = "(dimensionContent.snippet = :id{$index} AND dimensionContent.locale = :locale{$index})";
+                $conditions[] = "(dimensionContent.article = :id{$index} AND dimensionContent.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;
                 $parameters["locale{$index}"] = $locale;
             }
@@ -128,7 +128,7 @@ final class SnippetReindexProvider implements ReindexProviderInterface
 
         $qb->setParameters($parameters);
 
-        /** @var iterable<Snippet> */
+        /** @var iterable<Article> */
         return $qb->getQuery()->toIterable();
     }
 

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -425,8 +425,8 @@ final class SuluArticleBundle extends AbstractBundle
             ])
             ->tag('sulu_route.route_defaults_provider', ['resource_key' => 'articles']);
 
-        $services->set('sulu_article.article_index_listener')
-            ->class('Sulu\Article\Infrastructure\Sulu\Search\ArticleIndexListener')
+        $services->set('sulu_article.admin_article_index_listener')
+            ->class('Sulu\Article\Infrastructure\Sulu\Search\AdminArticleIndexListener')
             ->args([
                 new Reference('sulu_message_bus'),
             ])
@@ -439,8 +439,8 @@ final class SuluArticleBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => ArticleTranslationRemovedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleTranslationCopiedEvent::class, 'method' => 'onArticleChanged']);
 
-        $services->set('sulu_article.article_reindex_provider')
-            ->class('Sulu\Article\Infrastructure\Sulu\Search\ArticleReindexProvider')
+        $services->set('sulu_article.admin_article_reindex_provider')
+            ->class('Sulu\Article\Infrastructure\Sulu\Search\AdminArticleReindexProvider')
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
             ])

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
@@ -16,7 +16,7 @@ namespace Sulu\Article\Tests\Functional\Infrastructure\Sulu\Search;
 use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
-use Sulu\Article\Infrastructure\Sulu\Search\ArticleReindexProvider;
+use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleReindexProvider;
 use Sulu\Article\Tests\Traits\CreateArticleTrait;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -33,24 +33,24 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
  *     authored?: string|null,
  * }
  */
-class ArticleReindexProviderTest extends SuluTestCase
+class AdminArticleReindexProviderTest extends SuluTestCase
 {
     use SetGetPrivatePropertyTrait;
     use CreateArticleTrait;
 
     private EntityManagerInterface $entityManager;
-    private ArticleReindexProvider $provider;
+    private AdminArticleReindexProvider $provider;
 
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new ArticleReindexProvider($this->entityManager);
+        $this->provider = new AdminArticleReindexProvider($this->entityManager);
         $this->purgeDatabase();
     }
 
     public function testGetIndex(): void
     {
-        $this->assertSame('admin', ArticleReindexProvider::getIndex());
+        $this->assertSame('admin', AdminArticleReindexProvider::getIndex());
     }
 
     public function testTotal(): void

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/AdminArticleIndexListenerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/AdminArticleIndexListenerTest.php
@@ -26,13 +26,13 @@ use Sulu\Article\Domain\Event\ArticleTranslationAddedEvent;
 use Sulu\Article\Domain\Event\ArticleTranslationRemovedEvent;
 use Sulu\Article\Domain\Model\Article;
 use Sulu\Article\Domain\Model\ArticleInterface;
-use Sulu\Article\Infrastructure\Sulu\Search\ArticleIndexListener;
+use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleIndexListener;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[CoversClass(ArticleIndexListener::class)]
-class ArticleIndexListenerTest extends TestCase
+#[CoversClass(AdminArticleIndexListener::class)]
+class AdminArticleIndexListenerTest extends TestCase
 {
     use ProphecyTrait;
     use SetGetPrivatePropertyTrait;
@@ -41,12 +41,12 @@ class ArticleIndexListenerTest extends TestCase
      * @var ObjectProphecy<MessageBusInterface>
      */
     private ObjectProphecy $messageBus;
-    private ArticleIndexListener $listener;
+    private AdminArticleIndexListener $listener;
 
     protected function setUp(): void
     {
         $this->messageBus = $this->prophesize(MessageBusInterface::class);
-        $this->listener = new ArticleIndexListener($this->messageBus->reveal());
+        $this->listener = new AdminArticleIndexListener($this->messageBus->reveal());
     }
 
     public function testOnArticleChangedWithSnippetCreatedEvent(): void

--- a/packages/page/src/Infrastructure/Sulu/Search/AdminPageIndexListener.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/AdminPageIndexListener.php
@@ -30,46 +30,23 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *           use Symfony Dependency Injection to override or create your own Listener instead
  */
-final class PageIndexListener
+final class AdminPageIndexListener
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,
     ) {
     }
 
-    // Todo: Check if translation removed and translation restored event is needed.
     public function onPageChanged(PageCreatedEvent|PageModifiedEvent|PageRemovedEvent|PageRestoredEvent|PageTranslationRestoredEvent|PageTranslationAddedEvent|PageTranslationRemovedEvent $event): void
     {
-        $locale = $event->getResourceLocale();
-        $identifiers = [];
+        $resourceId = $event->getResourceId();
 
-        if ($event instanceof PageRemovedEvent) {
-            $locales = $event->getAllLocales();
+        $identifiers = \array_map(
+            fn (string $locale) => PageInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            $this->getLocales($event),
+        );
 
-            if (!$locales) {
-                return;
-            }
-
-            foreach ($locales as $locale) {
-                $identifiers[] = PageInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-            }
-        } elseif ($event instanceof PageRestoredEvent) {
-            $page = $event->getPage();
-            $dimensionContentCollection = new DimensionContentCollection($page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
-            $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);
-
-            if (!$unlocalizedDimensionContent?->getAvailableLocales()) {
-                return;
-            }
-
-            foreach ($unlocalizedDimensionContent->getAvailableLocales() as $locale) {
-                $identifiers[] = PageInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-            }
-        } elseif ($locale) {
-            $identifiers[] = PageInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-        }
-
-        if (!$identifiers) {
+        if ([] === $identifiers) {
             return;
         }
 
@@ -78,5 +55,25 @@ final class PageIndexListener
                 ->withIndex('admin')
                 ->withIdentifiers($identifiers),
         );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getLocales(PageCreatedEvent|PageModifiedEvent|PageRemovedEvent|PageRestoredEvent|PageTranslationRestoredEvent|PageTranslationAddedEvent|PageTranslationRemovedEvent $event): array
+    {
+        if ($event instanceof PageRemovedEvent) {
+            return $event->getAllLocales() ?? [];
+        }
+
+        if ($event instanceof PageRestoredEvent) {
+            $page = $event->getPage();
+            $dimensionContentCollection = new DimensionContentCollection($page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+            $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);
+
+            return $unlocalizedDimensionContent ? ($unlocalizedDimensionContent->getAvailableLocales() ?? []) : [];
+        }
+
+        return $event->getResourceLocale() ? [$event->getResourceLocale()] : [];
     }
 }

--- a/packages/page/src/Infrastructure/Sulu/Search/AdminPageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/AdminPageReindexProvider.php
@@ -33,7 +33,7 @@ use Sulu\Page\Domain\Model\PageInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-final class PageReindexProvider implements ReindexProviderInterface
+final class AdminPageReindexProvider implements ReindexProviderInterface
 {
     /**
      * @var EntityRepository<PageInterface>

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -514,8 +514,8 @@ final class SuluPageBundle extends AbstractBundle
                 ->tag('sulu_trash.restore_configuration_provider');
         }
 
-        $services->set('sulu_page.page_index_listener')
-            ->class('Sulu\Page\Infrastructure\Sulu\Search\PageIndexListener')
+        $services->set('sulu_page.admin_page_index_listener')
+            ->class('Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener')
             ->args([
                 new Reference('sulu_message_bus'),
             ])
@@ -527,8 +527,8 @@ final class SuluPageBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => PageTranslationAddedEvent::class, 'method' => 'onPageChanged'])
             ->tag('kernel.event_listener', ['event' => PageTranslationRemovedEvent::class, 'method' => 'onPageChanged']);
 
-        $services->set('sulu_page.page_reindex_provider')
-            ->class('Sulu\Page\Infrastructure\Sulu\Search\PageReindexProvider')
+        $services->set('sulu_page.admin_page_reindex_provider')
+            ->class('Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider')
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
             ])

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/AdminPageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/AdminPageReindexProviderTest.php
@@ -11,34 +11,34 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Search;
+namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Sulu\Snippet\Domain\Model\SnippetInterface;
-use Sulu\Snippet\Infrastructure\Sulu\Search\SnippetReindexProvider;
-use Sulu\Snippet\Tests\Traits\CreateSnippetTrait;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
 
-class SnippetReindexProviderTest extends SuluTestCase
+class AdminPageReindexProviderTest extends SuluTestCase
 {
-    use CreateSnippetTrait;
+    use CreatePageTrait;
     use SetGetPrivatePropertyTrait;
 
     private EntityManagerInterface $entityManager;
-    private SnippetReindexProvider $provider;
+    private AdminPageReindexProvider $provider;
 
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new SnippetReindexProvider($this->entityManager);
+        $this->provider = new AdminPageReindexProvider($this->entityManager);
         $this->purgeDatabase();
     }
 
     public function testGetIndex(): void
     {
-        $this->assertSame('admin', SnippetReindexProvider::getIndex());
+        $this->assertSame('admin', AdminPageReindexProvider::getIndex());
     }
 
     public function testTotal(): void
@@ -48,25 +48,28 @@ class SnippetReindexProviderTest extends SuluTestCase
 
     public function testProvideAll(): void
     {
-        $snippet1 = $this->createSnippet([
+        $page1 = $this->createPage([
             'en' => [
                 'live' => [
-                    'template' => 'snippet',
-                    'title' => 'Test Snippet',
+                    'template' => 'default',
+                    'title' => 'Test Page',
+                    'url' => '/test-page',
                 ],
             ],
         ]);
-        $snippet2 = $this->createSnippet([
+        $page2 = $this->createPage([
             'en' => [
                 'live' => [
-                    'template' => 'snippet',
-                    'title' => 'Test Snippet 2',
+                    'template' => 'default',
+                    'title' => 'Test Page 2',
+                    'url' => '/test-page-2',
                 ],
             ],
             'de' => [
                 'draft' => [
-                    'template' => 'snippet',
+                    'template' => 'default',
                     'title' => 'Test Schnipsel 2',
+                    'url' => '/test-schnipsel-2',
                 ],
             ],
         ]);
@@ -76,18 +79,18 @@ class SnippetReindexProviderTest extends SuluTestCase
         $changedDateString2 = '2024-11-29 15:30:00';
 
         $connection = self::getEntityManager()->getConnection();
-        $sql = 'UPDATE sn_snippet_dimension_contents SET changed = :changed, created = :created WHERE snippetUuid = :uuid';
+        $sql = 'UPDATE pa_page_dimension_contents SET changed = :changed, created = :created WHERE pageUuid = :uuid';
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString1,
             'created' => $createdAt,
-            'uuid' => $snippet1->getUuid(),
+            'uuid' => $page1->getUuid(),
         ]);
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString2,
             'created' => $createdAt,
-            'uuid' => $snippet2->getUuid(),
+            'uuid' => $page2->getUuid(),
         ]);
 
         $config = ReindexConfig::create()->withIndex('admin');
@@ -98,30 +101,30 @@ class SnippetReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::de',
-                'resourceKey' => SnippetInterface::RESOURCE_KEY,
-                'resourceId' => $snippet2->getUuid(),
+                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::de',
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $page2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
                 'title' => 'Test Schnipsel 2',
                 'locale' => 'de',
             ],
             [
-                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet1->getUuid() . '::en',
-                'resourceKey' => SnippetInterface::RESOURCE_KEY,
-                'resourceId' => $snippet1->getUuid(),
+                'id' => PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::en',
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $page1->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
-                'title' => 'Test Snippet',
+                'title' => 'Test Page',
                 'locale' => 'en',
             ],
             [
-                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::en',
-                'resourceKey' => SnippetInterface::RESOURCE_KEY,
-                'resourceId' => $snippet2->getUuid(),
+                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $page2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
-                'title' => 'Test Snippet 2',
+                'title' => 'Test Page 2',
                 'locale' => 'en',
             ],
         ];
@@ -137,31 +140,35 @@ class SnippetReindexProviderTest extends SuluTestCase
 
     public function testProvideWithSpecificIdentifiers(): void
     {
-        $snippet1 = $this->createSnippet([
+        $page1 = $this->createPage([
             'en' => [
                 'live' => [
-                    'template' => 'snippet',
-                    'title' => 'Cool Snippet 1',
+                    'template' => 'default',
+                    'title' => 'Cool Page 1',
+                    'url' => '/cool-page-1',
                 ],
             ],
             'de' => [
                 'live' => [
-                    'template' => 'snippet',
-                    'title' => 'Cool Snippet DE 1',
+                    'template' => 'default',
+                    'title' => 'Cool Page DE 1',
+                    'url' => '/cool-seite-de-1',
                 ],
             ],
         ]);
-        $snippet2 = $this->createSnippet([
+        $page2 = $this->createPage([
             'en' => [
                 'live' => [
-                    'template' => 'snippet',
-                    'title' => 'Not so cool Snippet 2',
+                    'template' => 'default',
+                    'title' => 'Not so cool Page 2',
+                    'url' => '/not-so-cool-page-2',
                 ],
             ],
             'de' => [
                 'draft' => [
-                    'template' => 'snippet',
-                    'title' => 'Not so cool Snippet DE 2',
+                    'template' => 'default',
+                    'title' => 'Not so cool Page DE 2',
+                    'url' => '/not-so-cool-seite-de-2',
                 ],
             ],
         ]);
@@ -171,23 +178,23 @@ class SnippetReindexProviderTest extends SuluTestCase
         $changedDateString2 = '2024-06-01 15:30:00';
 
         $connection = self::getEntityManager()->getConnection();
-        $sql = 'UPDATE sn_snippet_dimension_contents SET changed = :changed, created = :created WHERE snippetUuid = :uuid';
+        $sql = 'UPDATE pa_page_dimension_contents SET changed = :changed, created = :created WHERE pageUuid = :uuid';
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString1,
             'created' => $createdAt,
-            'uuid' => $snippet1->getUuid(),
+            'uuid' => $page1->getUuid(),
         ]);
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString2,
             'created' => $createdAt,
-            'uuid' => $snippet2->getUuid(),
+            'uuid' => $page2->getUuid(),
         ]);
 
         $identifiers = [
-            SnippetInterface::RESOURCE_KEY . '::' . $snippet1->getUuid() . '::de',
-            SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::en',
+            PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::de',
+            PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
         ];
 
         $config = ReindexConfig::create()
@@ -199,9 +206,9 @@ class SnippetReindexProviderTest extends SuluTestCase
         $this->assertCount(2, $results);
 
         $resultTitles = \array_column($results, 'title');
-        $this->assertContains('Cool Snippet DE 1', $resultTitles);
-        $this->assertContains('Not so cool Snippet 2', $resultTitles);
-        $this->assertNotContains('Cool Snippet 1', $resultTitles);
-        $this->assertNotContains('Not so cool Snippet DE 2', $resultTitles);
+        $this->assertContains('Cool Page DE 1', $resultTitles);
+        $this->assertContains('Not so cool Page 2', $resultTitles);
+        $this->assertNotContains('Cool Page 1', $resultTitles);
+        $this->assertNotContains('Not so cool Page DE 2', $resultTitles);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/AdminPageIndexListenerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/AdminPageIndexListenerTest.php
@@ -27,12 +27,12 @@ use Sulu\Page\Domain\Event\PageTranslationAddedEvent;
 use Sulu\Page\Domain\Event\PageTranslationRemovedEvent;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageInterface;
-use Sulu\Page\Infrastructure\Sulu\Search\PageIndexListener;
+use Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[CoversClass(PageIndexListener::class)]
-class PageIndexListenerTest extends TestCase
+#[CoversClass(AdminPageIndexListener::class)]
+class AdminPageIndexListenerTest extends TestCase
 {
     use ProphecyTrait;
     use SetGetPrivatePropertyTrait;
@@ -41,12 +41,12 @@ class PageIndexListenerTest extends TestCase
      * @var ObjectProphecy<MessageBusInterface>
      */
     private ObjectProphecy $messageBus;
-    private PageIndexListener $listener;
+    private AdminPageIndexListener $listener;
 
     protected function setUp(): void
     {
         $this->messageBus = $this->prophesize(MessageBusInterface::class);
-        $this->listener = new PageIndexListener($this->messageBus->reveal());
+        $this->listener = new AdminPageIndexListener($this->messageBus->reveal());
     }
 
     public function testOnPageChangedWithPageCreatedEvent(): void

--- a/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetIndexListener.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetIndexListener.php
@@ -28,7 +28,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *           use Symfony Dependency Injection to override or create your own Listener instead
  */
-final class SnippetIndexListener
+final class AdminSnippetIndexListener
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,
@@ -37,24 +37,14 @@ final class SnippetIndexListener
 
     public function onSnippetChanged(SnippetCreatedEvent|SnippetModifiedEvent|SnippetRemovedEvent|SnippetRestoredEvent|SnippetTranslationRestoredEvent|SnippetTranslationAddedEvent|SnippetTranslationRemovedEvent $event): void
     {
-        $locale = $event->getResourceLocale();
-        $identifiers = [];
+        $resourceId = $event->getResourceId();
 
-        if ($event instanceof SnippetRemovedEvent || $event instanceof SnippetRestoredEvent) {
-            $locales = $event->getAllLocales();
+        $identifiers = \array_map(
+            fn (string $locale) => SnippetInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            $this->getLocales($event),
+        );
 
-            if (!$locales) {
-                return;
-            }
-
-            foreach ($locales as $locale) {
-                $identifiers[] = SnippetInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-            }
-        } elseif ($locale) {
-            $identifiers[] = SnippetInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-        }
-
-        if (!$identifiers) {
+        if ([] === $identifiers) {
             return;
         }
 
@@ -63,5 +53,17 @@ final class SnippetIndexListener
                 ->withIndex('admin')
                 ->withIdentifiers($identifiers),
         );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getLocales(SnippetCreatedEvent|SnippetModifiedEvent|SnippetRemovedEvent|SnippetRestoredEvent|SnippetTranslationRestoredEvent|SnippetTranslationAddedEvent|SnippetTranslationRemovedEvent $event): array
+    {
+        if ($event instanceof SnippetRemovedEvent || $event instanceof SnippetRestoredEvent) {
+            return $event->getAllLocales() ?? [];
+        }
+
+        return $event->getResourceLocale() ? [$event->getResourceLocale()] : [];
     }
 }

--- a/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
@@ -11,19 +11,19 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Article\Infrastructure\Sulu\Search;
+namespace Sulu\Snippet\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
 use CmsIg\Seal\Reindex\ReindexProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
-use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
-use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
 
 /**
- * @phpstan-type Article array{
- *     articleId: int,
+ * @phpstan-type Snippet array{
+ *     snippetId: int,
  *     changed: \DateTimeImmutable,
  *     created: \DateTimeImmutable,
  *     title: string,
@@ -33,25 +33,25 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-final class ArticleReindexProvider implements ReindexProviderInterface
+final class AdminSnippetReindexProvider implements ReindexProviderInterface
 {
     /**
-     * @var EntityRepository<ArticleInterface>
+     * @var EntityRepository<SnippetInterface>
      */
-    protected EntityRepository $articleRepository;
+    protected EntityRepository $snippetRepository;
 
     /**
-     * @var EntityRepository<ArticleDimensionContentInterface>
+     * @var EntityRepository<SnippetDimensionContentInterface>
      */
     protected EntityRepository $dimensionContentRepository;
 
     public function __construct(
         EntityManagerInterface $entityManager,
     ) {
-        $repository = $entityManager->getRepository(ArticleInterface::class);
-        $dimensionContentRepository = $entityManager->getRepository(ArticleDimensionContentInterface::class);
+        $repository = $entityManager->getRepository(SnippetInterface::class);
+        $dimensionContentRepository = $entityManager->getRepository(SnippetDimensionContentInterface::class);
 
-        $this->articleRepository = $repository;
+        $this->snippetRepository = $repository;
         $this->dimensionContentRepository = $dimensionContentRepository;
     }
 
@@ -63,18 +63,18 @@ final class ArticleReindexProvider implements ReindexProviderInterface
 
     public function provide(ReindexConfig $reindexConfig): \Generator
     {
-        $articles = $this->loadArticles($reindexConfig->getIdentifiers());
+        $snippets = $this->loadSnippets($reindexConfig->getIdentifiers());
 
-        /** @var Article $article */
-        foreach ($articles as $article) {
+        /** @var Snippet $snippet */
+        foreach ($snippets as $snippet) {
             yield [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . ((string) $article['articleId']) . '::' . $article['locale'],
-                'resourceKey' => ArticleInterface::RESOURCE_KEY,
-                'resourceId' => (string) $article['articleId'],
-                'changedAt' => $article['changed']->format('c'),
-                'createdAt' => $article['created']->format('c'),
-                'title' => $article['title'],
-                'locale' => $article['locale'],
+                'id' => SnippetInterface::RESOURCE_KEY . '::' . ((string) $snippet['snippetId']) . '::' . $snippet['locale'],
+                'resourceKey' => SnippetInterface::RESOURCE_KEY,
+                'resourceId' => (string) $snippet['snippetId'],
+                'changedAt' => $snippet['changed']->format('c'),
+                'createdAt' => $snippet['created']->format('c'),
+                'title' => $snippet['title'],
+                'locale' => $snippet['locale'],
             ];
         }
     }
@@ -82,12 +82,12 @@ final class ArticleReindexProvider implements ReindexProviderInterface
     /**
      * @param string[] $identifiers
      *
-     * @return iterable<Article>
+     * @return iterable<Snippet>
      */
-    private function loadArticles(array $identifiers = []): iterable
+    private function loadSnippets(array $identifiers = []): iterable
     {
         $qb = $this->dimensionContentRepository->createQueryBuilder('dimensionContent')
-            ->select('IDENTITY(dimensionContent.article) AS articleId')
+            ->select('IDENTITY(dimensionContent.snippet) AS snippetId')
             ->addSelect('dimensionContent.created')
             ->addSelect('dimensionContent.changed')
             ->addSelect('dimensionContent.title')
@@ -107,14 +107,14 @@ final class ArticleReindexProvider implements ReindexProviderInterface
             foreach ($identifiers as $index => $identifier) {
                 $resourceKey = \explode('::', $identifier)[0];
 
-                if (ArticleInterface::RESOURCE_KEY !== $resourceKey) {
+                if (SnippetInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
                 $id = \explode('::', $identifier)[1] ?? '';
                 $locale = \explode('::', $identifier)[2] ?? '';
 
-                $conditions[] = "(dimensionContent.article = :id{$index} AND dimensionContent.locale = :locale{$index})";
+                $conditions[] = "(dimensionContent.snippet = :id{$index} AND dimensionContent.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;
                 $parameters["locale{$index}"] = $locale;
             }
@@ -128,7 +128,7 @@ final class ArticleReindexProvider implements ReindexProviderInterface
 
         $qb->setParameters($parameters);
 
-        /** @var iterable<Article> */
+        /** @var iterable<Snippet> */
         return $qb->getQuery()->toIterable();
     }
 

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -372,8 +372,8 @@ final class SuluSnippetBundle extends AbstractBundle
                 ->tag('sulu_trash.restore_configuration_provider');
         }
 
-        $services->set('sulu_snippet.snippet_index_listener')
-            ->class('Sulu\Snippet\Infrastructure\Sulu\Search\SnippetIndexListener')
+        $services->set('sulu_snippet.admin_snippet_index_listener')
+            ->class('Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetIndexListener')
             ->args([
                 new Reference('sulu_message_bus'),
             ])
@@ -385,8 +385,8 @@ final class SuluSnippetBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => SnippetTranslationAddedEvent::class, 'method' => 'onSnippetChanged'])
             ->tag('kernel.event_listener', ['event' => SnippetTranslationRemovedEvent::class, 'method' => 'onSnippetChanged']);
 
-        $services->set('sulu_snippet.snippet_reindex_provider')
-            ->class('Sulu\Snippet\Infrastructure\Sulu\Search\SnippetReindexProvider')
+        $services->set('sulu_snippet.admin_snippet_reindex_provider')
+            ->class('Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetReindexProvider')
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
             ])

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Search/AdminSnippetReindexProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Search/AdminSnippetReindexProviderTest.php
@@ -11,34 +11,34 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Search;
+namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Sulu\Page\Domain\Model\PageInterface;
-use Sulu\Page\Infrastructure\Sulu\Search\PageReindexProvider;
-use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
+use Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetReindexProvider;
+use Sulu\Snippet\Tests\Traits\CreateSnippetTrait;
 
-class PageReindexProviderTest extends SuluTestCase
+class AdminSnippetReindexProviderTest extends SuluTestCase
 {
-    use CreatePageTrait;
+    use CreateSnippetTrait;
     use SetGetPrivatePropertyTrait;
 
     private EntityManagerInterface $entityManager;
-    private PageReindexProvider $provider;
+    private AdminSnippetReindexProvider $provider;
 
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new PageReindexProvider($this->entityManager);
+        $this->provider = new AdminSnippetReindexProvider($this->entityManager);
         $this->purgeDatabase();
     }
 
     public function testGetIndex(): void
     {
-        $this->assertSame('admin', PageReindexProvider::getIndex());
+        $this->assertSame('admin', AdminSnippetReindexProvider::getIndex());
     }
 
     public function testTotal(): void
@@ -48,28 +48,25 @@ class PageReindexProviderTest extends SuluTestCase
 
     public function testProvideAll(): void
     {
-        $page1 = $this->createPage([
+        $snippet1 = $this->createSnippet([
             'en' => [
                 'live' => [
-                    'template' => 'default',
-                    'title' => 'Test Page',
-                    'url' => '/test-page',
+                    'template' => 'snippet',
+                    'title' => 'Test Snippet',
                 ],
             ],
         ]);
-        $page2 = $this->createPage([
+        $snippet2 = $this->createSnippet([
             'en' => [
                 'live' => [
-                    'template' => 'default',
-                    'title' => 'Test Page 2',
-                    'url' => '/test-page-2',
+                    'template' => 'snippet',
+                    'title' => 'Test Snippet 2',
                 ],
             ],
             'de' => [
                 'draft' => [
-                    'template' => 'default',
+                    'template' => 'snippet',
                     'title' => 'Test Schnipsel 2',
-                    'url' => '/test-schnipsel-2',
                 ],
             ],
         ]);
@@ -79,18 +76,18 @@ class PageReindexProviderTest extends SuluTestCase
         $changedDateString2 = '2024-11-29 15:30:00';
 
         $connection = self::getEntityManager()->getConnection();
-        $sql = 'UPDATE pa_page_dimension_contents SET changed = :changed, created = :created WHERE pageUuid = :uuid';
+        $sql = 'UPDATE sn_snippet_dimension_contents SET changed = :changed, created = :created WHERE snippetUuid = :uuid';
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString1,
             'created' => $createdAt,
-            'uuid' => $page1->getUuid(),
+            'uuid' => $snippet1->getUuid(),
         ]);
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString2,
             'created' => $createdAt,
-            'uuid' => $page2->getUuid(),
+            'uuid' => $snippet2->getUuid(),
         ]);
 
         $config = ReindexConfig::create()->withIndex('admin');
@@ -101,30 +98,30 @@ class PageReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::de',
-                'resourceKey' => PageInterface::RESOURCE_KEY,
-                'resourceId' => $page2->getUuid(),
+                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::de',
+                'resourceKey' => SnippetInterface::RESOURCE_KEY,
+                'resourceId' => $snippet2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
                 'title' => 'Test Schnipsel 2',
                 'locale' => 'de',
             ],
             [
-                'id' => PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::en',
-                'resourceKey' => PageInterface::RESOURCE_KEY,
-                'resourceId' => $page1->getUuid(),
+                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet1->getUuid() . '::en',
+                'resourceKey' => SnippetInterface::RESOURCE_KEY,
+                'resourceId' => $snippet1->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
-                'title' => 'Test Page',
+                'title' => 'Test Snippet',
                 'locale' => 'en',
             ],
             [
-                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
-                'resourceKey' => PageInterface::RESOURCE_KEY,
-                'resourceId' => $page2->getUuid(),
+                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::en',
+                'resourceKey' => SnippetInterface::RESOURCE_KEY,
+                'resourceId' => $snippet2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
-                'title' => 'Test Page 2',
+                'title' => 'Test Snippet 2',
                 'locale' => 'en',
             ],
         ];
@@ -140,35 +137,31 @@ class PageReindexProviderTest extends SuluTestCase
 
     public function testProvideWithSpecificIdentifiers(): void
     {
-        $page1 = $this->createPage([
+        $snippet1 = $this->createSnippet([
             'en' => [
                 'live' => [
-                    'template' => 'default',
-                    'title' => 'Cool Page 1',
-                    'url' => '/cool-page-1',
+                    'template' => 'snippet',
+                    'title' => 'Cool Snippet 1',
                 ],
             ],
             'de' => [
                 'live' => [
-                    'template' => 'default',
-                    'title' => 'Cool Page DE 1',
-                    'url' => '/cool-seite-de-1',
+                    'template' => 'snippet',
+                    'title' => 'Cool Snippet DE 1',
                 ],
             ],
         ]);
-        $page2 = $this->createPage([
+        $snippet2 = $this->createSnippet([
             'en' => [
                 'live' => [
-                    'template' => 'default',
-                    'title' => 'Not so cool Page 2',
-                    'url' => '/not-so-cool-page-2',
+                    'template' => 'snippet',
+                    'title' => 'Not so cool Snippet 2',
                 ],
             ],
             'de' => [
                 'draft' => [
-                    'template' => 'default',
-                    'title' => 'Not so cool Page DE 2',
-                    'url' => '/not-so-cool-seite-de-2',
+                    'template' => 'snippet',
+                    'title' => 'Not so cool Snippet DE 2',
                 ],
             ],
         ]);
@@ -178,23 +171,23 @@ class PageReindexProviderTest extends SuluTestCase
         $changedDateString2 = '2024-06-01 15:30:00';
 
         $connection = self::getEntityManager()->getConnection();
-        $sql = 'UPDATE pa_page_dimension_contents SET changed = :changed, created = :created WHERE pageUuid = :uuid';
+        $sql = 'UPDATE sn_snippet_dimension_contents SET changed = :changed, created = :created WHERE snippetUuid = :uuid';
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString1,
             'created' => $createdAt,
-            'uuid' => $page1->getUuid(),
+            'uuid' => $snippet1->getUuid(),
         ]);
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString2,
             'created' => $createdAt,
-            'uuid' => $page2->getUuid(),
+            'uuid' => $snippet2->getUuid(),
         ]);
 
         $identifiers = [
-            PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::de',
-            PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
+            SnippetInterface::RESOURCE_KEY . '::' . $snippet1->getUuid() . '::de',
+            SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::en',
         ];
 
         $config = ReindexConfig::create()
@@ -206,9 +199,9 @@ class PageReindexProviderTest extends SuluTestCase
         $this->assertCount(2, $results);
 
         $resultTitles = \array_column($results, 'title');
-        $this->assertContains('Cool Page DE 1', $resultTitles);
-        $this->assertContains('Not so cool Page 2', $resultTitles);
-        $this->assertNotContains('Cool Page 1', $resultTitles);
-        $this->assertNotContains('Not so cool Page DE 2', $resultTitles);
+        $this->assertContains('Cool Snippet DE 1', $resultTitles);
+        $this->assertContains('Not so cool Snippet 2', $resultTitles);
+        $this->assertNotContains('Cool Snippet 1', $resultTitles);
+        $this->assertNotContains('Not so cool Snippet DE 2', $resultTitles);
     }
 }

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Search/AdminSnippetIndexListenerTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Search/AdminSnippetIndexListenerTest.php
@@ -27,12 +27,12 @@ use Sulu\Snippet\Domain\Event\SnippetTranslationAddedEvent;
 use Sulu\Snippet\Domain\Event\SnippetTranslationRemovedEvent;
 use Sulu\Snippet\Domain\Model\Snippet;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
-use Sulu\Snippet\Infrastructure\Sulu\Search\SnippetIndexListener;
+use Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetIndexListener;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[CoversClass(SnippetIndexListener::class)]
-class SnippetIndexListenerTest extends TestCase
+#[CoversClass(AdminSnippetIndexListener::class)]
+class AdminSnippetIndexListenerTest extends TestCase
 {
     use ProphecyTrait;
     use SetGetPrivatePropertyTrait;
@@ -41,12 +41,12 @@ class SnippetIndexListenerTest extends TestCase
      * @var ObjectProphecy<MessageBusInterface>
      */
     private ObjectProphecy $messageBus;
-    private SnippetIndexListener $listener;
+    private AdminSnippetIndexListener $listener;
 
     protected function setUp(): void
     {
         $this->messageBus = $this->prophesize(MessageBusInterface::class);
-        $this->listener = new SnippetIndexListener($this->messageBus->reveal());
+        $this->listener = new AdminSnippetIndexListener($this->messageBus->reveal());
     }
 
     public function testOnSnippetChangedWithSnippetCreatedEvent(): void

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryIndexListener.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryIndexListener.php
@@ -26,7 +26,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *           use Symfony Dependency Injection to override or create your own Listener instead
  */
-final class CategoryIndexListener
+final class AdminCategoryIndexListener
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,
@@ -35,34 +35,14 @@ final class CategoryIndexListener
 
     public function onCategoryChanged(CategoryCreatedEvent|CategoryModifiedEvent|CategoryRemovedEvent|CategoryTranslationAddedEvent|CategoryRestoredEvent $event): void
     {
-        $locale = $event->getResourceLocale();
-        $identifiers = [];
+        $resourceId = $event->getResourceId();
 
-        if ($event instanceof CategoryRemovedEvent) {
-            $locales = $event->getAllLocales();
+        $identifiers = \array_map(
+            fn (string $locale) => CategoryInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            $this->getLocales($event),
+        );
 
-            if (!$locales) {
-                return;
-            }
-
-            foreach ($locales as $locale) {
-                $identifiers[] = CategoryInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-            }
-        } elseif ($event instanceof CategoryRestoredEvent) {
-            $category = $event->getCategory();
-
-            foreach ($category->getTranslations() as $translation) {
-                if (!$translation->getLocale()) {
-                    continue;
-                }
-
-                $identifiers[] = CategoryInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $translation->getLocale();
-            }
-        } elseif ($locale) {
-            $identifiers[] = CategoryInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-        }
-
-        if (!$identifiers) {
+        if ([] === $identifiers) {
             return;
         }
 
@@ -71,5 +51,27 @@ final class CategoryIndexListener
                 ->withIndex('admin')
                 ->withIdentifiers($identifiers),
         );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getLocales(CategoryCreatedEvent|CategoryModifiedEvent|CategoryRemovedEvent|CategoryTranslationAddedEvent|CategoryRestoredEvent $event): array
+    {
+        if ($event instanceof CategoryRemovedEvent) {
+            return $event->getAllLocales() ?? [];
+        }
+
+        if ($event instanceof CategoryRestoredEvent) {
+            $locales = [];
+            $category = $event->getCategory();
+            foreach ($category->getTranslations() as $translation) {
+                $locales[] = $translation->getLocale();
+            }
+
+            return $locales;
+        }
+
+        return [$event->getResourceLocale()];
     }
 }

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryReindexProvider.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryReindexProvider.php
@@ -32,7 +32,7 @@ use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-final class CategoryReindexProvider implements ReindexProviderInterface
+final class AdminCategoryReindexProvider implements ReindexProviderInterface
 {
     /**
      * @var EntityRepository<CategoryInterface>

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -80,8 +80,8 @@
         </service>
 
         <service
-                id="sulu_category.category_index_listener"
-                class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\CategoryIndexListener"
+                id="sulu_category.admin_category_index_listener"
+                class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\AdminCategoryIndexListener"
         >
             <argument type="service" id="sulu_message_bus"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\CategoryBundle\Domain\Event\CategoryCreatedEvent" method="onCategoryChanged"/>
@@ -92,8 +92,8 @@
         </service>
 
         <service
-                id="sulu_category.category_reindex_provider"
-                class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\CategoryReindexProvider"
+                id="sulu_category.admin_category_reindex_provider"
+                class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\AdminCategoryReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <tag name="cmsig_seal.reindex_provider"/>

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminCategoryReindexProviderTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminCategoryReindexProviderTest.php
@@ -18,27 +18,27 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation;
-use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\CategoryReindexProvider;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\AdminCategoryReindexProvider;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
-class CategoryReindexProviderTest extends SuluTestCase
+class AdminCategoryReindexProviderTest extends SuluTestCase
 {
     use SetGetPrivatePropertyTrait;
 
     private EntityManagerInterface $entityManager;
-    private CategoryReindexProvider $provider;
+    private AdminCategoryReindexProvider $provider;
 
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new CategoryReindexProvider($this->entityManager);
+        $this->provider = new AdminCategoryReindexProvider($this->entityManager);
         $this->purgeDatabase();
     }
 
     public function testGetIndex(): void
     {
-        $this->assertSame('admin', CategoryReindexProvider::getIndex());
+        $this->assertSame('admin', AdminCategoryReindexProvider::getIndex());
     }
 
     public function testTotal(): void

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminCategoryIndexListenerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminCategoryIndexListenerTest.php
@@ -26,13 +26,13 @@ use Sulu\Bundle\CategoryBundle\Domain\Event\CategoryTranslationAddedEvent;
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation;
-use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\CategoryIndexListener;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\AdminCategoryIndexListener;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[CoversClass(CategoryIndexListener::class)]
-class CategoryIndexListenerTest extends TestCase
+#[CoversClass(AdminCategoryIndexListener::class)]
+class AdminCategoryIndexListenerTest extends TestCase
 {
     use ProphecyTrait;
     use SetGetPrivatePropertyTrait;
@@ -41,12 +41,12 @@ class CategoryIndexListenerTest extends TestCase
      * @var ObjectProphecy<MessageBusInterface>
      */
     private ObjectProphecy $messageBus;
-    private CategoryIndexListener $listener;
+    private AdminCategoryIndexListener $listener;
 
     protected function setUp(): void
     {
         $this->messageBus = $this->prophesize(MessageBusInterface::class);
-        $this->listener = new CategoryIndexListener($this->messageBus->reveal());
+        $this->listener = new AdminCategoryIndexListener($this->messageBus->reveal());
     }
 
     public function testOnCategoryChangedWithCategoryCreatedEvent(): void

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminAccountReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminAccountReindexProvider.php
@@ -31,7 +31,7 @@ use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-final class AccountReindexProvider implements ReindexProviderInterface
+final class AdminAccountReindexProvider implements ReindexProviderInterface
 {
     /**
      * @var EntityRepository<AccountInterface>

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactIndexListener.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactIndexListener.php
@@ -30,7 +30,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *           use Symfony Dependency Injection to override or create your own Listener instead
  */
-final class ContactIndexListener
+final class AdminContactIndexListener
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactReindexProvider.php
@@ -32,7 +32,7 @@ use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-final class ContactReindexProvider implements ReindexProviderInterface
+final class AdminContactReindexProvider implements ReindexProviderInterface
 {
     /**
      * @var EntityRepository<ContactInterface>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -212,8 +212,8 @@
         </service>
 
         <service
-                id="sulu_contact.contact_index_listener"
-                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\ContactIndexListener"
+                id="sulu_contact.admin_contact_index_listener"
+                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AdminContactIndexListener"
         >
             <argument type="service" id="sulu_message_bus"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\ContactBundle\Domain\Event\AccountCreatedEvent" method="onAccountChanged"/>
@@ -227,16 +227,16 @@
         </service>
 
         <service
-                id="sulu_contact.account_reindex_provider"
-                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AccountReindexProvider"
+                id="sulu_contact.admin_account_reindex_provider"
+                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AdminAccountReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <tag name="cmsig_seal.reindex_provider"/>
         </service>
 
         <service
-                id="sulu_contact.contact_reindex_provider"
-                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\ContactReindexProvider"
+                id="sulu_contact.admin_contact_reindex_provider"
+                class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AdminContactReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <tag name="cmsig_seal.reindex_provider"/>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminAccountReindexProviderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminAccountReindexProviderTest.php
@@ -15,24 +15,21 @@ namespace Sulu\Bundle\ContactBundle\Tests\Functional\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Bundle\ContactBundle\Entity\Contact;
-use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
-use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\ContactReindexProvider;
+use Sulu\Bundle\ContactBundle\Entity\Account;
+use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AdminAccountReindexProvider;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionType;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
-use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
-class ContactReindexProviderTest extends SuluTestCase
+class AdminAccountReindexProviderTest extends SuluTestCase
 {
-    use SetGetPrivatePropertyTrait;
-
     private EntityManagerInterface $entityManager;
-    private ContactReindexProvider $provider;
+    private AdminAccountReindexProvider $provider;
 
     private MediaType $imageType;
 
@@ -41,7 +38,7 @@ class ContactReindexProviderTest extends SuluTestCase
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new ContactReindexProvider($this->entityManager);
+        $this->provider = new AdminAccountReindexProvider($this->entityManager);
         $this->purgeDatabase();
 
         $this->imageType = new MediaType();
@@ -64,13 +61,13 @@ class ContactReindexProviderTest extends SuluTestCase
 
     public function testGetIndex(): void
     {
-        $this->assertSame('admin', ContactReindexProvider::getIndex());
+        $this->assertSame('admin', AdminAccountReindexProvider::getIndex());
     }
 
     public function testTotal(): void
     {
-        $this->createContact();
-        $this->createContact();
+        $this->createAccount('Count 1');
+        $this->createAccount('Count 2');
 
         $this->entityManager->flush();
 
@@ -79,8 +76,8 @@ class ContactReindexProviderTest extends SuluTestCase
 
     public function testProvideAll(): void
     {
-        $contact1 = $this->createContact('Tom', 'Turbo', 'avatar1');
-        $contact2 = $this->createContact();
+        $account1 = $this->createAccount('Test Account 1', 'Media 1');
+        $account2 = $this->createAccount('Test Account 2');
 
         $this->entityManager->flush();
 
@@ -88,16 +85,16 @@ class ContactReindexProviderTest extends SuluTestCase
         $changedDateString2 = '2024-06-01 15:30:00';
 
         $connection = self::getEntityManager()->getConnection();
-        $sql = 'UPDATE co_contacts SET changed = :changed WHERE id = :id';
+        $sql = 'UPDATE co_accounts SET changed = :changed WHERE id = :id';
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString1,
-            'id' => $contact1->getId(),
+            'id' => $account1->getId(),
         ]);
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString2,
-            'id' => $contact2->getId(),
+            'id' => $account2->getId(),
         ]);
 
         $config = ReindexConfig::create()->withIndex('admin');
@@ -108,22 +105,22 @@ class ContactReindexProviderTest extends SuluTestCase
         $this->assertSame(
             [
                 [
-                    'id' => ContactInterface::RESOURCE_KEY . '::' . $contact1->getId(),
-                    'resourceKey' => ContactInterface::RESOURCE_KEY,
-                    'resourceId' => (string) $contact1->getId(),
-                    'mediaId' => (string) $contact1->getAvatar()?->getId(),
+                    'id' => AccountInterface::RESOURCE_KEY . '::' . $account1->getId(),
+                    'resourceKey' => AccountInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $account1->getId(),
+                    'mediaId' => (string) $account1->getLogo()?->getId(),
                     'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
                     'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
-                    'title' => $contact1->getFullName(),
+                    'title' => $account1->getName(),
                 ],
                 [
-                    'id' => ContactInterface::RESOURCE_KEY . '::' . $contact2->getId(),
-                    'resourceKey' => ContactInterface::RESOURCE_KEY,
-                    'resourceId' => (string) $contact2->getId(),
+                    'id' => AccountInterface::RESOURCE_KEY . '::' . $account2->getId(),
+                    'resourceKey' => AccountInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $account2->getId(),
                     'mediaId' => '',
                     'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
                     'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
-                    'title' => $contact2->getFullName(),
+                    'title' => $account2->getName(),
                 ],
             ],
             [...$results],
@@ -132,15 +129,15 @@ class ContactReindexProviderTest extends SuluTestCase
 
     public function testProvideWithSpecificIdentifiers(): void
     {
-        $contact1 = $this->createContact();
-        $contact2 = $this->createContact('Fritz', 'Fantom');
-        $contact3 = $this->createContact('Thomas', 'Brezina');
+        $account1 = $this->createAccount('Account One');
+        $account2 = $this->createAccount('Account Two');
+        $account3 = $this->createAccount('Account Three');
 
         $this->entityManager->flush();
 
         $identifiers = [
-            ContactInterface::RESOURCE_KEY . '::' . $contact1->getId(),
-            ContactInterface::RESOURCE_KEY . '::' . $contact3->getId(),
+            AccountInterface::RESOURCE_KEY . '::' . $account1->getId(),
+            AccountInterface::RESOURCE_KEY . '::' . $account3->getId(),
         ];
 
         $config = ReindexConfig::create()
@@ -152,26 +149,25 @@ class ContactReindexProviderTest extends SuluTestCase
         $this->assertCount(2, $results);
 
         $resultTitles = \array_column($results, 'title');
-        $this->assertContains('Tom Turbo', $resultTitles);
-        $this->assertContains('Thomas Brezina', $resultTitles);
-        $this->assertNotContains('Fritz Fantom', $resultTitles);
+        $this->assertContains('Account One', $resultTitles);
+        $this->assertContains('Account Three', $resultTitles);
+        $this->assertNotContains('Account Two', $resultTitles);
     }
 
-    private function createContact(string $firstName = 'Tom', string $lastName = 'Turbo', ?string $avatarName = null): Contact
+    private function createAccount(string $name, ?string $mediaName = null): Account
     {
-        $contact = new Contact();
-        $contact->setFirstName($firstName);
-        $contact->setLastName($lastName);
-        $contact->setCreated(new \DateTimeImmutable('2000-01-01 12:00:00'));
+        $account = new Account();
+        $account->setName($name);
+        $account->setCreated(new \DateTimeImmutable('2000-01-01 12:00:00'));
 
-        if (null !== $avatarName) {
-            $media = $this->createMedia($avatarName);
-            $contact->setAvatar($media);
+        if ($mediaName) {
+            $media = $this->createMedia($mediaName);
+            $account->setLogo($media);
         }
 
-        $this->entityManager->persist($contact);
+        $this->entityManager->persist($account);
 
-        return $contact;
+        return $account;
     }
 
     private function createMedia(string $name): Media

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminContactReindexProviderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminContactReindexProviderTest.php
@@ -15,21 +15,24 @@ namespace Sulu\Bundle\ContactBundle\Tests\Functional\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Bundle\ContactBundle\Entity\Account;
-use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
-use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AccountReindexProvider;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AdminContactReindexProvider;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionType;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
-class AccountReindexProviderTest extends SuluTestCase
+class AdminContactReindexProviderTest extends SuluTestCase
 {
+    use SetGetPrivatePropertyTrait;
+
     private EntityManagerInterface $entityManager;
-    private AccountReindexProvider $provider;
+    private AdminContactReindexProvider $provider;
 
     private MediaType $imageType;
 
@@ -38,7 +41,7 @@ class AccountReindexProviderTest extends SuluTestCase
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new AccountReindexProvider($this->entityManager);
+        $this->provider = new AdminContactReindexProvider($this->entityManager);
         $this->purgeDatabase();
 
         $this->imageType = new MediaType();
@@ -61,13 +64,13 @@ class AccountReindexProviderTest extends SuluTestCase
 
     public function testGetIndex(): void
     {
-        $this->assertSame('admin', AccountReindexProvider::getIndex());
+        $this->assertSame('admin', AdminContactReindexProvider::getIndex());
     }
 
     public function testTotal(): void
     {
-        $this->createAccount('Count 1');
-        $this->createAccount('Count 2');
+        $this->createContact();
+        $this->createContact();
 
         $this->entityManager->flush();
 
@@ -76,8 +79,8 @@ class AccountReindexProviderTest extends SuluTestCase
 
     public function testProvideAll(): void
     {
-        $account1 = $this->createAccount('Test Account 1', 'Media 1');
-        $account2 = $this->createAccount('Test Account 2');
+        $contact1 = $this->createContact('Tom', 'Turbo', 'avatar1');
+        $contact2 = $this->createContact();
 
         $this->entityManager->flush();
 
@@ -85,16 +88,16 @@ class AccountReindexProviderTest extends SuluTestCase
         $changedDateString2 = '2024-06-01 15:30:00';
 
         $connection = self::getEntityManager()->getConnection();
-        $sql = 'UPDATE co_accounts SET changed = :changed WHERE id = :id';
+        $sql = 'UPDATE co_contacts SET changed = :changed WHERE id = :id';
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString1,
-            'id' => $account1->getId(),
+            'id' => $contact1->getId(),
         ]);
 
         $connection->executeStatement($sql, [
             'changed' => $changedDateString2,
-            'id' => $account2->getId(),
+            'id' => $contact2->getId(),
         ]);
 
         $config = ReindexConfig::create()->withIndex('admin');
@@ -105,22 +108,22 @@ class AccountReindexProviderTest extends SuluTestCase
         $this->assertSame(
             [
                 [
-                    'id' => AccountInterface::RESOURCE_KEY . '::' . $account1->getId(),
-                    'resourceKey' => AccountInterface::RESOURCE_KEY,
-                    'resourceId' => (string) $account1->getId(),
-                    'mediaId' => (string) $account1->getLogo()?->getId(),
+                    'id' => ContactInterface::RESOURCE_KEY . '::' . $contact1->getId(),
+                    'resourceKey' => ContactInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $contact1->getId(),
+                    'mediaId' => (string) $contact1->getAvatar()?->getId(),
                     'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
                     'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
-                    'title' => $account1->getName(),
+                    'title' => $contact1->getFullName(),
                 ],
                 [
-                    'id' => AccountInterface::RESOURCE_KEY . '::' . $account2->getId(),
-                    'resourceKey' => AccountInterface::RESOURCE_KEY,
-                    'resourceId' => (string) $account2->getId(),
+                    'id' => ContactInterface::RESOURCE_KEY . '::' . $contact2->getId(),
+                    'resourceKey' => ContactInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $contact2->getId(),
                     'mediaId' => '',
                     'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
                     'createdAt' => (new \DateTimeImmutable('2000-01-01 12:00:00'))->format('c'),
-                    'title' => $account2->getName(),
+                    'title' => $contact2->getFullName(),
                 ],
             ],
             [...$results],
@@ -129,15 +132,15 @@ class AccountReindexProviderTest extends SuluTestCase
 
     public function testProvideWithSpecificIdentifiers(): void
     {
-        $account1 = $this->createAccount('Account One');
-        $account2 = $this->createAccount('Account Two');
-        $account3 = $this->createAccount('Account Three');
+        $contact1 = $this->createContact();
+        $contact2 = $this->createContact('Fritz', 'Fantom');
+        $contact3 = $this->createContact('Thomas', 'Brezina');
 
         $this->entityManager->flush();
 
         $identifiers = [
-            AccountInterface::RESOURCE_KEY . '::' . $account1->getId(),
-            AccountInterface::RESOURCE_KEY . '::' . $account3->getId(),
+            ContactInterface::RESOURCE_KEY . '::' . $contact1->getId(),
+            ContactInterface::RESOURCE_KEY . '::' . $contact3->getId(),
         ];
 
         $config = ReindexConfig::create()
@@ -149,25 +152,26 @@ class AccountReindexProviderTest extends SuluTestCase
         $this->assertCount(2, $results);
 
         $resultTitles = \array_column($results, 'title');
-        $this->assertContains('Account One', $resultTitles);
-        $this->assertContains('Account Three', $resultTitles);
-        $this->assertNotContains('Account Two', $resultTitles);
+        $this->assertContains('Tom Turbo', $resultTitles);
+        $this->assertContains('Thomas Brezina', $resultTitles);
+        $this->assertNotContains('Fritz Fantom', $resultTitles);
     }
 
-    private function createAccount(string $name, ?string $mediaName = null): Account
+    private function createContact(string $firstName = 'Tom', string $lastName = 'Turbo', ?string $avatarName = null): Contact
     {
-        $account = new Account();
-        $account->setName($name);
-        $account->setCreated(new \DateTimeImmutable('2000-01-01 12:00:00'));
+        $contact = new Contact();
+        $contact->setFirstName($firstName);
+        $contact->setLastName($lastName);
+        $contact->setCreated(new \DateTimeImmutable('2000-01-01 12:00:00'));
 
-        if ($mediaName) {
-            $media = $this->createMedia($mediaName);
-            $account->setLogo($media);
+        if (null !== $avatarName) {
+            $media = $this->createMedia($avatarName);
+            $contact->setAvatar($media);
         }
 
-        $this->entityManager->persist($account);
+        $this->entityManager->persist($contact);
 
-        return $account;
+        return $contact;
     }
 
     private function createMedia(string $name): Media

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminContactIndexListenerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminContactIndexListenerTest.php
@@ -30,13 +30,13 @@ use Sulu\Bundle\ContactBundle\Entity\Account;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
-use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\ContactIndexListener;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AdminContactIndexListener;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[CoversClass(ContactIndexListenerTest::class)]
-class ContactIndexListenerTest extends TestCase
+#[CoversClass(AdminContactIndexListenerTest::class)]
+class AdminContactIndexListenerTest extends TestCase
 {
     use ProphecyTrait;
     use SetGetPrivatePropertyTrait;
@@ -45,12 +45,12 @@ class ContactIndexListenerTest extends TestCase
      * @var ObjectProphecy<MessageBusInterface>
      */
     private ObjectProphecy $messageBus;
-    private ContactIndexListener $listener;
+    private AdminContactIndexListener $listener;
 
     protected function setUp(): void
     {
         $this->messageBus = $this->prophesize(MessageBusInterface::class);
-        $this->listener = new ContactIndexListener($this->messageBus->reveal());
+        $this->listener = new AdminContactIndexListener($this->messageBus->reveal());
     }
 
     public function testOnAccountChangedWithAccountCreatedEvent(): void

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionIndexListener.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionIndexListener.php
@@ -21,7 +21,7 @@ use Sulu\Bundle\MediaBundle\Domain\Event\CollectionRestoredEvent;
 use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-final class CollectionIndexListener
+final class AdminCollectionIndexListener
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,
@@ -30,31 +30,14 @@ final class CollectionIndexListener
 
     public function onCollectionChanged(CollectionCreatedEvent|CollectionModifiedEvent|CollectionRemovedEvent|CollectionRestoredEvent $event): void
     {
-        $locale = $event->getResourceLocale();
-        $identifiers = [];
+        $resourceId = $event->getResourceId();
 
-        if ($event instanceof CollectionRemovedEvent) {
-            $locales = $event->getAllLocales();
+        $identifiers = \array_map(
+            fn (string $locale) => CollectionInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            $this->getLocales($event),
+        );
 
-            if (!$locales) {
-                return;
-            }
-
-            foreach ($locales as $locale) {
-                $identifiers[] = CollectionInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-            }
-        } elseif ($event instanceof CollectionRestoredEvent) {
-            $collection = $event->getCollection();
-            $locales = $this->getLocales($collection);
-
-            foreach ($locales as $locale) {
-                $identifiers[] = CollectionInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-            }
-        } elseif ($locale) {
-            $identifiers[] = CollectionInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
-        }
-
-        if (!$identifiers) {
+        if ([] === $identifiers) {
             return;
         }
 
@@ -68,14 +51,22 @@ final class CollectionIndexListener
     /**
      * @return string[]
      */
-    private function getLocales(CollectionInterface $collection): array
+    private function getLocales(CollectionCreatedEvent|CollectionModifiedEvent|CollectionRemovedEvent|CollectionRestoredEvent $event): array
     {
-        $locales = [];
-
-        foreach ($collection->getMeta() as $meta) {
-            $locales[] = $meta->getLocale();
+        if ($event instanceof CollectionRemovedEvent) {
+            return $event->getAllLocales() ?? [];
         }
 
-        return $locales;
+        if ($event instanceof CollectionRestoredEvent) {
+            $locales = [];
+            $collection = $event->getCollection();
+            foreach ($collection->getMeta() as $meta) {
+                $locales[] = $meta->getLocale();
+            }
+
+            return $locales;
+        }
+
+        return $event->getResourceLocale() ? [$event->getResourceLocale()] : [];
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionReindexProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionReindexProvider.php
@@ -32,7 +32,7 @@ use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-final class CollectionReindexProvider implements ReindexProviderInterface
+final class AdminCollectionReindexProvider implements ReindexProviderInterface
 {
     /**
      * @var EntityRepository<CollectionMeta>

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaIndexListener.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaIndexListener.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\MediaBundle\Domain\Event\MediaVersionAddedEvent;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-final class MediaIndexListener
+final class AdminMediaIndexListener
 {
     public function __construct(
         private readonly MessageBusInterface $messageBus,

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaReindexProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaReindexProvider.php
@@ -32,7 +32,7 @@ use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
  * @internal this class is internal no backwards compatibility promise is given for this class
  *            use Symfony Dependency Injection to override or create your own ReindexProvider instead
  */
-final class MediaReindexProvider implements ReindexProviderInterface
+final class AdminMediaReindexProvider implements ReindexProviderInterface
 {
     /**
      * @var EntityRepository<MediaInterface>

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -465,8 +465,8 @@
         </service>
 
         <service
-                id="sulu_media.media_index_listener"
-                class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\MediaIndexListener"
+                id="sulu_media.admin_media_index_listener"
+                class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminMediaIndexListener"
         >
             <argument type="service" id="sulu_message_bus"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\MediaBundle\Domain\Event\MediaCreatedEvent" method="onMediaChanged"/>
@@ -477,8 +477,8 @@
         </service>
 
         <service
-                id="sulu_media.collection_index_listener"
-                class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\CollectionIndexListener"
+                id="sulu_media.admin_collection_index_listener"
+                class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminCollectionIndexListener"
         >
             <argument type="service" id="sulu_message_bus"/>
             <tag name="kernel.event_listener" event="Sulu\Bundle\MediaBundle\Domain\Event\CollectionCreatedEvent" method="onCollectionChanged"/>
@@ -488,16 +488,16 @@
         </service>
 
         <service
-                id="sulu_media.media_reindex_provider"
-                class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\MediaReindexProvider"
+                id="sulu_media.admin_media_reindex_provider"
+                class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminMediaReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <tag name="cmsig_seal.reindex_provider"/>
         </service>
 
         <service
-                id="sulu_media.collection_reindex_provider"
-                class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\CollectionReindexProvider"
+                id="sulu_media.admin_collection_reindex_provider"
+                class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminCollectionReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
             <tag name="cmsig_seal.reindex_provider"/>

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminCollectionReindexProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminCollectionReindexProviderTest.php
@@ -18,29 +18,29 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
 use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
-use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\CollectionReindexProvider;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminCollectionReindexProvider;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Tests\Functional\Traits\CreateMediaTrait;
 
-class CollectionReindexProviderTest extends SuluTestCase
+class AdminCollectionReindexProviderTest extends SuluTestCase
 {
     use SetGetPrivatePropertyTrait;
     use CreateMediaTrait;
 
     private EntityManagerInterface $entityManager;
-    private CollectionReindexProvider $provider;
+    private AdminCollectionReindexProvider $provider;
 
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new CollectionReindexProvider($this->entityManager);
+        $this->provider = new AdminCollectionReindexProvider($this->entityManager);
         $this->purgeDatabase();
     }
 
     public function testGetIndex(): void
     {
-        $this->assertSame('admin', CollectionReindexProvider::getIndex());
+        $this->assertSame('admin', AdminCollectionReindexProvider::getIndex());
     }
 
     public function testTotal(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminMediaReindexProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminMediaReindexProviderTest.php
@@ -24,16 +24,16 @@ use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
-use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\MediaReindexProvider;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminMediaReindexProvider;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
-class MediaReindexProviderTest extends SuluTestCase
+class AdminMediaReindexProviderTest extends SuluTestCase
 {
     use SetGetPrivatePropertyTrait;
 
     private EntityManagerInterface $entityManager;
-    private MediaReindexProvider $provider;
+    private AdminMediaReindexProvider $provider;
 
     private MediaType $imageType;
 
@@ -46,7 +46,7 @@ class MediaReindexProviderTest extends SuluTestCase
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new MediaReindexProvider($this->entityManager);
+        $this->provider = new AdminMediaReindexProvider($this->entityManager);
         $this->purgeDatabase();
         $this->setUpMedia();
         $this->setUpCollection();
@@ -54,7 +54,7 @@ class MediaReindexProviderTest extends SuluTestCase
 
     public function testGetIndex(): void
     {
-        $this->assertSame('admin', MediaReindexProvider::getIndex());
+        $this->assertSame('admin', AdminMediaReindexProvider::getIndex());
     }
 
     public function testTotal(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminCollectionIndexListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminCollectionIndexListenerTest.php
@@ -26,13 +26,13 @@ use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
 use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
 use Sulu\Bundle\MediaBundle\Entity\CollectionType;
-use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\CollectionIndexListener;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminCollectionIndexListener;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[CoversClass(CollectionIndexListener::class)]
-class CollectionIndexListenerTest extends TestCase
+#[CoversClass(AdminCollectionIndexListener::class)]
+class AdminCollectionIndexListenerTest extends TestCase
 {
     use ProphecyTrait;
     use SetGetPrivatePropertyTrait;
@@ -41,12 +41,12 @@ class CollectionIndexListenerTest extends TestCase
      * @var ObjectProphecy<MessageBusInterface>
      */
     private ObjectProphecy $messageBus;
-    private CollectionIndexListener $listener;
+    private AdminCollectionIndexListener $listener;
 
     protected function setUp(): void
     {
         $this->messageBus = $this->prophesize(MessageBusInterface::class);
-        $this->listener = new CollectionIndexListener($this->messageBus->reveal());
+        $this->listener = new AdminCollectionIndexListener($this->messageBus->reveal());
     }
 
     public function testOnCollectionChangedWithCollectionCreatedEvent(): void
@@ -68,6 +68,7 @@ class CollectionIndexListenerTest extends TestCase
     public function testOnCollectionChangedWithCollectionModifiedEvent(): void
     {
         $collection = $this->createCollection();
+        static::setPrivateProperty($collection, 'id', 1);
         $event = new CollectionModifiedEvent($collection, 'en', []);
 
         $expectedConfig = ReindexConfig::create()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminMediaIndexListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminMediaIndexListenerTest.php
@@ -32,13 +32,13 @@ use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
-use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\MediaIndexListener;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminMediaIndexListener;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-#[CoversClass(MediaIndexListener::class)]
-class MediaIndexListenerTest extends TestCase
+#[CoversClass(AdminMediaIndexListener::class)]
+class AdminMediaIndexListenerTest extends TestCase
 {
     use ProphecyTrait;
     use SetGetPrivatePropertyTrait;
@@ -47,7 +47,7 @@ class MediaIndexListenerTest extends TestCase
      * @var ObjectProphecy<MessageBusInterface>
      */
     private ObjectProphecy $messageBus;
-    private MediaIndexListener $listener;
+    private AdminMediaIndexListener $listener;
 
     private MediaType $imageType;
 
@@ -60,7 +60,7 @@ class MediaIndexListenerTest extends TestCase
     protected function setUp(): void
     {
         $this->messageBus = $this->prophesize(MessageBusInterface::class);
-        $this->listener = new MediaIndexListener($this->messageBus->reveal());
+        $this->listener = new AdminMediaIndexListener($this->messageBus->reveal());
         $this->setUpMedia();
         $this->setUpCollection();
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7672
| License | MIT

#### What's in this PR?

Rename Search providers and listeners to separate admin and website search.
This PR is build on top of #8294
