### PR TITLE
Fix webspaces field definition in website index

### DIFF
--- a/packages/search/config/schemas/website.php
+++ b/packages/search/config/schemas/website.php
@@ -17,7 +17,7 @@ return new Index('website', [
     'resourceKey' => new Field\TextField('resourceKey', searchable: false, filterable: true),
     'resourceId' => new Field\TextField('resourceId', searchable: false),
     'locale' => new Field\TextField('locale', searchable: false, filterable: true),
-    'webspaces' => new Field\TextField('title', multiple: true, searchable: false, filterable: true),
+    'webspaces' => new Field\TextField('webspaces', multiple: true, searchable: false, filterable: true),
     'title' => new Field\TextField('title'),
     'url' => new Field\TextField('url', searchable: false, filterable: true),
     'content' => new Field\TextField('content', multiple: true),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix webspaces field definition in website index.


#### Why?

Unexpected error during `composer fix`. 

<img width="1025" height="335" alt="Bildschirmfoto 2025-11-03 um 16 15 10" src="https://github.com/user-attachments/assets/cab34a79-2b8d-49e8-8e10-a56389041bf6" />