### PR TITLE
Fix clearing address field values via UI

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6241,96 +6241,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
 
 		-
-			message: "#^Cannot access offset 'addition' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'addressType' on mixed\\.$#"
-			count: 2
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'billingAddress' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'city' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'countryCode' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'deliveryAddress' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'latitude' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'longitude' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'note' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'number' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'postboxCity' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'postboxNumber' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'postboxPostcode' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'primaryAddress' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'state' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'street' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'title' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
-			message: "#^Cannot access offset 'zip' on mixed\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
-
-		-
 			message: "#^If condition is always true\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -8611,6 +8521,11 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
 
 		-
+			message: "#^Cannot access offset 'addresses' on mixed\\.$#"
+			count: 2
+			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+
+		-
 			message: "#^Cannot access offset 'contact' on mixed\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -8637,7 +8552,7 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 0 on mixed\\.$#"
-			count: 6
+			count: 8
 			path: src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
 
 		-
@@ -13222,11 +13137,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$fieldDescriptors of method Sulu\\\\Bundle\\\\MediaBundle\\\\Media\\\\ListBuilderFactory\\\\MediaListBuilderFactory\\:\\:getListBuilder\\(\\) expects array, array\\<Sulu\\\\Component\\\\Rest\\\\ListBuilder\\\\FieldDescriptorInterface\\>\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
-
-		-
-			message: "#^Parameter \\#1 \\$id of method Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\CollectionRepositoryInterface\\:\\:findCollectionTypeById\\(\\) expects int, mixed given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
 

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -1337,7 +1337,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
      * Updates the given address.
      *
      * @param Address $address The phone object to update
-     * @param mixed $entry The entry with the new data
+     * @param array $entry The entry with the new data
      * @param bool $isMain returns if address should be set to main
      *
      * @return bool True if successful, otherwise false
@@ -1389,11 +1389,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
         if (\array_key_exists('title', $entry)) {
             $address->setTitle($entry['title']);
         }
-        if (\array_key_exists('primaryAddress', $entry)) {
-            $isMain = $this->getBooleanValue($entry['primaryAddress']);
-        } else {
-            $isMain = false;
-        }
+        $isMain = $this->getBooleanValue($entry['primaryAddress'] ?? false);
         if (\array_key_exists('billingAddress', $entry)) {
             $address->setBillingAddress($this->getBooleanValue($entry['billingAddress']));
         }

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -1413,7 +1413,6 @@ abstract class AbstractContactManager implements ContactManagerInterface
             $address->setAddition($entry['addition']);
         }
 
-
         return $success;
     }
 

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -1356,62 +1356,63 @@ abstract class AbstractContactManager implements ContactManagerInterface
             throw new EntityNotFoundException(self::$addressTypeEntityName, $entry['addressType']);
         }
 
-        if (isset($entry['street'])) {
+        if (\array_key_exists('street', $entry)) {
             $address->setStreet($entry['street']);
         }
-        if (isset($entry['number'])) {
+        if (\array_key_exists('number', $entry)) {
             $address->setNumber($entry['number']);
         }
-        if (isset($entry['zip'])) {
+        if (\array_key_exists('zip', $entry)) {
             $address->setZip($entry['zip']);
         }
-        if (isset($entry['city'])) {
+        if (\array_key_exists('city', $entry)) {
             $address->setCity($entry['city']);
         }
-        if (isset($entry['state'])) {
+        if (\array_key_exists('state', $entry)) {
             $address->setState($entry['state']);
         }
-        if (isset($entry['countryCode'])) {
+        if (\array_key_exists('countryCode', $entry)) {
             $address->setCountryCode($entry['countryCode']);
         }
         if ($addressType) {
             $address->setAddressType($addressType);
         }
-        if (isset($entry['latitude'])) {
+        if (\array_key_exists('latitude', $entry)) {
             $address->setLatitude($entry['latitude'] ?: null);
         }
-        if (isset($entry['longitude'])) {
+        if (\array_key_exists('longitude', $entry)) {
             $address->setLongitude($entry['longitude'] ?: null);
         }
-        if (isset($entry['note'])) {
+        if (\array_key_exists('note', $entry)) {
             $address->setNote($entry['note']);
         }
-        if (isset($entry['title'])) {
+        if (\array_key_exists('title', $entry)) {
             $address->setTitle($entry['title']);
         }
-        if (isset($entry['primaryAddress'])) {
+        if (\array_key_exists('primaryAddress', $entry)) {
             $isMain = $this->getBooleanValue($entry['primaryAddress']);
         } else {
             $isMain = false;
         }
-        if (isset($entry['billingAddress'])) {
+        if (\array_key_exists('billingAddress', $entry)) {
             $address->setBillingAddress($this->getBooleanValue($entry['billingAddress']));
         }
-        if (isset($entry['deliveryAddress'])) {
+        if (\array_key_exists('deliveryAddress', $entry)) {
             $address->setDeliveryAddress($this->getBooleanValue($entry['deliveryAddress']));
         }
-        if (isset($entry['postboxCity'])) {
+        if (\array_key_exists('postboxCity', $entry)) {
             $address->setPostboxCity($entry['postboxCity']);
         }
-        if (isset($entry['postboxNumber'])) {
+        if (\array_key_exists('postboxNumber', $entry)) {
             $address->setPostboxNumber($entry['postboxNumber']);
         }
-        if (isset($entry['postboxPostcode'])) {
+        if (\array_key_exists('postboxPostcode', $entry)) {
             $address->setPostboxPostcode($entry['postboxPostcode']);
         }
-        if (isset($entry['addition'])) {
+        if (\array_key_exists('addition', $entry)) {
             $address->setAddition($entry['addition']);
         }
+
 
         return $success;
     }

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -1337,7 +1337,7 @@ abstract class AbstractContactManager implements ContactManagerInterface
      * Updates the given address.
      *
      * @param Address $address The phone object to update
-     * @param array $entry The entry with the new data
+     * @param array<string, mixed> $entry The entry with the new data
      * @param bool $isMain returns if address should be set to main
      *
      * @return bool True if successful, otherwise false

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -2050,6 +2050,83 @@ class AccountControllerTest extends SuluTestCase
         $this->assertEquals(true, $response->addresses[2]->primaryAddress);
     }
 
+    public function testEmptyValueAddressHandlingPut(): void
+    {
+        $emailType = $this->createEmailType('Private');
+        $addressType = $this->createAddressType('Private');
+        $address = $this->createAddress($addressType);
+        $account = $this->createAccount('Company', null, null, $address);
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->client->jsonRequest(
+            'PUT',
+            '/api/accounts/' . $account->getId(),
+            [
+                'name' => 'ExampleCompany',
+                'urls' => [],
+                'emails' => [
+                    [
+                        'email' => 'office@company.com',
+                        'emailType' => [
+                            'id' => $emailType->getId(),
+                            'name' => 'Private',
+                        ],
+                    ],
+                ],
+                'addresses' => [
+                    [
+                        'id' => $address->getId(),
+                        'street' => '',
+                        'number' => '',
+                        'zip' => null,
+                        'city' => null,
+                        'addressType' => $addressType->getId(),
+                        'billingAddress' => true,
+                        'primaryAddress' => true,
+                        'deliveryAddress' => null,
+                        'postboxNumber' => '',
+                    ],
+                ],
+            ]
+        );
+
+        $expectedAddress = [
+            'id' => $address->getId(),
+            'street' => '',
+            'number' => '',
+            'addition' => '',
+            'zip' => null,
+            'city' => null,
+            'state' => null,
+            'countryCode' => null,
+            'addressType' => $addressType->getId(),
+            'billingAddress' => true,
+            'primaryAddress' => true,
+            'deliveryAddress' => false,
+            'postboxCity' => null,
+            'postboxPostcode' => null,
+            'postboxNumber' => '',
+            'note' => null,
+            'title' => null,
+            'latitude' => null,
+            'longitude' => null,
+        ];
+
+        $response = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertEquals($expectedAddress, $response['addresses'][0]);
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/accounts/' . $account->getId()
+        );
+
+        $response = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+        $this->assertEquals($expectedAddress, $response['addresses'][0]);
+    }
+
     public function sortAddressesPrimaryLast()
     {
         return function($a, $b) {


### PR DESCRIPTION


| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8313
| Related issues/PRs | #8313
| License | MIT

#### What's in this PR?

Allows to clear address data from organizations via Admin UI

#### Why?

When emtpying a pre existing value from an address, the new empty value was not persisted.
