### PR TITLE
Fix remove translation handlers

### DIFF
--- a/packages/article/config/lists/articles.xml
+++ b/packages/article/config/lists/articles.xml
@@ -46,7 +46,7 @@
             <entity-name>ghostDimensionContent</entity-name>
             <field-name>Sulu\Article\Domain\Model\ArticleInterface.dimensionContents</field-name>
             <method>LEFT</method>
-            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL</condition>
+            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL AND ghostDimensionContent.version = 0</condition>
         </join>
     </joins>
 

--- a/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
@@ -13,6 +13,8 @@ namespace Sulu\Article\Application\MessageHandler;
 
 use Sulu\Article\Application\Message\RemoveArticleTranslationMessage;
 use Sulu\Article\Domain\Event\ArticleTranslationRemovedEvent;
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
+use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 
@@ -41,18 +43,15 @@ final class RemoveArticleTranslationMessageHandler
             if ($dimensionContent->getLocale() === $locale) {
                 $article->removeDimensionContent($dimensionContent);
                 $this->articleRepository->removeDimensionContent($dimensionContent);
-            } elseif ($dimensionContent->getGhostLocale() === $locale) {
-                $availableLocales = $dimensionContent->getAvailableLocales();
-                $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
+                continue;
+            }
 
-                if ([] === $availableLocales) {
-                    $article->removeDimensionContent($dimensionContent);
-                    $this->articleRepository->removeDimensionContent($dimensionContent);
+            if ($dimensionContent->getGhostLocale() === $locale) {
+                $this->handleGhostLocaleRemoval($dimensionContent, $article, $locale);
+                continue;
+            }
 
-                    continue;
-                }
-
-                $dimensionContent->setGhostLocale($availableLocales[0]);
+            if (null === $dimensionContent->getLocale()) {
                 $dimensionContent->removeAvailableLocale($locale);
             }
         }
@@ -61,5 +60,24 @@ final class RemoveArticleTranslationMessageHandler
             $article,
             $locale
         ));
+    }
+
+    private function handleGhostLocaleRemoval(
+        ArticleDimensionContentInterface $dimensionContent,
+        ArticleInterface $article,
+        string $locale
+    ): void {
+        $availableLocales = $dimensionContent->getAvailableLocales();
+        $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
+
+        if (empty($availableLocales)) {
+            $article->removeDimensionContent($dimensionContent);
+            $this->articleRepository->removeDimensionContent($dimensionContent);
+
+            return;
+        }
+
+        $dimensionContent->setGhostLocale($availableLocales[0]);
+        $dimensionContent->removeAvailableLocale($locale);
     }
 }

--- a/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
@@ -42,11 +42,11 @@ final class RemoveArticleTranslationMessageHandler
                 $article->removeDimensionContent($dimensionContent);
                 $this->articleRepository->removeDimensionContent($dimensionContent);
             } elseif ($dimensionContent->getGhostLocale() === $locale) {
-                /** @var string[] $availableLocales */
                 $availableLocales = $dimensionContent->getAvailableLocales();
-                $availableLocales = \array_values(\array_diff($availableLocales, [$locale]));
+                $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
 
                 if ([] === $availableLocales) {
+                    $article->removeDimensionContent($dimensionContent);
                     $this->articleRepository->removeDimensionContent($dimensionContent);
 
                     continue;

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\ActivityBundle\Infrastructure\Sulu\Admin\View\ActivityViewBuilde
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -176,11 +177,33 @@ class ArticleAdmin extends Admin
                 ->setTitleProperty('name'),
         );
 
+        $formToolbarActions = $this->contentViewBuilderFactory->getDefaultToolbarActions(ArticleInterface::class);
+        $formToolbarActions['delete'] = new DropdownToolbarAction(
+            'sulu_admin.delete',
+            'su-trash-alt',
+            [
+                new ToolbarAction(
+                    'sulu_admin.delete',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.delete)',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.delete',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.delete)',
+                        'delete_locale' => true,
+                    ]
+                ),
+            ]
+        );
+
         $viewBuilders = $this->contentViewBuilderFactory->createViews(
             ArticleInterface::class,
             static::EDIT_TABS_VIEW . '_' . $groupIdentifier,
             static::ADD_TABS_VIEW . '_' . $groupIdentifier,
             $securityContext,
+            toolbarActions: $formToolbarActions,
         );
 
         if (0 === \count($viewBuilders)) {

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -337,6 +337,67 @@ class ArticleControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testDeleteSingleLocale(string $id): void
+    {
+        $this->client->request('GET', '/admin/api/articles/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{template: string, title: string, url: string} $articleData */
+        $articleData = \json_decode((string) $response->getContent(), true);
+
+        $this->client->request('PUT', '/admin/api/articles/' . $id . '?locale=de', [], [], [], \json_encode([
+            'template' => $articleData['template'],
+            'title' => $articleData['title'] . ' (DE)',
+            'url' => '/de' . $articleData['url'],
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        /** @var array<int, string> $contentLocales */
+        $contentLocales = $content['contentLocales'];
+        $this->assertContains('en', $availableLocales);
+        $this->assertContains('de', $availableLocales);
+        $this->assertContains('en', $contentLocales);
+        $this->assertContains('de', $contentLocales);
+
+        $this->client->request('DELETE', '/admin/api/articles/' . $id . '?locale=de&deleteLocale=true');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(204, $response);
+
+        $this->client->request('GET', '/admin/api/articles/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        /** @var array<int, string> $contentLocales */
+        $contentLocales = $content['contentLocales'];
+        $this->assertNotContains('de', $availableLocales);
+        $this->assertContains('en', $availableLocales);
+        $this->assertNotContains('de', $contentLocales);
+        $this->assertContains('en', $contentLocales);
+
+        $this->client->request('GET', '/admin/api/articles/' . $id . '?locale=de');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertEquals('en', $content['ghostLocale']);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        $this->assertContains('en', $availableLocales);
+        $this->assertNotContains('de', $availableLocales);
+    }
+
+    #[Depends('testPost')]
     #[Depends('testGetList')]
     public function testDelete(string $id): int
     {
@@ -345,7 +406,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(204, $response);
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(3, $routeRepository->findBy([])); // TODO we need tackle this
+        $this->assertCount(4, $routeRepository->findBy([])); // TODO we need tackle this
 
         $trashRepository = self::getContainer()->get(TrashItemRepositoryInterface::class);
         $trashItem = $trashRepository->findOneBy([

--- a/packages/article/tests/Functional/Integration/responses/article_post_restore.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post_restore.json
@@ -2,14 +2,12 @@
     "author": null,
     "authored": "2020-06-09T00:00:00+00:00",
     "availableLocales": [
-        "en",
-        "de"
+        "en"
     ],
     "changed": "@datetime@",
     "changer": "@integer@",
     "contentLocales": [
-        "en",
-        "de"
+        "en"
     ],
     "created": "@datetime@",
     "creator": "@integer@",
@@ -23,7 +21,7 @@
     "excerptSegment": "updated-segment",
     "excerptTags": [],
     "excerptTitle": "Excerpt Title 2",
-    "ghostLocale": "de",
+    "ghostLocale": "en",
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/article/tests/Unit/Application/MessageHandler/RemoveArticleTranslationMessageHandlerTest.php
+++ b/packages/article/tests/Unit/Application/MessageHandler/RemoveArticleTranslationMessageHandlerTest.php
@@ -64,7 +64,7 @@ class RemoveArticleTranslationMessageHandlerTest extends TestCase
         $this->articleRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $article->getDimensionContents());
     }
@@ -88,7 +88,7 @@ class RemoveArticleTranslationMessageHandlerTest extends TestCase
         $this->articleRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $article->getDimensionContents());
     }
@@ -114,7 +114,7 @@ class RemoveArticleTranslationMessageHandlerTest extends TestCase
         $this->articleRepository->removeDimensionContent(Argument::any())->shouldNotBeCalled();
         $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(1, $article->getDimensionContents());
         $this->assertSame('de', $dimensionContent->getGhostLocale());
@@ -139,7 +139,7 @@ class RemoveArticleTranslationMessageHandlerTest extends TestCase
         $this->articleRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $article->getDimensionContents());
     }
@@ -176,7 +176,7 @@ class RemoveArticleTranslationMessageHandlerTest extends TestCase
         $this->articleRepository->removeDimensionContent($dimensionContent3)->shouldNotBeCalled();
         $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(2, $article->getDimensionContents());
         $this->assertSame('de', $dimensionContent3->getGhostLocale());
@@ -202,6 +202,6 @@ class RemoveArticleTranslationMessageHandlerTest extends TestCase
             return $event->getArticle() === $article && $event->getResourceLocale() === $locale;
         }))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
     }
 }

--- a/packages/article/tests/Unit/Application/MessageHandler/RemoveArticleTranslationMessageHandlerTest.php
+++ b/packages/article/tests/Unit/Application/MessageHandler/RemoveArticleTranslationMessageHandlerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Tests\Unit\Application\MessageHandler;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -21,10 +20,11 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Article\Application\Message\RemoveArticleTranslationMessage;
 use Sulu\Article\Application\MessageHandler\RemoveArticleTranslationMessageHandler;
 use Sulu\Article\Domain\Event\ArticleTranslationRemovedEvent;
+use Sulu\Article\Domain\Model\Article;
 use Sulu\Article\Domain\Model\ArticleDimensionContent;
-use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 class RemoveArticleTranslationMessageHandlerTest extends TestCase
 {
@@ -47,167 +47,159 @@ class RemoveArticleTranslationMessageHandlerTest extends TestCase
         );
     }
 
-    public function testInvokeRemovesMatchingLocale(): void
+    public function testRemoveDimensionContentWhenDirectLocaleMatches(): void
     {
         $identifier = ['uuid' => 'article-123'];
         $locale = 'en';
         $message = new RemoveArticleTranslationMessage($identifier, $locale);
 
-        $article = $this->prophesize(ArticleInterface::class);
-        $dimensionContent1 = $this->prophesize(ArticleDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('en');
-        $dimensionContent1->getGhostLocale()->willReturn(null);
+        $article = new Article('article-123');
+        $dimensionContent = new ArticleDimensionContent($article);
+        $dimensionContent->setLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContent2 = $this->prophesize(ArticleDimensionContent::class);
-        $dimensionContent2->getLocale()->willReturn('de');
-        $dimensionContent2->getGhostLocale()->willReturn(null);
+        $article->addDimensionContent($dimensionContent);
 
-        $dimensionContents = new ArrayCollection([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-        ]);
-
-        $this->articleRepository->getOneBy($identifier)->willReturn($article->reveal());
-        $article->getDimensionContents()->willReturn($dimensionContents);
-
-        $article->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->articleRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        $article->removeDimensionContent($dimensionContent2->reveal())->shouldNotBeCalled();
-        $this->articleRepository->removeDimensionContent($dimensionContent2->reveal())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(ArticleTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->articleRepository->getOneBy($identifier)->willReturn($article);
+        $this->articleRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $article->getDimensionContents());
     }
 
-    public function testInvokeRemovesGhostLocale(): void
+    public function testRemoveDimensionContentWhenGhostLocaleMatchesAndNoRemainingLocales(): void
     {
         $identifier = ['uuid' => 'article-123'];
         $locale = 'en';
         $message = new RemoveArticleTranslationMessage($identifier, $locale);
 
-        $article = $this->prophesize(ArticleInterface::class);
-        $dimensionContent1 = $this->prophesize(ArticleDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn(null);
-        $dimensionContent1->getGhostLocale()->willReturn('en');
+        $article = new Article('article-123');
+        $dimensionContent = new ArticleDimensionContent($article);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->addAvailableLocale('en');
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContents = new ArrayCollection([$dimensionContent1->reveal()]);
+        $article->addDimensionContent($dimensionContent);
 
-        $this->articleRepository->getOneBy($identifier)->willReturn($article->reveal());
-        $article->getDimensionContents()->willReturn($dimensionContents);
-
-        $article->removeDimensionContent($dimensionContent1->reveal())->shouldNotBeCalled();
-        $this->articleRepository->removeDimensionContent($dimensionContent1->reveal())->shouldNotBeCalled();
-
-        $dimensionContent1->getAvailableLocales()->willReturn(['en', 'de']);
-        $dimensionContent1->setGhostLocale('de')->shouldBeCalled();
-        $dimensionContent1->removeAvailableLocale('en')->shouldBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(ArticleTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->articleRepository->getOneBy($identifier)->willReturn($article);
+        $this->articleRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $article->getDimensionContents());
     }
 
-    public function testInvokeRemovesDimensionContentWhenNoAvailableLocalesLeft(): void
+    public function testUpdateGhostLocaleWhenGhostLocaleMatchesWithRemainingLocales(): void
     {
         $identifier = ['uuid' => 'article-123'];
         $locale = 'en';
         $message = new RemoveArticleTranslationMessage($identifier, $locale);
 
-        $article = $this->prophesize(ArticleInterface::class);
-        $dimensionContent1 = $this->prophesize(ArticleDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn(null);
-        $dimensionContent1->getGhostLocale()->willReturn('en');
-        $dimensionContent1->getAvailableLocales()->willReturn(['en']);
+        $article = new Article('article-123');
+        $dimensionContent = new ArticleDimensionContent($article);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->addAvailableLocale('en');
+        $dimensionContent->addAvailableLocale('de');
+        $dimensionContent->addAvailableLocale('fr');
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContents = new ArrayCollection([$dimensionContent1->reveal()]);
+        $article->addDimensionContent($dimensionContent);
 
-        $this->articleRepository->getOneBy($identifier)->willReturn($article->reveal());
-        $article->getDimensionContents()->willReturn($dimensionContents);
-
-        $this->articleRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        $dimensionContent1->setGhostLocale(Argument::any())->shouldNotBeCalled();
-        $dimensionContent1->removeAvailableLocale(Argument::any())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(ArticleTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->articleRepository->getOneBy($identifier)->willReturn($article);
+        $this->articleRepository->removeDimensionContent(Argument::any())->shouldNotBeCalled();
+        $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(1, $article->getDimensionContents());
+        $this->assertSame('de', $dimensionContent->getGhostLocale());
+        $this->assertSame(['de', 'fr'], $dimensionContent->getAvailableLocales());
     }
 
-    public function testInvokeHandlesMultipleDimensionContents(): void
+    public function testHandleNullAvailableLocales(): void
     {
         $identifier = ['uuid' => 'article-123'];
         $locale = 'en';
         $message = new RemoveArticleTranslationMessage($identifier, $locale);
 
-        $article = $this->prophesize(ArticleInterface::class);
+        $article = new Article('article-123');
+        $dimensionContent = new ArticleDimensionContent($article);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        // Dimension content with matching locale
-        $dimensionContent1 = $this->prophesize(ArticleDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('en');
-        $dimensionContent1->getGhostLocale()->willReturn(null);
+        $article->addDimensionContent($dimensionContent);
 
-        // Dimension content with ghost locale
-        $dimensionContent2 = $this->prophesize(ArticleDimensionContent::class);
-        $dimensionContent2->getLocale()->willReturn(null);
-        $dimensionContent2->getGhostLocale()->willReturn('en');
-        $dimensionContent2->getAvailableLocales()->willReturn(['en', 'de', 'fr']);
-
-        // Dimension content that should not be affected
-        $dimensionContent3 = $this->prophesize(ArticleDimensionContent::class);
-        $dimensionContent3->getLocale()->willReturn('de');
-        $dimensionContent3->getGhostLocale()->willReturn(null);
-
-        $dimensionContents = new ArrayCollection([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-            $dimensionContent3->reveal(),
-        ]);
-
-        $this->articleRepository->getOneBy($identifier)->willReturn($article->reveal());
-        $article->getDimensionContents()->willReturn($dimensionContents);
-
-        // First dimension content should be removed
-        $article->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->articleRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        // Second dimension content should have ghost locale updated
-        $dimensionContent2->setGhostLocale('de')->shouldBeCalled();
-        $dimensionContent2->removeAvailableLocale('en')->shouldBeCalled();
-
-        // Third dimension content should not be affected
-        $article->removeDimensionContent($dimensionContent3->reveal())->shouldNotBeCalled();
-        $this->articleRepository->removeDimensionContent($dimensionContent3->reveal())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(ArticleTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->articleRepository->getOneBy($identifier)->willReturn($article);
+        $this->articleRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $article->getDimensionContents());
     }
 
-    public function testInvokeCollectsEvent(): void
+    public function testProcessMultipleDimensionContents(): void
     {
         $identifier = ['uuid' => 'article-123'];
         $locale = 'en';
         $message = new RemoveArticleTranslationMessage($identifier, $locale);
 
-        $article = $this->prophesize(ArticleInterface::class);
-        $this->articleRepository->getOneBy($identifier)->willReturn($article->reveal());
-        $article->getDimensionContents()->willReturn(new ArrayCollection([]));
+        $article = new Article('article-123');
 
-        $this->domainEventCollector->collect(Argument::that(function($event) use ($article, $locale) {
-            return $event instanceof ArticleTranslationRemovedEvent
-                && $event->getArticle() === $article->reveal()
-                && $event->getResourceLocale() === $locale;
+        $dimensionContent1 = new ArticleDimensionContent($article);
+        $dimensionContent1->setLocale($locale);
+        $dimensionContent1->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $article->addDimensionContent($dimensionContent1);
+
+        $dimensionContent2 = new ArticleDimensionContent($article);
+        $dimensionContent2->setLocale('de');
+        $dimensionContent2->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $article->addDimensionContent($dimensionContent2);
+
+        $dimensionContent3 = new ArticleDimensionContent($article);
+        $dimensionContent3->setLocale(null);
+        $dimensionContent3->setGhostLocale($locale);
+        $dimensionContent3->addAvailableLocale('en');
+        $dimensionContent3->addAvailableLocale('de');
+        $dimensionContent3->setStage(DimensionContentInterface::STAGE_LIVE);
+        $article->addDimensionContent($dimensionContent3);
+
+        $this->articleRepository->getOneBy($identifier)->willReturn($article);
+        $this->articleRepository->removeDimensionContent($dimensionContent1)->shouldBeCalled();
+        $this->articleRepository->removeDimensionContent($dimensionContent2)->shouldNotBeCalled();
+        $this->articleRepository->removeDimensionContent($dimensionContent3)->shouldNotBeCalled();
+        $this->domainEventCollector->collect(Argument::type(ArticleTranslationRemovedEvent::class))->shouldBeCalled();
+
+        ($this->handler)($message);
+
+        $this->assertCount(2, $article->getDimensionContents());
+        $this->assertSame('de', $dimensionContent3->getGhostLocale());
+        $this->assertSame(['de'], $dimensionContent3->getAvailableLocales());
+    }
+
+    public function testCollectsDomainEvent(): void
+    {
+        $identifier = ['uuid' => 'article-123'];
+        $locale = 'en';
+        $message = new RemoveArticleTranslationMessage($identifier, $locale);
+
+        $article = new Article('article-123');
+        $dimensionContent = new ArticleDimensionContent($article);
+        $dimensionContent->setLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $article->addDimensionContent($dimensionContent);
+
+        $this->articleRepository->getOneBy($identifier)->willReturn($article);
+        $this->articleRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+
+        $this->domainEventCollector->collect(Argument::that(function(ArticleTranslationRemovedEvent $event) use ($article, $locale) {
+            return $event->getArticle() === $article && $event->getResourceLocale() === $locale;
         }))->shouldBeCalled();
 
         ($this->handler)($message);

--- a/packages/page/config/lists/pages.xml
+++ b/packages/page/config/lists/pages.xml
@@ -46,7 +46,7 @@
             <entity-name>ghostDimensionContent</entity-name>
             <field-name>Sulu\Page\Domain\Model\PageInterface.dimensionContents</field-name>
             <method>LEFT</method>
-            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL</condition>
+            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL AND ghostDimensionContent.version = 0</condition>
         </join>
     </joins>
 

--- a/packages/page/src/Application/MessageHandler/RemovePageTranslationMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageTranslationMessageHandler.php
@@ -14,6 +14,8 @@ namespace Sulu\Page\Application\MessageHandler;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Page\Application\Message\RemovePageTranslationMessage;
 use Sulu\Page\Domain\Event\PageTranslationRemovedEvent;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 
 /**
@@ -41,18 +43,15 @@ final class RemovePageTranslationMessageHandler
             if ($dimensionContent->getLocale() === $locale) {
                 $page->removeDimensionContent($dimensionContent);
                 $this->pageRepository->removeDimensionContent($dimensionContent);
-            } elseif ($dimensionContent->getGhostLocale() === $locale) {
-                $availableLocales = $dimensionContent->getAvailableLocales();
-                $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
+                continue;
+            }
 
-                if ([] === $availableLocales) {
-                    $page->removeDimensionContent($dimensionContent);
-                    $this->pageRepository->removeDimensionContent($dimensionContent);
+            if ($dimensionContent->getGhostLocale() === $locale) {
+                $this->handleGhostLocaleRemoval($dimensionContent, $page, $locale);
+                continue;
+            }
 
-                    continue;
-                }
-
-                $dimensionContent->setGhostLocale($availableLocales[0]);
+            if (null === $dimensionContent->getLocale()) {
                 $dimensionContent->removeAvailableLocale($locale);
             }
         }
@@ -61,5 +60,24 @@ final class RemovePageTranslationMessageHandler
             $page,
             $locale
         ));
+    }
+
+    private function handleGhostLocaleRemoval(
+        PageDimensionContentInterface $dimensionContent,
+        PageInterface $snippet,
+        string $locale
+    ): void {
+        $availableLocales = $dimensionContent->getAvailableLocales();
+        $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
+
+        if (empty($availableLocales)) {
+            $snippet->removeDimensionContent($dimensionContent);
+            $this->pageRepository->removeDimensionContent($dimensionContent);
+
+            return;
+        }
+
+        $dimensionContent->setGhostLocale($availableLocales[0]);
+        $dimensionContent->removeAvailableLocale($locale);
     }
 }

--- a/packages/page/src/Application/MessageHandler/RemovePageTranslationMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageTranslationMessageHandler.php
@@ -38,15 +38,15 @@ final class RemovePageTranslationMessageHandler
         $dimensionContents = $page->getDimensionContents();
 
         foreach ($dimensionContents as $dimensionContent) {
-            if ($dimensionContent->getLocale() === $locale || $dimensionContent->getGhostLocale() === $locale) {
+            if ($dimensionContent->getLocale() === $locale) {
                 $page->removeDimensionContent($dimensionContent);
                 $this->pageRepository->removeDimensionContent($dimensionContent);
             } elseif ($dimensionContent->getGhostLocale() === $locale) {
-                /** @var string[] $availableLocales */
                 $availableLocales = $dimensionContent->getAvailableLocales();
-                $availableLocales = \array_values(\array_diff($availableLocales, [$locale]));
+                $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
 
                 if ([] === $availableLocales) {
+                    $page->removeDimensionContent($dimensionContent);
                     $this->pageRepository->removeDimensionContent($dimensionContent);
 
                     continue;

--- a/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
+++ b/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
@@ -125,11 +125,25 @@ class PageAdmin extends Admin
                     'disabled_condition' => '(_permissions && !_permissions.edit)',
                 ]
             ),
-            'delete' => new ToolbarAction(
+            'delete' => new DropdownToolbarAction(
                 'sulu_admin.delete',
+                'su-trash-alt',
                 [
-                    'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
-                    'router_attributes_to_back_view' => ['webspace'],
+                    new ToolbarAction(
+                        'sulu_admin.delete',
+                        [
+                            'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                            'router_attributes_to_back_view' => ['webspace'],
+                        ]
+                    ),
+                    new ToolbarAction(
+                        'sulu_admin.delete',
+                        [
+                            'visible_condition' => '(!_permissions || _permissions.delete) && url != "/"',
+                            'router_attributes_to_back_view' => ['webspace'],
+                            'delete_locale' => true,
+                        ]
+                    ),
                 ]
             ),
             'edit' => new DropdownToolbarAction(

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -688,7 +688,7 @@ class PageControllerTest extends SuluTestCase
     }
 
     #[Depends('testCopy')]
-    public function testMove(string $id): void
+    public function testMove(string $id): string
     {
         $this->client->request('POST', '/admin/api/pages/' . $id . '?locale=en&action=move&destination=0199ee04-c220-784e-a6fa-ac985870f2d5');
 
@@ -698,6 +698,69 @@ class PageControllerTest extends SuluTestCase
         $this->client->request('GET', '/admin/api/pages?locale=en&webspace=sulu-io&expandedIds=' . $id);
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('page_cget_after_move.json', $response);
+
+        return $id;
+    }
+
+    #[Depends('testMove')]
+    public function testDeleteSingleLocale(string $id): void
+    {
+        $this->client->request('GET', '/admin/api/pages/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{template: string, title: string, url: string} $pageData */
+        $pageData = \json_decode((string) $response->getContent(), true);
+
+        $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=de', [], [], [], \json_encode([
+            'template' => $pageData['template'],
+            'title' => $pageData['title'] . ' (DE)',
+            'url' => '/de' . $pageData['url'],
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        /** @var array<int, string> $contentLocales */
+        $contentLocales = $content['contentLocales'];
+        $this->assertContains('en', $availableLocales);
+        $this->assertContains('de', $availableLocales);
+        $this->assertContains('en', $contentLocales);
+        $this->assertContains('de', $contentLocales);
+
+        $this->client->request('DELETE', '/admin/api/pages/' . $id . '?locale=en&deleteLocale=true');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(204, $response);
+
+        $this->client->request('GET', '/admin/api/pages/' . $id . '?locale=de');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        /** @var array<int, string> $contentLocales */
+        $contentLocales = $content['contentLocales'];
+        $this->assertNotContains('en', $availableLocales);
+        $this->assertContains('de', $availableLocales);
+        $this->assertNotContains('en', $contentLocales);
+        $this->assertContains('de', $contentLocales);
+
+        $this->client->request('GET', '/admin/api/pages/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertEquals('de', $content['ghostLocale']);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        $this->assertContains('de', $availableLocales);
+        $this->assertNotContains('en', $availableLocales);
     }
 
     #[Depends('testPost')]
@@ -709,7 +772,7 @@ class PageControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(204, $response);
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(10, $routeRepository->findBy([])); // TODO we need tackle this
+        $this->assertCount(11, $routeRepository->findBy([])); // TODO we need tackle this
 
         $trashRepository = self::getContainer()->get(TrashItemRepositoryInterface::class);
         $trashItem = $trashRepository->findOneBy([
@@ -724,7 +787,7 @@ class PageControllerTest extends SuluTestCase
     }
 
     #[Depends('testDelete')]
-    public function testRestore(int $trashItemId): void
+    public function testRestore(int $trashItemId): string
     {
         $trashItem = $this->getContainer()->get(TrashItemRepositoryInterface::class)->findOneBy(['id' => $trashItemId]);
         $this->assertNotNull($trashItem);
@@ -736,6 +799,8 @@ class PageControllerTest extends SuluTestCase
         $this->client->request('GET', '/admin/api/pages/' . $trashItem->getResourceId() . '?locale=en');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('page_post_restore.json', $response, 200);
+
+        return $trashItem->getResourceId();
     }
 
     protected function getSnapshotFolder(): string

--- a/packages/page/tests/Unit/Application/MessageHandler/RemovePageTranslationMessageHandlerTest.php
+++ b/packages/page/tests/Unit/Application/MessageHandler/RemovePageTranslationMessageHandlerTest.php
@@ -64,7 +64,7 @@ class RemovePageTranslationMessageHandlerTest extends TestCase
         $this->pageRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $page->getDimensionContents());
     }
@@ -88,7 +88,7 @@ class RemovePageTranslationMessageHandlerTest extends TestCase
         $this->pageRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $page->getDimensionContents());
     }
@@ -114,7 +114,7 @@ class RemovePageTranslationMessageHandlerTest extends TestCase
         $this->pageRepository->removeDimensionContent(Argument::any())->shouldNotBeCalled();
         $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(1, $page->getDimensionContents());
         $this->assertSame('de', $dimensionContent->getGhostLocale());
@@ -139,7 +139,7 @@ class RemovePageTranslationMessageHandlerTest extends TestCase
         $this->pageRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $page->getDimensionContents());
     }
@@ -176,7 +176,7 @@ class RemovePageTranslationMessageHandlerTest extends TestCase
         $this->pageRepository->removeDimensionContent($dimensionContent3)->shouldNotBeCalled();
         $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(2, $page->getDimensionContents());
         $this->assertSame('de', $dimensionContent3->getGhostLocale());
@@ -202,6 +202,6 @@ class RemovePageTranslationMessageHandlerTest extends TestCase
             return $event->getPage() === $page && $event->getResourceLocale() === $locale;
         }))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
     }
 }

--- a/packages/page/tests/Unit/Application/MessageHandler/RemovePageTranslationMessageHandlerTest.php
+++ b/packages/page/tests/Unit/Application/MessageHandler/RemovePageTranslationMessageHandlerTest.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Tests\Unit\Application\MessageHandler;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Application\Message\RemovePageTranslationMessage;
 use Sulu\Page\Application\MessageHandler\RemovePageTranslationMessageHandler;
 use Sulu\Page\Domain\Event\PageTranslationRemovedEvent;
+use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
-use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 
 class RemovePageTranslationMessageHandlerTest extends TestCase
@@ -47,163 +47,159 @@ class RemovePageTranslationMessageHandlerTest extends TestCase
         );
     }
 
-    public function testInvokeRemovesMatchingLocale(): void
+    public function testRemoveDimensionContentWhenDirectLocaleMatches(): void
     {
         $identifier = ['uuid' => 'page-123'];
         $locale = 'en';
         $message = new RemovePageTranslationMessage($identifier, $locale);
 
-        $page = $this->prophesize(PageInterface::class);
-        $dimensionContent1 = $this->prophesize(PageDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('en');
-        $dimensionContent1->getGhostLocale()->willReturn(null);
+        $page = new Page('page-123');
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContent2 = $this->prophesize(PageDimensionContent::class);
-        $dimensionContent2->getLocale()->willReturn('de');
-        $dimensionContent2->getGhostLocale()->willReturn(null);
+        $page->addDimensionContent($dimensionContent);
 
-        $dimensionContents = new ArrayCollection([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-        ]);
-
-        $this->pageRepository->getOneBy($identifier)->willReturn($page->reveal());
-        $page->getDimensionContents()->willReturn($dimensionContents);
-
-        $page->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->pageRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        $page->removeDimensionContent($dimensionContent2->reveal())->shouldNotBeCalled();
-        $this->pageRepository->removeDimensionContent($dimensionContent2->reveal())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(PageTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->pageRepository->getOneBy($identifier)->willReturn($page);
+        $this->pageRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $page->getDimensionContents());
     }
 
-    public function testInvokeRemovesMatchingGhostLocale(): void
+    public function testRemoveDimensionContentWhenGhostLocaleMatchesAndNoRemainingLocales(): void
     {
         $identifier = ['uuid' => 'page-123'];
         $locale = 'en';
         $message = new RemovePageTranslationMessage($identifier, $locale);
 
-        $page = $this->prophesize(PageInterface::class);
-        $dimensionContent1 = $this->prophesize(PageDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('de');
-        $dimensionContent1->getGhostLocale()->willReturn('en');
+        $page = new Page('page-123');
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->addAvailableLocale('en');
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContents = new ArrayCollection([$dimensionContent1->reveal()]);
+        $page->addDimensionContent($dimensionContent);
 
-        $this->pageRepository->getOneBy($identifier)->willReturn($page->reveal());
-        $page->getDimensionContents()->willReturn($dimensionContents);
-
-        $page->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->pageRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(PageTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->pageRepository->getOneBy($identifier)->willReturn($page);
+        $this->pageRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $page->getDimensionContents());
     }
 
-    public function testInvokeUpdatesGhostLocaleInElseIfBranch(): void
+    public function testUpdateGhostLocaleWhenGhostLocaleMatchesWithRemainingLocales(): void
     {
         $identifier = ['uuid' => 'page-123'];
         $locale = 'en';
         $message = new RemovePageTranslationMessage($identifier, $locale);
 
-        $page = $this->prophesize(PageInterface::class);
-        $dimensionContent1 = $this->prophesize(PageDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('de');
-        $dimensionContent1->getGhostLocale()->willReturn('en');
+        $page = new Page('page-123');
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->addAvailableLocale('en');
+        $dimensionContent->addAvailableLocale('de');
+        $dimensionContent->addAvailableLocale('fr');
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContents = new ArrayCollection([$dimensionContent1->reveal()]);
+        $page->addDimensionContent($dimensionContent);
 
-        $this->pageRepository->getOneBy($identifier)->willReturn($page->reveal());
-        $page->getDimensionContents()->willReturn($dimensionContents);
-
-        $page->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->pageRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        $dimensionContent1->getAvailableLocales()->shouldNotBeCalled();
-        $dimensionContent1->setGhostLocale(Argument::any())->shouldNotBeCalled();
-        $dimensionContent1->removeAvailableLocale(Argument::any())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(PageTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->pageRepository->getOneBy($identifier)->willReturn($page);
+        $this->pageRepository->removeDimensionContent(Argument::any())->shouldNotBeCalled();
+        $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(1, $page->getDimensionContents());
+        $this->assertSame('de', $dimensionContent->getGhostLocale());
+        $this->assertSame(['de', 'fr'], $dimensionContent->getAvailableLocales());
     }
 
-    public function testInvokeHandlesMultipleDimensionContents(): void
+    public function testHandleNullAvailableLocales(): void
     {
         $identifier = ['uuid' => 'page-123'];
         $locale = 'en';
         $message = new RemovePageTranslationMessage($identifier, $locale);
 
-        $page = $this->prophesize(PageInterface::class);
+        $page = new Page('page-123');
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        // Dimension content with matching locale
-        $dimensionContent1 = $this->prophesize(PageDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('en');
-        $dimensionContent1->getGhostLocale()->willReturn(null);
+        $page->addDimensionContent($dimensionContent);
 
-        // Dimension content with matching ghost locale
-        $dimensionContent2 = $this->prophesize(PageDimensionContent::class);
-        $dimensionContent2->getLocale()->willReturn('de');
-        $dimensionContent2->getGhostLocale()->willReturn('en');
-
-        // Dimension content that should not be affected
-        $dimensionContent3 = $this->prophesize(PageDimensionContent::class);
-        $dimensionContent3->getLocale()->willReturn('de');
-        $dimensionContent3->getGhostLocale()->willReturn(null);
-
-        $dimensionContents = new ArrayCollection([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-            $dimensionContent3->reveal(),
-        ]);
-
-        $this->pageRepository->getOneBy($identifier)->willReturn($page->reveal());
-        $page->getDimensionContents()->willReturn($dimensionContents);
-
-        // First dimension content should be removed
-        $page->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->pageRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        // Second dimension content should be removed
-        $page->removeDimensionContent($dimensionContent2->reveal())->shouldBeCalled();
-        $this->pageRepository->removeDimensionContent($dimensionContent2->reveal())->shouldBeCalled();
-
-        // Third dimension content should not be affected
-        $page->removeDimensionContent($dimensionContent3->reveal())->shouldNotBeCalled();
-        $this->pageRepository->removeDimensionContent($dimensionContent3->reveal())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(PageTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->pageRepository->getOneBy($identifier)->willReturn($page);
+        $this->pageRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $page->getDimensionContents());
     }
 
-    public function testInvokeCollectsEvent(): void
+    public function testProcessMultipleDimensionContents(): void
     {
         $identifier = ['uuid' => 'page-123'];
         $locale = 'en';
         $message = new RemovePageTranslationMessage($identifier, $locale);
 
-        $page = $this->prophesize(PageInterface::class);
-        $this->pageRepository->getOneBy($identifier)->willReturn($page->reveal());
-        $page->getDimensionContents()->willReturn(new ArrayCollection([]));
+        $page = new Page('page-123');
 
-        $this->domainEventCollector->collect(Argument::that(function($event) use ($page, $locale) {
-            return $event instanceof PageTranslationRemovedEvent
-                && $event->getPage() === $page->reveal()
-                && $event->getResourceLocale() === $locale;
+        $dimensionContent1 = new PageDimensionContent($page);
+        $dimensionContent1->setLocale($locale);
+        $dimensionContent1->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $page->addDimensionContent($dimensionContent1);
+
+        $dimensionContent2 = new PageDimensionContent($page);
+        $dimensionContent2->setLocale('de');
+        $dimensionContent2->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $page->addDimensionContent($dimensionContent2);
+
+        $dimensionContent3 = new PageDimensionContent($page);
+        $dimensionContent3->setLocale(null);
+        $dimensionContent3->setGhostLocale($locale);
+        $dimensionContent3->addAvailableLocale('en');
+        $dimensionContent3->addAvailableLocale('de');
+        $dimensionContent3->setStage(DimensionContentInterface::STAGE_LIVE);
+        $page->addDimensionContent($dimensionContent3);
+
+        $this->pageRepository->getOneBy($identifier)->willReturn($page);
+        $this->pageRepository->removeDimensionContent($dimensionContent1)->shouldBeCalled();
+        $this->pageRepository->removeDimensionContent($dimensionContent2)->shouldNotBeCalled();
+        $this->pageRepository->removeDimensionContent($dimensionContent3)->shouldNotBeCalled();
+        $this->domainEventCollector->collect(Argument::type(PageTranslationRemovedEvent::class))->shouldBeCalled();
+
+        ($this->handler)($message);
+
+        $this->assertCount(2, $page->getDimensionContents());
+        $this->assertSame('de', $dimensionContent3->getGhostLocale());
+        $this->assertSame(['de'], $dimensionContent3->getAvailableLocales());
+    }
+
+    public function testCollectsDomainEvent(): void
+    {
+        $identifier = ['uuid' => 'page-123'];
+        $locale = 'en';
+        $message = new RemovePageTranslationMessage($identifier, $locale);
+
+        $page = new Page('page-123');
+        $dimensionContent = new PageDimensionContent($page);
+        $dimensionContent->setLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $page->addDimensionContent($dimensionContent);
+
+        $this->pageRepository->getOneBy($identifier)->willReturn($page);
+        $this->pageRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+
+        $this->domainEventCollector->collect(Argument::that(function(PageTranslationRemovedEvent $event) use ($page, $locale) {
+            return $event->getPage() === $page && $event->getResourceLocale() === $locale;
         }))->shouldBeCalled();
 
         ($this->handler)($message);

--- a/packages/snippet/config/lists/snippets.xml
+++ b/packages/snippet/config/lists/snippets.xml
@@ -46,7 +46,7 @@
             <entity-name>ghostDimensionContent</entity-name>
             <field-name>Sulu\Snippet\Domain\Model\SnippetInterface.dimensionContents</field-name>
             <method>LEFT</method>
-            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL</condition>
+            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL AND ghostDimensionContent.version = 0</condition>
         </join>
     </joins>
 

--- a/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
@@ -38,15 +38,15 @@ final class RemoveSnippetTranslationMessageHandler
         $dimensionContents = $snippet->getDimensionContents();
 
         foreach ($dimensionContents as $dimensionContent) {
-            if ($dimensionContent->getLocale() === $locale || $dimensionContent->getGhostLocale() === $locale) {
+            if ($dimensionContent->getLocale() === $locale) {
                 $snippet->removeDimensionContent($dimensionContent);
                 $this->snippetRepository->removeDimensionContent($dimensionContent);
             } elseif ($dimensionContent->getGhostLocale() === $locale) {
-                /** @var string[] $availableLocales */
                 $availableLocales = $dimensionContent->getAvailableLocales();
-                $availableLocales = \array_values(\array_diff($availableLocales, [$locale]));
+                $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
 
                 if ([] === $availableLocales) {
+                    $snippet->removeDimensionContent($dimensionContent);
                     $this->snippetRepository->removeDimensionContent($dimensionContent);
 
                     continue;

--- a/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
@@ -14,6 +14,8 @@ namespace Sulu\Snippet\Application\MessageHandler;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Snippet\Application\Message\RemoveSnippetTranslationMessage;
 use Sulu\Snippet\Domain\Event\SnippetTranslationRemovedEvent;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 
 /**
@@ -41,18 +43,15 @@ final class RemoveSnippetTranslationMessageHandler
             if ($dimensionContent->getLocale() === $locale) {
                 $snippet->removeDimensionContent($dimensionContent);
                 $this->snippetRepository->removeDimensionContent($dimensionContent);
-            } elseif ($dimensionContent->getGhostLocale() === $locale) {
-                $availableLocales = $dimensionContent->getAvailableLocales();
-                $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
+                continue;
+            }
 
-                if ([] === $availableLocales) {
-                    $snippet->removeDimensionContent($dimensionContent);
-                    $this->snippetRepository->removeDimensionContent($dimensionContent);
+            if ($dimensionContent->getGhostLocale() === $locale) {
+                $this->handleGhostLocaleRemoval($dimensionContent, $snippet, $locale);
+                continue;
+            }
 
-                    continue;
-                }
-
-                $dimensionContent->setGhostLocale($availableLocales[0]);
+            if (null === $dimensionContent->getLocale()) {
                 $dimensionContent->removeAvailableLocale($locale);
             }
         }
@@ -61,5 +60,24 @@ final class RemoveSnippetTranslationMessageHandler
             $snippet,
             $locale
         ));
+    }
+
+    private function handleGhostLocaleRemoval(
+        SnippetDimensionContentInterface $dimensionContent,
+        SnippetInterface $snippet,
+        string $locale
+    ): void {
+        $availableLocales = $dimensionContent->getAvailableLocales();
+        $availableLocales = \array_values(\array_diff($availableLocales ?? [], [$locale]));
+
+        if (empty($availableLocales)) {
+            $snippet->removeDimensionContent($dimensionContent);
+            $this->snippetRepository->removeDimensionContent($dimensionContent);
+
+            return;
+        }
+
+        $dimensionContent->setGhostLocale($availableLocales[0]);
+        $dimensionContent->removeAvailableLocale($locale);
     }
 }

--- a/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAdmin.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAdmin.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\ActivityBundle\Infrastructure\Sulu\Admin\View\ActivityViewBuilde
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -111,11 +112,33 @@ class SnippetAdmin extends Admin
                     ->setTitleProperty('name')
             );
 
+            $formToolbarActions = $this->contentViewBuilderFactory->getDefaultToolbarActions(SnippetInterface::class);
+            $formToolbarActions['delete'] = new DropdownToolbarAction(
+                'sulu_admin.delete',
+                'su-trash-alt',
+                [
+                    new ToolbarAction(
+                        'sulu_admin.delete',
+                        [
+                            'visible_condition' => '(!_permissions || _permissions.delete)',
+                        ]
+                    ),
+                    new ToolbarAction(
+                        'sulu_admin.delete',
+                        [
+                            'visible_condition' => '(!_permissions || _permissions.delete)',
+                            'delete_locale' => true,
+                        ]
+                    ),
+                ]
+            );
+
             $viewBuilders = $this->contentViewBuilderFactory->createViews(
                 SnippetInterface::class,
                 static::EDIT_TABS_VIEW,
                 static::ADD_TABS_VIEW,
-                static::SECURITY_CONTEXT
+                static::SECURITY_CONTEXT,
+                toolbarActions: $formToolbarActions,
             );
 
             foreach ($viewBuilders as $viewBuilder) {

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -241,7 +241,7 @@ class SnippetControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
-    public function testGetListWithTypesFilter(string $id): void
+    public function testGetListWithTypesFilter(): void
     {
         // Test filtering by existing type - should return the snippet
         $this->client->request('GET', '/admin/api/snippets?locale=en&types=snippet');
@@ -257,6 +257,58 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('GET', '/admin/api/snippets?locale=en&types=snippet,other-template');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('snippet_cget_types_filter_multiple.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
+    public function testDeleteSingleLocale(string $id): void
+    {
+        $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{template: string, title: string} $snippetData */
+        $snippetData = \json_decode((string) $response->getContent(), true);
+
+        $this->client->request('PUT', '/admin/api/snippets/' . $id . '?locale=de', [], [], [], \json_encode([
+            'template' => $snippetData['template'],
+            'title' => $snippetData['title'] . ' (DE)',
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        $this->assertContains('en', $availableLocales);
+        $this->assertContains('de', $availableLocales);
+
+        $this->client->request('DELETE', '/admin/api/snippets/' . $id . '?locale=de&deleteLocale=true');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(204, $response);
+
+        $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        $this->assertNotContains('de', $availableLocales);
+        $this->assertContains('en', $availableLocales);
+
+        $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=de');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertEquals('en', $content['ghostLocale']);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        $this->assertContains('en', $availableLocales);
+        $this->assertNotContains('de', $availableLocales);
     }
 
     #[Depends('testPost')]

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
@@ -1,7 +1,6 @@
 {
     "availableLocales": [
-        "en",
-        "de"
+        "en"
     ],
     "changed": "@datetime@",
     "changer" : "@integer@",
@@ -17,7 +16,7 @@
     "excerptSegment": null,
     "excerptTags": [],
     "excerptTitle": "Excerpt Title 2",
-    "ghostLocale": "de",
+    "ghostLocale": "en",
     "id": "@string@",
     "image": null,
     "locale": "en",

--- a/packages/snippet/tests/Unit/Application/MessageHandler/RemoveSnippetTranslationMessageHandlerTest.php
+++ b/packages/snippet/tests/Unit/Application/MessageHandler/RemoveSnippetTranslationMessageHandlerTest.php
@@ -64,7 +64,7 @@ class RemoveSnippetTranslationMessageHandlerTest extends TestCase
         $this->snippetRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $snippet->getDimensionContents());
     }
@@ -88,7 +88,7 @@ class RemoveSnippetTranslationMessageHandlerTest extends TestCase
         $this->snippetRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $snippet->getDimensionContents());
     }
@@ -114,7 +114,7 @@ class RemoveSnippetTranslationMessageHandlerTest extends TestCase
         $this->snippetRepository->removeDimensionContent(Argument::any())->shouldNotBeCalled();
         $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(1, $snippet->getDimensionContents());
         $this->assertSame('de', $dimensionContent->getGhostLocale());
@@ -139,7 +139,7 @@ class RemoveSnippetTranslationMessageHandlerTest extends TestCase
         $this->snippetRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
         $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(0, $snippet->getDimensionContents());
     }
@@ -176,7 +176,7 @@ class RemoveSnippetTranslationMessageHandlerTest extends TestCase
         $this->snippetRepository->removeDimensionContent($dimensionContent3)->shouldNotBeCalled();
         $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
 
         $this->assertCount(2, $snippet->getDimensionContents());
         $this->assertSame('de', $dimensionContent3->getGhostLocale());
@@ -202,6 +202,6 @@ class RemoveSnippetTranslationMessageHandlerTest extends TestCase
             return $event->getSnippet() === $snippet && $event->getResourceLocale() === $locale;
         }))->shouldBeCalled();
 
-        ($this->handler)($message);
+        $this->handler->__invoke($message);
     }
 }

--- a/packages/snippet/tests/Unit/Application/MessageHandler/RemoveSnippetTranslationMessageHandlerTest.php
+++ b/packages/snippet/tests/Unit/Application/MessageHandler/RemoveSnippetTranslationMessageHandlerTest.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace Sulu\Snippet\Tests\Unit\Application\MessageHandler;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Snippet\Application\Message\RemoveSnippetTranslationMessage;
 use Sulu\Snippet\Application\MessageHandler\RemoveSnippetTranslationMessageHandler;
 use Sulu\Snippet\Domain\Event\SnippetTranslationRemovedEvent;
+use Sulu\Snippet\Domain\Model\Snippet;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContent;
-use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 
 class RemoveSnippetTranslationMessageHandlerTest extends TestCase
@@ -47,163 +47,159 @@ class RemoveSnippetTranslationMessageHandlerTest extends TestCase
         );
     }
 
-    public function testInvokeRemovesMatchingLocale(): void
+    public function testRemoveDimensionContentWhenDirectLocaleMatches(): void
     {
         $identifier = ['uuid' => 'snippet-123'];
         $locale = 'en';
         $message = new RemoveSnippetTranslationMessage($identifier, $locale);
 
-        $snippet = $this->prophesize(SnippetInterface::class);
-        $dimensionContent1 = $this->prophesize(SnippetDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('en');
-        $dimensionContent1->getGhostLocale()->willReturn(null);
+        $snippet = new Snippet('snippet-123');
+        $dimensionContent = new SnippetDimensionContent($snippet);
+        $dimensionContent->setLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContent2 = $this->prophesize(SnippetDimensionContent::class);
-        $dimensionContent2->getLocale()->willReturn('de');
-        $dimensionContent2->getGhostLocale()->willReturn(null);
+        $snippet->addDimensionContent($dimensionContent);
 
-        $dimensionContents = new ArrayCollection([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-        ]);
-
-        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet->reveal());
-        $snippet->getDimensionContents()->willReturn($dimensionContents);
-
-        $snippet->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->snippetRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        $snippet->removeDimensionContent($dimensionContent2->reveal())->shouldNotBeCalled();
-        $this->snippetRepository->removeDimensionContent($dimensionContent2->reveal())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(SnippetTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet);
+        $this->snippetRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $snippet->getDimensionContents());
     }
 
-    public function testInvokeRemovesMatchingGhostLocale(): void
+    public function testRemoveDimensionContentWhenGhostLocaleMatchesAndNoRemainingLocales(): void
     {
         $identifier = ['uuid' => 'snippet-123'];
         $locale = 'en';
         $message = new RemoveSnippetTranslationMessage($identifier, $locale);
 
-        $snippet = $this->prophesize(SnippetInterface::class);
-        $dimensionContent1 = $this->prophesize(SnippetDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('de');
-        $dimensionContent1->getGhostLocale()->willReturn('en');
+        $snippet = new Snippet('snippet-123');
+        $dimensionContent = new SnippetDimensionContent($snippet);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->addAvailableLocale('en');
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContents = new ArrayCollection([$dimensionContent1->reveal()]);
+        $snippet->addDimensionContent($dimensionContent);
 
-        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet->reveal());
-        $snippet->getDimensionContents()->willReturn($dimensionContents);
-
-        $snippet->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->snippetRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(SnippetTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet);
+        $this->snippetRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $snippet->getDimensionContents());
     }
 
-    public function testInvokeUpdatesGhostLocaleInElseIfBranch(): void
+    public function testUpdateGhostLocaleWhenGhostLocaleMatchesWithRemainingLocales(): void
     {
         $identifier = ['uuid' => 'snippet-123'];
         $locale = 'en';
         $message = new RemoveSnippetTranslationMessage($identifier, $locale);
 
-        $snippet = $this->prophesize(SnippetInterface::class);
-        $dimensionContent1 = $this->prophesize(SnippetDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('de');
-        $dimensionContent1->getGhostLocale()->willReturn('en');
+        $snippet = new Snippet('snippet-123');
+        $dimensionContent = new SnippetDimensionContent($snippet);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->addAvailableLocale('en');
+        $dimensionContent->addAvailableLocale('de');
+        $dimensionContent->addAvailableLocale('fr');
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContents = new ArrayCollection([$dimensionContent1->reveal()]);
+        $snippet->addDimensionContent($dimensionContent);
 
-        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet->reveal());
-        $snippet->getDimensionContents()->willReturn($dimensionContents);
-
-        $snippet->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->snippetRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        $dimensionContent1->getAvailableLocales()->shouldNotBeCalled();
-        $dimensionContent1->setGhostLocale(Argument::any())->shouldNotBeCalled();
-        $dimensionContent1->removeAvailableLocale(Argument::any())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(SnippetTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet);
+        $this->snippetRepository->removeDimensionContent(Argument::any())->shouldNotBeCalled();
+        $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(1, $snippet->getDimensionContents());
+        $this->assertSame('de', $dimensionContent->getGhostLocale());
+        $this->assertSame(['de', 'fr'], $dimensionContent->getAvailableLocales());
     }
 
-    public function testInvokeHandlesMultipleDimensionContents(): void
+    public function testHandleNullAvailableLocales(): void
     {
         $identifier = ['uuid' => 'snippet-123'];
         $locale = 'en';
         $message = new RemoveSnippetTranslationMessage($identifier, $locale);
 
-        $snippet = $this->prophesize(SnippetInterface::class);
+        $snippet = new Snippet('snippet-123');
+        $dimensionContent = new SnippetDimensionContent($snippet);
+        $dimensionContent->setLocale(null);
+        $dimensionContent->setGhostLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        // Dimension content with matching locale
-        $dimensionContent1 = $this->prophesize(SnippetDimensionContent::class);
-        $dimensionContent1->getLocale()->willReturn('en');
-        $dimensionContent1->getGhostLocale()->willReturn(null);
+        $snippet->addDimensionContent($dimensionContent);
 
-        // Dimension content with matching ghost locale
-        $dimensionContent2 = $this->prophesize(SnippetDimensionContent::class);
-        $dimensionContent2->getLocale()->willReturn('de');
-        $dimensionContent2->getGhostLocale()->willReturn('en');
-
-        // Dimension content that should not be affected
-        $dimensionContent3 = $this->prophesize(SnippetDimensionContent::class);
-        $dimensionContent3->getLocale()->willReturn('de');
-        $dimensionContent3->getGhostLocale()->willReturn(null);
-
-        $dimensionContents = new ArrayCollection([
-            $dimensionContent1->reveal(),
-            $dimensionContent2->reveal(),
-            $dimensionContent3->reveal(),
-        ]);
-
-        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet->reveal());
-        $snippet->getDimensionContents()->willReturn($dimensionContents);
-
-        // First dimension content should be removed
-        $snippet->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-        $this->snippetRepository->removeDimensionContent($dimensionContent1->reveal())->shouldBeCalled();
-
-        // Second dimension content should be removed
-        $snippet->removeDimensionContent($dimensionContent2->reveal())->shouldBeCalled();
-        $this->snippetRepository->removeDimensionContent($dimensionContent2->reveal())->shouldBeCalled();
-
-        // Third dimension content should not be affected
-        $snippet->removeDimensionContent($dimensionContent3->reveal())->shouldNotBeCalled();
-        $this->snippetRepository->removeDimensionContent($dimensionContent3->reveal())->shouldNotBeCalled();
-
-        $this->domainEventCollector->collect(
-            Argument::type(SnippetTranslationRemovedEvent::class)
-        )->shouldBeCalled();
+        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet);
+        $this->snippetRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+        $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
 
         ($this->handler)($message);
+
+        $this->assertCount(0, $snippet->getDimensionContents());
     }
 
-    public function testInvokeCollectsEvent(): void
+    public function testProcessMultipleDimensionContents(): void
     {
         $identifier = ['uuid' => 'snippet-123'];
         $locale = 'en';
         $message = new RemoveSnippetTranslationMessage($identifier, $locale);
 
-        $snippet = $this->prophesize(SnippetInterface::class);
-        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet->reveal());
-        $snippet->getDimensionContents()->willReturn(new ArrayCollection([]));
+        $snippet = new Snippet('snippet-123');
 
-        $this->domainEventCollector->collect(Argument::that(function($event) use ($snippet, $locale) {
-            return $event instanceof SnippetTranslationRemovedEvent
-                && $event->getSnippet() === $snippet->reveal()
-                && $event->getResourceLocale() === $locale;
+        $dimensionContent1 = new SnippetDimensionContent($snippet);
+        $dimensionContent1->setLocale($locale);
+        $dimensionContent1->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $snippet->addDimensionContent($dimensionContent1);
+
+        $dimensionContent2 = new SnippetDimensionContent($snippet);
+        $dimensionContent2->setLocale('de');
+        $dimensionContent2->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $snippet->addDimensionContent($dimensionContent2);
+
+        $dimensionContent3 = new SnippetDimensionContent($snippet);
+        $dimensionContent3->setLocale(null);
+        $dimensionContent3->setGhostLocale($locale);
+        $dimensionContent3->addAvailableLocale('en');
+        $dimensionContent3->addAvailableLocale('de');
+        $dimensionContent3->setStage(DimensionContentInterface::STAGE_LIVE);
+        $snippet->addDimensionContent($dimensionContent3);
+
+        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet);
+        $this->snippetRepository->removeDimensionContent($dimensionContent1)->shouldBeCalled();
+        $this->snippetRepository->removeDimensionContent($dimensionContent2)->shouldNotBeCalled();
+        $this->snippetRepository->removeDimensionContent($dimensionContent3)->shouldNotBeCalled();
+        $this->domainEventCollector->collect(Argument::type(SnippetTranslationRemovedEvent::class))->shouldBeCalled();
+
+        ($this->handler)($message);
+
+        $this->assertCount(2, $snippet->getDimensionContents());
+        $this->assertSame('de', $dimensionContent3->getGhostLocale());
+        $this->assertSame(['de'], $dimensionContent3->getAvailableLocales());
+    }
+
+    public function testCollectsDomainEvent(): void
+    {
+        $identifier = ['uuid' => 'snippet-123'];
+        $locale = 'en';
+        $message = new RemoveSnippetTranslationMessage($identifier, $locale);
+
+        $snippet = new Snippet('snippet-123');
+        $dimensionContent = new SnippetDimensionContent($snippet);
+        $dimensionContent->setLocale($locale);
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
+        $snippet->addDimensionContent($dimensionContent);
+
+        $this->snippetRepository->getOneBy($identifier)->willReturn($snippet);
+        $this->snippetRepository->removeDimensionContent($dimensionContent)->shouldBeCalled();
+
+        $this->domainEventCollector->collect(Argument::that(function(SnippetTranslationRemovedEvent $event) use ($snippet, $locale) {
+            return $event->getSnippet() === $snippet && $event->getResourceLocale() === $locale;
         }))->shouldBeCalled();
 
         ($this->handler)($message);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT

#### What's in this PR?

Fixes issues with the remove single locale functionality:
- added toolbaraction for articles/snippets/pages
- fixed the messagehandler for ghost locales
- Adjusted the unit tests to not use mocking for simple entities

#### Why?

It did not work as expected.

