### PR TITLE
Deprecate `ImageTransformationCompilerPass`

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -13,6 +13,7 @@ Deprecated compiler passes:
 * `Sulu\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterLocalizationProvidersPass` (`sulu.localization_provider`) `tagged_iterator`
 * `Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddAdminPass` (`sulu.admin`) `tagged_iterator`
 * `Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\AddMetadataProvider` (`sulu_admin.property_metadata_mapper`) `tagged_locator`
+* `Sulu\Bundle\MediaBundle\DependencyInjection\ImageTransformationCompilerPass` (`sulu_media.image.transformation`) `tagged_locator`
 
 ## 2.6.11
 

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/ImageTransformationCompilerPass.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Compiler pass for collecting services tagged with sulu_media.image.transformation.
+ *
+ * @deprecated use the tagged_locator
  */
 class ImageTransformationCompilerPass implements CompilerPassInterface
 {

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/TransformationPool.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/TransformationPool.php
@@ -24,7 +24,7 @@ class TransformationPool implements TransformationPoolInterface
      */
     private $transformations = [];
 
-    public function __construct(private ContainerInterface $container)
+    public function __construct(private ?ContainerInterface $container = null)
     {
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/TransformationPool.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/TransformationPool.php
@@ -48,7 +48,10 @@ class TransformationPool implements TransformationPoolInterface
     public function get($name)
     {
         try {
-            return $this->container->get($name);
+            /** @var TransformationInterface $service */
+            $service = $this->container->get($name);
+
+            return $service;
         } catch (\Throwable) {
             // do nothing and try the old logic.
         }

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/TransformationPool.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/TransformationPool.php
@@ -47,13 +47,15 @@ class TransformationPool implements TransformationPoolInterface
      */
     public function get($name)
     {
-        try {
-            /** @var TransformationInterface $service */
-            $service = $this->container->get($name);
+        if (null !== $this->container) {
+            try {
+                /** @var TransformationInterface $service */
+                $service = $this->container->get($name);
 
-            return $service;
-        } catch (\Throwable) {
-            // do nothing and try the old logic.
+                return $service;
+            } catch (\Throwable) {
+                // do nothing and try the old logic.
+            }
         }
 
         if (\array_key_exists($name, $this->transformations)) {

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/TransformationPool.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/TransformationPool.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\ImageConverter;
 
+use Psr\Container\ContainerInterface;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\Transformation\TransformationInterface;
 
 /**
@@ -23,8 +24,14 @@ class TransformationPool implements TransformationPoolInterface
      */
     private $transformations = [];
 
+    public function __construct(private ContainerInterface $container)
+    {
+    }
+
     /**
      * @param string $alias
+     *
+     * @deprecated Use the constructor instead
      */
     public function add(TransformationInterface $transformation, $alias)
     {
@@ -40,6 +47,12 @@ class TransformationPool implements TransformationPoolInterface
      */
     public function get($name)
     {
+        try {
+            return $this->container->get($name);
+        } catch (\Throwable) {
+            // do nothing and try the old logic.
+        }
+
         if (\array_key_exists($name, $this->transformations)) {
             return $this->transformations[$name];
         }

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -220,9 +220,7 @@
         <service id="sulu_media.image.scaler" class="%sulu_media.image.scaler.class%" />
         <service id="sulu_media.image.cropper" class="%sulu_media.image.cropper.class%" />
 
-        <service id="sulu_media.image.transformation_pool" class="%sulu_media.image.transformation_pool.class%">
-            <argument type="tagged_locator" tag="sulu_media.image.transformation" index-by="alias" />
-        </service>
+        <service id="sulu_media.image.transformation_pool" class="%sulu_media.image.transformation_pool.class%" />
 
         <service id="sulu_media.image.transformation.crop" class="%sulu_media.image.transformation.crop.class%">
             <tag name="sulu_media.image.transformation" alias="crop" />

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -220,7 +220,9 @@
         <service id="sulu_media.image.scaler" class="%sulu_media.image.scaler.class%" />
         <service id="sulu_media.image.cropper" class="%sulu_media.image.cropper.class%" />
 
-        <service id="sulu_media.image.transformation_pool" class="%sulu_media.image.transformation_pool.class%" />
+        <service id="sulu_media.image.transformation_pool" class="%sulu_media.image.transformation_pool.class%">
+            <argument type="tagged_locator" tag="sulu_media.image.transformation" index-by="alias" />
+        </service>
 
         <service id="sulu_media.image.transformation.crop" class="%sulu_media.image.transformation.crop.class%">
             <tag name="sulu_media.image.transformation" alias="crop" />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | #7402
| License | MIT
| Documentation PR | =

#### What's in this PR?
Deprecating the compilerpass for the image transformations and replacing it with a tagged_locator.

#### Why?
* Less code
* Lazily intitalizing services for transformations