### PR TITLE
Using key in mapped fragment

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import React, {Fragment} from 'react';
 import Icon from '../Icon';
 import suggestionStyles from './suggestion.scss';
 import type {Node} from 'react';
@@ -49,13 +49,13 @@ export default class Suggestion extends React.PureComponent<Props> {
             <span>
                 {splittedText.map((splitText, index) => {
                     return (
-                        <>
+                        <Fragment key={'suggestion.'+index}>
                             {splitText}
                             {highlightedWords && highlightedWords[index]
                                 ? <strong>{highlightedWords[index]}</strong>
                                 : null
                             }
-                        </>
+                        </Fragment>
                     );
                 })}
             </span>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/AutoCompletePopover/Suggestion.js
@@ -49,7 +49,7 @@ export default class Suggestion extends React.PureComponent<Props> {
             <span>
                 {splittedText.map((splitText, index) => {
                     return (
-                        <Fragment key={'suggestion.'+index}>
+                        <Fragment key={'suggestion.' + index}>
                             {splitText}
                             {highlightedWords && highlightedWords[index]
                                 ? <strong>{highlightedWords[index]}</strong>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding a key to a list of elements.

#### Why?
React uses keys to track which elements in a list have changed. If we don't provide a key here it's going to throw an error in the console as soon as a autocomplete box is opened.
