### PR TITLE
Fix visible versions for ghost dimensions

### DIFF
--- a/packages/article/config/lists/articles.xml
+++ b/packages/article/config/lists/articles.xml
@@ -46,7 +46,7 @@
             <entity-name>ghostDimensionContent</entity-name>
             <field-name>Sulu\Article\Domain\Model\ArticleInterface.dimensionContents</field-name>
             <method>LEFT</method>
-            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL</condition>
+            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL AND ghostDimensionContent.version = 0</condition>
         </join>
     </joins>
 

--- a/packages/page/config/lists/pages.xml
+++ b/packages/page/config/lists/pages.xml
@@ -46,7 +46,7 @@
             <entity-name>ghostDimensionContent</entity-name>
             <field-name>Sulu\Page\Domain\Model\PageInterface.dimensionContents</field-name>
             <method>LEFT</method>
-            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL</condition>
+            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL AND ghostDimensionContent.version = 0</condition>
         </join>
     </joins>
 

--- a/packages/snippet/config/lists/snippets.xml
+++ b/packages/snippet/config/lists/snippets.xml
@@ -46,7 +46,7 @@
             <entity-name>ghostDimensionContent</entity-name>
             <field-name>Sulu\Snippet\Domain\Model\SnippetInterface.dimensionContents</field-name>
             <method>LEFT</method>
-            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL</condition>
+            <condition>ghostDimensionContent.locale = unlocalizedDimensionContent.ghostLocale AND ghostDimensionContent.stage = 'draft' AND dimensionContent IS NULL AND ghostDimensionContent.version = 0</condition>
         </join>
     </joins>
 


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
  | Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
  | License | MIT
  | Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

  #### What's in this PR?

  This PR fixes the join condition for ghost dimension content in admin list queries for articles, pages, and snippets. The fix adds a version filter (`ghostDimensionContent.version = 0`) to ensure only the
  current version of ghost content is displayed.

  #### Why?

  When displaying ghost content (fallback content from a different locale) in admin lists, the query was not filtering by version. This could cause issues where historical versions of ghost content were
  incorrectly included in list views instead of only showing the current version (version 0).

  The fix ensures that when a content item doesn't exist in the requested locale and falls back to ghost content, only the current version of that ghost content is considered, not historical versions.
