### PR TITLE
Use ::class for search services definitions

### DIFF
--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -51,6 +51,8 @@ use Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver\SingleArticleSelec
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
 use Sulu\Article\Infrastructure\Sulu\Reference\ArticleReferenceRefresher;
 use Sulu\Article\Infrastructure\Sulu\Route\ArticleRouteDefaultsProvider;
+use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleIndexListener;
+use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleReindexProvider;
 use Sulu\Article\Infrastructure\Sulu\Sitemap\ArticlesSitemapProvider;
 use Sulu\Article\Infrastructure\Sulu\Trash\ArticleTrashItemHandler;
 use Sulu\Article\Infrastructure\Symfony\Twig\ArticleTwigExtension;
@@ -427,7 +429,7 @@ final class SuluArticleBundle extends AbstractBundle
             ->tag('sulu_route.route_defaults_provider', ['resource_key' => 'articles']);
 
         $services->set('sulu_article.admin_article_index_listener')
-            ->class('Sulu\Article\Infrastructure\Sulu\Search\AdminArticleIndexListener')
+            ->class(AdminArticleIndexListener::class)
             ->args([
                 new Reference('sulu_message_bus'),
             ])
@@ -441,7 +443,7 @@ final class SuluArticleBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => ArticleTranslationCopiedEvent::class, 'method' => 'onArticleChanged']);
 
         $services->set('sulu_article.admin_article_reindex_provider')
-            ->class('Sulu\Article\Infrastructure\Sulu\Search\AdminArticleReindexProvider')
+            ->class(AdminArticleReindexProvider::class)
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
             ])

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -63,6 +63,8 @@ use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
 use Sulu\Page\Infrastructure\Sulu\Content\Visitor\SegmentSmartContentFiltersVisitor;
 use Sulu\Page\Infrastructure\Sulu\Reference\PageReferenceRefresher;
 use Sulu\Page\Infrastructure\Sulu\Route\WebspaceSiteRouteGenerator;
+use Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener;
+use Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider;
 use Sulu\Page\Infrastructure\Sulu\Sitemap\PagesSitemapProvider;
 use Sulu\Page\Infrastructure\Sulu\Trash\PageTrashItemHandler;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\ContentPathTwigExtension;
@@ -518,7 +520,7 @@ final class SuluPageBundle extends AbstractBundle
         }
 
         $services->set('sulu_page.admin_page_index_listener')
-            ->class('Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener')
+            ->class(AdminPageIndexListener::class)
             ->args([
                 new Reference('sulu_message_bus'),
             ])
@@ -531,7 +533,7 @@ final class SuluPageBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => PageTranslationRemovedEvent::class, 'method' => 'onPageChanged']);
 
         $services->set('sulu_page.admin_page_reindex_provider')
-            ->class('Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider')
+            ->class(AdminPageReindexProvider::class)
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
             ])

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -51,6 +51,8 @@ use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SnippetSelectionPr
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
 use Sulu\Snippet\Infrastructure\Sulu\Content\SnippetSmartContentProvider;
 use Sulu\Snippet\Infrastructure\Sulu\Reference\SnippetReferenceRefresher;
+use Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetIndexListener;
+use Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetReindexProvider;
 use Sulu\Snippet\Infrastructure\Sulu\Trash\SnippetTrashItemHandler;
 use Sulu\Snippet\Infrastructure\Symfony\CompilerPass\SnippetAreaCompilerPass;
 use Sulu\Snippet\Infrastructure\Symfony\Normalizer\SnippetAreaNormalizer;
@@ -373,7 +375,7 @@ final class SuluSnippetBundle extends AbstractBundle
         }
 
         $services->set('sulu_snippet.admin_snippet_index_listener')
-            ->class('Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetIndexListener')
+            ->class(AdminSnippetIndexListener::class)
             ->args([
                 new Reference('sulu_message_bus'),
             ])
@@ -386,7 +388,7 @@ final class SuluSnippetBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => SnippetTranslationRemovedEvent::class, 'method' => 'onSnippetChanged']);
 
         $services->set('sulu_snippet.admin_snippet_reindex_provider')
-            ->class('Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetReindexProvider')
+            ->class(AdminSnippetReindexProvider::class)
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
             ])


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #8297
| License | MIT

#### What's in this PR?

Use class string `::class` for search services.
