### PR TITLE
Remove redundant var tag

### DIFF
--- a/src/Sulu/Bundle/ActivityBundle/Infrastructure/Sulu/Admin/View/ActivityViewBuilderFactory.php
+++ b/src/Sulu/Bundle/ActivityBundle/Infrastructure/Sulu/Admin/View/ActivityViewBuilderFactory.php
@@ -32,7 +32,6 @@ class ActivityViewBuilderFactory implements ActivityViewBuilderFactoryInterface
         string $resourceKey,
         string $resourceIdRouterAttribute = 'id'
     ): ListViewBuilderInterface {
-        /** @var ListViewBuilderInterface $activityListViewBuilder */
         $activityListViewBuilder = $this->viewBuilderFactory
             ->createListViewBuilder($name, $path)
             ->setResourceKey(ActivityInterface::RESOURCE_KEY)

--- a/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
@@ -75,7 +75,6 @@ class ActivityController extends AbstractRestController implements ClassResource
             $configurationFieldDescriptors
         );
 
-        /** @var DoctrineListBuilder $listBuilder */
         $listBuilder = $this->listBuilderFactory->create($this->activityClass);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
         $listBuilder->setSelectFields($fieldDescriptors);

--- a/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/Navigation/NavigationItem.php
@@ -343,7 +343,6 @@ class NavigationItem implements \Iterator
                 return $item;
             }
             foreach ($item->getChildren() as $child) {
-                /* @var NavigationItem $child */
                 $stack[] = $child;
             }
         }
@@ -361,7 +360,6 @@ class NavigationItem implements \Iterator
     public function findChildren(self $navigationItem)
     {
         foreach ($this->getChildren() as $child) {
-            /** @var NavigationItem $child */
             if ($child->equalsChildless($navigationItem)) {
                 return $child;
             }
@@ -460,7 +458,6 @@ class NavigationItem implements \Iterator
         });
 
         foreach ($children as $key => $child) {
-            /* @var NavigationItem $child */
             $array['items'][$key] = $child->toArray();
         }
 

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/CachingTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Functional/CachingTest.php
@@ -57,7 +57,6 @@ class CachingTest extends SuluTestCase
         $this->assertContains('X-Sulu-Target-Group', $response->getVary());
         $this->assertStringContainsString('miss', $response->headers->get('x-symfony-cache'));
         $this->assertCount(2, $response->headers->getCookies());
-        /** @var Cookie $visitorTargetGroupCookie */
         $visitorTargetGroupCookie = $response->headers->getCookies()[0];
         $this->assertEquals('_svtg', $visitorTargetGroupCookie->getName());
         $this->assertEquals($targetGroup->getId(), $visitorTargetGroupCookie->getValue());

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -23,7 +23,6 @@ use Sulu\Bundle\CategoryBundle\Entity\KeywordRepositoryInterface;
 use Sulu\Bundle\CategoryBundle\Exception\KeywordIsMultipleReferencedException;
 use Sulu\Bundle\CategoryBundle\Exception\KeywordNotUniqueException;
 use Sulu\Component\Rest\AbstractRestController;
-use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\ListRepresentation;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -84,7 +84,6 @@ class KeywordController extends AbstractRestController implements ClassResourceI
 
         $fieldDescriptor = $this->fieldDescriptorFactory->getFieldDescriptors('category_keywords');
 
-        /** @var DoctrineListBuilder $listBuilder */
         $listBuilder = $this->listBuilderFactory->create($this->keywordClass);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptor);
 

--- a/src/Sulu/Bundle/CategoryBundle/Trash/CategoryTrashItemHandler.php
+++ b/src/Sulu/Bundle/CategoryBundle/Trash/CategoryTrashItemHandler.php
@@ -150,7 +150,6 @@ final class CategoryTrashItemHandler implements
                 'keywords' => [],
             ];
 
-            /** @var MediaInterface $media */
             foreach ($translation->getMedias() as $media) {
                 $translationData['mediaIds'][] = $media->getId();
             }

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -101,7 +101,6 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
         }
 
         // Reload address to get all data (including relational data).
-        /** @var AddressEntity $address */
         $address = $accountAddress->getAddress();
         $address = $this->em->getRepository(AddressEntity::class)
             ->findById($address->getId());

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -459,7 +459,6 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
         }
 
         // reload address to get all data (including relational data)
-        /** @var Address $address */
         $address = $contactAddress->getAddress();
         $address = $this->em->getRepository(Address::class)->findById($address->getId());
 

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -750,7 +750,6 @@ class AccountController extends AbstractRestController implements ClassResourceI
             }
 
             $addresses = $account->getAddresses();
-            /** @var AddressEntity $address */
             foreach ($addresses as $address) {
                 if (!$address->hasRelations()) {
                     $this->entityManager->remove($address);

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -750,6 +750,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
             }
 
             $addresses = $account->getAddresses();
+            /** @var AddressEntity $address */
             foreach ($addresses as $address) {
                 if (!$address->hasRelations()) {
                     $this->entityManager->remove($address);

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -187,7 +187,6 @@ class CollectionManager implements CollectionManagerInterface
             'systemCollections' => $systemCollections,
         ];
 
-        /** @var CollectionEntity[] $entities */
         $entities = $this->collectionRepository->findCollectionSet(
             $depth,
             $filter,

--- a/src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
+++ b/src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
@@ -255,7 +255,6 @@ class ImageMapContentType extends ComplexContentType implements ContentTypeExpor
                 $isImport
             );
 
-            /** @var PropertyInterface $subProperty */
             foreach ($propertyType->getChildProperties() as $subProperty) {
                 if (!isset($hotspot[$subProperty->getName()])) {
                     continue;

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
@@ -44,7 +44,6 @@ class MediaRedirectController
         $format = $this->getRequestParameter($request, 'format');
 
         try {
-            /** @var Media $media */
             $media = $this->mediaManager->getById($id, $locale);
         } catch (MediaNotFoundException $e) {
             throw new NotFoundHttpException($e->getMessage(), $e);

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -600,7 +600,6 @@ class FileVersion implements AuditableInterface
 
             $this->formatOptions->clear();
             foreach ($newFormatOptionsArray as $newFormatOptions) {
-                /* @var FormatOptions $newFormatOptions */
                 $newFormatOptions->setFileVersion($this);
                 $this->addFormatOptions($newFormatOptions);
             }

--- a/src/Sulu/Bundle/MediaBundle/Media/ListBuilderFactory/MediaListBuilderFactory.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ListBuilderFactory/MediaListBuilderFactory.php
@@ -44,7 +44,6 @@ class MediaListBuilderFactory
         bool $sortByDefault = true,
         ?int $collectionId = null
     ): DoctrineListBuilder {
-        /** @var DoctrineListBuilder $listBuilder */
         $listBuilder = $this->doctrineListBuilderFactory->create($this->mediaClass);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -474,6 +474,7 @@ class WebspaceCopyCommand extends Command
         }
 
         foreach ($structureArray[$property->getName()] as &$structure) {
+            /** @var ItemMetadata $component */
             $component = $property->getComponentByName($structure['type']);
             $children = $this->getBlockConfigChildren($component);
             /** @var PropertyMetadata $child */

--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -474,7 +474,6 @@ class WebspaceCopyCommand extends Command
         }
 
         foreach ($structureArray[$property->getName()] as &$structure) {
-            /** @var ItemMetadata $component */
             $component = $property->getComponentByName($structure['type']);
             $children = $this->getBlockConfigChildren($component);
             /** @var PropertyMetadata $child */

--- a/src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
@@ -15,7 +15,6 @@ use PHPCR\NodeInterface;
 use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollectorInterface;
 use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
 use Sulu\Bundle\SearchBundle\Search\Factory;
-use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Content\ContentTypeExportInterface;

--- a/src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
@@ -227,7 +227,6 @@ class ExcerptStructureExtension extends AbstractExtension implements ExportExten
         // Reset the properties before new initialization.
         $this->properties = [];
 
-        /** @var PropertyInterface $property */
         foreach ($this->getExcerptStructure($locale)->getProperties() as $property) {
             $this->properties[] = $property->getName();
         }

--- a/src/Sulu/Bundle/PageBundle/Repository/ResourceLocatorRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/ResourceLocatorRepository.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\PageBundle\Repository;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Content\Exception\ResourceLocatorGeneratorException;
-use Sulu\Component\Content\Types\ResourceLocator\ResourceLocatorInformation;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 
 /**

--- a/src/Sulu/Bundle/PageBundle/Repository/ResourceLocatorRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/ResourceLocatorRepository.php
@@ -39,7 +39,6 @@ class ResourceLocatorRepository implements ResourceLocatorRepositoryInterface
 
     public function generate($parts, $parentUuid, $webspaceKey, $languageCode, $templateKey, $segmentKey = null)
     {
-        /** @var StructureInterface $structure */
         $structure = $this->structureManager->getStructure($templateKey);
         $title = $this->implodeRlpParts($structure, $parts);
 
@@ -71,7 +70,6 @@ class ResourceLocatorRepository implements ResourceLocatorRepositoryInterface
         $urls = $resourceLocatorStrategy->loadHistoryByContentUuid($uuid, $webspaceKey, $languageCode);
 
         $result = [];
-        /** @var ResourceLocatorInformation $url */
         foreach ($urls as $url) {
             $defaultParameter = '&language=' . $languageCode . '&webspace=' . $webspaceKey;
             $deleteParameter = '?path=' . $url->getResourceLocator() . $defaultParameter;

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperSnippetTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperSnippetTest.php
@@ -101,7 +101,6 @@ class ContentMapperSnippetTest extends SuluTestCase
         $this->documentManager->persist($document, 'de');
         $this->documentManager->flush();
 
-        /** @var SnippetDocument $document */
         $document = $this->createSnippetDocument();
         $document->setStructureType('animal');
         $document->setTitle('Some other animal');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Mapper/ContentMapperTest.php
@@ -91,7 +91,6 @@ class ContentMapperTest extends SuluTestCase
         $this->sessionManager = $this->getContainer()->get('sulu.phpcr.session');
         $this->extensionManager = $this->getContainer()->get('sulu_page.extension.manager');
 
-        /** @var bool $hasTokenStorage */
         $hasTokenStorage = $this->getContainer()->has('security.token_storage');
         if ($hasTokenStorage) {
             $this->tokenStorage = $this->getContainer()->get('security.token_storage');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SearchManagerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SearchManagerTest.php
@@ -47,7 +47,6 @@ class SearchManagerTest extends BaseTestCase
         /** @var QueryHit $firstHit */
         $firstHit = $result->current();
         $this->assertInstanceOf(QueryHit::class, $firstHit);
-        /** @var Document $document */
         $document = $firstHit->getDocument();
         $this->assertInstanceOf(Document::class, $document);
         $this->assertEquals('page_sulu_io', $document->getIndex());

--- a/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
@@ -54,7 +54,6 @@ EOT
 
         $batchSize = (int) $input->getOption('batch-size');
 
-        /** @var EntityRepository $repository */
         $repository = $this->entityManager->getRepository($input->getArgument('entity'));
 
         $query = $repository->createQueryBuilder('entity')->select('count(entity.id)')->getQuery();

--- a/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
+++ b/src/Sulu/Bundle/RouteBundle/Command/UpdateRouteCommand.php
@@ -12,7 +12,6 @@
 namespace Sulu\Bundle\RouteBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
 use Sulu\Bundle\RouteBundle\Manager\RouteManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
@@ -81,7 +81,6 @@ class WebsiteSearchControllerTest extends SuluTestCase
 
     public function testSearchExactTerm(): void
     {
-        /** @var Crawler $crawler */
         $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Product');
         $response = $this->websiteClient->getResponse();
 
@@ -91,7 +90,6 @@ class WebsiteSearchControllerTest extends SuluTestCase
 
     public function testSearchExactTermEndingWithSpace(): void
     {
-        /** @var Crawler $crawler */
         $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Product%20');
         $response = $this->websiteClient->getResponse();
 
@@ -101,7 +99,6 @@ class WebsiteSearchControllerTest extends SuluTestCase
 
     public function testSearchIncompleteTerm(): void
     {
-        /** @var Crawler $crawler */
         $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Prod');
         $response = $this->websiteClient->getResponse();
 
@@ -111,7 +108,6 @@ class WebsiteSearchControllerTest extends SuluTestCase
 
     public function testSearchTermFuzzy(): void
     {
-        /** @var Crawler $crawler */
         $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Prodoct');
         $response = $this->websiteClient->getResponse();
 
@@ -121,7 +117,6 @@ class WebsiteSearchControllerTest extends SuluTestCase
 
     public function testSearchTermWithSpecialChar(): void
     {
-        /** @var Crawler $crawler */
         $crawler = $this->websiteClient->request('GET', 'http://de.sulu.lo/search?q=Prod*?t');
         $response = $this->websiteClient->getResponse();
 

--- a/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Functional/Controller/WebsiteSearchControllerTest.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Symfony\Component\DomCrawler\Crawler;
 
 class WebsiteSearchControllerTest extends SuluTestCase
 {

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -117,7 +117,6 @@ class ResettingController
     public function sendEmailAction(Request $request)
     {
         try {
-            /** @var UserInterface $user */
             $user = $this->findUser($request->get('user'));
             $maxNumberEmails = $this->tokenSendLimit;
 

--- a/src/Sulu/Bundle/SnippetBundle/Trash/SnippetTrashItemHandler.php
+++ b/src/Sulu/Bundle/SnippetBundle/Trash/SnippetTrashItemHandler.php
@@ -56,7 +56,6 @@ final class SnippetTrashItemHandler implements
             'locales' => [],
         ];
 
-        /** @var string $locale */
         foreach ($this->documentInspector->getLocales($snippet) as $locale) {
             /** @var SnippetDocument $localizedSnippet */
             $localizedSnippet = $this->documentManager->find($snippet->getUuid(), $locale);

--- a/src/Sulu/Bundle/WebsiteBundle/Analytics/AnalyticsManager.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Analytics/AnalyticsManager.php
@@ -85,7 +85,6 @@ class AnalyticsManager implements AnalyticsManagerInterface
 
     public function create($webspaceKey, $data)
     {
-        /** @var AnalyticsInterface $entity */
         $entity = $this->analyticsRepository->createNew();
         $this->setData($entity, $webspaceKey, $data);
 

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/WebsiteController.php
@@ -42,7 +42,6 @@ abstract class WebsiteController extends AbstractController
         $preview = false,
         $partial = false
     ) {
-        /** @var Request $request */
         $request = $this->getRequest();
 
         // extract format twig file

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapper;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationQueryBuilder;
-use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;
 use Sulu\Component\Content\ContentTypeManagerInterface;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Navigation/NavigationMapperTest.php
@@ -814,7 +814,6 @@ class ExcerptStructureExtension extends AbstractExtension
     private function initExcerptStructure()
     {
         $excerptStructure = $this->structureManager->getStructure(self::EXCERPT_EXTENSION_NAME);
-        /** @var PropertyInterface $property */
         foreach ($excerptStructure->getProperties() as $property) {
             $this->properties[] = $property->getName();
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -483,7 +483,6 @@ class ExcerptStructureExtension extends AbstractExtension
     private function initExcerptStructure()
     {
         $excerptStructure = $this->structureManager->getStructure(self::EXCERPT_EXTENSION_NAME);
-        /** @var PropertyInterface $property */
         foreach ($excerptStructure->getProperties() as $property) {
             $this->properties[] = $property->getName();
         }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapGeneratorTest.php
@@ -17,7 +17,6 @@ use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapContentQueryBuilder;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGenerator;
-use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\Compat\Structure;
 use Sulu\Component\Content\Compat\StructureInterface;
 use Sulu\Component\Content\Compat\StructureManagerInterface;

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTwigExtensionTraitTest.php
@@ -62,7 +62,6 @@ class MemoizeTwigExtensionTraitTest extends TestCase
             ->will(function(array $arguments) {return $arguments[2](); })
             ->shouldBeCalled();
 
-        /** @var TwigFunction[] $result */
         $result = $this->getFunctions();
 
         $this->assertInstanceOf(TwigFunction::class, $result[0]);

--- a/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
+++ b/src/Sulu/Component/Content/Compat/Block/BlockProperty.php
@@ -107,7 +107,6 @@ class BlockProperty extends Property implements BlockPropertyInterface
                 $type->setSettings($item['settings']);
             }
 
-            /** @var PropertyInterface $subProperty */
             foreach ($type->getChildProperties() as $subProperty) {
                 if (!isset($item[$subProperty->getName()])) {
                     continue;

--- a/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/CopyLocaleSubscriber.php
@@ -19,7 +19,6 @@ use Sulu\Component\Content\Document\Behavior\ResourceSegmentBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\WebspaceBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
-use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\ResourceLocatorStrategyPoolInterface;
 use Sulu\Component\DocumentManager\Behavior\Mapping\LocaleBehavior;
 use Sulu\Component\DocumentManager\Behavior\Mapping\ParentBehavior;
@@ -197,7 +196,6 @@ class CopyLocaleSubscriber implements EventSubscriberInterface
 
         $properties = $metadata->getProperties();
 
-        /** @var PropertyMetadata $property */
         foreach ($properties as $property) {
             if (self::PAGE_TREE_ROUTE_TYPE === $property->getName()) {
                 return $property->getName();

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowCopyPropertiesSubscriber.php
@@ -123,7 +123,6 @@ class ShadowCopyPropertiesSubscriber implements EventSubscriberInterface
     {
         /** @var string $shadowLocale */
         $shadowLocale = $document->getShadowLocale();
-        /** @var string $locale */
         $locale = $document->getLocale();
 
         $tags = $this->getTags($node, $shadowLocale);

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -32,6 +32,7 @@ class TimestampableSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $event)
     {
         $metadata = $event->getClassMetadata();
+        /** @var \ReflectionClass<object>|null $reflection */
         $reflection = $metadata->getReflectionClass();
 
         if (null !== $reflection && $reflection->implementsInterface(TimestampableInterface::class)) {

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -42,6 +42,7 @@ class UserBlameSubscriber
     public function loadClassMetadata(LoadClassMetadataEventArgs $event)
     {
         $metadata = $event->getClassMetadata();
+        /** @var \ReflectionClass<object>|null $reflection */
         $reflection = $metadata->getReflectionClass();
 
         if (null !== $reflection && $reflection->implementsInterface(UserBlameInterface::class)) {

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -131,7 +131,6 @@ abstract class AbstractListBuilder implements ListBuilderInterface
                     return true;
                 }
 
-                /** @var AbstractPropertyMetadata $propertyMetadata */
                 $propertyMetadata = $fieldDescriptor->getMetadata();
 
                 return FieldDescriptorInterface::VISIBILITY_NEVER !== $propertyMetadata->getVisibility();

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -14,7 +14,6 @@ namespace Sulu\Component\Rest\ListBuilder;
 use Sulu\Component\Rest\Exception\InvalidSearchException;
 use Sulu\Component\Rest\ListBuilder\Expression\ExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry;
-use Sulu\Component\Rest\ListBuilder\Metadata\AbstractPropertyMetadata;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 abstract class AbstractListBuilder implements ListBuilderInterface

--- a/src/Sulu/Component/Util/SuluVersionPass.php
+++ b/src/Sulu/Component/Util/SuluVersionPass.php
@@ -39,7 +39,6 @@ class SuluVersionPass implements CompilerPassInterface
     {
         $version = '_._._';
 
-        /** @var SplFileInfo $composerFile */
         $composerFile = new SplFileInfo($dir . '/composer.lock', '', '');
         if (!$composerFile->isFile()) {
             return $version;
@@ -66,7 +65,6 @@ class SuluVersionPass implements CompilerPassInterface
     {
         $version = null;
 
-        /** @var SplFileInfo $composerFile */
         $composerFile = new SplFileInfo($dir . '/composer.json', '', '');
         if (!$composerFile->isFile()) {
             return $version;

--- a/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
@@ -95,13 +95,11 @@ class WebspaceInitializerTest extends TestCase
 
     public function testInitialize(): void
     {
-        /** @var Webspace $webspace1 */
         $webspace1 = new Webspace();
         $webspace1->setKey('webspace1');
         $webspace1->setTheme('theme1');
         $webspace1->setLocalizations([new Localization('de'), new Localization('en')]);
 
-        /** @var Webspace $webspace2 */
         $webspace2 = new Webspace();
         $webspace2->setKey('webspace2');
         $webspace2->setTheme('theme1');

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -337,7 +337,6 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertInstanceOf(PortalInformation::class, $portalInformation);
         $this->assertEquals('de_at', $portalInformation->getLocalization()->getLocale());
 
-        /** @var Webspace $webspace */
         $webspace = $portalInformation->getWebspace();
 
         $this->assertEquals('Sulu CMF', $webspace->getName());
@@ -625,7 +624,6 @@ class WebspaceManagerTest extends WebspaceTestCase
         $this->assertEquals('sulu.at', $portalInformation->getRedirect());
         $this->assertEquals('www.sulu.at', $portalInformation->getUrl());
 
-        /** @var Webspace $webspace */
         $webspace = $portalInformation->getWebspace();
 
         $this->assertEquals('Sulu CMF', $webspace->getName());

--- a/tests/phpstan/object-manager.php
+++ b/tests/phpstan/object-manager.php
@@ -15,7 +15,6 @@ use App\Kernel;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Dotenv\Dotenv;
 
 require \dirname(__DIR__, 2) . '/vendor/autoload.php';
@@ -24,7 +23,6 @@ require \dirname(__DIR__, 2) . '/vendor/autoload.php';
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG'], Kernel::CONTEXT_ADMIN);
 $kernel->boot();
 
-/** @var ContainerInterface $container */
 $container = $kernel->getContainer();
 
 /** @var EntityManager $objectManager */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing var tags that according to phpstorm can be inferred from the code already

#### Why?
* Less documentation that can be out of date.
* Hides less errors
