### PR TITLE
Add website permission checks to PageSmartContentProvider/PageSitemapProvider/PageSelections

### DIFF
--- a/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoader.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoader.php
@@ -112,9 +112,14 @@ class ResolvableResourceLoader implements ResolvableResourceLoaderInterface
 
         $resourceIds = \array_map(fn (ResolvableResource $resource) => $resource->getId(), $resolvableResources);
 
+        // We can use the metadata of the first resource, as all resources share the same metadata structure
+        // different metadata structures will lead to different metadataIdentifiers and thus different resource loading calls
+        $params = \count($resolvableResources) > 0 ? \reset($resolvableResources)->getMetadata() ?? [] : [];
+
         return $resourceLoader->load(
             $resourceIds,
             $locale,
+            $params
         );
     }
 }

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -28,6 +28,12 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
     ) {
     }
 
+    /**
+     * @param array<int|string, mixed> $content
+     * @param array<string, array<string|int, array<string, mixed>>> $resolvedResources
+     *
+     * @return array<int|string, mixed>
+     */
     public function replaceResolvableResourcesWithResolvedValues(
         array $content,
         array $resolvedResources,
@@ -35,55 +41,91 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
         int $maxDepth
     ): array {
         if ($depth > $maxDepth) {
-            // replace non resolved resources with null
-            \array_walk_recursive($content, function(&$value) {
-                if ($value instanceof ResolvableResource) {
-                    // TODO add callback with exception in dev mode
-                    $value = null;
-                }
-            });
-
-            return $content;
+            return $this->replaceUnresolvedWithNull($content);
         }
 
         if (0 === \count($resolvedResources)) {
             return $content;
         }
 
-        $hasReplaced = false;
-        \array_walk_recursive($content, function(&$value) use ($resolvedResources, &$hasReplaced) {
-            if (!$value instanceof ResolvableInterface) {
-                return;
+        $onlyResolvableResources = true;
+        foreach ($content as $key => $value) {
+            if ($value instanceof ResolvableInterface) {
+                $content[$key] = $this->resolveValue(
+                    $value,
+                    $resolvedResources
+                );
+
+                // If resolved to array, recurse into it
+                if (\is_array($content[$key])) {
+                    $content[$key] = $this->replaceResolvableResourcesWithResolvedValues(
+                        $content[$key],
+                        $resolvedResources,
+                        $depth + 1,
+                        $maxDepth
+                    );
+                }
+                continue;
             }
+            $onlyResolvableResources = false;
 
-            $resource = $resolvedResources[$value->getResourceLoaderKey()][$value->getId()][$value->getMetadataIdentifier()] ?? null;
-
-            if (null !== $resource && $value instanceof ResolvableResource && $value->getResourceKey()) {
-                $this->populateReferenceStore($value->getId(), $value->getResourceKey());
+            if (\is_array($value)) {
+                $content[$key] = $this->replaceResolvableResourcesWithResolvedValues(
+                    $value,
+                    $resolvedResources,
+                    $depth + 1,
+                    $maxDepth
+                );
             }
+        }
 
-            if (null === $resource) {
-                $value = null;
-
-                return;
+        // this is required for e.g. selections where some entities are not resolved
+        // due to insufficient permissions
+        if ($onlyResolvableResources) {
+            // remove non-resolved resources if all values were resolvable resources
+            $isList = \array_is_list($content);
+            $content = \array_filter($content, static fn ($value) => null !== $value);
+            if ($isList) {
+                $content = \array_values($content);
             }
+        }
 
-            $value = $value->executeResourceCallback($resource);
-            $hasReplaced = true;
-        });
+        return $content;
+    }
 
-        // Recursively replace ResolvableResource instances in nested arrays
-        // if a replacement was made in the previous step.
-        // This is necessary to resolve nested ResolvableResource instances
-        // which might have been added during the first replacement,
-        // e.g., when a ResolvableResource is replaced with an array containing another ResolvableResource.
-        if ($hasReplaced) {
-            $content = $this->replaceResolvableResourcesWithResolvedValues(
-                $content,
-                $resolvedResources,
-                $depth + 1,
-                $maxDepth
-            );
+    /**
+     * @param array<string, array<string|int, array<string, mixed>>> $resolvedResources
+     */
+    private function resolveValue(
+        ResolvableInterface $value,
+        array $resolvedResources
+    ): mixed {
+        $loaderKey = $value->getResourceLoaderKey();
+        $id = $value->getId();
+        $metadataIdentifier = $value->getMetadataIdentifier();
+
+        $resource = $resolvedResources[$loaderKey][$id][$metadataIdentifier] ?? null;
+
+        if (null !== $resource && $value instanceof ResolvableResource && $value->getResourceKey()) {
+            $this->populateReferenceStore($value->getId(), $value->getResourceKey());
+        }
+
+        return null === $resource ? null : $value->executeResourceCallback($resource);
+    }
+
+    /**
+     * @param array<int|string, mixed> $content
+     *
+     * @return array<int|string, mixed>
+     */
+    private function replaceUnresolvedWithNull(array $content): array
+    {
+        foreach ($content as $key => $value) {
+            if ($value instanceof ResolvableResource) {
+                $content[$key] = null;
+            } elseif (\is_array($value)) {
+                $content[$key] = $this->replaceUnresolvedWithNull($value);
+            }
         }
 
         return $content;

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -56,7 +56,6 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
                     $resolvedResources
                 );
 
-                // If resolved to array, recurse into it
                 if (\is_array($content[$key])) {
                     $content[$key] = $this->replaceResolvableResourcesWithResolvedValues(
                         $content[$key],
@@ -73,7 +72,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
                 $content[$key] = $this->replaceResolvableResourcesWithResolvedValues(
                     $value,
                     $resolvedResources,
-                    $depth + 1,
+                    $depth, // only increase depth for ResolvableInterface
                     $maxDepth
                 );
             }

--- a/packages/page/src/Domain/Repository/PageRepositoryInterface.php
+++ b/packages/page/src/Domain/Repository/PageRepositoryInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Page\Domain\Repository;
 
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Exception\PageNotFoundException;
 use Sulu\Page\Domain\Model\PageInterface;
@@ -45,6 +46,7 @@ interface PageRepositoryInterface
      *     locale?: string,
      *     stage?: string,
      *     load_ghost_content?: bool,
+     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     page_admin?: bool,
@@ -62,6 +64,7 @@ interface PageRepositoryInterface
      *     uuids?: string[],
      *     locale?: string,
      *     stage?: string,
+     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     page_admin?: bool,
@@ -88,6 +91,7 @@ interface PageRepositoryInterface
      *     limit?: int,
      *     navigationContexts?: string[],
      *     depth?: int,
+     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     id?: 'asc'|'desc',
@@ -120,6 +124,7 @@ interface PageRepositoryInterface
      *     limit?: int,
      *     navigationContexts?: string[],
      *     depth?: int,
+     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     id?: 'asc'|'desc',
@@ -150,6 +155,7 @@ interface PageRepositoryInterface
      *     templateKeys?: string[],
      *     page?: int,
      *     limit?: int,
+     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     id?: 'asc'|'desc',
@@ -173,6 +179,7 @@ interface PageRepositoryInterface
      *     tagNames?: string[],
      *     tagOperator?: 'AND'|'OR',
      *     templateKeys?: string[],
+     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      */
     public function countBy(array $filters = []): int;

--- a/packages/page/src/Domain/Repository/PageRepositoryInterface.php
+++ b/packages/page/src/Domain/Repository/PageRepositoryInterface.php
@@ -46,7 +46,7 @@ interface PageRepositoryInterface
      *     locale?: string,
      *     stage?: string,
      *     load_ghost_content?: bool,
-     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
+     *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     page_admin?: bool,
@@ -64,7 +64,7 @@ interface PageRepositoryInterface
      *     uuids?: string[],
      *     locale?: string,
      *     stage?: string,
-     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
+     *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     page_admin?: bool,
@@ -91,7 +91,7 @@ interface PageRepositoryInterface
      *     limit?: int,
      *     navigationContexts?: string[],
      *     depth?: int,
-     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
+     *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     id?: 'asc'|'desc',
@@ -124,7 +124,7 @@ interface PageRepositoryInterface
      *     limit?: int,
      *     navigationContexts?: string[],
      *     depth?: int,
-     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
+     *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     id?: 'asc'|'desc',
@@ -155,7 +155,7 @@ interface PageRepositoryInterface
      *     templateKeys?: string[],
      *     page?: int,
      *     limit?: int,
-     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
+     *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     id?: 'asc'|'desc',
@@ -179,7 +179,7 @@ interface PageRepositoryInterface
      *     tagNames?: string[],
      *     tagOperator?: 'AND'|'OR',
      *     templateKeys?: string[],
-     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
+     *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      */
     public function countBy(array $filters = []): int;

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -20,6 +20,8 @@ use Doctrine\ORM\Query\Expr\OrderBy;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 use Gedmo\Tree\Hydrator\ORM\TreeObjectHydrator;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Domain\Exception\PageNotFoundException;
@@ -68,6 +70,11 @@ class PageRepository implements PageRepositoryInterface
     protected $dimensionContentQueryEnhancer;
 
     /**
+     * @var AccessControlQueryEnhancer
+     */
+    private $accessControlQueryEnhancer;
+
+    /**
      * @var class-string<PageInterface>
      */
     protected $pageClassName;
@@ -79,7 +86,8 @@ class PageRepository implements PageRepositoryInterface
 
     public function __construct(
         EntityManagerInterface $entityManager,
-        DimensionContentQueryEnhancer $dimensionContentQueryEnhancer
+        DimensionContentQueryEnhancer $dimensionContentQueryEnhancer,
+        AccessControlQueryEnhancer $accessControlQueryEnhancer
     ) {
         $repository = $entityManager->getRepository(PageInterface::class);
         Assert::isInstanceOf($repository, NestedTreeRepository::class);
@@ -88,6 +96,7 @@ class PageRepository implements PageRepositoryInterface
         $this->entityDimensionContentRepository = $entityManager->getRepository(PageDimensionContentInterface::class);
         $this->entityManager = $entityManager;
         $this->dimensionContentQueryEnhancer = $dimensionContentQueryEnhancer;
+        $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
         $this->pageClassName = $this->entityRepository->getClassName();
         $this->pageDimensionContentClassName = $this->entityDimensionContentRepository->getClassName();
     }
@@ -261,6 +270,7 @@ class PageRepository implements PageRepositoryInterface
      *     limit?: int,
      *     navigationContexts?: string[],
      *     depth?: int,
+     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     uuid?: 'asc'|'desc',
@@ -275,6 +285,9 @@ class PageRepository implements PageRepositoryInterface
      */
     private function createQueryBuilder(array $filters, array $sortBy = [], array $selects = []): QueryBuilder
     {
+        $permissionConfig = $filters['permissionConfig'] ?? null;
+        unset($filters['permissionConfig']);
+
         foreach ($selects as $selectGroup => $value) {
             if (!$value) {
                 continue;
@@ -387,6 +400,17 @@ class PageRepository implements PageRepositoryInterface
                     ->andWhere('navigationContext.navigationContext IN (:navigationContexts)')
                     ->setParameter('navigationContexts', $navigationContexts);
             }
+        }
+
+        if (null !== $permissionConfig && isset($permissionConfig['permission'])) {
+            $this->accessControlQueryEnhancer->enhance(
+                $queryBuilder,
+                $permissionConfig['user'] ?? null,
+                $permissionConfig['permission'],
+                PageInterface::class,
+                'page',
+                'uuid'
+            );
         }
 
         return $queryBuilder;

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -25,6 +25,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Domain\Exception\PageNotFoundException;
+use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
@@ -407,7 +408,7 @@ class PageRepository implements PageRepositoryInterface
                 $queryBuilder,
                 $accessControl['user'] ?? null,
                 $accessControl['permission'],
-                PageInterface::class,
+                Page::class,
                 'page',
                 'uuid'
             );

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -270,7 +270,7 @@ class PageRepository implements PageRepositoryInterface
      *     limit?: int,
      *     navigationContexts?: string[],
      *     depth?: int,
-     *     permissionConfig?: array{user?: UserInterface|null, permission?: int|null},
+     *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
      *     uuid?: 'asc'|'desc',
@@ -285,8 +285,8 @@ class PageRepository implements PageRepositoryInterface
      */
     private function createQueryBuilder(array $filters, array $sortBy = [], array $selects = []): QueryBuilder
     {
-        $permissionConfig = $filters['permissionConfig'] ?? null;
-        unset($filters['permissionConfig']);
+        $accessControl = $filters['accessControl'] ?? null;
+        unset($filters['accessControl']);
 
         foreach ($selects as $selectGroup => $value) {
             if (!$value) {
@@ -402,11 +402,11 @@ class PageRepository implements PageRepositoryInterface
             }
         }
 
-        if (null !== $permissionConfig && isset($permissionConfig['permission'])) {
+        if (null !== $accessControl && isset($accessControl['permission'])) {
             $this->accessControlQueryEnhancer->enhance(
                 $queryBuilder,
-                $permissionConfig['user'] ?? null,
-                $permissionConfig['permission'],
+                $accessControl['user'] ?? null,
+                $accessControl['permission'],
                 PageInterface::class,
                 'page',
                 'uuid'

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -30,6 +30,7 @@ use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
+use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
@@ -294,7 +295,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
                 $queryBuilder,
                 $user,
                 $permission,
-                PageInterface::class,
+                Page::class,
                 $alias,
                 'uuid'
             );

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -112,7 +112,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         private array $bundles,
         private WebspaceManagerInterface $webspaceManager,
         private AccessControlQueryEnhancer $accessControlQueryEnhancer,
-        private Security $security,
+        private ?Security $security,
         private ?array $permissions = null,
     ) {
         $this->entityRepository = $entityManager->getRepository(PageInterface::class);
@@ -283,7 +283,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
     ): void {
         $webspace = $this->webspaceManager->findWebspaceByKey($filters['webspaceKey'] ?? null);
         /** @var UserInterface|null $user */
-        $user = $webspace && $webspace->hasWebsiteSecurity() ? $this->security->getUser() : null;
+        $user = $webspace && $webspace->hasWebsiteSecurity() && $this->security ? $this->security->getUser() : null;
         /** @var int|null $permission */
         $permission = $webspace && $webspace->hasWebsiteSecurity() && $this->permissions
             ? $this->permissions[PermissionTypes::VIEW]
@@ -296,6 +296,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
                 $permission,
                 PageInterface::class,
                 $alias,
+                'uuid'
             );
         }
     }
@@ -321,8 +322,8 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
                 Join::WITH,
                 'datasourcePage.uuid = :datasource',
             )
-                ->andWhere($alias . '.lft >= datasourcePage.lft')
-                ->andWhere($alias . '.rgt <= datasourcePage.rgt')
+                ->andWhere($alias . '.lft > datasourcePage.lft')
+                ->andWhere($alias . '.rgt < datasourcePage.rgt')
                 ->setParameter('datasource', $datasource);
         } else {
             $queryBuilder->andWhere($alias . '.parent = :datasource')

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -24,13 +24,17 @@ use Sulu\Bundle\AdminBundle\SmartContent\Configuration\BuilderInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfigurationInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentQueryEnhancer;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
@@ -54,6 +58,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  *       audienceTargeting?: bool,
  *       targetGroupId?: int,
  *       segmentKey?: string,
+ *       webspaceKey?: string,
  *   }
  * @phpstan-type PageSmartContentCountFilters array{
  *       categories: int[],
@@ -74,6 +79,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  *       audienceTargeting?: bool,
  *       targetGroupId?: int,
  *       segmentKey?: string,
+ *       webspaceKey?: string,
  *   }
  */
 readonly class PageSmartContentProvider implements SmartContentProviderInterface
@@ -95,6 +101,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
 
     /**
      * @param array<string, mixed> $bundles
+     * @param mixed[]|null $permissions
      */
     public function __construct(
         private DimensionContentQueryEnhancer $dimensionContentQueryEnhancer,
@@ -103,6 +110,10 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         private ?TokenStorageInterface $tokenStorage,
         EntityManagerInterface $entityManager,
         private array $bundles,
+        private WebspaceManagerInterface $webspaceManager,
+        private AccessControlQueryEnhancer $accessControlQueryEnhancer,
+        private Security $security,
+        private ?array $permissions = null,
     ) {
         $this->entityRepository = $entityManager->getRepository(PageInterface::class);
         $this->entityDimensionContentRepository = $entityManager->getRepository(PageDimensionContentInterface::class);
@@ -162,6 +173,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
             [],
         );
         $this->addInternalFilters($queryBuilder, $filters, $alias);
+        $this->enhanceQueryBuilderWithAccessControl($queryBuilder, $filters, $alias);
 
         $queryBuilder->select('COUNT(DISTINCT page.uuid)');
 
@@ -197,6 +209,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
             $sortBys,
         );
         $this->addInternalFilters($queryBuilder, $filters, $alias);
+        $this->enhanceQueryBuilderWithAccessControl($queryBuilder, $filters, $alias);
 
         // TODO refactor this part to not use distinct
         // we need the distinct here, because joins due to tags/categories can lead to duplicate results
@@ -256,6 +269,35 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         }
 
         return $filters;
+    }
+
+    /**
+     * Enhances the query builder with access control filtering if webspace has security enabled.
+     *
+     * @param array{webspaceKey?: string} $filters
+     */
+    private function enhanceQueryBuilderWithAccessControl(
+        QueryBuilder $queryBuilder,
+        array $filters,
+        string $alias
+    ): void {
+        $webspace = $this->webspaceManager->findWebspaceByKey($filters['webspaceKey'] ?? null);
+        /** @var UserInterface|null $user */
+        $user = $webspace && $webspace->hasWebsiteSecurity() ? $this->security->getUser() : null;
+        /** @var int|null $permission */
+        $permission = $webspace && $webspace->hasWebsiteSecurity() && $this->permissions
+            ? $this->permissions[PermissionTypes::VIEW]
+            : null;
+
+        if ($permission) {
+            $this->accessControlQueryEnhancer->enhance(
+                $queryBuilder,
+                $user,
+                $permission,
+                PageInterface::class,
+                $alias,
+            );
+        }
     }
 
     /**

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -38,17 +38,11 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
             return ContentView::create([], ['ids' => [], ...$params]);
         }
 
-        /** @var string[] $ids */
-        $ids = $data;
-
-        /** @var array{locale: string, stage: string} $filters */
-        $filters = [
-            'locale' => $locale,
-            'stage' => 'live',
-        ];
-
         /** @var string $resourceLoaderKey */
         $resourceLoaderKey = $params['resourceLoader'] ?? PageResourceLoader::getKey();
+
+        /** @var string[] $ids */
+        $ids = $data;
 
         return ContentView::createResolvablesWithReferences(
             ids: $ids,
@@ -61,7 +55,6 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
             priority: 150,
             metadata: [
                 'properties' => $params['properties'] ?? null,
-                'filters' => $filters,
             ]
         );
     }

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -11,14 +11,10 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Component\Security\Authentication\UserInterface;
-use Sulu\Component\Security\Authorization\PermissionTypes;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
-use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
@@ -27,16 +23,6 @@ use Symfony\Bundle\SecurityBundle\Security;
  */
 class PageSelectionPropertyResolver implements PropertyResolverInterface
 {
-    /**
-     * @param mixed[]|null $permissions
-     */
-    public function __construct(
-        private readonly ?Security $security,
-        private readonly ?array $permissions,
-        private readonly RequestAnalyzerInterface $requestAnalyzer,
-    ) {
-    }
-
     /**
      * @param array{
      *     resourceLoader?: string,
@@ -55,25 +41,11 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
         /** @var string[] $ids */
         $ids = $data;
 
-        /** @var array{locale: string, stage: string, permissionConfig?: array{user: UserInterface|null, permission: int}} $filters */
+        /** @var array{locale: string, stage: string} $filters */
         $filters = [
             'locale' => $locale,
             'stage' => 'live',
         ];
-
-        $webspace = $this->requestAnalyzer->getWebspace();
-        // @phpstan-ignore booleanAnd.leftAlwaysTrue (PHPDoc lies, getWebspace() can return null)
-        if ($webspace && $webspace->hasWebsiteSecurity() && $this->security && $this->permissions) {
-            $user = $this->security->getUser();
-            $permission = $this->permissions[PermissionTypes::VIEW] ?? null;
-
-            if (\is_int($permission)) {
-                $filters['permissionConfig'] = [
-                    'user' => $user instanceof UserInterface ? $user : null,
-                    'permission' => $permission,
-                ];
-            }
-        }
 
         /** @var string $resourceLoaderKey */
         $resourceLoaderKey = $params['resourceLoader'] ?? PageResourceLoader::getKey();

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -11,10 +11,14 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
@@ -23,6 +27,16 @@ use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
  */
 class PageSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param mixed[]|null $permissions
+     */
+    public function __construct(
+        private readonly ?Security $security,
+        private readonly ?array $permissions,
+        private readonly RequestAnalyzerInterface $requestAnalyzer,
+    ) {
+    }
+
     /**
      * @param array{
      *     resourceLoader?: string,
@@ -38,11 +52,31 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
             return ContentView::create([], ['ids' => [], ...$params]);
         }
 
-        /** @var string $resourceLoaderKey */
-        $resourceLoaderKey = $params['resourceLoader'] ?? PageResourceLoader::getKey();
-
         /** @var string[] $ids */
         $ids = $data;
+
+        /** @var array{locale: string, stage: string, permissionConfig?: array{user: UserInterface|null, permission: int}} $filters */
+        $filters = [
+            'locale' => $locale,
+            'stage' => 'live',
+        ];
+
+        $webspace = $this->requestAnalyzer->getWebspace();
+        // @phpstan-ignore booleanAnd.leftAlwaysTrue (PHPDoc lies, getWebspace() can return null)
+        if ($webspace && $webspace->hasWebsiteSecurity() && $this->security && $this->permissions) {
+            $user = $this->security->getUser();
+            $permission = $this->permissions[PermissionTypes::VIEW] ?? null;
+
+            if (\is_int($permission)) {
+                $filters['permissionConfig'] = [
+                    'user' => $user instanceof UserInterface ? $user : null,
+                    'permission' => $permission,
+                ];
+            }
+        }
+
+        /** @var string $resourceLoaderKey */
+        $resourceLoaderKey = $params['resourceLoader'] ?? PageResourceLoader::getKey();
 
         return ContentView::createResolvablesWithReferences(
             ids: $ids,
@@ -55,6 +89,7 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
             priority: 150,
             metadata: [
                 'properties' => $params['properties'] ?? null,
+                'filters' => $filters,
             ]
         );
     }

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -11,14 +11,10 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Component\Security\Authentication\UserInterface;
-use Sulu\Component\Security\Authorization\PermissionTypes;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
-use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
@@ -27,16 +23,6 @@ use Symfony\Bundle\SecurityBundle\Security;
  */
 class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
 {
-    /**
-     * @param mixed[]|null $permissions
-     */
-    public function __construct(
-        private readonly ?Security $security,
-        private readonly ?array $permissions,
-        private readonly RequestAnalyzerInterface $requestAnalyzer,
-    ) {
-    }
-
     /**
      * @param array{
      *     resourceLoader?: string,
@@ -49,25 +35,11 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
             return ContentView::create(null, ['id' => null, ...$params]);
         }
 
-        /** @var array{locale: string, stage: string, permissionConfig?: array{user: UserInterface|null, permission: int}} $filters */
+        /** @var array{locale: string, stage: string} $filters */
         $filters = [
             'locale' => $locale,
             'stage' => 'live',
         ];
-
-        $webspace = $this->requestAnalyzer->getWebspace();
-        // @phpstan-ignore booleanAnd.leftAlwaysTrue (PHPDoc lies, getWebspace() can return null)
-        if ($webspace && $webspace->hasWebsiteSecurity() && $this->security && $this->permissions) {
-            $user = $this->security->getUser();
-            $permission = $this->permissions[PermissionTypes::VIEW] ?? null;
-
-            if (\is_int($permission)) {
-                $filters['permissionConfig'] = [
-                    'user' => $user instanceof UserInterface ? $user : null,
-                    'permission' => $permission,
-                ];
-            }
-        }
 
         /** @var string $resourceLoaderKey */
         $resourceLoaderKey = $params['resourceLoader'] ?? PageResourceLoader::getKey();

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -11,10 +11,14 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @internal if you need to override this service, create a new service with based on PropertyResolverInterface instead of extending this class
@@ -23,6 +27,16 @@ use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
  */
 class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
 {
+    /**
+     * @param mixed[]|null $permissions
+     */
+    public function __construct(
+        private readonly ?Security $security,
+        private readonly ?array $permissions,
+        private readonly RequestAnalyzerInterface $requestAnalyzer,
+    ) {
+    }
+
     /**
      * @param array{
      *     resourceLoader?: string,
@@ -33,6 +47,26 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
     {
         if (!\is_string($data)) {
             return ContentView::create(null, ['id' => null, ...$params]);
+        }
+
+        /** @var array{locale: string, stage: string, permissionConfig?: array{user: UserInterface|null, permission: int}} $filters */
+        $filters = [
+            'locale' => $locale,
+            'stage' => 'live',
+        ];
+
+        $webspace = $this->requestAnalyzer->getWebspace();
+        // @phpstan-ignore booleanAnd.leftAlwaysTrue (PHPDoc lies, getWebspace() can return null)
+        if ($webspace && $webspace->hasWebsiteSecurity() && $this->security && $this->permissions) {
+            $user = $this->security->getUser();
+            $permission = $this->permissions[PermissionTypes::VIEW] ?? null;
+
+            if (\is_int($permission)) {
+                $filters['permissionConfig'] = [
+                    'user' => $user instanceof UserInterface ? $user : null,
+                    'permission' => $permission,
+                ];
+            }
         }
 
         /** @var string $resourceLoaderKey */
@@ -49,6 +83,7 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
             priority: 150,
             metadata: [
                 'properties' => $params['properties'] ?? null,
+                'filters' => $filters,
             ]
         );
     }

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -35,12 +35,6 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
             return ContentView::create(null, ['id' => null, ...$params]);
         }
 
-        /** @var array{locale: string, stage: string} $filters */
-        $filters = [
-            'locale' => $locale,
-            'stage' => 'live',
-        ];
-
         /** @var string $resourceLoaderKey */
         $resourceLoaderKey = $params['resourceLoader'] ?? PageResourceLoader::getKey();
 
@@ -55,7 +49,6 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
             priority: 150,
             metadata: [
                 'properties' => $params['properties'] ?? null,
-                'filters' => $filters,
             ]
         );
     }

--- a/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
@@ -33,7 +33,16 @@ class PageResourceLoader implements ResourceLoaderInterface
      */
     public function load(array $ids, ?string $locale, array $params = []): array
     {
-        $result = $this->pageRepository->findBy(['uuids' => $ids]);
+        /** @var array{uuids: array<string>, locale?: string, stage?: string, permissionConfig?: array{user: \Sulu\Component\Security\Authentication\UserInterface|null, permission: int}} $filters */
+        $filters = ['uuids' => $ids];
+
+        if (($params['filters'] ?? null) && \is_array($params['filters'])) {
+            /** @var array{locale?: string, stage?: string, permissionConfig?: array{user: \Sulu\Component\Security\Authentication\UserInterface|null, permission: int}} $paramsFilters */
+            $paramsFilters = $params['filters'];
+            $filters = \array_merge($filters, $paramsFilters);
+        }
+
+        $result = $this->pageRepository->findBy($filters);
 
         $mappedResult = [];
         foreach ($result as $page) {

--- a/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
@@ -11,8 +11,12 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader;
 
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @internal if you need to override this service, create a new service with based on ResourceLoaderInterface instead of extending this class
@@ -23,8 +27,14 @@ class PageResourceLoader implements ResourceLoaderInterface
 {
     public const RESOURCE_LOADER_KEY = 'page';
 
+    /**
+     * @param mixed[]|null $permissions
+     */
     public function __construct(
         private PageRepositoryInterface $pageRepository,
+        private readonly ?Security $security,
+        private readonly ?array $permissions,
+        private readonly RequestAnalyzerInterface $requestAnalyzer,
     ) {
     }
 
@@ -33,13 +43,27 @@ class PageResourceLoader implements ResourceLoaderInterface
      */
     public function load(array $ids, ?string $locale, array $params = []): array
     {
-        /** @var array{uuids: array<string>, locale?: string, stage?: string, permissionConfig?: array{user: \Sulu\Component\Security\Authentication\UserInterface|null, permission: int}} $filters */
+        /** @var array{uuids: array<string>, locale?: string, stage?: string, accessControl?: array{user: UserInterface|null, permission: int}} $filters */
         $filters = ['uuids' => $ids];
 
         if (($params['filters'] ?? null) && \is_array($params['filters'])) {
-            /** @var array{locale?: string, stage?: string, permissionConfig?: array{user: \Sulu\Component\Security\Authentication\UserInterface|null, permission: int}} $paramsFilters */
+            /** @var array{locale?: string, stage?: string, accessControl?: array{user: UserInterface|null, permission: int}} $paramsFilters */
             $paramsFilters = $params['filters'];
             $filters = \array_merge($filters, $paramsFilters);
+        }
+
+        $webspace = $this->requestAnalyzer->getWebspace();
+        // @phpstan-ignore booleanAnd.leftAlwaysTrue
+        if ($webspace && $webspace->hasWebsiteSecurity() && $this->security && $this->permissions && !isset($filters['accessControl'])) {
+            $user = $this->security->getUser();
+            $permission = $this->permissions[PermissionTypes::VIEW] ?? null;
+
+            if (\is_int($permission)) {
+                $filters['accessControl'] = [
+                    'user' => $user instanceof UserInterface ? $user : null,
+                    'permission' => $permission,
+                ];
+            }
         }
 
         $result = $this->pageRepository->findBy($filters);

--- a/packages/page/src/Infrastructure/Sulu/Content/Visitor/PageSmartContentFiltersVisitor.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/Visitor/PageSmartContentFiltersVisitor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Content\Visitor;
+
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Content\Application\Visitor\SmartContentFiltersVisitorInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal This class should not be instantiated by a project.
+ *           Create your own smart content filters visitor to change its behaviour.
+ */
+class PageSmartContentFiltersVisitor implements SmartContentFiltersVisitorInterface
+{
+    public function __construct(
+        private RequestAnalyzerInterface $requestAnalyzer,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    public function visit(array $data, array $filters, array $parameters): array
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return $filters;
+        }
+
+        $webspace = $this->requestAnalyzer->getWebspace();
+
+        if ($webspace instanceof Webspace) { // @phpstan-ignore-line instanceof.alwaysTrue
+            $filters['webspaceKey'] = $webspace->getKey();
+        }
+
+        return $filters;
+    }
+}

--- a/packages/page/src/Infrastructure/Sulu/Sitemap/PagesSitemapProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Sitemap/PagesSitemapProvider.php
@@ -24,6 +24,7 @@ use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 
@@ -32,7 +33,7 @@ use Symfony\Bundle\SecurityBundle\Security;
  *           projects can create there own sitemap providers or use symfony
  *           dependency injection container to override this sitemap provider service
  *
- * @phpstan-type Page array{
+ * @phpstan-type PageData array{
  *     lastModified: \DateTimeImmutable|null,
  *     changed: \DateTimeImmutable,
  *     locale: string,
@@ -115,7 +116,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
                 $alternateRoutes[$pageUuid][$alternateLocale][] = $alternateSlug;
             }
 
-            /** @var Page $page */
+            /** @var PageData $page */
             foreach ($pagesIterator as $page) {
                 $pages[] = $page;
 
@@ -174,7 +175,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
                 $queryBuilder,
                 $user,
                 $permission,
-                PageInterface::class,
+                Page::class,
                 $alias,
                 'uuid'
             );
@@ -182,7 +183,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
     }
 
     /**
-     * @return iterable<Page>
+     * @return iterable<PageData>
      */
     private function getPages(string $webspaceKey, string $locale): iterable
     {
@@ -225,7 +226,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
         $queryBuilder->orderBy('route.slug', 'ASC');
 
         /**
-         * @var iterable<Page>
+         * @var iterable<PageData>
          */
         return $queryBuilder->getQuery()->toIterable();
     }
@@ -269,7 +270,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
     }
 
     /**
-     * @param Page $page
+     * @param PageData $page
      * @param array<string, array<string, string[]>> $alternatePages
      */
     private function generateSitemapUrl(

--- a/packages/page/src/Infrastructure/Sulu/Sitemap/PagesSitemapProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Sitemap/PagesSitemapProvider.php
@@ -13,14 +13,19 @@ namespace Sulu\Page\Infrastructure\Sulu\Sitemap;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
 use Sulu\Bundle\WebsiteBundle\Sitemap\AbstractSitemapProvider;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapAlternateLink;
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @internal your code should not create direct dependencies on this implementation
@@ -48,10 +53,16 @@ class PagesSitemapProvider extends AbstractSitemapProvider
      */
     protected EntityRepository $entityRepository;
 
+    /**
+     * @param mixed[]|null $permissions
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
         private readonly WebspaceManagerInterface $webspaceManager,
         private readonly string $environment,
+        private readonly AccessControlQueryEnhancer $accessControlQueryEnhancer,
+        private readonly Security $security,
+        private readonly ?array $permissions = null,
     ) {
         $repository = $entityManager->getRepository(PageInterface::class);
 
@@ -129,8 +140,6 @@ class PagesSitemapProvider extends AbstractSitemapProvider
             }
 
             foreach ($pages as $page) {
-                // Todo: Add access control check.
-
                 $sitemapUrl = $this->generateSitemapUrl($page, $alternatePages, $portalInformation, $host, $scheme);
 
                 if (!$sitemapUrl) {
@@ -142,6 +151,33 @@ class PagesSitemapProvider extends AbstractSitemapProvider
         }
 
         return $result;
+    }
+
+    /**
+     * Enhances the query builder with access control filtering if webspace has security enabled.
+     */
+    private function enhanceQueryBuilderWithAccessControl(
+        QueryBuilder $queryBuilder,
+        string $webspaceKey,
+        string $alias
+    ): void {
+        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+        /** @var UserInterface|null $user */
+        $user = $webspace && $webspace->hasWebsiteSecurity() ? $this->security->getUser() : null;
+        /** @var int|null $permission */
+        $permission = $webspace && $webspace->hasWebsiteSecurity() && $this->permissions
+            ? $this->permissions[PermissionTypes::VIEW]
+            : null;
+
+        if ($permission) {
+            $this->accessControlQueryEnhancer->enhance(
+                $queryBuilder,
+                $user,
+                $permission,
+                PageInterface::class,
+                $alias,
+            );
+        }
     }
 
     /**
@@ -172,6 +208,8 @@ class PagesSitemapProvider extends AbstractSitemapProvider
             ->setParameter('stage', DimensionContentInterface::STAGE_LIVE)
             ->setParameter('version', DimensionContentInterface::CURRENT_VERSION)
             ->setParameter('hide', false);
+
+        $this->enhanceQueryBuilderWithAccessControl($queryBuilder, $webspaceKey, 'page');
 
         $queryBuilder->select('dimensionContent.lastModified');
         $queryBuilder->addSelect('dimensionContent.changed');
@@ -214,6 +252,8 @@ class PagesSitemapProvider extends AbstractSitemapProvider
             ->setParameter('stage', DimensionContentInterface::STAGE_LIVE)
             ->setParameter('version', DimensionContentInterface::CURRENT_VERSION)
             ->setParameter('hide', false);
+
+        $this->enhanceQueryBuilderWithAccessControl($queryBuilder, $webspaceKey, 'page');
 
         $queryBuilder->select('dimensionContent.locale');
         $queryBuilder->addSelect('route.slug');

--- a/packages/page/src/Infrastructure/Sulu/Sitemap/PagesSitemapProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Sitemap/PagesSitemapProvider.php
@@ -61,7 +61,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
         private readonly WebspaceManagerInterface $webspaceManager,
         private readonly string $environment,
         private readonly AccessControlQueryEnhancer $accessControlQueryEnhancer,
-        private readonly Security $security,
+        private readonly ?Security $security,
         private readonly ?array $permissions = null,
     ) {
         $repository = $entityManager->getRepository(PageInterface::class);
@@ -163,7 +163,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
     ): void {
         $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
         /** @var UserInterface|null $user */
-        $user = $webspace && $webspace->hasWebsiteSecurity() ? $this->security->getUser() : null;
+        $user = $webspace && $webspace->hasWebsiteSecurity() && $this->security ? $this->security->getUser() : null;
         /** @var int|null $permission */
         $permission = $webspace && $webspace->hasWebsiteSecurity() && $this->permissions
             ? $this->permissions[PermissionTypes::VIEW]
@@ -176,6 +176,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
                 $permission,
                 PageInterface::class,
                 $alias,
+                'uuid'
             );
         }
     }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -279,20 +279,10 @@ final class SuluPageBundle extends AbstractBundle
         // Property Resolver services
         $services->set('sulu_page.page_selection_property_resolver')
             ->class(PageSelectionPropertyResolver::class)
-            ->args([
-                new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
-                param('sulu_security.permissions'),
-                new Reference('sulu_core.webspace.request_analyzer'),
-            ])
             ->tag('sulu_content.property_resolver');
 
         $services->set('sulu_page.single_page_selection_property_resolver')
             ->class(SinglePageSelectionPropertyResolver::class)
-            ->args([
-                new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
-                param('sulu_security.permissions'),
-                new Reference('sulu_core.webspace.request_analyzer'),
-            ])
             ->tag('sulu_content.property_resolver');
 
         $services->set('sulu_page.segment_block_visitor')
@@ -307,6 +297,9 @@ final class SuluPageBundle extends AbstractBundle
             ->class(PageResourceLoader::class)
             ->args([
                 new Reference('sulu_page.page_repository'),
+                new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                param('sulu_security.permissions'),
+                new Reference('sulu_core.webspace.request_analyzer'),
             ])
             ->tag('sulu_content.resource_loader', ['type' => PageResourceLoader::RESOURCE_LOADER_KEY]);
 

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -279,10 +279,20 @@ final class SuluPageBundle extends AbstractBundle
         // Property Resolver services
         $services->set('sulu_page.page_selection_property_resolver')
             ->class(PageSelectionPropertyResolver::class)
+            ->args([
+                new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                param('sulu_security.permissions'),
+                new Reference('sulu_core.webspace.request_analyzer'),
+            ])
             ->tag('sulu_content.property_resolver');
 
         $services->set('sulu_page.single_page_selection_property_resolver')
             ->class(SinglePageSelectionPropertyResolver::class)
+            ->args([
+                new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                param('sulu_security.permissions'),
+                new Reference('sulu_core.webspace.request_analyzer'),
+            ])
             ->tag('sulu_content.property_resolver');
 
         $services->set('sulu_page.segment_block_visitor')
@@ -340,6 +350,7 @@ final class SuluPageBundle extends AbstractBundle
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_content.dimension_content_query_enhancer'),
+                new Reference('sulu_security.access_control_query_enhancer'),
             ]);
 
         $services->alias(PageRepositoryInterface::class, 'sulu_page.page_repository');

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -60,6 +60,7 @@ use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\BlockVisitor\SegmentB
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionPropertyResolver;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\SinglePageSelectionPropertyResolver;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
+use Sulu\Page\Infrastructure\Sulu\Content\Visitor\PageSmartContentFiltersVisitor;
 use Sulu\Page\Infrastructure\Sulu\Content\Visitor\SegmentSmartContentFiltersVisitor;
 use Sulu\Page\Infrastructure\Sulu\Reference\PageReferenceRefresher;
 use Sulu\Page\Infrastructure\Sulu\Route\WebspaceSiteRouteGenerator;
@@ -420,8 +421,20 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('security.token_storage', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 new Reference('doctrine.orm.entity_manager'),
                 param('kernel.bundles'),
+                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_security.access_control_query_enhancer'),
+                new Reference('security.helper'),
+                param('sulu_security.permissions'),
             ])
             ->tag('sulu_content.smart_content_provider', ['type' => PageInterface::RESOURCE_KEY]);
+
+        $services->set('sulu_page.page_smart_content_filters_visitor_webspace')
+            ->class(PageSmartContentFiltersVisitor::class)
+            ->args([
+                new Reference('sulu_core.webspace.request_analyzer'),
+                new Reference('request_stack'),
+            ])
+            ->tag('sulu_content.smart_content_filters_visitor');
 
         $services->set('sulu_page.page_smart_content_filters_visitor')
             ->class(SegmentSmartContentFiltersVisitor::class)
@@ -499,7 +512,9 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_core.webspace.webspace_manager'),
                 '%kernel.environment%',
-                new Reference('sulu_security.access_control_manager'),
+                new Reference('sulu_security.access_control_query_enhancer'),
+                new Reference('security.helper'),
+                param('sulu_security.permissions'),
             ])
             ->tag('sulu.sitemap.provider');
 

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -423,7 +423,7 @@ final class SuluPageBundle extends AbstractBundle
                 param('kernel.bundles'),
                 new Reference('sulu_core.webspace.webspace_manager'),
                 new Reference('sulu_security.access_control_query_enhancer'),
-                new Reference('security.helper'),
+                new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
                 param('sulu_security.permissions'),
             ])
             ->tag('sulu_content.smart_content_provider', ['type' => PageInterface::RESOURCE_KEY]);
@@ -513,7 +513,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_core.webspace.webspace_manager'),
                 '%kernel.environment%',
                 new Reference('sulu_security.access_control_query_enhancer'),
-                new Reference('security.helper'),
+                new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
                 param('sulu_security.permissions'),
             ])
             ->tag('sulu.sitemap.provider');

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/PageRepositoryPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/PageRepositoryPermissionTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Doctrine\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
+
+class PageRepositoryPermissionTest extends SuluTestCase
+{
+    use CreatePageTrait;
+    use CreatePageWithPermissionsTrait;
+
+    private EntityManagerInterface $entityManager;
+    private PageRepositoryInterface $pageRepository;
+    private Role $anonymousRole;
+    private Page $homepageNonSecure;
+    private Page $homepageSecure;
+    private int $viewPermission;
+
+    protected function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->entityManager = $this->getEntityManager();
+
+        $this->pageRepository = $this->getContainer()->get('sulu_page.page_repository');
+        $this->anonymousRole = $this->createAnonymousRoleWithWebspacePermissions('sulu-test-secure');
+
+        $permissions = $this->getContainer()->getParameter('sulu_security.permissions');
+        $this->viewPermission = $permissions[PermissionTypes::VIEW];
+
+        // Create homepages for both webspaces
+        $this->homepageNonSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-io');
+
+        $this->homepageSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-test-secure');
+    }
+
+    public function testFindIdentifiersByWithoutPermissionsReturnsAllPages(): void
+    {
+        // Create pages
+        $page1 = $this->createSimplePage('sulu-io', 'en', 'Page 1');
+        $page2 = $this->createSimplePage('sulu-io', 'en', 'Page 2');
+        $page3 = $this->createSimplePage('sulu-io', 'en', 'Page 3');
+
+        $this->entityManager->clear();
+
+        $uuids = [$page1->getUuid(), $page2->getUuid(), $page3->getUuid()];
+        $result = $this->pageRepository->findIdentifiersBy([
+            'uuids' => $uuids,
+            'locale' => 'en',
+            'stage' => 'live',
+        ]);
+
+        /** @var array<array{uuid: string}> $resultArray */
+        $resultArray = \iterator_to_array($result);
+        $resultUuids = \array_column($resultArray, 'uuid');
+
+        $this->assertCount(3, $resultUuids);
+        $this->assertContains($page1->getUuid(), $resultUuids);
+        $this->assertContains($page2->getUuid(), $resultUuids);
+        $this->assertContains($page3->getUuid(), $resultUuids);
+    }
+
+    public function testFindIdentifiersByWithPermissionsFiltersPages(): void
+    {
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+        $deniedPage1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 1');
+        $deniedPage2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 2');
+
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage1, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage2, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        $systemStore = $this->getContainer()->get('sulu_security.system_store');
+        $systemStore->setSystem('sulu-test-secure');
+
+        $uuids = [$allowedPage->getUuid(), $deniedPage1->getUuid(), $deniedPage2->getUuid()];
+
+        $result = $this->pageRepository->findIdentifiersBy(
+            [
+                'uuids' => $uuids,
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => null,
+                    'permission' => $this->viewPermission,
+                ],
+            ]
+        );
+
+        $resultUuids = \array_column(\iterator_to_array($result), 'uuid');
+
+        $this->assertContains($allowedPage->getUuid(), $resultUuids);
+        $this->assertNotContains($deniedPage1->getUuid(), $resultUuids);
+        $this->assertNotContains($deniedPage2->getUuid(), $resultUuids);
+    }
+
+    public function testFindIdentifiersByWithMixedPermissions(): void
+    {
+        $allowed1 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 1');
+        $allowed2 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 2');
+        $denied1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 1');
+        $denied2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 2');
+
+        $this->grantViewAccessToPage($allowed1, $this->anonymousRole);
+        $this->grantViewAccessToPage($allowed2, $this->anonymousRole);
+        $this->denyAccessToPage($denied1, $this->anonymousRole);
+        $this->denyAccessToPage($denied2, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        $systemStore = $this->getContainer()->get('sulu_security.system_store');
+        $systemStore->setSystem('sulu-test-secure');
+
+        $uuids = [$allowed1->getUuid(), $denied1->getUuid(), $allowed2->getUuid(), $denied2->getUuid()];
+
+        $result = $this->pageRepository->findIdentifiersBy(
+            [
+                'uuids' => $uuids,
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => null,
+                    'permission' => $this->viewPermission,
+                ],
+            ]
+        );
+
+        /** @var array<array{uuid: string}> $resultArray */
+        $resultArray = \iterator_to_array($result);
+        $resultUuids = \array_column($resultArray, 'uuid');
+
+        $this->assertCount(2, $resultUuids);
+        $this->assertContains($allowed1->getUuid(), $resultUuids);
+        $this->assertContains($allowed2->getUuid(), $resultUuids);
+        $this->assertNotContains($denied1->getUuid(), $resultUuids);
+        $this->assertNotContains($denied2->getUuid(), $resultUuids);
+    }
+
+    public function testFindIdentifiersByWithAllDeniedReturnsEmpty(): void
+    {
+        $denied1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 1');
+        $denied2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 2');
+
+        $this->denyAccessToPage($denied1, $this->anonymousRole);
+        $this->denyAccessToPage($denied2, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        $systemStore = $this->getContainer()->get('sulu_security.system_store');
+        $systemStore->setSystem('sulu-test-secure');
+
+        $uuids = [$denied1->getUuid(), $denied2->getUuid()];
+
+        $result = $this->pageRepository->findIdentifiersBy(
+            [
+                'uuids' => $uuids,
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => null,
+                    'permission' => $this->viewPermission,
+                ],
+            ]
+        );
+
+        $this->assertSame([], \iterator_to_array($result));
+    }
+
+    public function testFindIdentifiersByWithoutAccessControlUsesWebspacePermissions(): void
+    {
+        $pageWithoutAcl = $this->createSimplePage('sulu-test-secure', 'en', 'Page Without ACL');
+
+        $this->entityManager->clear();
+
+        $systemStore = $this->getContainer()->get('sulu_security.system_store');
+        $systemStore->setSystem('sulu-test-secure');
+
+        $uuids = [$pageWithoutAcl->getUuid()];
+
+        $result = $this->pageRepository->findIdentifiersBy(
+            [
+                'uuids' => $uuids,
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => null,
+                    'permission' => $this->viewPermission,
+                ],
+            ]
+        );
+
+        $resultUuids = \array_column(\iterator_to_array($result), 'uuid');
+
+        $this->assertContains($pageWithoutAcl->getUuid(), $resultUuids);
+    }
+
+    /**
+     * Helper to create a simple page with live content.
+     */
+    private function createSimplePage(string $webspaceKey, string $locale, string $title, string $template = 'default'): Page
+    {
+        // Generate URL from title (convert to lowercase, replace spaces with dashes)
+        $url = '/' . \strtolower(\str_replace(' ', '-', $title));
+
+        // Determine which homepage to use based on webspace
+        $homepage = 'sulu-io' === $webspaceKey ? $this->homepageNonSecure : $this->homepageSecure;
+
+        return $this->createPage([
+            $locale => [
+                'live' => [
+                    'template' => $template,
+                    'title' => $title,
+                    'url' => $url,
+                    'parentId' => $homepage->getUuid(),
+                ],
+            ],
+        ], $webspaceKey);
+    }
+}

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/PageRepositoryPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/PageRepositoryPermissionTest.php
@@ -115,7 +115,7 @@ class PageRepositoryPermissionTest extends SuluTestCase
                 'uuids' => $uuids,
                 'locale' => 'en',
                 'stage' => 'live',
-                'permissionConfig' => [
+                'accessControl' => [
                     'user' => null,
                     'permission' => $this->viewPermission,
                 ],
@@ -153,7 +153,7 @@ class PageRepositoryPermissionTest extends SuluTestCase
                 'uuids' => $uuids,
                 'locale' => 'en',
                 'stage' => 'live',
-                'permissionConfig' => [
+                'accessControl' => [
                     'user' => null,
                     'permission' => $this->viewPermission,
                 ],
@@ -191,7 +191,7 @@ class PageRepositoryPermissionTest extends SuluTestCase
                 'uuids' => $uuids,
                 'locale' => 'en',
                 'stage' => 'live',
-                'permissionConfig' => [
+                'accessControl' => [
                     'user' => null,
                     'permission' => $this->viewPermission,
                 ],
@@ -217,7 +217,7 @@ class PageRepositoryPermissionTest extends SuluTestCase
                 'uuids' => $uuids,
                 'locale' => 'en',
                 'stage' => 'live',
-                'permissionConfig' => [
+                'accessControl' => [
                     'user' => null,
                     'permission' => $this->viewPermission,
                 ],

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentProviderPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentProviderPermissionTest.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Content;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Infrastructure\Sulu\Content\PageSmartContentProvider;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
+
+class PageSmartContentProviderPermissionTest extends SuluTestCase
+{
+    use CreatePageTrait;
+    use CreatePageWithPermissionsTrait;
+
+    private EntityManagerInterface $entityManager;
+    private PageSmartContentProvider $provider;
+    private Role $anonymousRole;
+    private Page $homepageNonSecure;
+    private Page $homepageSecure;
+
+    protected function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->entityManager = $this->getEntityManager();
+
+        $this->provider = $this->getContainer()->get('sulu_page.page_smart_content_provider');
+        $this->anonymousRole = $this->createAnonymousRoleWithWebspacePermissions('sulu-test-secure');
+
+        // Create homepages for both webspaces
+        $this->homepageNonSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-io');
+
+        $this->homepageSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-test-secure');
+    }
+
+    public function testFindByWithoutWebspaceSecurityShowsAllPages(): void
+    {
+        // Create pages in webspace WITHOUT security
+        $page1 = $this->createSimplePage('sulu-io', 'en', 'Page 1');
+        $page2 = $this->createSimplePage('sulu-io', 'en', 'Page 2');
+        $page3 = $this->createSimplePage('sulu-io', 'en', 'Page 3');
+
+        // Deny access to one page (should have no effect without webspace security)
+        $this->denyAccessToPage($page2, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Query pages
+        $result = $this->provider->findFlatBy(
+            $this->createFilters('sulu-io', 'en'),
+            []
+        );
+
+        // All pages should be returned because webspace doesn't have security enabled
+        $this->assertCount(3, $result);
+        $uuids = \array_column($result, 'id');
+        $this->assertContains($page1->getUuid(), $uuids);
+        $this->assertContains($page2->getUuid(), $uuids);
+        $this->assertContains($page3->getUuid(), $uuids);
+    }
+
+    public function testFindByWithWebspaceSecurityFiltersPagesWithoutPermissions(): void
+    {
+        // Create pages in secure webspace
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+        $deniedPage1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 1');
+        $deniedPage2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 2');
+
+        // Grant VIEW permission to only one page
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage1, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage2, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Query pages
+        $result = $this->provider->findFlatBy(
+            $this->createFilters('sulu-test-secure', 'en'),
+            []
+        );
+
+        // Only allowed page should be returned
+        $uuids = \array_column($result, 'id');
+        $this->assertContains($allowedPage->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage1->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage2->getUuid(), $uuids);
+    }
+
+    public function testFindByWithWebspaceSecurityAndMixedPermissions(): void
+    {
+        // Create pages with mixed permissions
+        $allowed1 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 1');
+        $allowed2 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 2');
+        $denied1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 1');
+        $denied2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 2');
+        $denied3 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 3');
+
+        // Set permissions
+        $this->grantViewAccessToPage($allowed1, $this->anonymousRole);
+        $this->grantViewAccessToPage($allowed2, $this->anonymousRole);
+        $this->denyAccessToPage($denied1, $this->anonymousRole);
+        $this->denyAccessToPage($denied2, $this->anonymousRole);
+        $this->denyAccessToPage($denied3, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Query pages
+        $result = $this->provider->findFlatBy(
+            $this->createFilters('sulu-test-secure', 'en'),
+            []
+        );
+
+        // Only allowed pages should be returned
+        $this->assertCount(2, \array_filter($result, function($item) use ($allowed1, $allowed2) {
+            return \in_array($item['id'], [$allowed1->getUuid(), $allowed2->getUuid()]);
+        }));
+
+        $uuids = \array_column($result, 'id');
+        $this->assertContains($allowed1->getUuid(), $uuids);
+        $this->assertContains($allowed2->getUuid(), $uuids);
+        $this->assertNotContains($denied1->getUuid(), $uuids);
+        $this->assertNotContains($denied2->getUuid(), $uuids);
+        $this->assertNotContains($denied3->getUuid(), $uuids);
+    }
+
+    public function testCountByWithWebspaceSecurityRespectsPermissions(): void
+    {
+        // Create pages
+        $allowed1 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 1');
+        $allowed2 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 2');
+        $denied1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 1');
+        $denied2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 2');
+
+        // Set permissions
+        $this->grantViewAccessToPage($allowed1, $this->anonymousRole);
+        $this->grantViewAccessToPage($allowed2, $this->anonymousRole);
+        $this->denyAccessToPage($denied1, $this->anonymousRole);
+        $this->denyAccessToPage($denied2, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Count pages
+        $count = $this->provider->countBy(
+            $this->createFilters('sulu-test-secure', 'en')
+        );
+
+        // Should count only accessible pages (homepage + 2 allowed pages)
+        $this->assertGreaterThanOrEqual(2, $count);
+    }
+
+    public function testFindByRespectsWebspaceSecurityFlagPerWebspace(): void
+    {
+        // Create same page in both webspaces
+        $securePageAllowed = $this->createSimplePage('sulu-test-secure', 'en', 'Secure Allowed');
+        $securePageDenied = $this->createSimplePage('sulu-test-secure', 'en', 'Secure Denied');
+        $normalPage = $this->createSimplePage('sulu-io', 'en', 'Normal Page');
+
+        // Set permissions
+        $this->grantViewAccessToPage($securePageAllowed, $this->anonymousRole);
+        $this->denyAccessToPage($securePageDenied, $this->anonymousRole);
+        $this->denyAccessToPage($normalPage, $this->anonymousRole); // Should have no effect
+
+        $this->entityManager->clear();
+
+        // Query secure webspace - should filter
+        $secureResult = $this->provider->findFlatBy(
+            $this->createFilters('sulu-test-secure', 'en'),
+            []
+        );
+
+        $secureUuids = \array_column($secureResult, 'id');
+        $this->assertContains($securePageAllowed->getUuid(), $secureUuids);
+        $this->assertNotContains($securePageDenied->getUuid(), $secureUuids);
+
+        // Query normal webspace - should NOT filter
+        $normalResult = $this->provider->findFlatBy(
+            $this->createFilters('sulu-io', 'en'),
+            []
+        );
+
+        $normalUuids = \array_column($normalResult, 'id');
+        $this->assertContains($normalPage->getUuid(), $normalUuids); // Should be included despite denied permission
+    }
+
+    public function testFindByWithPageWithoutAccessControlEntryUsesWebspacePermissions(): void
+    {
+        // Create page WITHOUT setting any access control
+        $pageWithoutAcl = $this->createSimplePage('sulu-test-secure', 'en', 'Page Without ACL');
+
+        // Don't call setPagePermissions - no AccessControl entry
+
+        $this->entityManager->clear();
+
+        // Query pages
+        $result = $this->provider->findFlatBy(
+            $this->createFilters('sulu-test-secure', 'en'),
+            []
+        );
+
+        // Page should be visible (anonymous role has webspace-level permissions)
+        $uuids = \array_column($result, 'id');
+        $this->assertContains($pageWithoutAcl->getUuid(), $uuids);
+    }
+
+    /**
+     * Helper to create a simple page with live content.
+     */
+    private function createSimplePage(string $webspaceKey, string $locale, string $title, string $template = 'default'): Page
+    {
+        // Generate URL from title (convert to lowercase, replace spaces with dashes)
+        $url = '/' . \strtolower(\str_replace(' ', '-', $title));
+
+        // Determine which homepage to use based on webspace
+        $homepage = 'sulu-io' === $webspaceKey ? $this->homepageNonSecure : $this->homepageSecure;
+
+        return $this->createPage([
+            $locale => [
+                'live' => [
+                    'template' => $template,
+                    'title' => $title,
+                    'url' => $url,
+                    'parentId' => $homepage->getUuid(),
+                ],
+            ],
+        ], $webspaceKey);
+    }
+
+    /**
+     * @param array<string, mixed> $additionalFilters
+     *
+     * @return array{categories: array<int>, categoryOperator: 'AND'|'OR', websiteCategories: array<string>, websiteCategoryOperator: 'AND'|'OR', tags: array<string>, tagOperator: 'AND'|'OR', websiteTags: array<string>, websiteTagOperator: 'AND'|'OR', types: array<string>, typesOperator: 'OR', locale: string, dataSource: string|null, limit: int|null, offset: int, includeSubFolders: bool, excludeDuplicates: bool, webspaceKey: string, stage: string}
+     */
+    private function createFilters(string $webspaceKey, string $locale, array $additionalFilters = []): array
+    {
+        // Determine which homepage to use based on webspace
+        $homepage = 'sulu-io' === $webspaceKey ? $this->homepageNonSecure : $this->homepageSecure;
+
+        /** @var array{categories: array<int>, categoryOperator: 'AND'|'OR', websiteCategories: array<string>, websiteCategoryOperator: 'AND'|'OR', tags: array<string>, tagOperator: 'AND'|'OR', websiteTags: array<string>, websiteTagOperator: 'AND'|'OR', types: array<string>, typesOperator: 'OR', locale: string, dataSource: string|null, limit: int|null, offset: int, includeSubFolders: bool, excludeDuplicates: bool, webspaceKey: string, stage: string} */
+        return \array_merge([
+            'locale' => $locale,
+            'webspaceKey' => $webspaceKey,
+            'dataSource' => $homepage->getUuid(),
+            'includeSubFolders' => true,
+            'categories' => [],
+            'categoryOperator' => 'OR',
+            'websiteCategories' => [],
+            'websiteCategoryOperator' => 'OR',
+            'tags' => [],
+            'tagOperator' => 'OR',
+            'websiteTags' => [],
+            'websiteTagOperator' => 'OR',
+            'types' => [],
+            'typesOperator' => 'OR',
+            'limit' => null,
+            'offset' => 0,
+            'excludeDuplicates' => false,
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+        ], $additionalFilters);
+    }
+}

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverPermissionTest.php
@@ -60,7 +60,7 @@ class PageSelectionPropertyResolverPermissionTest extends SuluTestCase
         ], 'sulu-test-secure');
     }
 
-    public function testPageRepositoryWithoutPermissionConfigReturnsAllPages(): void
+    public function testPageRepositoryWithoutaccessControlReturnsAllPages(): void
     {
         $page1 = $this->createSimplePage('sulu-io', 'en', 'Page 1');
         $page2 = $this->createSimplePage('sulu-io', 'en', 'Page 2');
@@ -76,7 +76,7 @@ class PageSelectionPropertyResolverPermissionTest extends SuluTestCase
         $this->assertCount(3, $result);
     }
 
-    public function testPageRepositoryWithPermissionConfigFiltersPagesWithoutPermissions(): void
+    public function testPageRepositoryWithaccessControlFiltersPagesWithoutPermissions(): void
     {
         $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
         $deniedPage1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 1');
@@ -191,7 +191,7 @@ class PageSelectionPropertyResolverPermissionTest extends SuluTestCase
      *     uuids: string[],
      *     locale: string,
      *     stage: string,
-     *     permissionConfig: array{user: null, permission: int},
+     *     accessControl: array{user: null, permission: int},
      * }
      */
     private function createFiltersWithPermissions(array $uuids, int $permission = 64, string $locale = 'en', string $stage = 'live'): array
@@ -200,7 +200,7 @@ class PageSelectionPropertyResolverPermissionTest extends SuluTestCase
             'uuids' => $uuids,
             'locale' => $locale,
             'stage' => $stage,
-            'permissionConfig' => [
+            'accessControl' => [
                 'user' => null,
                 'permission' => $permission,
             ],

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverPermissionTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
+
+class PageSelectionPropertyResolverPermissionTest extends SuluTestCase
+{
+    use CreatePageTrait;
+    use CreatePageWithPermissionsTrait;
+
+    private EntityManagerInterface $entityManager;
+    private PageRepositoryInterface $pageRepository;
+    private Role $anonymousRole;
+    private Page $homepageNonSecure;
+    private Page $homepageSecure;
+
+    protected function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->entityManager = $this->getEntityManager();
+        $this->pageRepository = $this->getContainer()->get('sulu_page.page_repository');
+        $this->anonymousRole = $this->createAnonymousRoleWithWebspacePermissions('sulu-test-secure');
+
+        $this->homepageNonSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-io');
+
+        $this->homepageSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-test-secure');
+    }
+
+    public function testPageRepositoryWithoutPermissionConfigReturnsAllPages(): void
+    {
+        $page1 = $this->createSimplePage('sulu-io', 'en', 'Page 1');
+        $page2 = $this->createSimplePage('sulu-io', 'en', 'Page 2');
+        $page3 = $this->createSimplePage('sulu-io', 'en', 'Page 3');
+
+        $this->denyAccessToPage($page2, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $filters = $this->createFilters([$page1->getUuid(), $page2->getUuid(), $page3->getUuid()]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(3, $result);
+    }
+
+    public function testPageRepositoryWithPermissionConfigFiltersPagesWithoutPermissions(): void
+    {
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+        $deniedPage1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 1');
+        $deniedPage2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 2');
+
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage1, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage2, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $filters = $this->createFiltersWithPermissions([$allowedPage->getUuid(), $deniedPage1->getUuid(), $deniedPage2->getUuid()]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(1, $result);
+        $uuids = \array_map(fn ($page) => $page->getUuid(), $result);
+        $this->assertContains($allowedPage->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage1->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage2->getUuid(), $uuids);
+    }
+
+    public function testPageRepositoryWithMixedPermissions(): void
+    {
+        $allowed1 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 1');
+        $allowed2 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 2');
+        $denied1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 1');
+        $denied2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 2');
+
+        $this->grantViewAccessToPage($allowed1, $this->anonymousRole);
+        $this->grantViewAccessToPage($allowed2, $this->anonymousRole);
+        $this->denyAccessToPage($denied1, $this->anonymousRole);
+        $this->denyAccessToPage($denied2, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $filters = $this->createFiltersWithPermissions([
+            $allowed1->getUuid(),
+            $allowed2->getUuid(),
+            $denied1->getUuid(),
+            $denied2->getUuid(),
+        ]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(2, $result);
+        $uuids = \array_map(fn ($page) => $page->getUuid(), $result);
+        $this->assertContains($allowed1->getUuid(), $uuids);
+        $this->assertContains($allowed2->getUuid(), $uuids);
+        $this->assertNotContains($denied1->getUuid(), $uuids);
+        $this->assertNotContains($denied2->getUuid(), $uuids);
+    }
+
+    public function testPageRepositoryWithPageWithoutAccessControlEntryUsesWebspacePermissions(): void
+    {
+        $pageWithoutAcl = $this->createSimplePage('sulu-test-secure', 'en', 'Page Without ACL');
+        $this->entityManager->clear();
+
+        $filters = $this->createFiltersWithPermissions([$pageWithoutAcl->getUuid()]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(1, $result);
+        $this->assertSame($pageWithoutAcl->getUuid(), $result[0]->getUuid());
+    }
+
+    public function testPageRepositoryWithEmptySelection(): void
+    {
+        $filters = $this->createFiltersWithPermissions([]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(0, $result);
+    }
+
+    public function testPageRepositoryWithAllDeniedPages(): void
+    {
+        $denied1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 1');
+        $denied2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 2');
+
+        $this->denyAccessToPage($denied1, $this->anonymousRole);
+        $this->denyAccessToPage($denied2, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $filters = $this->createFiltersWithPermissions([$denied1->getUuid(), $denied2->getUuid()]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(0, $result);
+    }
+
+    /**
+     * @param string[] $uuids
+     *
+     * @return array{
+     *     uuids: string[],
+     *     locale: string,
+     *     stage: string,
+     * }
+     */
+    private function createFilters(array $uuids, string $locale = 'en', string $stage = 'live'): array
+    {
+        return [
+            'uuids' => $uuids,
+            'locale' => $locale,
+            'stage' => $stage,
+        ];
+    }
+
+    /**
+     * @param string[] $uuids
+     *
+     * @return array{
+     *     uuids: string[],
+     *     locale: string,
+     *     stage: string,
+     *     permissionConfig: array{user: null, permission: int},
+     * }
+     */
+    private function createFiltersWithPermissions(array $uuids, int $permission = 64, string $locale = 'en', string $stage = 'live'): array
+    {
+        return [
+            'uuids' => $uuids,
+            'locale' => $locale,
+            'stage' => $stage,
+            'permissionConfig' => [
+                'user' => null,
+                'permission' => $permission,
+            ],
+        ];
+    }
+
+    private function createSimplePage(string $webspaceKey, string $locale, string $title, string $template = 'default'): Page
+    {
+        $url = '/' . \strtolower(\str_replace(' ', '-', $title));
+        $homepage = 'sulu-io' === $webspaceKey ? $this->homepageNonSecure : $this->homepageSecure;
+
+        return $this->createPage([
+            $locale => [
+                'live' => [
+                    'template' => $template,
+                    'title' => $title,
+                    'url' => $url,
+                    'parentId' => $homepage->getUuid(),
+                ],
+            ],
+        ], $webspaceKey);
+    }
+}

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverPermissionTest.php
@@ -60,7 +60,7 @@ class SinglePageSelectionPropertyResolverPermissionTest extends SuluTestCase
         ], 'sulu-test-secure');
     }
 
-    public function testPageRepositoryWithoutPermissionConfigReturnsPage(): void
+    public function testPageRepositoryWithoutaccessControlReturnsPage(): void
     {
         $page = $this->createSimplePage('sulu-io', 'en', 'Page 1');
 
@@ -75,7 +75,7 @@ class SinglePageSelectionPropertyResolverPermissionTest extends SuluTestCase
         $this->assertSame($page->getUuid(), $result[0]->getUuid());
     }
 
-    public function testPageRepositoryWithPermissionConfigFiltersPageWithoutPermission(): void
+    public function testPageRepositoryWithaccessControlFiltersPageWithoutPermission(): void
     {
         $deniedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page');
 
@@ -89,7 +89,7 @@ class SinglePageSelectionPropertyResolverPermissionTest extends SuluTestCase
         $this->assertCount(0, $result);
     }
 
-    public function testPageRepositoryWithPermissionConfigReturnsAllowedPage(): void
+    public function testPageRepositoryWithaccessControlReturnsAllowedPage(): void
     {
         $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
 
@@ -174,7 +174,7 @@ class SinglePageSelectionPropertyResolverPermissionTest extends SuluTestCase
      *     uuids: string[],
      *     locale: string,
      *     stage: string,
-     *     permissionConfig: array{user: null, permission: int},
+     *     accessControl: array{user: null, permission: int},
      * }
      */
     private function createFiltersWithPermissions(array $uuids, int $permission = 64, string $locale = 'en', string $stage = 'live'): array
@@ -183,7 +183,7 @@ class SinglePageSelectionPropertyResolverPermissionTest extends SuluTestCase
             'uuids' => $uuids,
             'locale' => $locale,
             'stage' => $stage,
-            'permissionConfig' => [
+            'accessControl' => [
                 'user' => null,
                 'permission' => $permission,
             ],

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverPermissionTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Content\PropertyResolver;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
+
+class SinglePageSelectionPropertyResolverPermissionTest extends SuluTestCase
+{
+    use CreatePageTrait;
+    use CreatePageWithPermissionsTrait;
+
+    private EntityManagerInterface $entityManager;
+    private PageRepositoryInterface $pageRepository;
+    private Role $anonymousRole;
+    private Page $homepageNonSecure;
+    private Page $homepageSecure;
+
+    protected function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->entityManager = $this->getEntityManager();
+        $this->pageRepository = $this->getContainer()->get('sulu_page.page_repository');
+        $this->anonymousRole = $this->createAnonymousRoleWithWebspacePermissions('sulu-test-secure');
+
+        $this->homepageNonSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-io');
+
+        $this->homepageSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-test-secure');
+    }
+
+    public function testPageRepositoryWithoutPermissionConfigReturnsPage(): void
+    {
+        $page = $this->createSimplePage('sulu-io', 'en', 'Page 1');
+
+        $this->denyAccessToPage($page, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $filters = $this->createFilters([$page->getUuid()]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(1, $result);
+        $this->assertSame($page->getUuid(), $result[0]->getUuid());
+    }
+
+    public function testPageRepositoryWithPermissionConfigFiltersPageWithoutPermission(): void
+    {
+        $deniedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page');
+
+        $this->denyAccessToPage($deniedPage, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $filters = $this->createFiltersWithPermissions([$deniedPage->getUuid()]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(0, $result);
+    }
+
+    public function testPageRepositoryWithPermissionConfigReturnsAllowedPage(): void
+    {
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $filters = $this->createFiltersWithPermissions([$allowedPage->getUuid()]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(1, $result);
+        $this->assertSame($allowedPage->getUuid(), $result[0]->getUuid());
+    }
+
+    public function testPageRepositoryWithPageWithoutAccessControlEntryUsesWebspacePermissions(): void
+    {
+        $pageWithoutAcl = $this->createSimplePage('sulu-test-secure', 'en', 'Page Without ACL');
+        $this->entityManager->clear();
+
+        $filters = $this->createFiltersWithPermissions([$pageWithoutAcl->getUuid()]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(1, $result);
+        $this->assertSame($pageWithoutAcl->getUuid(), $result[0]->getUuid());
+    }
+
+    public function testPageRepositoryRespectsWebspaceSecurityFlagPerWebspace(): void
+    {
+        $securePageDenied = $this->createSimplePage('sulu-test-secure', 'en', 'Secure Denied');
+        $normalPageDenied = $this->createSimplePage('sulu-io', 'en', 'Normal Denied');
+
+        $this->denyAccessToPage($securePageDenied, $this->anonymousRole);
+        $this->denyAccessToPage($normalPageDenied, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $secureFilters = $this->createFiltersWithPermissions([$securePageDenied->getUuid()]);
+
+        $secureResult = \iterator_to_array($this->pageRepository->findBy($secureFilters));
+
+        $this->assertCount(0, $secureResult);
+
+        $normalFilters = $this->createFilters([$normalPageDenied->getUuid()]);
+
+        $normalResult = \iterator_to_array($this->pageRepository->findBy($normalFilters));
+
+        $this->assertCount(1, $normalResult);
+        $this->assertSame($normalPageDenied->getUuid(), $normalResult[0]->getUuid());
+    }
+
+    public function testPageRepositoryWithEmptySelectionReturnsEmptyArray(): void
+    {
+        $filters = $this->createFiltersWithPermissions([]);
+
+        $result = \iterator_to_array($this->pageRepository->findBy($filters));
+
+        $this->assertCount(0, $result);
+    }
+
+    /**
+     * @param string[] $uuids
+     *
+     * @return array{
+     *     uuids: string[],
+     *     locale: string,
+     *     stage: string,
+     * }
+     */
+    private function createFilters(array $uuids, string $locale = 'en', string $stage = 'live'): array
+    {
+        return [
+            'uuids' => $uuids,
+            'locale' => $locale,
+            'stage' => $stage,
+        ];
+    }
+
+    /**
+     * @param string[] $uuids
+     *
+     * @return array{
+     *     uuids: string[],
+     *     locale: string,
+     *     stage: string,
+     *     permissionConfig: array{user: null, permission: int},
+     * }
+     */
+    private function createFiltersWithPermissions(array $uuids, int $permission = 64, string $locale = 'en', string $stage = 'live'): array
+    {
+        return [
+            'uuids' => $uuids,
+            'locale' => $locale,
+            'stage' => $stage,
+            'permissionConfig' => [
+                'user' => null,
+                'permission' => $permission,
+            ],
+        ];
+    }
+
+    private function createSimplePage(string $webspaceKey, string $locale, string $title, string $template = 'default'): Page
+    {
+        $url = '/' . \strtolower(\str_replace(' ', '-', $title));
+        $homepage = 'sulu-io' === $webspaceKey ? $this->homepageNonSecure : $this->homepageSecure;
+
+        return $this->createPage([
+            $locale => [
+                'live' => [
+                    'template' => $template,
+                    'title' => $title,
+                    'url' => $url,
+                    'parentId' => $homepage->getUuid(),
+                ],
+            ],
+        ], $webspaceKey);
+    }
+}

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Sitemap/PagesSitemapProviderPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Sitemap/PagesSitemapProviderPermissionTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Sitemap;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Infrastructure\Sulu\Sitemap\PagesSitemapProvider;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
+
+class PagesSitemapProviderPermissionTest extends SuluTestCase
+{
+    use CreatePageTrait;
+    use CreatePageWithPermissionsTrait;
+
+    private EntityManagerInterface $entityManager;
+    private PagesSitemapProvider $provider;
+    private Role $anonymousRole;
+    private Page $homepageNonSecure;
+    private Page $homepageSecure;
+
+    protected function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->entityManager = $this->getEntityManager();
+
+        $this->provider = $this->getContainer()->get('sulu_page.pages_sitemap_provider');
+        $this->anonymousRole = $this->createAnonymousRoleWithWebspacePermissions('sulu-test-secure');
+
+        // Create homepages for both webspaces
+        $this->homepageNonSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-io');
+
+        $this->homepageSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ], 'sulu-test-secure');
+    }
+
+    public function testBuildWithoutWebspaceSecurityShowsAllPages(): void
+    {
+        // Create pages in webspace WITHOUT security
+        $page1 = $this->createSimplePage('sulu-io', 'en', 'Page 1');
+        $page2 = $this->createSimplePage('sulu-io', 'en', 'Page 2');
+        $page3 = $this->createSimplePage('sulu-io', 'en', 'Page 3');
+
+        // Deny access to one page (should have no effect without webspace security)
+        $this->denyAccessToPage($page2, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Build sitemap
+        $result = $this->provider->build(1, 'http', 'sulu.io');
+
+        // All pages should be in sitemap (webspace doesn't have security)
+        $this->assertGreaterThanOrEqual(3, \count($result));
+    }
+
+    public function testBuildWithWebspaceSecurityFiltersPages(): void
+    {
+        // Create pages in secure webspace
+        $allowedPage1 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page 1');
+        $allowedPage2 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page 2');
+        $deniedPage1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 1');
+        $deniedPage2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 2');
+        $deniedPage3 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 3');
+
+        // Set permissions
+        $this->grantViewAccessToPage($allowedPage1, $this->anonymousRole);
+        $this->grantViewAccessToPage($allowedPage2, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage1, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage2, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage3, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Build sitemap
+        $result = $this->provider->build(1, 'http', 'sulu-secure.io');
+
+        // Only allowed pages should be in sitemap
+        $urls = \array_map(fn ($sitemapUrl) => $sitemapUrl->getLoc(), $result);
+
+        // Filter to only pages we created (exclude homepage which might exist)
+        $pageUrls = \array_filter($urls, function($url) {
+            return \str_contains($url, 'allowed') || \str_contains($url, 'denied');
+        });
+
+        // Should have 2 allowed pages
+        $allowedUrls = \array_filter($pageUrls, fn ($url) => \str_contains($url, 'allowed'));
+        $this->assertCount(2, $allowedUrls);
+
+        // Should NOT have denied pages
+        $deniedUrls = \array_filter($pageUrls, fn ($url) => \str_contains($url, 'denied'));
+        $this->assertCount(0, $deniedUrls);
+    }
+
+    public function testBuildWithWebspaceSecurityFiltersAlternateRoutes(): void
+    {
+        // Create page with English locale
+        $pageEn = $this->createSimplePage('sulu-test-secure', 'en', 'Test Page EN');
+
+        // Add German translation - note: we're creating a NEW page here, not modifying pageEn
+        // In a real scenario you'd want to modify the same page, but for this test we'll create separate
+        $pageDe = $this->createPage([
+            'de' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Test Page DE',
+                    'url' => '/test-page-de',
+                    'parentId' => $this->homepageSecure->getUuid(),
+                ],
+            ],
+        ], 'sulu-test-secure');
+
+        // Grant VIEW access to page (permissions are per page, not per locale)
+        $this->grantViewAccessToPage($pageEn, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Build sitemap
+        $result = $this->provider->build(1, 'http', 'sulu-secure.io');
+
+        // Find sitemap entry for our page
+        $testPageEntries = \array_filter($result, function($sitemapUrl) {
+            return \str_contains($sitemapUrl->getLoc(), 'test-page');
+        });
+
+        $this->assertGreaterThan(0, \count($testPageEntries));
+
+        // Check that alternate links include German version
+        foreach ($testPageEntries as $entry) {
+            $alternateLinks = $entry->getAlternateLinks();
+            if (\count($alternateLinks) > 0) {
+                $locales = \array_map(fn ($link) => $link->getLocale(), $alternateLinks);
+                // If page is accessible, both locales should be in alternate links
+                $this->assertTrue(\in_array('de', $locales) || \in_array('en', $locales));
+            }
+        }
+    }
+
+    public function testBuildRespectsPageLevelAndWebspaceLevelPermissions(): void
+    {
+        // Create pages
+        $pageWithWebspacePermission = $this->createSimplePage('sulu-test-secure', 'en', 'Page With Webspace Permission');
+        $pageWithDeniedPermission = $this->createSimplePage('sulu-test-secure', 'en', 'Page With Denied Permission');
+
+        // Anonymous role has webspace-level VIEW permission (from setUp)
+        // Grant access to first page
+        $this->grantViewAccessToPage($pageWithWebspacePermission, $this->anonymousRole);
+
+        // Explicitly deny access to second page (object-level deny overrides webspace permission)
+        $this->denyAccessToPage($pageWithDeniedPermission, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Build sitemap
+        $result = $this->provider->build(1, 'http', 'sulu-secure.io');
+
+        $urls = \array_map(fn ($sitemapUrl) => $sitemapUrl->getLoc(), $result);
+
+        // Page with explicit VIEW permission should be included
+        $allowedUrls = \array_filter($urls, fn ($url) => \str_contains($url, 'with-webspace-permission'));
+        $this->assertGreaterThan(0, \count($allowedUrls));
+
+        // Page with explicit DENY should be excluded
+        $deniedUrls = \array_filter($urls, fn ($url) => \str_contains($url, 'with-denied-permission'));
+        $this->assertCount(0, $deniedUrls);
+    }
+
+    public function testBuildExcludesPagesWithSeoHideInSitemap(): void
+    {
+        // Create page with seoHideInSitemap
+        $hiddenPage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Hidden Page',
+                    'url' => '/hidden-page',
+                    'seoHideInSitemap' => true,
+                    'parentId' => $this->homepageSecure->getUuid(),
+                ],
+            ],
+        ], 'sulu-test-secure');
+
+        $visiblePage = $this->createSimplePage('sulu-test-secure', 'en', 'Visible Page');
+
+        // Grant permissions to both
+        $this->grantViewAccessToPage($hiddenPage, $this->anonymousRole);
+        $this->grantViewAccessToPage($visiblePage, $this->anonymousRole);
+
+        $this->entityManager->clear();
+
+        // Build sitemap
+        $result = $this->provider->build(1, 'http', 'sulu-secure.io');
+
+        $urls = \array_map(fn ($sitemapUrl) => $sitemapUrl->getLoc(), $result);
+
+        // Hidden page should NOT be in sitemap (seoHideInSitemap takes precedence)
+        $hiddenUrls = \array_filter($urls, fn ($url) => \str_contains($url, 'hidden-page'));
+        $this->assertCount(0, $hiddenUrls);
+
+        // Visible page should be in sitemap
+        $visibleUrls = \array_filter($urls, fn ($url) => \str_contains($url, 'visible-page'));
+        $this->assertGreaterThan(0, \count($visibleUrls));
+    }
+
+    /**
+     * Helper to create a simple page with live content.
+     */
+    private function createSimplePage(string $webspaceKey, string $locale, string $title, string $template = 'default'): Page
+    {
+        // Generate URL from title (convert to lowercase, replace spaces with dashes)
+        $url = '/' . \strtolower(\str_replace(' ', '-', $title));
+
+        // Determine which homepage to use based on webspace
+        $homepage = 'sulu-io' === $webspaceKey ? $this->homepageNonSecure : $this->homepageSecure;
+
+        return $this->createPage([
+            $locale => [
+                'live' => [
+                    'template' => $template,
+                    'title' => $title,
+                    'url' => $url,
+                    'parentId' => $homepage->getUuid(),
+                ],
+            ],
+        ], $webspaceKey);
+    }
+}

--- a/packages/page/tests/Traits/CreatePageWithPermissionsTrait.php
+++ b/packages/page/tests/Traits/CreatePageWithPermissionsTrait.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Traits;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
+use Sulu\Bundle\SecurityBundle\Entity\Permission;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Page\Domain\Model\PageInterface;
+
+trait CreatePageWithPermissionsTrait
+{
+    abstract protected static function getEntityManager(): EntityManagerInterface;
+
+    protected function createAnonymousRoleWithWebspacePermissions(string $webspaceKey = 'sulu-test-secure'): Role
+    {
+        $role = new Role();
+        $role->setName('Anonymous User Website');
+        $role->setSystem($webspaceKey);
+        $role->setAnonymous(true);
+
+        $permission = new Permission();
+        $permission->setRole($role);
+        $permission->setPermissions(127); // All permissions at webspace level
+        $permission->setContext(\sprintf('sulu.webspaces.%s', $webspaceKey));
+        $role->addPermission($permission);
+
+        self::getEntityManager()->persist($role);
+        self::getEntityManager()->persist($permission);
+        self::getEntityManager()->flush();
+
+        return $role;
+    }
+
+    protected function setPagePermissions(PageInterface $page, Role $role, int $permissions): void
+    {
+        $accessControl = new AccessControl();
+        $accessControl->setPermissions($permissions);
+        $accessControl->setEntityId($page->getUuid());
+        $accessControl->setEntityClass(PageInterface::class);
+        $accessControl->setRole($role);
+
+        self::getEntityManager()->persist($accessControl);
+        self::getEntityManager()->flush();
+    }
+
+    protected function denyAccessToPage(PageInterface $page, Role $role): void
+    {
+        $this->setPagePermissions($page, $role, 0);
+    }
+
+    protected function grantViewAccessToPage(PageInterface $page, Role $role): void
+    {
+        $this->setPagePermissions($page, $role, 64); // VIEW permission
+    }
+
+    protected function grantAllAccessToPage(PageInterface $page, Role $role): void
+    {
+        $this->setPagePermissions($page, $role, 127); // All permissions
+    }
+}

--- a/packages/page/tests/Traits/CreatePageWithPermissionsTrait.php
+++ b/packages/page/tests/Traits/CreatePageWithPermissionsTrait.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageInterface;
 
 trait CreatePageWithPermissionsTrait
@@ -48,7 +49,7 @@ trait CreatePageWithPermissionsTrait
         $accessControl = new AccessControl();
         $accessControl->setPermissions($permissions);
         $accessControl->setEntityId($page->getUuid());
-        $accessControl->setEntityClass(PageInterface::class);
+        $accessControl->setEntityClass(Page::class);
         $accessControl->setRole($role);
 
         self::getEntityManager()->persist($accessControl);

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -14,19 +16,41 @@ namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolv
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Security as WebspaceSecurity;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionPropertyResolver;
+use Symfony\Bundle\SecurityBundle\Security;
 
 #[CoversClass(PageSelectionPropertyResolver::class)]
 class PageSelectionPropertyResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     private PageSelectionPropertyResolver $resolver;
+    /**
+     * @var ObjectProphecy<RequestAnalyzerInterface>
+     */
+    private ObjectProphecy $requestAnalyzer;
 
     public function setUp(): void
     {
-        $this->resolver = new PageSelectionPropertyResolver();
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->requestAnalyzer->getWebspace()->willReturn(null);
+
+        $this->resolver = new PageSelectionPropertyResolver(
+            null,
+            null,
+            $this->requestAnalyzer->reveal()
+        );
     }
 
     public function testResolveEmpty(): void
@@ -145,6 +169,10 @@ class PageSelectionPropertyResolverTest extends TestCase
                 'property1' => 'value1',
                 'property2' => 'value2',
             ],
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();
@@ -163,6 +191,10 @@ class PageSelectionPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'properties' => null,
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();
@@ -183,11 +215,136 @@ class PageSelectionPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'properties' => null,
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();
         $this->assertCount(1, $references);
         $this->assertSame('1', $references[0]->getResourceId());
         $this->assertSame(PageInterface::RESOURCE_KEY, $references[0]->getResourceKey());
+    }
+
+    public function testResolveWithSecureWebspaceAndAuthenticatedUser(): void
+    {
+        $webspace = new Webspace();
+        $webspaceSecurity = new WebspaceSecurity();
+        $webspaceSecurity->setSystem('website');
+        $webspaceSecurity->setPermissionCheck(true);
+        $webspace->setSecurity($webspaceSecurity);
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $resolver = new PageSelectionPropertyResolver(
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $contentView = $resolver->resolve(['1'], 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $this->assertSame([
+            'properties' => null,
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => $user->reveal(),
+                    'permission' => 64,
+                ],
+            ],
+        ], $content[0]->getMetadata());
+    }
+
+    public function testResolveWithNonSecureWebspace(): void
+    {
+        $webspace = new Webspace();
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $resolver = new PageSelectionPropertyResolver(
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $contentView = $resolver->resolve(['1'], 'en');
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $metadata = $content[0]->getMetadata();
+        $this->assertIsArray($metadata);
+        $this->assertArrayHasKey('filters', $metadata);
+        $filters = $metadata['filters'];
+        $this->assertIsArray($filters);
+        $this->assertArrayNotHasKey('permissionConfig', $filters);
+    }
+
+    public function testResolvePermissionConfigPreservesOtherMetadata(): void
+    {
+        $webspace = new Webspace();
+        $webspaceSecurity = new WebspaceSecurity();
+        $webspaceSecurity->setSystem('website');
+        $webspaceSecurity->setPermissionCheck(true);
+        $webspace->setSecurity($webspaceSecurity);
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $resolver = new PageSelectionPropertyResolver(
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $contentView = $resolver->resolve(['1'], 'en', [
+            'properties' => [
+                'property1' => 'value1',
+            ],
+        ]);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+
+        $metadata = $content[0]->getMetadata();
+        $this->assertSame([
+            'properties' => [
+                'property1' => 'value1',
+            ],
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => $user->reveal(),
+                    'permission' => 64,
+                ],
+            ],
+        ], $metadata);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
@@ -17,17 +17,10 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Component\Security\Authentication\UserInterface;
-use Sulu\Component\Security\Authorization\PermissionTypes;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Sulu\Component\Webspace\Security as WebspaceSecurity;
-use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionPropertyResolver;
-use Symfony\Bundle\SecurityBundle\Security;
 
 #[CoversClass(PageSelectionPropertyResolver::class)]
 class PageSelectionPropertyResolverTest extends TestCase
@@ -35,22 +28,10 @@ class PageSelectionPropertyResolverTest extends TestCase
     use ProphecyTrait;
 
     private PageSelectionPropertyResolver $resolver;
-    /**
-     * @var ObjectProphecy<RequestAnalyzerInterface>
-     */
-    private ObjectProphecy $requestAnalyzer;
 
     public function setUp(): void
     {
-        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-
-        $this->requestAnalyzer->getWebspace()->willReturn(null);
-
-        $this->resolver = new PageSelectionPropertyResolver(
-            null,
-            null,
-            $this->requestAnalyzer->reveal()
-        );
+        $this->resolver = new PageSelectionPropertyResolver();
     }
 
     public function testResolveEmpty(): void
@@ -225,126 +206,5 @@ class PageSelectionPropertyResolverTest extends TestCase
         $this->assertCount(1, $references);
         $this->assertSame('1', $references[0]->getResourceId());
         $this->assertSame(PageInterface::RESOURCE_KEY, $references[0]->getResourceKey());
-    }
-
-    public function testResolveWithSecureWebspaceAndAuthenticatedUser(): void
-    {
-        $webspace = new Webspace();
-        $webspaceSecurity = new WebspaceSecurity();
-        $webspaceSecurity->setSystem('website');
-        $webspaceSecurity->setPermissionCheck(true);
-        $webspace->setSecurity($webspaceSecurity);
-
-        $user = $this->prophesize(UserInterface::class);
-
-        $security = $this->prophesize(Security::class);
-        $security->getUser()->willReturn($user->reveal());
-
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $resolver = new PageSelectionPropertyResolver(
-            $security->reveal(),
-            [PermissionTypes::VIEW => 64],
-            $requestAnalyzer->reveal()
-        );
-
-        $contentView = $resolver->resolve(['1'], 'en');
-
-        $content = $contentView->getContent();
-        $this->assertIsArray($content);
-        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
-
-        $this->assertSame([
-            'properties' => null,
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-                'permissionConfig' => [
-                    'user' => $user->reveal(),
-                    'permission' => 64,
-                ],
-            ],
-        ], $content[0]->getMetadata());
-    }
-
-    public function testResolveWithNonSecureWebspace(): void
-    {
-        $webspace = new Webspace();
-
-        $user = $this->prophesize(UserInterface::class);
-
-        $security = $this->prophesize(Security::class);
-        $security->getUser()->willReturn($user->reveal());
-
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $resolver = new PageSelectionPropertyResolver(
-            $security->reveal(),
-            [PermissionTypes::VIEW => 64],
-            $requestAnalyzer->reveal()
-        );
-
-        $contentView = $resolver->resolve(['1'], 'en');
-
-        $content = $contentView->getContent();
-        $this->assertIsArray($content);
-        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
-
-        $metadata = $content[0]->getMetadata();
-        $this->assertIsArray($metadata);
-        $this->assertArrayHasKey('filters', $metadata);
-        $filters = $metadata['filters'];
-        $this->assertIsArray($filters);
-        $this->assertArrayNotHasKey('permissionConfig', $filters);
-    }
-
-    public function testResolvePermissionConfigPreservesOtherMetadata(): void
-    {
-        $webspace = new Webspace();
-        $webspaceSecurity = new WebspaceSecurity();
-        $webspaceSecurity->setSystem('website');
-        $webspaceSecurity->setPermissionCheck(true);
-        $webspace->setSecurity($webspaceSecurity);
-
-        $user = $this->prophesize(UserInterface::class);
-
-        $security = $this->prophesize(Security::class);
-        $security->getUser()->willReturn($user->reveal());
-
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $resolver = new PageSelectionPropertyResolver(
-            $security->reveal(),
-            [PermissionTypes::VIEW => 64],
-            $requestAnalyzer->reveal()
-        );
-
-        $contentView = $resolver->resolve(['1'], 'en', [
-            'properties' => [
-                'property1' => 'value1',
-            ],
-        ]);
-
-        $content = $contentView->getContent();
-        $this->assertIsArray($content);
-        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
-
-        $metadata = $content[0]->getMetadata();
-        $this->assertSame([
-            'properties' => [
-                'property1' => 'value1',
-            ],
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-                'permissionConfig' => [
-                    'user' => $user->reveal(),
-                    'permission' => 64,
-                ],
-            ],
-        ], $metadata);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
@@ -150,10 +150,6 @@ class PageSelectionPropertyResolverTest extends TestCase
                 'property1' => 'value1',
                 'property2' => 'value2',
             ],
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();
@@ -172,10 +168,6 @@ class PageSelectionPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'properties' => null,
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();
@@ -196,10 +188,6 @@ class PageSelectionPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'properties' => null,
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
@@ -17,17 +17,10 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
-use Sulu\Component\Security\Authentication\UserInterface;
-use Sulu\Component\Security\Authorization\PermissionTypes;
-use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Sulu\Component\Webspace\Security as WebspaceSecurity;
-use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\SinglePageSelectionPropertyResolver;
-use Symfony\Bundle\SecurityBundle\Security;
 
 #[CoversClass(SinglePageSelectionPropertyResolver::class)]
 class SinglePageSelectionPropertyResolverTest extends TestCase
@@ -35,22 +28,10 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
     use ProphecyTrait;
 
     private SinglePageSelectionPropertyResolver $resolver;
-    /**
-     * @var ObjectProphecy<RequestAnalyzerInterface>
-     */
-    private ObjectProphecy $requestAnalyzer;
 
     public function setUp(): void
     {
-        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-
-        $this->requestAnalyzer->getWebspace()->willReturn(null);
-
-        $this->resolver = new SinglePageSelectionPropertyResolver(
-            null,
-            null,
-            $this->requestAnalyzer->reveal()
-        );
+        $this->resolver = new SinglePageSelectionPropertyResolver();
     }
 
     public function testResolveEmpty(): void
@@ -209,123 +190,5 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
         $this->assertCount(1, $references);
         $this->assertSame('1', $references[0]->getResourceId());
         $this->assertSame(PageInterface::RESOURCE_KEY, $references[0]->getResourceKey());
-    }
-
-    public function testResolveWithSecureWebspaceAndAuthenticatedUser(): void
-    {
-        $webspace = new Webspace();
-        $webspaceSecurity = new WebspaceSecurity();
-        $webspaceSecurity->setSystem('website');
-        $webspaceSecurity->setPermissionCheck(true);
-        $webspace->setSecurity($webspaceSecurity);
-
-        $user = $this->prophesize(UserInterface::class);
-
-        $security = $this->prophesize(Security::class);
-        $security->getUser()->willReturn($user->reveal());
-
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $resolver = new SinglePageSelectionPropertyResolver(
-            $security->reveal(),
-            [PermissionTypes::VIEW => 64],
-            $requestAnalyzer->reveal()
-        );
-
-        $contentView = $resolver->resolve('1', 'en');
-
-        $content = $contentView->getContent();
-        $this->assertInstanceOf(ResolvableResource::class, $content);
-
-        $this->assertSame([
-            'properties' => null,
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-                'permissionConfig' => [
-                    'user' => $user->reveal(),
-                    'permission' => 64,
-                ],
-            ],
-        ], $content->getMetadata());
-    }
-
-    public function testResolveWithNonSecureWebspace(): void
-    {
-        $webspace = new Webspace();
-
-        $user = $this->prophesize(UserInterface::class);
-
-        $security = $this->prophesize(Security::class);
-        $security->getUser()->willReturn($user->reveal());
-
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $resolver = new SinglePageSelectionPropertyResolver(
-            $security->reveal(),
-            [PermissionTypes::VIEW => 64],
-            $requestAnalyzer->reveal()
-        );
-
-        $contentView = $resolver->resolve('1', 'en');
-
-        $content = $contentView->getContent();
-        $this->assertInstanceOf(ResolvableResource::class, $content);
-
-        $metadata = $content->getMetadata();
-        $this->assertIsArray($metadata);
-        $this->assertArrayHasKey('filters', $metadata);
-        $filters = $metadata['filters'];
-        $this->assertIsArray($filters);
-        $this->assertArrayNotHasKey('permissionConfig', $filters);
-    }
-
-    public function testResolvePermissionConfigPreservesOtherMetadata(): void
-    {
-        $webspace = new Webspace();
-        $webspaceSecurity = new WebspaceSecurity();
-        $webspaceSecurity->setSystem('website');
-        $webspaceSecurity->setPermissionCheck(true);
-        $webspace->setSecurity($webspaceSecurity);
-
-        $user = $this->prophesize(UserInterface::class);
-
-        $security = $this->prophesize(Security::class);
-        $security->getUser()->willReturn($user->reveal());
-
-        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
-        $requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $resolver = new SinglePageSelectionPropertyResolver(
-            $security->reveal(),
-            [PermissionTypes::VIEW => 64],
-            $requestAnalyzer->reveal()
-        );
-
-        $contentView = $resolver->resolve('1', 'en', [
-            'properties' => [
-                'property1' => 'value1',
-            ],
-        ]);
-
-        $content = $contentView->getContent();
-        $this->assertInstanceOf(ResolvableResource::class, $content);
-
-        $metadata = $content->getMetadata();
-        $this->assertSame([
-            'properties' => [
-                'property1' => 'value1',
-            ],
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-                'permissionConfig' => [
-                    'user' => $user->reveal(),
-                    'permission' => 64,
-                ],
-            ],
-        ], $metadata);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -14,19 +16,41 @@ namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolv
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Security as WebspaceSecurity;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\SinglePageSelectionPropertyResolver;
+use Symfony\Bundle\SecurityBundle\Security;
 
 #[CoversClass(SinglePageSelectionPropertyResolver::class)]
 class SinglePageSelectionPropertyResolverTest extends TestCase
 {
+    use ProphecyTrait;
+
     private SinglePageSelectionPropertyResolver $resolver;
+    /**
+     * @var ObjectProphecy<RequestAnalyzerInterface>
+     */
+    private ObjectProphecy $requestAnalyzer;
 
     public function setUp(): void
     {
-        $this->resolver = new SinglePageSelectionPropertyResolver();
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->requestAnalyzer->getWebspace()->willReturn(null);
+
+        $this->resolver = new SinglePageSelectionPropertyResolver(
+            null,
+            null,
+            $this->requestAnalyzer->reveal()
+        );
     }
 
     public function testResolveEmpty(): void
@@ -131,6 +155,10 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
                 'property1' => 'value1',
                 'property2' => 'value2',
             ],
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();
@@ -148,6 +176,10 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'properties' => null,
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();
@@ -167,11 +199,133 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'properties' => null,
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();
         $this->assertCount(1, $references);
         $this->assertSame('1', $references[0]->getResourceId());
         $this->assertSame(PageInterface::RESOURCE_KEY, $references[0]->getResourceKey());
+    }
+
+    public function testResolveWithSecureWebspaceAndAuthenticatedUser(): void
+    {
+        $webspace = new Webspace();
+        $webspaceSecurity = new WebspaceSecurity();
+        $webspaceSecurity->setSystem('website');
+        $webspaceSecurity->setPermissionCheck(true);
+        $webspace->setSecurity($webspaceSecurity);
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $resolver = new SinglePageSelectionPropertyResolver(
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $contentView = $resolver->resolve('1', 'en');
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $this->assertSame([
+            'properties' => null,
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => $user->reveal(),
+                    'permission' => 64,
+                ],
+            ],
+        ], $content->getMetadata());
+    }
+
+    public function testResolveWithNonSecureWebspace(): void
+    {
+        $webspace = new Webspace();
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $resolver = new SinglePageSelectionPropertyResolver(
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $contentView = $resolver->resolve('1', 'en');
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $metadata = $content->getMetadata();
+        $this->assertIsArray($metadata);
+        $this->assertArrayHasKey('filters', $metadata);
+        $filters = $metadata['filters'];
+        $this->assertIsArray($filters);
+        $this->assertArrayNotHasKey('permissionConfig', $filters);
+    }
+
+    public function testResolvePermissionConfigPreservesOtherMetadata(): void
+    {
+        $webspace = new Webspace();
+        $webspaceSecurity = new WebspaceSecurity();
+        $webspaceSecurity->setSystem('website');
+        $webspaceSecurity->setPermissionCheck(true);
+        $webspace->setSecurity($webspaceSecurity);
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $resolver = new SinglePageSelectionPropertyResolver(
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $contentView = $resolver->resolve('1', 'en', [
+            'properties' => [
+                'property1' => 'value1',
+            ],
+        ]);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+
+        $metadata = $content->getMetadata();
+        $this->assertSame([
+            'properties' => [
+                'property1' => 'value1',
+            ],
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => $user->reveal(),
+                    'permission' => 64,
+                ],
+            ],
+        ], $metadata);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
@@ -136,10 +136,6 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
                 'property1' => 'value1',
                 'property2' => 'value2',
             ],
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();
@@ -157,10 +153,6 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'properties' => null,
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();
@@ -180,10 +172,6 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
 
         $this->assertSame([
             'properties' => null,
-            'filters' => [
-                'locale' => 'en',
-                'stage' => 'live',
-            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoaderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoaderTest.php
@@ -17,9 +17,14 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Security as WebspaceSecurity;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class PageResourceLoaderTest extends TestCase
 {
@@ -31,12 +36,26 @@ class PageResourceLoaderTest extends TestCase
      */
     private ObjectProphecy $pageRepository;
 
+    /**
+     * @var ObjectProphecy<RequestAnalyzerInterface>
+     */
+    private ObjectProphecy $requestAnalyzer;
+
     private PageResourceLoader $loader;
 
     public function setUp(): void
     {
         $this->pageRepository = $this->prophesize(PageRepositoryInterface::class);
-        $this->loader = new PageResourceLoader($this->pageRepository->reveal());
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->requestAnalyzer->getWebspace()->willReturn(null);
+
+        $this->loader = new PageResourceLoader(
+            $this->pageRepository->reveal(),
+            null,
+            null,
+            $this->requestAnalyzer->reveal()
+        );
     }
 
     public function testGetKey(): void
@@ -84,7 +103,7 @@ class PageResourceLoaderTest extends TestCase
         $this->assertSame(['123-123-123' => $page], $result);
     }
 
-    public function testLoadWithPermissionConfigInFilters(): void
+    public function testLoadWithaccessControlInFilters(): void
     {
         $page = $this->createPage('123-123-123');
         $user = $this->prophesize(UserInterface::class);
@@ -93,7 +112,7 @@ class PageResourceLoaderTest extends TestCase
             'uuids' => ['123-123-123'],
             'locale' => 'en',
             'stage' => 'live',
-            'permissionConfig' => [
+            'accessControl' => [
                 'user' => $user->reveal(),
                 'permission' => 64,
             ],
@@ -104,7 +123,7 @@ class PageResourceLoaderTest extends TestCase
             'filters' => [
                 'locale' => 'en',
                 'stage' => 'live',
-                'permissionConfig' => [
+                'accessControl' => [
                     'user' => $user->reveal(),
                     'permission' => 64,
                 ],
@@ -160,6 +179,140 @@ class PageResourceLoaderTest extends TestCase
 
         $result = $this->loader->load(['123-123-123'], 'en', [
             'filters' => 'invalid',
+        ]);
+
+        $this->assertSame(['123-123-123' => $page], $result);
+    }
+
+    public function testLoadWithSecureWebspaceAndAuthenticatedUser(): void
+    {
+        $webspace = new Webspace();
+        $webspaceSecurity = new WebspaceSecurity();
+        $webspaceSecurity->setSystem('website');
+        $webspaceSecurity->setPermissionCheck(true);
+        $webspace->setSecurity($webspaceSecurity);
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $loader = new PageResourceLoader(
+            $this->pageRepository->reveal(),
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $page = $this->createPage('123-123-123');
+
+        $this->pageRepository->findBy([
+            'uuids' => ['123-123-123'],
+            'locale' => 'en',
+            'stage' => 'live',
+            'accessControl' => [
+                'user' => $user->reveal(),
+                'permission' => 64,
+            ],
+        ])->willReturn([$page])
+            ->shouldBeCalled();
+
+        $result = $loader->load(['123-123-123'], 'en', [
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
+        ]);
+
+        $this->assertSame(['123-123-123' => $page], $result);
+    }
+
+    public function testLoadWithNonSecureWebspace(): void
+    {
+        $webspace = new Webspace();
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $loader = new PageResourceLoader(
+            $this->pageRepository->reveal(),
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $page = $this->createPage('123-123-123');
+
+        $this->pageRepository->findBy(Argument::that(function(array $filters) {
+            return isset($filters['uuids'])
+                && !isset($filters['accessControl']);
+        }))->willReturn([$page])
+            ->shouldBeCalled();
+
+        $result = $loader->load(['123-123-123'], 'en', [
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
+        ]);
+
+        $this->assertSame(['123-123-123' => $page], $result);
+    }
+
+    public function testLoadDoesNotOverrideExistingAccessControlFilter(): void
+    {
+        $webspace = new Webspace();
+        $webspaceSecurity = new WebspaceSecurity();
+        $webspaceSecurity->setSystem('website');
+        $webspaceSecurity->setPermissionCheck(true);
+        $webspace->setSecurity($webspaceSecurity);
+
+        $user = $this->prophesize(UserInterface::class);
+
+        $security = $this->prophesize(Security::class);
+        $security->getUser()->willReturn($user->reveal());
+
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $loader = new PageResourceLoader(
+            $this->pageRepository->reveal(),
+            $security->reveal(),
+            [PermissionTypes::VIEW => 64],
+            $requestAnalyzer->reveal()
+        );
+
+        $page = $this->createPage('123-123-123');
+
+        // Should use the existing accessControl from filters, not add a new one
+        $this->pageRepository->findBy([
+            'uuids' => ['123-123-123'],
+            'locale' => 'en',
+            'stage' => 'live',
+            'accessControl' => [
+                'user' => null,
+                'permission' => 32,
+            ],
+        ])->willReturn([$page])
+            ->shouldBeCalled();
+
+        $result = $loader->load(['123-123-123'], 'en', [
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+                'accessControl' => [
+                    'user' => null,
+                    'permission' => 32,
+                ],
+            ],
         ]);
 
         $this->assertSame(['123-123-123' => $page], $result);

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoaderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoaderTest.php
@@ -12,9 +12,11 @@
 namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
@@ -59,6 +61,108 @@ class PageResourceLoaderTest extends TestCase
             '123-123-123' => $page1,
             '321-321-321' => $page2,
         ], $result);
+    }
+
+    public function testLoadWithFiltersFromParams(): void
+    {
+        $page = $this->createPage('123-123-123');
+
+        $this->pageRepository->findBy([
+            'uuids' => ['123-123-123'],
+            'locale' => 'en',
+            'stage' => 'live',
+        ])->willReturn([$page])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load(['123-123-123'], 'en', [
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+            ],
+        ]);
+
+        $this->assertSame(['123-123-123' => $page], $result);
+    }
+
+    public function testLoadWithPermissionConfigInFilters(): void
+    {
+        $page = $this->createPage('123-123-123');
+        $user = $this->prophesize(UserInterface::class);
+
+        $this->pageRepository->findBy([
+            'uuids' => ['123-123-123'],
+            'locale' => 'en',
+            'stage' => 'live',
+            'permissionConfig' => [
+                'user' => $user->reveal(),
+                'permission' => 64,
+            ],
+        ])->willReturn([$page])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load(['123-123-123'], 'en', [
+            'filters' => [
+                'locale' => 'en',
+                'stage' => 'live',
+                'permissionConfig' => [
+                    'user' => $user->reveal(),
+                    'permission' => 64,
+                ],
+            ],
+        ]);
+
+        $this->assertSame(['123-123-123' => $page], $result);
+    }
+
+    public function testLoadWithEmptyParams(): void
+    {
+        $page = $this->createPage('123-123-123');
+
+        $this->pageRepository->findBy([
+            'uuids' => ['123-123-123'],
+        ])->willReturn([$page])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load(['123-123-123'], 'en', []);
+
+        $this->assertSame(['123-123-123' => $page], $result);
+    }
+
+    public function testLoadPreservesUuidsWhenMergingFilters(): void
+    {
+        $page = $this->createPage('123-123-123');
+
+        $this->pageRepository->findBy(Argument::that(function(array $filters) {
+            return isset($filters['uuids'])
+                && $filters['uuids'] === ['123-123-123']
+                && isset($filters['locale'])
+                && 'de' === $filters['locale'];
+        }))->willReturn([$page])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load(['123-123-123'], 'en', [
+            'filters' => [
+                'locale' => 'de',
+            ],
+        ]);
+
+        $this->assertSame(['123-123-123' => $page], $result);
+    }
+
+    public function testLoadWithNonArrayFilters(): void
+    {
+        $page = $this->createPage('123-123-123');
+
+        $this->pageRepository->findBy([
+            'uuids' => ['123-123-123'],
+        ])->willReturn([$page])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load(['123-123-123'], 'en', [
+            'filters' => 'invalid',
+        ]);
+
+        $this->assertSame(['123-123-123' => $page], $result);
     }
 
     private static function createPage(string $id): Page

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/Visitor/PageSmartContentFiltersVisitorTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/Visitor/PageSmartContentFiltersVisitorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content\Visitor;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Page\Infrastructure\Sulu\Content\Visitor\PageSmartContentFiltersVisitor;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class PageSmartContentFiltersVisitorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<RequestAnalyzerInterface>
+     */
+    private ObjectProphecy $requestAnalyzer;
+    /**
+     * @var ObjectProphecy<RequestStack>
+     */
+    private ObjectProphecy $requestStack;
+    private PageSmartContentFiltersVisitor $visitor;
+
+    protected function setUp(): void
+    {
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+
+        $this->visitor = new PageSmartContentFiltersVisitor(
+            $this->requestAnalyzer->reveal(),
+            $this->requestStack->reveal()
+        );
+    }
+
+    public function testVisitAddsWebspaceKeyToFilters(): void
+    {
+        $request = $this->prophesize(Request::class);
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getKey()->willReturn('example');
+
+        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace->reveal());
+
+        $filters = ['locale' => 'en'];
+        $result = $this->visitor->visit([], $filters, []);
+
+        $this->assertArrayHasKey('webspaceKey', $result);
+        $this->assertEquals('example', $result['webspaceKey']);
+        $this->assertEquals('en', $result['locale']);
+    }
+
+    public function testVisitWithoutRequestReturnsFiltersUnchanged(): void
+    {
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+
+        $filters = ['locale' => 'en'];
+        $result = $this->visitor->visit([], $filters, []);
+
+        $this->assertEquals($filters, $result);
+        $this->assertArrayNotHasKey('webspaceKey', $result);
+    }
+
+    public function testVisitWithoutWebspaceReturnsFiltersUnchanged(): void
+    {
+        $request = $this->prophesize(Request::class);
+
+        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
+        $this->requestAnalyzer->getWebspace()->willReturn(null);
+
+        $filters = ['locale' => 'en'];
+        $result = $this->visitor->visit([], $filters, []);
+
+        $this->assertEquals($filters, $result);
+        $this->assertArrayNotHasKey('webspaceKey', $result);
+    }
+
+    public function testVisitPreservesExistingFilters(): void
+    {
+        $request = $this->prophesize(Request::class);
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getKey()->willReturn('sulu-io');
+
+        $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace->reveal());
+
+        $filters = [
+            'locale' => 'de',
+            'tags' => ['tag1', 'tag2'],
+            'categories' => [1, 2, 3],
+        ];
+
+        $result = $this->visitor->visit([], $filters, []);
+
+        $this->assertEquals('sulu-io', $result['webspaceKey']);
+        $this->assertEquals('de', $result['locale']);
+        $this->assertEquals(['tag1', 'tag2'], $result['tags']);
+        $this->assertEquals([1, 2, 3], $result['categories']);
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -34,14 +34,16 @@ class AccessControlQueryEnhancer
         ?UserInterface $user,
         int $permission,
         string $entityClass,
-        string $entityAlias
+        string $entityAlias,
+        string $entityIdField = 'id'
     ): void {
         $this->enhanceQueryWithAccessControl(
             $queryBuilder,
             $user,
             $permission,
             $entityClass,
-            $entityAlias
+            $entityAlias,
+            $entityIdField
         );
     }
 
@@ -87,9 +89,12 @@ class AccessControlQueryEnhancer
         string $entityIdField = 'id',
         ?string $entityClassField = null
     ): void {
+        // Extract just the field name from the full path (e.g., 'page.uuid' -> 'uuid')
+        $fieldName = \str_contains($entityIdField, '.') ? \substr($entityIdField, \strrpos($entityIdField, '.') + 1) : $entityIdField;
+
         $subQueryBuilder = $this->entityManager->createQueryBuilder()
             ->from($entityClass, 'entity')
-            ->select('entity.id');
+            ->select('entity.' . $fieldName);
 
         $accessClassCondition = 'accessControl.entityClass = :entityClass';
         if ($entityClassField) {
@@ -115,10 +120,10 @@ class AccessControlQueryEnhancer
         $subQueryBuilder->setParameter('permission', $permission);
 
         $result = $subQueryBuilder->getQuery()->getScalarResult();
-        $ids = \array_column($result, 'id');
+        $ids = \array_column($result, $fieldName);
 
         if (\count($ids) > 0) {
-            $queryBuilder->andWhere(\sprintf('%s.id NOT IN (:accessControlIds)', $entityAlias));
+            $queryBuilder->andWhere(\sprintf('%s.%s NOT IN (:accessControlIds)', $entityAlias, $fieldName));
             $queryBuilder->setParameter('accessControlIds', $ids);
         }
     }

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -89,12 +89,9 @@ class AccessControlQueryEnhancer
         string $entityIdField = 'id',
         ?string $entityClassField = null
     ): void {
-        // Extract just the field name from the full path (e.g., 'page.uuid' -> 'uuid')
-        $fieldName = \str_contains($entityIdField, '.') ? \substr($entityIdField, \strrpos($entityIdField, '.') + 1) : $entityIdField;
-
         $subQueryBuilder = $this->entityManager->createQueryBuilder()
             ->from($entityClass, 'entity')
-            ->select('entity.' . $fieldName);
+            ->select('entity.' . $entityIdField);
 
         $accessClassCondition = 'accessControl.entityClass = :entityClass';
         if ($entityClassField) {
@@ -120,10 +117,10 @@ class AccessControlQueryEnhancer
         $subQueryBuilder->setParameter('permission', $permission);
 
         $result = $subQueryBuilder->getQuery()->getScalarResult();
-        $ids = \array_column($result, $fieldName);
+        $ids = \array_column($result, $entityIdField);
 
         if (\count($ids) > 0) {
-            $queryBuilder->andWhere(\sprintf('%s.%s NOT IN (:accessControlIds)', $entityAlias, $fieldName));
+            $queryBuilder->andWhere(\sprintf('(%s.%s NOT IN (:accessControlIds) OR %s.%s IS NULL)', $entityAlias, $entityIdField, $entityAlias, $entityIdField));
             $queryBuilder->setParameter('accessControlIds', $ids);
         }
     }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1362,7 +1362,7 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
-        $this->queryBuilder->andWhere('Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds)')
+        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds) OR Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
@@ -1424,7 +1424,7 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
-        $this->queryBuilder->andWhere('Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds)')
+        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds) OR Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
@@ -1482,7 +1482,7 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
-        $this->queryBuilder->andWhere(\stdClass::class . '.id NOT IN (:accessControlIds)')
+        $this->queryBuilder->andWhere('(stdClass.id NOT IN (:accessControlIds) OR stdClass.id IS NULL)')
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
@@ -1552,7 +1552,7 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
-        $this->queryBuilder->andWhere(\stdClass::class . '.id NOT IN (:accessControlIds)')
+        $this->queryBuilder->andWhere('(stdClass.id NOT IN (:accessControlIds) OR stdClass.id IS NULL)')
             ->shouldBeCalled();
 
         $this->queryBuilder->leftJoin(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds permission handling for PageSmartContentProvider
Adds permission handling for PageSitemapProvider

#### Why?

Missing functionality in Sulu 3.0