### PR TITLE
Support property mapping in NavigationTwigExtensions and make properties mandatory in Twig extensions

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -167,33 +167,50 @@ and update your templates definition to use the new controller:
 
 ### Navigation Twig Extension property filtering
 
-The navigation Twig functions and repository methods now support custom property filtering, allowing you to specify
-which fields should be resolved from the content.
+The navigation Twig functions and repository methods now support custom property filtering, and the default properties
+have been simplified to improve performance.
 
 **What Changed:**
 
-All navigation-related Twig extension methods now accept an optional `$properties` parameter that allows you to customize
-which content fields are resolved. When not provided, the extension uses the defaults from Sulu 2.x that include commonly
-needed fields like `uuid`, `title`, `url`, `webspaceKey`, `template`, etc.
+1. The `$loadExcerpt` parameter has been removed from all navigation functions
+2. The default properties have been reduced to only `title` and `url`
+3. All navigation-related Twig extension methods accept an optional `$properties` parameter for custom fields
 
-**Using custom properties in Twig:**
+**Migration:**
 
-You can now customize which fields are resolved by passing a properties array to the navigation functions:
+If you need the old default properties, explicitly pass them to the navigation functions:
 
 ```twig
-{# Load only specific fields #}
-{% set navigation = sulu_navigation_root_flat('main', 2, false, {
-    'content.uuid': 'object.resource.id',
-    'content.title': 'title',
-    'content.url': 'url'
+{# Old behavior (Sulu 2.6) #}
+{% set navigation = sulu_navigation_root_flat('main', 2, false) %}
+
+{# New behavior - explicitly specify needed properties #}
+{% set navigation = sulu_navigation_root_flat('main', 2, {
+    'uuid': 'object.resource.id',
+    'title': 'title',
+    'url': 'url',
+    'webspaceKey': 'object.resource.webspaceKey',
+    'template': 'object.templateKey',
+    'changed': 'object.changed',
+    'changer': 'object.changer',
+    'created': 'object.created',
+    'creator': 'object.creator',
+    'linkProvider': 'object.linkData.linkProvider'
 }) %}
 
-{# Load excerpt fields along with default content fields #}
-{% set navigationWithExcerpt = sulu_navigation_root_flat('main', 2, true) %}
+{# For excerpt fields, include them explicitly #}
+{% set navigationWithExcerpt = sulu_navigation_root_flat('main', 2, {
+    'title': 'title',
+    'url': 'url',
+    'excerpt.title': 'excerpt.title',
+    'excerpt.description': 'excerpt.description',
+    'excerpt.image': 'excerpt.image'
+}) %}
 ```
 
-The property mapping uses the format `'output_key': 'content_resolver_path'`, where the content resolver path can 
-access nested object properties using dot notation (e.g., `'object.resource.webspaceKey'`).
+Be aware, that the "nodeType" was replaced by "linkProvider", this field must be adjusted accordingly.  The property mapping
+uses the format `'output_key': 'content_resolver_path'`, where the content resolver path can access nested object
+properties using dot notation (e.g., `'object.resource.webspaceKey'`).
 
 ### Add new Content storage tables
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -165,6 +165,36 @@ and update your templates definition to use the new controller:
 +<controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
 ```
 
+### Navigation Twig Extension property filtering
+
+The navigation Twig functions and repository methods now support custom property filtering, allowing you to specify
+which fields should be resolved from the content.
+
+**What Changed:**
+
+All navigation-related Twig extension methods now accept an optional `$properties` parameter that allows you to customize
+which content fields are resolved. When not provided, the extension uses the defaults from Sulu 2.x that include commonly
+needed fields like `uuid`, `title`, `url`, `webspaceKey`, `template`, etc.
+
+**Using custom properties in Twig:**
+
+You can now customize which fields are resolved by passing a properties array to the navigation functions:
+
+```twig
+{# Load only specific fields #}
+{% set navigation = sulu_navigation_root_flat('main', 2, false, {
+    'content.uuid': 'object.resource.id',
+    'content.title': 'title',
+    'content.url': 'url'
+}) %}
+
+{# Load excerpt fields along with default content fields #}
+{% set navigationWithExcerpt = sulu_navigation_root_flat('main', 2, true) %}
+```
+
+The property mapping uses the format `'output_key': 'content_resolver_path'`, where the content resolver path can 
+access nested object properties using dot notation (e.g., `'object.resource.webspaceKey'`).
+
 ### Add new Content storage tables
 
 The new content storage architecture requires a new database schema. You can execute the following sql statements
@@ -1196,6 +1226,16 @@ and directly modifying the new `Route` entity is sufficient.
 ### Changed methods for 3.0
 
 - `Sulu\Bundle\ContactBundle\Controller\AbstractMediaController::__construct`
+- `Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension::flatRootNavigationFunction` (added `?array $properties = null`)
+- `Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension::treeRootNavigationFunction` (added `?array $properties = null`)
+- `Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension::flatNavigationFunction` (added `?array $properties = null`)
+- `Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension::treeNavigationFunction` (added `?array $properties = null`)
+- `Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension::breadcrumbFunction` (added `?array $properties = null`)
+- `Sulu\Page\Domain\Repository\NavigationRepositoryInterface::getNavigationFlat` (added `array $properties = []`)
+- `Sulu\Page\Domain\Repository\NavigationRepositoryInterface::getNavigationTree` (added `array $properties = []`)
+- `Sulu\Page\Domain\Repository\NavigationRepositoryInterface::getNavigationFlatByUuid` (added `array $properties = []`)
+- `Sulu\Page\Domain\Repository\NavigationRepositoryInterface::getNavigationTreeByUuid` (added `array $properties = []`)
+- `Sulu\Page\Domain\Repository\NavigationRepositoryInterface::getBreadcrumb` (added `array $properties = []`)
 
 ### Piwik replaced with Matomo script
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -165,6 +165,68 @@ and update your templates definition to use the new controller:
 +<controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
 ```
 
+### Content load Twig functions split and properties now required
+
+The Sulu 2.6 `sulu_content_load` function has been split into separate `sulu_page_load` and `sulu_article_load` functions.
+Additionally, the `properties` parameter is now mandatory, and a new optional `locale` parameter has been added.
+
+**What Changed:**
+
+**For Pages and Articles (Sulu 2.6 → Sulu 3.0):**
+- `sulu_content_load(uuid, ?properties)` → `sulu_page_load(uuid, properties, ?locale)`
+- `sulu_content_load(uuid, ?properties)` → `sulu_article_load(uuid, properties, ?locale)`
+
+**For Snippets (Sulu 2.6 → Sulu 3.0):**
+- `sulu_snippet_load_by_area(area, ?webspaceKey, ?locale)` → `sulu_snippet_load_by_area(areaKey, properties, ?webspaceKey, ?locale)`
+
+**Key Changes:**
+1. **Function split**: The single `sulu_content_load` function has been replaced with `sulu_page_load` and `sulu_article_load`
+2. **Properties mandatory**: The `properties` parameter was optional in Sulu 2.6 but is now required in Sulu 3.0
+3. **Locale parameter added**: A new optional `locale` parameter allows you to load content in a specific locale (previously always used the current request's locale)
+4. **Snippet properties**: The `properties` parameter is completely new for snippets in Sulu 3.0
+
+**Migration:**
+
+Update all Twig templates to use the new function names and pass the properties array explicitly:
+
+```twig
+{# Old Sulu 2.6 #}
+{% set page = sulu_content_load(page_uuid) %}
+{% set page = sulu_content_load(page_uuid, ['title', 'description']) %}
+{% set article = sulu_content_load(article_uuid) %}
+{% set snippet = sulu_snippet_load_by_area('footer', 'sulu-io', 'en') %}
+
+{# New Sulu 3.0 - use separate functions, properties mandatory #}
+{% set page = sulu_page_load(page_uuid, {
+    'title': 'title',
+    'description': 'description',
+}) %}
+
+{# Optionally specify locale (new in 3.0) #}
+{% set page = sulu_page_load(page_uuid, {
+    'title': 'title',
+    'url': 'url'
+}, 'en') %}
+
+{# Use sulu_article_load for articles #}
+{% set article = sulu_article_load(article_uuid, {
+    'title': 'title',
+    'description': 'description'
+}) %}
+
+{# Snippets now require properties parameter #}
+{% set snippet = sulu_snippet_load_by_area('footer', {
+    'title': 'title',
+    'image': 'image'
+}, 'sulu-io', 'en') %}
+```
+
+**Note:** The property mapping uses the format `'output_key': 'content_resolver_path'`. For example:
+- `'title': 'title'` - Maps the content's title field to the `title` key in the output
+- `'url': 'url'` - Maps the content's URL to the `url` key
+- `'content': 'content'` - Maps all template data fields to the `content` key
+- `'excerpt.description': 'excerpt.description'` - Maps excerpt extension fields
+
 ### Navigation Twig functions renamed to `sulu_page_` prefix
 
 All navigation-related Twig functions have been renamed to include the `sulu_page_` prefix instead of just `sulu_`

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -165,6 +165,19 @@ and update your templates definition to use the new controller:
 +<controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
 ```
 
+### Navigation Twig functions renamed to `sulu_page_` prefix
+
+All navigation-related Twig functions have been renamed to include the `sulu_page_` prefix instead of just `sulu_`
+to better reflect that they come from the page package.
+
+**Old function names:**
+- `sulu_navigation_root_flat` → `sulu_page_navigation_root_flat`
+- `sulu_navigation_root_tree` → `sulu_page_navigation_root_tree`
+- `sulu_navigation_flat` → `sulu_page_navigation_flat`
+- `sulu_navigation_tree` → `sulu_page_navigation_tree`
+- `sulu_breadcrumb` → `sulu_page_breadcrumb`
+- `sulu_navigation_is_active` → `sulu_page_navigation_is_active`
+
 ### Navigation Twig Extension property filtering
 
 The navigation Twig functions and repository methods now support custom property filtering, and the default properties
@@ -184,8 +197,8 @@ If you need the old default properties, explicitly pass them to the navigation f
 {# Old behavior (Sulu 2.6) #}
 {% set navigation = sulu_navigation_root_flat('main', 2, false) %}
 
-{# New behavior - explicitly specify needed properties #}
-{% set navigation = sulu_navigation_root_flat('main', 2, {
+{# New behavior - use new function names and explicitly specify needed properties #}
+{% set navigation = sulu_page_navigation_root_flat('main', 2, {
     'uuid': 'object.resource.id',
     'title': 'title',
     'url': 'url',
@@ -199,7 +212,7 @@ If you need the old default properties, explicitly pass them to the navigation f
 }) %}
 
 {# For excerpt fields, include them explicitly #}
-{% set navigationWithExcerpt = sulu_navigation_root_flat('main', 2, {
+{% set navigationWithExcerpt = sulu_page_navigation_root_flat('main', 2, {
     'title': 'title',
     'url': 'url',
     'excerpt.title': 'excerpt.title',

--- a/packages/article/src/Infrastructure/Symfony/Twig/ArticleTwigExtension.php
+++ b/packages/article/src/Infrastructure/Symfony/Twig/ArticleTwigExtension.php
@@ -43,14 +43,14 @@ class ArticleTwigExtension extends AbstractExtension
     }
 
     /**
-     * @param array<string, string>|null $properties
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>|null
      */
     public function loadArticle(
         string $uuid,
+        array $properties,
         ?string $locale = null,
-        ?array $properties = null,
     ): ?array {
         if (null === $locale) {
             $localization = $this->requestAnalyzer->getCurrentLocalization();

--- a/packages/article/tests/Functional/Infrastructure/Symfony/Twig/ArticleTwigExtensionTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Symfony/Twig/ArticleTwigExtensionTest.php
@@ -15,7 +15,6 @@ namespace Sulu\Article\Tests\Functional\Infrastructure\Symfony\Twig;
 
 use Sulu\Article\Infrastructure\Symfony\Twig\ArticleTwigExtension;
 use Sulu\Article\Tests\Traits\CreateArticleTrait;
-use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Tests\Functional\Traits\CreateMediaTrait;
 
@@ -55,20 +54,14 @@ class ArticleTwigExtensionTest extends SuluTestCase
             ],
         ]);
 
-        $result = $this->articleTwigExtension->loadArticle($article->getUuid(), 'en');
+        $result = $this->articleTwigExtension->loadArticle($article->getUuid(), [], 'en');
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('content', $result);
 
         /** @var array<string, mixed> $content */
         $content = $result['content'];
-        $this->assertArrayHasKey('title', $content);
-        $this->assertSame('Test Article', $content['title']);
-        $this->assertArrayHasKey('description', $content);
-        $this->assertSame('This is a test article description', $content['description']);
-        $this->assertArrayHasKey('image', $content);
-        $this->assertInstanceOf(Media::class, $content['image']);
-        $this->assertSame($media->getId(), $content['image']->getId());
+        $this->assertEmpty($content);
     }
 
     public function testLoadArticleWithProperties(): void
@@ -98,7 +91,7 @@ class ArticleTwigExtensionTest extends SuluTestCase
             'description' => 'description',
         ];
 
-        $result = $this->articleTwigExtension->loadArticle($article->getUuid(), 'en', $properties);
+        $result = $this->articleTwigExtension->loadArticle($article->getUuid(), $properties, 'en');
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('title', $result);
@@ -114,7 +107,7 @@ class ArticleTwigExtensionTest extends SuluTestCase
 
     public function testLoadArticleReturnsNullWhenArticleNotFound(): void
     {
-        $result = $this->articleTwigExtension->loadArticle('nonexistent-uuid', 'en');
+        $result = $this->articleTwigExtension->loadArticle('nonexistent-uuid', [], 'en');
 
         $this->assertNull($result);
     }

--- a/packages/page/src/Domain/Repository/NavigationRepositoryInterface.php
+++ b/packages/page/src/Domain/Repository/NavigationRepositoryInterface.php
@@ -14,7 +14,7 @@ namespace Sulu\Page\Domain\Repository;
 interface NavigationRepositoryInterface
 {
     /**
-     * @param array<string, mixed> $properties
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>[]
      */
@@ -28,7 +28,7 @@ interface NavigationRepositoryInterface
     ): array;
 
     /**
-     * @param array<string, mixed> $properties
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>[]
      */
@@ -42,7 +42,7 @@ interface NavigationRepositoryInterface
     ): array;
 
     /**
-     * @param array<string, mixed> $properties
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>[]
      */
@@ -56,7 +56,7 @@ interface NavigationRepositoryInterface
     ): array;
 
     /**
-     * @param array<string, mixed> $properties
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>[]
      */
@@ -70,7 +70,7 @@ interface NavigationRepositoryInterface
     ): array;
 
     /**
-     * @param array<string, mixed> $properties
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>[]
      */

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -315,32 +315,19 @@ class NavigationRepository implements NavigationRepositoryInterface
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
+        // prefix all properties with "nav." to only resolve navigation related content
+        foreach ($properties as $key => $value) {
+            unset($properties[$key]);
+            $properties['nav.' . $key] = $value;
+        }
+
         /** @var array{
-         *     resource: object,
-         *     content: array<string, mixed>,
-         *     view: mixed[],
-         *     extension: array<string, array<string, mixed>>,
-         *     excerpt?: mixed[]
+         *     nav: array<string, mixed>,
          * } $resolvedContent
          */
         $resolvedContent = $this->contentResolver->resolve($pageDimensionContent, $properties);
 
-        $result = [...$resolvedContent['content']];
-
-        // Include excerpt data if any excerpt properties were requested
-        $hasExcerptProperties = false;
-        foreach ($properties as $key => $value) {
-            if (\str_starts_with($key, 'excerpt.')) {
-                $hasExcerptProperties = true;
-                break;
-            }
-        }
-
-        if ($hasExcerptProperties) {
-            $result['excerpt'] = $resolvedContent['excerpt'] ?? [];
-        }
-
-        return $result;
+        return $resolvedContent['nav'];
     }
 
     /**

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -79,9 +79,7 @@ class NavigationRepository implements NavigationRepositoryInterface
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
-        $loadExcerpt = (bool) ($properties['excerpt'] ?? false);
-
-        return $this->normalizePageTree($pages, $loadExcerpt, $locale, 1, $depth);
+        return $this->normalizePageTree($pages, $properties, $locale, 1, $depth);
     }
 
     public function getNavigationFlat(
@@ -101,7 +99,7 @@ class NavigationRepository implements NavigationRepositoryInterface
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
-        return $this->resolveAndNormalizePages($pages, $locale, $this->shouldLoadExcerpt($properties));
+        return $this->resolveAndNormalizePages($pages, $locale, $properties);
     }
 
     public function getNavigationFlatByUuid(
@@ -117,7 +115,7 @@ class NavigationRepository implements NavigationRepositoryInterface
         /** @var iterable<PageInterface> $pages */
         $pages = $this->createQueryBuilder($filters)->getQuery()->getResult();
 
-        return $this->resolveAndNormalizePages($pages, $locale, $this->shouldLoadExcerpt($properties));
+        return $this->resolveAndNormalizePages($pages, $locale, $properties);
     }
 
     public function getNavigationTreeByUuid(
@@ -131,7 +129,7 @@ class NavigationRepository implements NavigationRepositoryInterface
         $filters = $this->buildChildrenFilters($uuid, $locale, $webspaceKey, $depth, $navigationContext);
         $pages = $this->findByAsTree($filters);
 
-        return $this->normalizePageTree($pages, $this->shouldLoadExcerpt($properties), $locale, 1, $depth);
+        return $this->normalizePageTree($pages, $properties, $locale, 1, $depth);
     }
 
     public function getBreadcrumb(
@@ -157,15 +155,7 @@ class NavigationRepository implements NavigationRepositoryInterface
         /** @var PageInterface[] $pages */
         $pages = [...$ancestors, $page];
 
-        return $this->resolveAndNormalizePages($pages, $locale, $this->shouldLoadExcerpt($properties));
-    }
-
-    /**
-     * @param array<string, mixed> $properties
-     */
-    private function shouldLoadExcerpt(array $properties): bool
-    {
-        return (bool) ($properties['excerpt'] ?? false);
+        return $this->resolveAndNormalizePages($pages, $locale, $properties);
     }
 
     /**
@@ -202,18 +192,18 @@ class NavigationRepository implements NavigationRepositoryInterface
 
     /**
      * @param iterable<PageInterface> $pages
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>[]
      */
     private function resolveAndNormalizePages(
         iterable $pages,
         string $locale,
-        bool $loadExcerpt
+        array $properties
     ): array {
         $result = [];
         foreach ($pages as $page) {
-            $content = $this->resolvePageContent($page, $locale);
-            $result[] = $this->normalizePageContent($content, $loadExcerpt);
+            $result[] = $this->resolvePageContent($page, $locale, $properties);
         }
 
         return $result;
@@ -294,18 +284,18 @@ class NavigationRepository implements NavigationRepositoryInterface
 
     /**
      * @param iterable<PageInterface> $pages
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>[]
      */
-    private function normalizePageTree(iterable $pages, bool $loadExcerpt, string $locale, int $depth, int $maxDepth): array
+    private function normalizePageTree(iterable $pages, array $properties, string $locale, int $depth, int $maxDepth): array
     {
         $result = [];
         foreach ($pages as $page) {
-            $content = $this->resolvePageContent($page, $locale);
-            $normalizedContent = $this->normalizePageContent($content, $loadExcerpt);
+            $normalizedContent = $this->resolvePageContent($page, $locale, $properties);
 
             $children = $depth < $maxDepth ? $page->getChildren() : [];
-            $normalizedContent['children'] = $this->normalizePageTree($children, $loadExcerpt, $locale, $depth + 1, $maxDepth);
+            $normalizedContent['children'] = $this->normalizePageTree($children, $properties, $locale, $depth + 1, $maxDepth);
 
             $result[] = $normalizedContent;
         }
@@ -314,49 +304,40 @@ class NavigationRepository implements NavigationRepositoryInterface
     }
 
     /**
-     * @return array{
-     *      resource: object,
-     *      content: mixed,
-     *      view: mixed[],
-     *      extension: array<string, array<string, mixed>>,
-     * }
+     * @param array<string, string> $properties
+     *
+     * @return array<string, mixed>
      */
-    private function resolvePageContent(PageInterface $page, string $locale): array
+    protected function resolvePageContent(PageInterface $page, string $locale, array $properties): array
     {
         $pageDimensionContent = $this->contentAggregator->aggregate($page, [
             'locale' => $locale,
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
-        return $this->contentResolver->resolve($pageDimensionContent);
-    }
-
-    /**
-     * @param array{
-     *      resource: object,
-     *      content: mixed,
-     *      view: mixed[],
-     *      extension: array<string, array<string, mixed>>,
-     *  } $content
-     *
-     * @return array<string, mixed>
-     */
-    private function normalizePageContent(array $content, bool $loadExcerpt): array
-    {
         /** @var array{
-         *      extension: array<string, array<string, mixed>>,
-         * } $contentData
+         *     resource: object,
+         *     content: array<string, mixed>,
+         *     view: mixed[],
+         *     extension: array<string, array<string, mixed>>,
+         *     excerpt?: mixed[]
+         * } $resolvedContent
          */
-        $contentData = $content['content'];
-        /** @var PageInterface $page */
-        $page = $content['resource'];
-        $result = [
-            ...$contentData,
-            ...['webspaceKey' => $page->getWebspaceKey()],
-        ];
+        $resolvedContent = $this->contentResolver->resolve($pageDimensionContent, $properties);
 
-        if ($loadExcerpt) {
-            $result['excerpt'] = $content['extension']['excerpt'];
+        $result = [...$resolvedContent['content']];
+
+        // Include excerpt data if any excerpt properties were requested
+        $hasExcerptProperties = false;
+        foreach ($properties as $key => $value) {
+            if (\str_starts_with($key, 'excerpt.')) {
+                $hasExcerptProperties = true;
+                break;
+            }
+        }
+
+        if ($hasExcerptProperties) {
+            $result['excerpt'] = $resolvedContent['excerpt'] ?? [];
         }
 
         return $result;

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -33,7 +33,7 @@ class NavigationTwigExtension extends AbstractExtension
     ) {
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('sulu_navigation_root_flat', [$this, 'flatRootNavigationFunction']),
@@ -46,9 +46,11 @@ class NavigationTwigExtension extends AbstractExtension
     }
 
     /**
+     * @param array<string, string>|null $properties
+     *
      * @return array<string, mixed>[]
      */
-    public function flatRootNavigationFunction(string $navigationContext, int $depth = 1, bool $loadExcerpt = false): array
+    public function flatRootNavigationFunction(string $navigationContext, int $depth = 1, bool $loadExcerpt = false, ?array $properties = null): array
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -61,14 +63,16 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $segment?->getKey(),
             $depth,
-            ['loadExcerpt' => $loadExcerpt],
+            $properties ?? $this->getDefaultProperties($loadExcerpt),
         );
     }
 
     /**
+     * @param array<string, string>|null $properties
+     *
      * @return array<string, mixed>[]
      */
-    public function treeRootNavigationFunction(string $navigationContext, int $depth = 1, bool $loadExcerpt = false): array
+    public function treeRootNavigationFunction(string $navigationContext, int $depth = 1, bool $loadExcerpt = false, ?array $properties = null): array
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -81,11 +85,13 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $segment?->getKey(),
             $depth,
-            ['excerpt' => $loadExcerpt],
+            $properties ?? $this->getDefaultProperties($loadExcerpt)
         );
     }
 
     /**
+     * @param array<string, string>|null $properties
+     *
      * @return array<string, mixed>[]
      */
     public function flatNavigationFunction(
@@ -93,7 +99,8 @@ class NavigationTwigExtension extends AbstractExtension
         ?string $context = null,
         int $depth = 1,
         bool $loadExcerpt = false,
-        ?int $level = null
+        ?int $level = null,
+        ?array $properties = null
     ): array {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -104,7 +111,7 @@ class NavigationTwigExtension extends AbstractExtension
                 $uuid,
                 $locale,
                 $webspaceKey,
-                []
+                $properties ?? $this->getDefaultProperties(false)
             );
 
             if (!isset($breadcrumb[$level])) {
@@ -125,11 +132,13 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $depth,
             $context,
-            ['excerpt' => $loadExcerpt]
+            $properties ?? $this->getDefaultProperties($loadExcerpt)
         );
     }
 
     /**
+     * @param array<string, string>|null $properties
+     *
      * @return array<string, mixed>[]
      */
     public function treeNavigationFunction(
@@ -137,7 +146,8 @@ class NavigationTwigExtension extends AbstractExtension
         ?string $context = null,
         int $depth = 1,
         bool $loadExcerpt = false,
-        ?int $level = null
+        ?int $level = null,
+        ?array $properties = null
     ): array {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -148,7 +158,7 @@ class NavigationTwigExtension extends AbstractExtension
                 $uuid,
                 $locale,
                 $webspaceKey,
-                []
+                $properties ?? $this->getDefaultProperties(false)
             );
 
             if (!isset($breadcrumb[$level])) {
@@ -169,14 +179,16 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $depth,
             $context,
-            ['excerpt' => $loadExcerpt]
+            $properties ?? $this->getDefaultProperties($loadExcerpt)
         );
     }
 
     /**
+     * @param array<string, string>|null $properties
+     *
      * @return array<string, mixed>[]
      */
-    public function breadcrumbFunction(string $uuid): array
+    public function breadcrumbFunction(string $uuid, ?array $properties = null): array
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -185,7 +197,7 @@ class NavigationTwigExtension extends AbstractExtension
             $uuid,
             $locale,
             $webspaceKey,
-            []
+            $properties ?? $this->getDefaultProperties(false)
         );
     }
 
@@ -197,4 +209,38 @@ class NavigationTwigExtension extends AbstractExtension
 
         return (bool) \preg_match(\sprintf('/%s([\/]|$)/', \preg_quote($itemPath, '/')), $requestPath);
     }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getDefaultProperties(bool $loadExcerpt): array
+    {
+        $properties = [
+            'content.uuid' => 'object.resource.id',
+            'content.title' => 'title',
+            'content.url' => 'url',
+            'content.webspaceKey' => 'object.resource.webspaceKey',
+            'content.template' => 'object.templateKey',
+            'content.changed' => 'object.changed',
+            'content.changer' => 'object.changer',
+            'content.created' => 'object.created',
+            'content.creator' => 'object.creator',
+            'content.linkProvider' => 'object.linkData.linkProvider',
+        ];
+
+        if ($loadExcerpt) {
+            $properties['excerpt.title'] = 'excerpt.title';
+            $properties['excerpt.more'] = 'excerpt.more';
+            $properties['excerpt.description'] = 'excerpt.description';
+            $properties['excerpt.segment'] = 'excerpt.segment';
+            $properties['excerpt.categories'] = 'excerpt.categories';
+            $properties['excerpt.tags'] = 'excerpt.tags';
+            $properties['excerpt.audienceTargetGroups'] = 'excerpt.audienceTargetGroups';
+            $properties['excerpt.icon'] = 'excerpt.icon';
+            $properties['excerpt.image'] = 'excerpt.image';
+        }
+
+        return $properties;
+    }
+
 }

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -242,5 +242,4 @@ class NavigationTwigExtension extends AbstractExtension
 
         return $properties;
     }
-
 }

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -216,16 +216,16 @@ class NavigationTwigExtension extends AbstractExtension
     private function getDefaultProperties(bool $loadExcerpt): array
     {
         $properties = [
-            'content.uuid' => 'object.resource.id',
-            'content.title' => 'title',
-            'content.url' => 'url',
-            'content.webspaceKey' => 'object.resource.webspaceKey',
-            'content.template' => 'object.templateKey',
-            'content.changed' => 'object.changed',
-            'content.changer' => 'object.changer',
-            'content.created' => 'object.created',
-            'content.creator' => 'object.creator',
-            'content.linkProvider' => 'object.linkData.linkProvider',
+            'uuid' => 'object.resource.id',
+            'title' => 'title',
+            'url' => 'url',
+            'webspaceKey' => 'object.resource.webspaceKey',
+            'template' => 'object.templateKey',
+            'changed' => 'object.changed',
+            'changer' => 'object.changer',
+            'created' => 'object.created',
+            'creator' => 'object.creator',
+            'linkProvider' => 'object.linkData.linkProvider',
         ];
 
         if ($loadExcerpt) {

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -36,12 +36,12 @@ class NavigationTwigExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('sulu_navigation_root_flat', [$this, 'flatRootNavigationFunction']),
-            new TwigFunction('sulu_navigation_root_tree', [$this, 'treeRootNavigationFunction']),
-            new TwigFunction('sulu_navigation_flat', [$this, 'flatNavigationFunction']),
-            new TwigFunction('sulu_navigation_tree', [$this, 'treeNavigationFunction']),
-            new TwigFunction('sulu_breadcrumb', [$this, 'breadcrumbFunction']),
-            new TwigFunction('sulu_navigation_is_active', [$this, 'navigationIsActiveFunction']),
+            new TwigFunction('sulu_page_navigation_root_flat', [$this, 'flatRootNavigationFunction']),
+            new TwigFunction('sulu_page_navigation_root_tree', [$this, 'treeRootNavigationFunction']),
+            new TwigFunction('sulu_page_navigation_flat', [$this, 'flatNavigationFunction']),
+            new TwigFunction('sulu_page_navigation_tree', [$this, 'treeNavigationFunction']),
+            new TwigFunction('sulu_page_breadcrumb', [$this, 'breadcrumbFunction']),
+            new TwigFunction('sulu_page_navigation_is_active', [$this, 'navigationIsActiveFunction']),
         ];
     }
 

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -50,7 +50,7 @@ class NavigationTwigExtension extends AbstractExtension
      *
      * @return array<string, mixed>[]
      */
-    public function flatRootNavigationFunction(string $navigationContext, int $depth = 1, bool $loadExcerpt = false, ?array $properties = null): array
+    public function flatRootNavigationFunction(string $navigationContext, int $depth = 1, ?array $properties = null): array
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -63,7 +63,7 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $segment?->getKey(),
             $depth,
-            $properties ?? $this->getDefaultProperties($loadExcerpt),
+            $properties ?? $this->getDefaultProperties(),
         );
     }
 
@@ -72,7 +72,7 @@ class NavigationTwigExtension extends AbstractExtension
      *
      * @return array<string, mixed>[]
      */
-    public function treeRootNavigationFunction(string $navigationContext, int $depth = 1, bool $loadExcerpt = false, ?array $properties = null): array
+    public function treeRootNavigationFunction(string $navigationContext, int $depth = 1, ?array $properties = null): array
     {
         $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
@@ -85,7 +85,7 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $segment?->getKey(),
             $depth,
-            $properties ?? $this->getDefaultProperties($loadExcerpt)
+            $properties ?? $this->getDefaultProperties()
         );
     }
 
@@ -98,7 +98,6 @@ class NavigationTwigExtension extends AbstractExtension
         string $uuid,
         ?string $context = null,
         int $depth = 1,
-        bool $loadExcerpt = false,
         ?int $level = null,
         ?array $properties = null
     ): array {
@@ -111,7 +110,7 @@ class NavigationTwigExtension extends AbstractExtension
                 $uuid,
                 $locale,
                 $webspaceKey,
-                $properties ?? $this->getDefaultProperties(false)
+                $properties ?? $this->getDefaultProperties()
             );
 
             if (!isset($breadcrumb[$level])) {
@@ -132,7 +131,7 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $depth,
             $context,
-            $properties ?? $this->getDefaultProperties($loadExcerpt)
+            $properties ?? $this->getDefaultProperties()
         );
     }
 
@@ -145,7 +144,6 @@ class NavigationTwigExtension extends AbstractExtension
         string $uuid,
         ?string $context = null,
         int $depth = 1,
-        bool $loadExcerpt = false,
         ?int $level = null,
         ?array $properties = null
     ): array {
@@ -158,7 +156,7 @@ class NavigationTwigExtension extends AbstractExtension
                 $uuid,
                 $locale,
                 $webspaceKey,
-                $properties ?? $this->getDefaultProperties(false)
+                $properties ?? $this->getDefaultProperties()
             );
 
             if (!isset($breadcrumb[$level])) {
@@ -179,7 +177,7 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $depth,
             $context,
-            $properties ?? $this->getDefaultProperties($loadExcerpt)
+            $properties ?? $this->getDefaultProperties()
         );
     }
 
@@ -197,7 +195,7 @@ class NavigationTwigExtension extends AbstractExtension
             $uuid,
             $locale,
             $webspaceKey,
-            $properties ?? $this->getDefaultProperties(false)
+            $properties ?? $this->getDefaultProperties()
         );
     }
 
@@ -213,33 +211,11 @@ class NavigationTwigExtension extends AbstractExtension
     /**
      * @return array<string, string>
      */
-    private function getDefaultProperties(bool $loadExcerpt): array
+    private function getDefaultProperties(): array
     {
-        $properties = [
-            'uuid' => 'object.resource.id',
+        return [
             'title' => 'title',
             'url' => 'url',
-            'webspaceKey' => 'object.resource.webspaceKey',
-            'template' => 'object.templateKey',
-            'changed' => 'object.changed',
-            'changer' => 'object.changer',
-            'created' => 'object.created',
-            'creator' => 'object.creator',
-            'linkProvider' => 'object.linkData.linkProvider',
         ];
-
-        if ($loadExcerpt) {
-            $properties['excerpt.title'] = 'excerpt.title';
-            $properties['excerpt.more'] = 'excerpt.more';
-            $properties['excerpt.description'] = 'excerpt.description';
-            $properties['excerpt.segment'] = 'excerpt.segment';
-            $properties['excerpt.categories'] = 'excerpt.categories';
-            $properties['excerpt.tags'] = 'excerpt.tags';
-            $properties['excerpt.audienceTargetGroups'] = 'excerpt.audienceTargetGroups';
-            $properties['excerpt.icon'] = 'excerpt.icon';
-            $properties['excerpt.image'] = 'excerpt.image';
-        }
-
-        return $properties;
     }
 }

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/PageTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/PageTwigExtension.php
@@ -43,14 +43,14 @@ class PageTwigExtension extends AbstractExtension
     }
 
     /**
-     * @param array<string, string>|null $properties
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>|null
      */
     public function loadPage(
         string $uuid,
+        array $properties,
         ?string $locale = null,
-        ?array $properties = null,
     ): ?array {
         if (null === $locale) {
             $localization = $this->requestAnalyzer->getCurrentLocalization();

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -25,6 +25,39 @@ class NavigationRepositoryLinkTest extends SuluTestCase
 
     private NavigationRepositoryInterface $navigationRepository;
 
+    /**
+     * @return array<string, string>
+     */
+    private function getDefaultProperties(bool $withExcerpt = false): array
+    {
+        $properties = [
+            'content.uuid' => 'object.resource.id',
+            'content.title' => 'title',
+            'content.url' => 'url',
+            'content.webspaceKey' => 'object.resource.webspaceKey',
+            'content.template' => 'object.templateKey',
+            'content.changed' => 'object.changed',
+            'content.changer' => 'object.changer',
+            'content.created' => 'object.created',
+            'content.creator' => 'object.creator',
+            'content.linkProvider' => 'object.linkData.linkProvider',
+        ];
+
+        if ($withExcerpt) {
+            $properties['excerpt.title'] = 'excerpt.title';
+            $properties['excerpt.more'] = 'excerpt.more';
+            $properties['excerpt.description'] = 'excerpt.description';
+            $properties['excerpt.segment'] = 'excerpt.segment';
+            $properties['excerpt.categories'] = 'excerpt.categories';
+            $properties['excerpt.tags'] = 'excerpt.tags';
+            $properties['excerpt.audienceTargetGroups'] = 'excerpt.audienceTargetGroups';
+            $properties['excerpt.icon'] = 'excerpt.icon';
+            $properties['excerpt.image'] = 'excerpt.image';
+        }
+
+        return $properties;
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -119,7 +152,8 @@ class NavigationRepositoryLinkTest extends SuluTestCase
             'en',
             'sulu-io',
             null,
-            1
+            1,
+            $this->getDefaultProperties()
         );
 
         /** @var array<string, mixed> $contentPageNav */
@@ -149,7 +183,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
             'sulu-io',
             null,
             1,
-            ['excerpt' => true]
+            $this->getDefaultProperties(true)
         );
 
         // Test internal link with excerpt
@@ -177,6 +211,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
             'sulu-io',
             null,
             2,
+            $this->getDefaultProperties()
         );
 
         // Test content page

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -31,16 +31,16 @@ class NavigationRepositoryLinkTest extends SuluTestCase
     private function getDefaultProperties(bool $withExcerpt = false): array
     {
         $properties = [
-            'content.uuid' => 'object.resource.id',
-            'content.title' => 'title',
-            'content.url' => 'url',
-            'content.webspaceKey' => 'object.resource.webspaceKey',
-            'content.template' => 'object.templateKey',
-            'content.changed' => 'object.changed',
-            'content.changer' => 'object.changer',
-            'content.created' => 'object.created',
-            'content.creator' => 'object.creator',
-            'content.linkProvider' => 'object.linkData.linkProvider',
+            'uuid' => 'object.resource.id',
+            'title' => 'title',
+            'url' => 'url',
+            'webspaceKey' => 'object.resource.webspaceKey',
+            'template' => 'object.templateKey',
+            'changed' => 'object.changed',
+            'changer' => 'object.changer',
+            'created' => 'object.created',
+            'creator' => 'object.creator',
+            'linkProvider' => 'object.linkData.linkProvider',
         ];
 
         if ($withExcerpt) {

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -36,6 +36,25 @@ class NavigationRepositoryTest extends SuluTestCase
     private Page $child2;
     private Page $grandchild1;
 
+    /**
+     * @return array<string, string>
+     */
+    private function getDefaultProperties(): array
+    {
+        return [
+            'content.uuid' => 'object.resource.id',
+            'content.title' => 'title',
+            'content.url' => 'url',
+            'content.webspaceKey' => 'object.resource.webspaceKey',
+            'content.template' => 'object.templateKey',
+            'content.changed' => 'object.changed',
+            'content.changer' => 'object.changer',
+            'content.created' => 'object.created',
+            'content.creator' => 'object.creator',
+            'content.linkProvider' => 'object.linkData.linkProvider',
+        ];
+    }
+
     protected function setUp(): void
     {
         self::purgeDatabase();
@@ -191,7 +210,9 @@ class NavigationRepositoryTest extends SuluTestCase
             $this->parent->getUuid(),
             'en',
             'sulu-io',
-            1
+            1,
+            null,
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(2, $result);
@@ -206,7 +227,9 @@ class NavigationRepositoryTest extends SuluTestCase
             $this->parent->getUuid(),
             'en',
             'sulu-io',
-            1
+            1,
+            null,
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(2, $result1);
@@ -216,7 +239,9 @@ class NavigationRepositoryTest extends SuluTestCase
             $this->parent->getUuid(),
             'en',
             'sulu-io',
-            2
+            2,
+            null,
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(3, $result2);
@@ -234,7 +259,8 @@ class NavigationRepositoryTest extends SuluTestCase
             'en',
             'sulu-io',
             1,
-            'main'
+            'main',
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(1, $result);
@@ -246,7 +272,8 @@ class NavigationRepositoryTest extends SuluTestCase
             'en',
             'sulu-io',
             1,
-            'footer'
+            'footer',
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(1, $resultFooter);
@@ -259,7 +286,9 @@ class NavigationRepositoryTest extends SuluTestCase
             'non-existent-uuid',
             'en',
             'sulu-io',
-            1
+            1,
+            null,
+            $this->getDefaultProperties()
         );
 
         $this->assertSame([], $result);
@@ -271,7 +300,9 @@ class NavigationRepositoryTest extends SuluTestCase
             $this->parent->getUuid(),
             'en',
             'sulu-io',
-            1
+            1,
+            null,
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(2, $result);
@@ -288,7 +319,9 @@ class NavigationRepositoryTest extends SuluTestCase
             $this->parent->getUuid(),
             'en',
             'sulu-io',
-            1
+            1,
+            null,
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(2, $result1);
@@ -300,7 +333,9 @@ class NavigationRepositoryTest extends SuluTestCase
             $this->parent->getUuid(),
             'en',
             'sulu-io',
-            2
+            2,
+            null,
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(2, $result2);
@@ -318,7 +353,8 @@ class NavigationRepositoryTest extends SuluTestCase
             'en',
             'sulu-io',
             2,
-            'main'
+            'main',
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(1, $result);
@@ -335,7 +371,9 @@ class NavigationRepositoryTest extends SuluTestCase
             'non-existent-uuid',
             'en',
             'sulu-io',
-            1
+            1,
+            null,
+            $this->getDefaultProperties()
         );
 
         $this->assertSame([], $result);
@@ -346,7 +384,8 @@ class NavigationRepositoryTest extends SuluTestCase
         $result = $this->navigationRepository->getBreadcrumb(
             $this->grandchild1->getUuid(),
             'en',
-            'sulu-io'
+            'sulu-io',
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(3, $result);
@@ -363,7 +402,8 @@ class NavigationRepositoryTest extends SuluTestCase
         $result = $this->navigationRepository->getBreadcrumb(
             $this->child1->getUuid(),
             'en',
-            'sulu-io'
+            'sulu-io',
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(2, $result);
@@ -374,7 +414,8 @@ class NavigationRepositoryTest extends SuluTestCase
         $resultParent = $this->navigationRepository->getBreadcrumb(
             $this->parent->getUuid(),
             'en',
-            'sulu-io'
+            'sulu-io',
+            $this->getDefaultProperties()
         );
 
         $this->assertCount(1, $resultParent);
@@ -386,7 +427,8 @@ class NavigationRepositoryTest extends SuluTestCase
         $result = $this->navigationRepository->getBreadcrumb(
             'non-existent-uuid',
             'en',
-            'sulu-io'
+            'sulu-io',
+            $this->getDefaultProperties()
         );
 
         $this->assertSame([], $result);

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -42,16 +42,16 @@ class NavigationRepositoryTest extends SuluTestCase
     private function getDefaultProperties(): array
     {
         return [
-            'content.uuid' => 'object.resource.id',
-            'content.title' => 'title',
-            'content.url' => 'url',
-            'content.webspaceKey' => 'object.resource.webspaceKey',
-            'content.template' => 'object.templateKey',
-            'content.changed' => 'object.changed',
-            'content.changer' => 'object.changer',
-            'content.created' => 'object.created',
-            'content.creator' => 'object.creator',
-            'content.linkProvider' => 'object.linkData.linkProvider',
+            'uuid' => 'object.resource.id',
+            'title' => 'title',
+            'url' => 'url',
+            'webspaceKey' => 'object.resource.webspaceKey',
+            'template' => 'object.templateKey',
+            'changed' => 'object.changed',
+            'changer' => 'object.changer',
+            'created' => 'object.created',
+            'creator' => 'object.creator',
+            'linkProvider' => 'object.linkData.linkProvider',
         ];
     }
 

--- a/packages/page/tests/Functional/Infrastructure/Symfony/Twig/Extension/PageTwigExtensionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Symfony/Twig/Extension/PageTwigExtensionTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Tests\Functional\Infrastructure\Symfony\Twig\Extension;
 
-use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Tests\Functional\Traits\CreateMediaTrait;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\PageTwigExtension;
@@ -55,20 +54,14 @@ class PageTwigExtensionTest extends SuluTestCase
             ],
         ]);
 
-        $result = $this->pageTwigExtension->loadPage($page->getUuid(), 'en');
+        $result = $this->pageTwigExtension->loadPage($page->getUuid(), [], 'en');
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('content', $result);
 
         /** @var array<string, mixed> $content */
         $content = $result['content'];
-        $this->assertArrayHasKey('title', $content);
-        $this->assertSame('Test Page', $content['title']);
-        $this->assertArrayHasKey('description', $content);
-        $this->assertSame('This is a test page description', $content['description']);
-        $this->assertArrayHasKey('image', $content);
-        $this->assertInstanceOf(Media::class, $content['image']);
-        $this->assertSame($media->getId(), $content['image']->getId());
+        $this->assertEmpty($content);
     }
 
     public function testLoadPageWithProperties(): void
@@ -98,7 +91,7 @@ class PageTwigExtensionTest extends SuluTestCase
             'description' => 'description',
         ];
 
-        $result = $this->pageTwigExtension->loadPage($page->getUuid(), 'en', $properties);
+        $result = $this->pageTwigExtension->loadPage($page->getUuid(), $properties, 'en');
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('title', $result);
@@ -114,7 +107,7 @@ class PageTwigExtensionTest extends SuluTestCase
 
     public function testLoadPageReturnsNullWhenPageNotFound(): void
     {
-        $result = $this->pageTwigExtension->loadPage('nonexistent-uuid', 'en');
+        $result = $this->pageTwigExtension->loadPage('nonexistent-uuid', [], 'en');
 
         $this->assertNull($result);
     }

--- a/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
@@ -155,11 +156,15 @@ class NavigationRepositoryTest extends TestCase
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($page->reveal(), ['locale' => 'en', 'stage' => 'live'])
             ->willReturn($dimensionContent->reveal());
-        $this->contentResolver->resolve($dimensionContent->reveal())->willReturn([
+        $this->contentResolver->resolve($dimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $page->reveal(),
-            'content' => ['title' => 'Page Title'],
+            'content' => [
+                'title' => 'Page Title',
+                'webspaceKey' => 'sulu-io',
+            ],
             'view' => [],
             'extension' => ['excerpt' => ['title' => 'Excerpt Title']],
+            'excerpt' => ['title' => 'Excerpt Title'],
         ]);
 
         $result = $this->navigationRepository->getNavigationTree('main', 'en', 'sulu-io', 'segment-key', 1, $this->getDefaultProperties(true));
@@ -220,14 +225,18 @@ class NavigationRepositoryTest extends TestCase
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($page->reveal(), ['locale' => 'de', 'stage' => 'live'])
             ->willReturn($dimensionContent->reveal());
-        $this->contentResolver->resolve($dimensionContent->reveal())->willReturn([
+        $this->contentResolver->resolve($dimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $page->reveal(),
-            'content' => ['title' => 'German Page', 'description' => 'Test'],
+            'content' => [
+                'title' => 'German Page',
+                'description' => 'Test',
+                'webspaceKey' => 'sulu-io',
+            ],
             'view' => [],
             'extension' => [],
         ]);
 
-        $result = $this->navigationRepository->getNavigationFlat('footer', 'de', 'sulu-io', null, 2, []);
+        $result = $this->navigationRepository->getNavigationFlat('footer', 'de', 'sulu-io', null, 2, $this->getDefaultProperties(false));
 
         $this->assertNotEmpty($result);
         $this->assertCount(1, $result);
@@ -286,14 +295,17 @@ class NavigationRepositoryTest extends TestCase
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($page->reveal(), ['locale' => 'en', 'stage' => 'live'])
             ->willReturn($dimensionContent->reveal());
-        $this->contentResolver->resolve($dimensionContent->reveal())->willReturn([
+        $this->contentResolver->resolve($dimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $page->reveal(),
-            'content' => ['title' => 'No Segment Page'],
+            'content' => [
+                'title' => 'No Segment Page',
+                'webspaceKey' => 'test-webspace',
+            ],
             'view' => [],
             'extension' => [],
         ]);
 
-        $result = $this->navigationRepository->getNavigationTree('sidebar', 'en', 'test-webspace', null, 3);
+        $result = $this->navigationRepository->getNavigationTree('sidebar', 'en', 'test-webspace', null, 3, $this->getDefaultProperties(false));
 
         $this->assertNotEmpty($result);
         $this->assertCount(1, $result);
@@ -353,7 +365,7 @@ class NavigationRepositoryTest extends TestCase
         $parentDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($parentPage->reveal(), ['locale' => 'en', 'stage' => 'live'])
             ->willReturn($parentDimensionContent->reveal());
-        $this->contentResolver->resolve($parentDimensionContent->reveal())->willReturn([
+        $this->contentResolver->resolve($parentDimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $parentPage->reveal(),
             'content' => ['title' => 'Parent Page'],
             'view' => [],
@@ -364,7 +376,7 @@ class NavigationRepositoryTest extends TestCase
         $childDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($childPage->reveal(), ['locale' => 'en', 'stage' => 'live'])
             ->willReturn($childDimensionContent->reveal());
-        $this->contentResolver->resolve($childDimensionContent->reveal())->willReturn([
+        $this->contentResolver->resolve($childDimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $childPage->reveal(),
             'content' => ['title' => 'Child Page'],
             'view' => [],
@@ -372,7 +384,7 @@ class NavigationRepositoryTest extends TestCase
         ]);
 
         /** @var array<int, array{title: string, children: array<int, array{title: string, children: array<string, mixed>}>}> $result */
-        $result = $this->navigationRepository->getNavigationTree('main', 'en', 'sulu-io', 'segment-a', 2);
+        $result = $this->navigationRepository->getNavigationTree('main', 'en', 'sulu-io', 'segment-a', 2, $this->getDefaultProperties(false));
 
         $this->assertNotEmpty($result);
         $this->assertCount(1, $result);
@@ -430,7 +442,7 @@ class NavigationRepositoryTest extends TestCase
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($page->reveal(), ['locale' => 'en', 'stage' => 'live'])
             ->willReturn($dimensionContent->reveal());
-        $this->contentResolver->resolve($dimensionContent->reveal())->willReturn([
+        $this->contentResolver->resolve($dimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $page->reveal(),
             'content' => ['title' => 'Page with Excerpt'],
             'view' => [],
@@ -441,6 +453,12 @@ class NavigationRepositoryTest extends TestCase
                     'segment' => 'test-segment',
                     'audienceTargetGroups' => [1, 2],
                 ],
+            ],
+            'excerpt' => [
+                'title' => 'Excerpt Title',
+                'description' => 'Excerpt Description',
+                'segment' => 'test-segment',
+                'audienceTargetGroups' => [1, 2],
             ],
         ]);
 

--- a/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -47,6 +47,39 @@ class NavigationRepositoryTest extends TestCase
     /** @var ObjectProphecy<ContentResolverInterface> */
     private ObjectProphecy $contentResolver;
 
+    /**
+     * @return array<string, string>
+     */
+    private function getDefaultProperties(bool $loadExcerpt): array
+    {
+        $properties = [
+            'content.uuid' => 'object.resource.id',
+            'content.title' => 'title',
+            'content.url' => 'url',
+            'content.webspaceKey' => 'object.resource.webspaceKey',
+            'content.template' => 'object.templateKey',
+            'content.changed' => 'object.changed',
+            'content.changer' => 'object.changer',
+            'content.created' => 'object.created',
+            'content.creator' => 'object.creator',
+            'content.linkProvider' => 'object.linkData.linkProvider',
+        ];
+
+        if ($loadExcerpt) {
+            $properties['excerpt.title'] = 'excerpt.title';
+            $properties['excerpt.more'] = 'excerpt.more';
+            $properties['excerpt.description'] = 'excerpt.description';
+            $properties['excerpt.segment'] = 'excerpt.segment';
+            $properties['excerpt.categories'] = 'excerpt.categories';
+            $properties['excerpt.tags'] = 'excerpt.tags';
+            $properties['excerpt.audienceTargetGroups'] = 'excerpt.audienceTargetGroups';
+            $properties['excerpt.icon'] = 'excerpt.icon';
+            $properties['excerpt.image'] = 'excerpt.image';
+        }
+
+        return $properties;
+    }
+
     protected function setUp(): void
     {
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
@@ -129,7 +162,7 @@ class NavigationRepositoryTest extends TestCase
             'extension' => ['excerpt' => ['title' => 'Excerpt Title']],
         ]);
 
-        $result = $this->navigationRepository->getNavigationTree('main', 'en', 'sulu-io', 'segment-key', 1, ['excerpt' => true]);
+        $result = $this->navigationRepository->getNavigationTree('main', 'en', 'sulu-io', 'segment-key', 1, $this->getDefaultProperties(true));
 
         $this->assertNotEmpty($result);
         $this->assertCount(1, $result);
@@ -412,7 +445,7 @@ class NavigationRepositoryTest extends TestCase
         ]);
 
         /** @var array<int, array{excerpt?: array{title: string, segment: string}}> $result */
-        $result = $this->navigationRepository->getNavigationFlat('main', 'en', 'sulu-io', 'test-segment', 1, ['excerpt' => true]);
+        $result = $this->navigationRepository->getNavigationFlat('main', 'en', 'sulu-io', 'test-segment', 1, $this->getDefaultProperties(true));
 
         $this->assertNotEmpty($result);
         $this->assertCount(1, $result);

--- a/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -54,16 +54,16 @@ class NavigationRepositoryTest extends TestCase
     private function getDefaultProperties(bool $loadExcerpt): array
     {
         $properties = [
-            'content.uuid' => 'object.resource.id',
-            'content.title' => 'title',
-            'content.url' => 'url',
-            'content.webspaceKey' => 'object.resource.webspaceKey',
-            'content.template' => 'object.templateKey',
-            'content.changed' => 'object.changed',
-            'content.changer' => 'object.changer',
-            'content.created' => 'object.created',
-            'content.creator' => 'object.creator',
-            'content.linkProvider' => 'object.linkData.linkProvider',
+            'uuid' => 'object.resource.id',
+            'title' => 'title',
+            'url' => 'url',
+            'webspaceKey' => 'object.resource.webspaceKey',
+            'template' => 'object.templateKey',
+            'changed' => 'object.changed',
+            'changer' => 'object.changer',
+            'created' => 'object.created',
+            'creator' => 'object.creator',
+            'linkProvider' => 'object.linkData.linkProvider',
         ];
 
         if ($loadExcerpt) {
@@ -158,13 +158,12 @@ class NavigationRepositoryTest extends TestCase
             ->willReturn($dimensionContent->reveal());
         $this->contentResolver->resolve($dimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $page->reveal(),
-            'content' => [
+            'nav' => [
                 'title' => 'Page Title',
                 'webspaceKey' => 'sulu-io',
+                'excerpt' => ['title' => 'Excerpt Title'],
             ],
             'view' => [],
-            'extension' => ['excerpt' => ['title' => 'Excerpt Title']],
-            'excerpt' => ['title' => 'Excerpt Title'],
         ]);
 
         $result = $this->navigationRepository->getNavigationTree('main', 'en', 'sulu-io', 'segment-key', 1, $this->getDefaultProperties(true));
@@ -227,13 +226,12 @@ class NavigationRepositoryTest extends TestCase
             ->willReturn($dimensionContent->reveal());
         $this->contentResolver->resolve($dimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $page->reveal(),
-            'content' => [
+            'nav' => [
                 'title' => 'German Page',
                 'description' => 'Test',
                 'webspaceKey' => 'sulu-io',
             ],
             'view' => [],
-            'extension' => [],
         ]);
 
         $result = $this->navigationRepository->getNavigationFlat('footer', 'de', 'sulu-io', null, 2, $this->getDefaultProperties(false));
@@ -297,12 +295,11 @@ class NavigationRepositoryTest extends TestCase
             ->willReturn($dimensionContent->reveal());
         $this->contentResolver->resolve($dimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $page->reveal(),
-            'content' => [
+            'nav' => [
                 'title' => 'No Segment Page',
                 'webspaceKey' => 'test-webspace',
             ],
             'view' => [],
-            'extension' => [],
         ]);
 
         $result = $this->navigationRepository->getNavigationTree('sidebar', 'en', 'test-webspace', null, 3, $this->getDefaultProperties(false));
@@ -367,9 +364,8 @@ class NavigationRepositoryTest extends TestCase
             ->willReturn($parentDimensionContent->reveal());
         $this->contentResolver->resolve($parentDimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $parentPage->reveal(),
-            'content' => ['title' => 'Parent Page'],
+            'nav' => ['title' => 'Parent Page'],
             'view' => [],
-            'extension' => [],
         ]);
 
         // Setup content resolution for child
@@ -378,9 +374,8 @@ class NavigationRepositoryTest extends TestCase
             ->willReturn($childDimensionContent->reveal());
         $this->contentResolver->resolve($childDimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $childPage->reveal(),
-            'content' => ['title' => 'Child Page'],
+            'nav' => ['title' => 'Child Page'],
             'view' => [],
-            'extension' => [],
         ]);
 
         /** @var array<int, array{title: string, children: array<int, array{title: string, children: array<string, mixed>}>}> $result */
@@ -444,9 +439,8 @@ class NavigationRepositoryTest extends TestCase
             ->willReturn($dimensionContent->reveal());
         $this->contentResolver->resolve($dimensionContent->reveal(), Argument::type('array'))->willReturn([
             'resource' => $page->reveal(),
-            'content' => ['title' => 'Page with Excerpt'],
-            'view' => [],
-            'extension' => [
+            'nav' => [
+                'title' => 'Page with Excerpt',
                 'excerpt' => [
                     'title' => 'Excerpt Title',
                     'description' => 'Excerpt Description',
@@ -454,12 +448,7 @@ class NavigationRepositoryTest extends TestCase
                     'audienceTargetGroups' => [1, 2],
                 ],
             ],
-            'excerpt' => [
-                'title' => 'Excerpt Title',
-                'description' => 'Excerpt Description',
-                'segment' => 'test-segment',
-                'audienceTargetGroups' => [1, 2],
-            ],
+            'view' => [],
         ]);
 
         /** @var array<int, array{excerpt?: array{title: string, segment: string}}> $result */

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
@@ -28,34 +28,12 @@ class NavigationTwigExtensionTest extends TestCase
     /**
      * @return array<string, string>
      */
-    private function getDefaultProperties(bool $loadExcerpt): array
+    private function getDefaultProperties(): array
     {
-        $properties = [
-            'uuid' => 'object.resource.id',
+        return [
             'title' => 'title',
             'url' => 'url',
-            'webspaceKey' => 'object.resource.webspaceKey',
-            'template' => 'object.templateKey',
-            'changed' => 'object.changed',
-            'changer' => 'object.changer',
-            'created' => 'object.created',
-            'creator' => 'object.creator',
-            'linkProvider' => 'object.linkData.linkProvider',
         ];
-
-        if ($loadExcerpt) {
-            $properties['excerpt.title'] = 'excerpt.title';
-            $properties['excerpt.more'] = 'excerpt.more';
-            $properties['excerpt.description'] = 'excerpt.description';
-            $properties['excerpt.segment'] = 'excerpt.segment';
-            $properties['excerpt.categories'] = 'excerpt.categories';
-            $properties['excerpt.tags'] = 'excerpt.tags';
-            $properties['excerpt.audienceTargetGroups'] = 'excerpt.audienceTargetGroups';
-            $properties['excerpt.icon'] = 'excerpt.icon';
-            $properties['excerpt.image'] = 'excerpt.image';
-        }
-
-        return $properties;
     }
 
     /**
@@ -106,11 +84,11 @@ class NavigationTwigExtensionTest extends TestCase
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
         $requestAnalyzer->getSegment()->willReturn(null);
 
-        $navigationRepository->getNavigationFlat('main', 'en', 'sulu-io', null, 1, $this->getDefaultProperties(false))
+        $navigationRepository->getNavigationFlat('main', 'en', 'sulu-io', null, 1, $this->getDefaultProperties())
             ->willReturn([['title' => 'Page 1']])
             ->shouldBeCalled();
 
-        $result = $extension->flatRootNavigationFunction('main', 1, false);
+        $result = $extension->flatRootNavigationFunction('main', 1);
 
         $this->assertEquals([['title' => 'Page 1']], $result);
     }
@@ -133,11 +111,11 @@ class NavigationTwigExtensionTest extends TestCase
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
         $requestAnalyzer->getSegment()->willReturn(null);
 
-        $navigationRepository->getNavigationTree('main', 'en', 'sulu-io', null, 2, $this->getDefaultProperties(true))
+        $navigationRepository->getNavigationTree('main', 'en', 'sulu-io', null, 2, $this->getDefaultProperties())
             ->willReturn([['title' => 'Page 1', 'children' => []]])
             ->shouldBeCalled();
 
-        $result = $extension->treeRootNavigationFunction('main', 2, true);
+        $result = $extension->treeRootNavigationFunction('main', 2);
 
         $this->assertEquals([['title' => 'Page 1', 'children' => []]], $result);
     }
@@ -159,11 +137,11 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('en');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationRepository->getNavigationFlatByUuid('parent-uuid', 'en', 'sulu-io', 2, 'main', $this->getDefaultProperties(true))
+        $navigationRepository->getNavigationFlatByUuid('parent-uuid', 'en', 'sulu-io', 2, 'main', $this->getDefaultProperties())
             ->willReturn([['title' => 'Child 1'], ['title' => 'Child 2']])
             ->shouldBeCalled();
 
-        $result = $extension->flatNavigationFunction('parent-uuid', 'main', 2, true);
+        $result = $extension->flatNavigationFunction('parent-uuid', 'main', 2);
 
         $this->assertEquals([['title' => 'Child 1'], ['title' => 'Child 2']], $result);
     }
@@ -185,11 +163,11 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('en');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationRepository->getNavigationTreeByUuid('parent-uuid', 'en', 'sulu-io', 2, null, $this->getDefaultProperties(false))
+        $navigationRepository->getNavigationTreeByUuid('parent-uuid', 'en', 'sulu-io', 2, null, $this->getDefaultProperties())
             ->willReturn([['title' => 'Child 1', 'children' => [['title' => 'Grandchild 1']]]])
             ->shouldBeCalled();
 
-        $result = $extension->treeNavigationFunction('parent-uuid', null, 2, false);
+        $result = $extension->treeNavigationFunction('parent-uuid', null, 2);
 
         $this->assertEquals([['title' => 'Child 1', 'children' => [['title' => 'Grandchild 1']]]], $result);
     }
@@ -211,7 +189,7 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('en');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties(false))
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties())
             ->willReturn([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'child-uuid', 'title' => 'Child']])
             ->shouldBeCalled();
 
@@ -243,15 +221,15 @@ class NavigationTwigExtensionTest extends TestCase
             ['uuid' => 'child-uuid', 'title' => 'Child'],
         ];
 
-        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties(false))
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties())
             ->willReturn($breadcrumb)
             ->shouldBeCalled();
 
-        $navigationRepository->getNavigationFlatByUuid('grandparent-uuid', 'en', 'sulu-io', 1, null, $this->getDefaultProperties(false))
+        $navigationRepository->getNavigationFlatByUuid('grandparent-uuid', 'en', 'sulu-io', 1, null, $this->getDefaultProperties())
             ->willReturn([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'uncle-uuid', 'title' => 'Uncle']])
             ->shouldBeCalled();
 
-        $result = $extension->flatNavigationFunction('child-uuid', null, 1, false, 0);
+        $result = $extension->flatNavigationFunction('child-uuid', null, 1, 0);
 
         $this->assertEquals([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'uncle-uuid', 'title' => 'Uncle']], $result);
     }
@@ -277,11 +255,11 @@ class NavigationTwigExtensionTest extends TestCase
             ['uuid' => 'parent-uuid', 'title' => 'Parent'],
         ];
 
-        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties(false))
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties())
             ->willReturn($breadcrumb)
             ->shouldBeCalled();
 
-        $result = $extension->flatNavigationFunction('child-uuid', null, 1, false, 5);
+        $result = $extension->flatNavigationFunction('child-uuid', null, 1, 5);
 
         $this->assertEquals([], $result);
     }

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
@@ -31,16 +31,16 @@ class NavigationTwigExtensionTest extends TestCase
     private function getDefaultProperties(bool $loadExcerpt): array
     {
         $properties = [
-            'content.uuid' => 'object.resource.id',
-            'content.title' => 'title',
-            'content.url' => 'url',
-            'content.webspaceKey' => 'object.resource.webspaceKey',
-            'content.template' => 'object.templateKey',
-            'content.changed' => 'object.changed',
-            'content.changer' => 'object.changer',
-            'content.created' => 'object.created',
-            'content.creator' => 'object.creator',
-            'content.linkProvider' => 'object.linkData.linkProvider',
+            'uuid' => 'object.resource.id',
+            'title' => 'title',
+            'url' => 'url',
+            'webspaceKey' => 'object.resource.webspaceKey',
+            'template' => 'object.templateKey',
+            'changed' => 'object.changed',
+            'changer' => 'object.changer',
+            'created' => 'object.created',
+            'creator' => 'object.creator',
+            'linkProvider' => 'object.linkData.linkProvider',
         ];
 
         if ($loadExcerpt) {

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
@@ -26,6 +26,39 @@ class NavigationTwigExtensionTest extends TestCase
     use ProphecyTrait;
 
     /**
+     * @return array<string, string>
+     */
+    private function getDefaultProperties(bool $loadExcerpt): array
+    {
+        $properties = [
+            'content.uuid' => 'object.resource.id',
+            'content.title' => 'title',
+            'content.url' => 'url',
+            'content.webspaceKey' => 'object.resource.webspaceKey',
+            'content.template' => 'object.templateKey',
+            'content.changed' => 'object.changed',
+            'content.changer' => 'object.changer',
+            'content.created' => 'object.created',
+            'content.creator' => 'object.creator',
+            'content.linkProvider' => 'object.linkData.linkProvider',
+        ];
+
+        if ($loadExcerpt) {
+            $properties['excerpt.title'] = 'excerpt.title';
+            $properties['excerpt.more'] = 'excerpt.more';
+            $properties['excerpt.description'] = 'excerpt.description';
+            $properties['excerpt.segment'] = 'excerpt.segment';
+            $properties['excerpt.categories'] = 'excerpt.categories';
+            $properties['excerpt.tags'] = 'excerpt.tags';
+            $properties['excerpt.audienceTargetGroups'] = 'excerpt.audienceTargetGroups';
+            $properties['excerpt.icon'] = 'excerpt.icon';
+            $properties['excerpt.image'] = 'excerpt.image';
+        }
+
+        return $properties;
+    }
+
+    /**
      * @return array<array{bool, string, string}>
      */
     public static function activeElementProvider(): array
@@ -73,7 +106,7 @@ class NavigationTwigExtensionTest extends TestCase
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
         $requestAnalyzer->getSegment()->willReturn(null);
 
-        $navigationRepository->getNavigationFlat('main', 'en', 'sulu-io', null, 1, ['loadExcerpt' => false])
+        $navigationRepository->getNavigationFlat('main', 'en', 'sulu-io', null, 1, $this->getDefaultProperties(false))
             ->willReturn([['title' => 'Page 1']])
             ->shouldBeCalled();
 
@@ -100,7 +133,7 @@ class NavigationTwigExtensionTest extends TestCase
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
         $requestAnalyzer->getSegment()->willReturn(null);
 
-        $navigationRepository->getNavigationTree('main', 'en', 'sulu-io', null, 2, ['excerpt' => true])
+        $navigationRepository->getNavigationTree('main', 'en', 'sulu-io', null, 2, $this->getDefaultProperties(true))
             ->willReturn([['title' => 'Page 1', 'children' => []]])
             ->shouldBeCalled();
 
@@ -126,7 +159,7 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('en');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationRepository->getNavigationFlatByUuid('parent-uuid', 'en', 'sulu-io', 2, 'main', ['excerpt' => true])
+        $navigationRepository->getNavigationFlatByUuid('parent-uuid', 'en', 'sulu-io', 2, 'main', $this->getDefaultProperties(true))
             ->willReturn([['title' => 'Child 1'], ['title' => 'Child 2']])
             ->shouldBeCalled();
 
@@ -152,7 +185,7 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('en');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationRepository->getNavigationTreeByUuid('parent-uuid', 'en', 'sulu-io', 2, null, ['excerpt' => false])
+        $navigationRepository->getNavigationTreeByUuid('parent-uuid', 'en', 'sulu-io', 2, null, $this->getDefaultProperties(false))
             ->willReturn([['title' => 'Child 1', 'children' => [['title' => 'Grandchild 1']]]])
             ->shouldBeCalled();
 
@@ -178,7 +211,7 @@ class NavigationTwigExtensionTest extends TestCase
         $localization = new Localization('en');
         $requestAnalyzer->getCurrentLocalization()->willReturn($localization);
 
-        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', [])
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties(false))
             ->willReturn([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'child-uuid', 'title' => 'Child']])
             ->shouldBeCalled();
 
@@ -210,11 +243,11 @@ class NavigationTwigExtensionTest extends TestCase
             ['uuid' => 'child-uuid', 'title' => 'Child'],
         ];
 
-        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', [])
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties(false))
             ->willReturn($breadcrumb)
             ->shouldBeCalled();
 
-        $navigationRepository->getNavigationFlatByUuid('grandparent-uuid', 'en', 'sulu-io', 1, null, ['excerpt' => false])
+        $navigationRepository->getNavigationFlatByUuid('grandparent-uuid', 'en', 'sulu-io', 1, null, $this->getDefaultProperties(false))
             ->willReturn([['uuid' => 'parent-uuid', 'title' => 'Parent'], ['uuid' => 'uncle-uuid', 'title' => 'Uncle']])
             ->shouldBeCalled();
 
@@ -244,7 +277,7 @@ class NavigationTwigExtensionTest extends TestCase
             ['uuid' => 'parent-uuid', 'title' => 'Parent'],
         ];
 
-        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', [])
+        $navigationRepository->getBreadcrumb('child-uuid', 'en', 'sulu-io', $this->getDefaultProperties(false))
             ->willReturn($breadcrumb)
             ->shouldBeCalled();
 

--- a/packages/snippet/src/Infrastructure/Symfony/Twig/SnippetAreaTwigExtension.php
+++ b/packages/snippet/src/Infrastructure/Symfony/Twig/SnippetAreaTwigExtension.php
@@ -43,15 +43,15 @@ class SnippetAreaTwigExtension extends AbstractExtension
     }
 
     /**
-     * @param array<string, string>|null $properties
+     * @param array<string, string> $properties
      *
      * @return array<string, mixed>|null
      */
     public function loadSnippetByArea(
         string $areaKey,
+        array $properties,
         ?string $webspaceKey = null,
         ?string $locale = null,
-        ?array $properties = null,
     ): ?array {
         if (null === $webspaceKey) {
             $webspace = $this->requestAnalyzer->getWebspace();

--- a/packages/snippet/tests/Functional/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Snippet\Tests\Functional\Infrastructure\Symfony\Twig;
 
-use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Tests\Functional\Traits\CreateMediaTrait;
 use Sulu\Snippet\Infrastructure\Symfony\Twig\SnippetAreaTwigExtension;
@@ -57,20 +56,14 @@ class SnippetAreaTwigExtensionTest extends SuluTestCase
 
         self::getEntityManager()->flush();
 
-        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', 'sulu-io', 'en');
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', [], 'sulu-io', 'en');
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('content', $result);
 
         /** @var array<string, mixed> $content */
         $content = $result['content'];
-        $this->assertArrayHasKey('title', $content);
-        $this->assertSame('Test Snippet', $content['title']);
-        $this->assertArrayHasKey('description', $content);
-        $this->assertSame('This is a test snippet description', $content['description']);
-        $this->assertArrayHasKey('image', $content);
-        $this->assertInstanceOf(Media::class, $content['image']);
-        $this->assertSame($media->getId(), $content['image']->getId());
+        $this->assertEmpty($content);
     }
 
     public function testLoadSnippetByAreaWithProperties(): void
@@ -102,7 +95,7 @@ class SnippetAreaTwigExtensionTest extends SuluTestCase
             'description' => 'description',
         ];
 
-        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', 'sulu-io', 'en', $properties);
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', $properties, 'sulu-io', 'en');
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('title', $result);
@@ -118,7 +111,7 @@ class SnippetAreaTwigExtensionTest extends SuluTestCase
 
     public function testLoadSnippetByAreaReturnsNullWhenAreaNotFound(): void
     {
-        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('nonexistent', 'sulu-io', 'en');
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('nonexistent', [], 'sulu-io', 'en');
 
         $this->assertNull($result);
     }
@@ -136,7 +129,7 @@ class SnippetAreaTwigExtensionTest extends SuluTestCase
 
         self::getEntityManager()->flush();
 
-        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', 'sulu-io', 'en');
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', [], 'sulu-io', 'en');
 
         $this->assertNull($result);
     }

--- a/packages/snippet/tests/Unit/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
@@ -84,9 +84,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $webspaceKey = 'example';
         $locale = 'en';
 
-        // Create real objects
         $snippet = new Snippet('test-snippet-uuid');
-
         $snippetDimensionContent = new SnippetDimensionContent($snippet);
         $snippetDimensionContent->setTemplateData(['title' => 'Test Snippet']);
 
@@ -114,9 +112,9 @@ class SnippetAreaTwigExtensionTest extends TestCase
             ]
         )->willReturn($snippetDimensionContent);
 
-        $this->contentResolver->resolve($snippetDimensionContent, null)->willReturn($resolvedContent);
+        $this->contentResolver->resolve($snippetDimensionContent, [])->willReturn($resolvedContent);
 
-        $result = $this->extension->loadSnippetByArea($areaKey, $webspaceKey, $locale);
+        $result = $this->extension->loadSnippetByArea($areaKey, [], $webspaceKey, $locale);
 
         $this->assertSame($resolvedContent, $result);
 
@@ -168,9 +166,9 @@ class SnippetAreaTwigExtensionTest extends TestCase
             ]
         )->willReturn($snippetDimensionContent);
 
-        $this->contentResolver->resolve($snippetDimensionContent, null)->willReturn($resolvedContent);
+        $this->contentResolver->resolve($snippetDimensionContent, [])->willReturn($resolvedContent);
 
-        $result = $this->extension->loadSnippetByArea($areaKey);
+        $result = $this->extension->loadSnippetByArea($areaKey, []);
 
         $this->assertSame($resolvedContent, $result);
 
@@ -186,7 +184,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
 
         $this->requestAnalyzer->getWebspace()->willReturn(null);
 
-        $result = $this->extension->loadSnippetByArea($areaKey);
+        $result = $this->extension->loadSnippetByArea($areaKey, []);
 
         $this->assertNull($result);
     }
@@ -202,7 +200,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
         $this->requestAnalyzer->getCurrentLocalization()->willReturn(null);
 
-        $result = $this->extension->loadSnippetByArea($areaKey);
+        $result = $this->extension->loadSnippetByArea($areaKey, []);
 
         $this->assertNull($result);
     }
@@ -218,7 +216,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             'areaKey' => $areaKey,
         ])->willReturn(null);
 
-        $result = $this->extension->loadSnippetByArea($areaKey, $webspaceKey, $locale);
+        $result = $this->extension->loadSnippetByArea($areaKey, [], $webspaceKey, $locale);
 
         $this->assertNull($result);
     }
@@ -236,7 +234,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             'areaKey' => $areaKey,
         ])->willReturn($snippetArea);
 
-        $result = $this->extension->loadSnippetByArea($areaKey, $webspaceKey, $locale);
+        $result = $this->extension->loadSnippetByArea($areaKey, [], $webspaceKey, $locale);
 
         $this->assertNull($result);
     }
@@ -251,7 +249,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             ->willThrow(new SnippetAreaNotFoundException(['areaKey' => $areaKey]));
 
         $this->expectException(SnippetAreaNotFoundException::class);
-        $this->extension->loadSnippetByArea($areaKey, $webspaceKey, $locale);
+        $this->extension->loadSnippetByArea($areaKey, [], $webspaceKey, $locale);
     }
 
     public function testLoadSnippetByAreaWithProperties(): void
@@ -292,7 +290,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
 
         $this->contentResolver->resolve($snippetDimensionContent, $properties)->willReturn($resolvedContent);
 
-        $result = $this->extension->loadSnippetByArea($areaKey, $webspaceKey, $locale, $properties);
+        $result = $this->extension->loadSnippetByArea($areaKey, $properties, $webspaceKey, $locale);
 
         $this->assertSame($resolvedContent, $result);
     }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -25,9 +25,9 @@
                         <a href="{{ sulu_content_root_path() }}">Homepage</a>
                     </li>
 
-                    {% for item in sulu_navigation_root_tree('main') %}
+                    {% for item in sulu_page_navigation_root_tree('main') %}
                         <li>
-                            <a href="{{ sulu_content_path(item.url, item.webspaceKey) }}"
+                            <a href="{{ sulu_content_path(item.url) }}"
                                title="{{ item.title }}">{{ item.title }}</a>
                         </li>
                     {% endfor %}


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | yes
  | Deprecations? | no
  | Related issues/PRs | #7672
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  This PR refactors the Twig extension APIs to improve performance and make property field resolution explicit and customizable.

  **Navigation Functions:**
  - Renamed all navigation functions with `sulu_page_` prefix (e.g., `sulu_navigation_root_flat` → `sulu_page_navigation_root_flat`)
  - Removed `$loadExcerpt` boolean parameter
  - Added optional `$properties` parameter for custom field selection
  - Simplified default properties to only `title` and `url`

  **Content Load Functions:**
  - Made `$properties` parameter mandatory for page, article, and snippet loading

  #### Why?

  1. **Performance**: The old system loaded many unnecessary fields by default, causing performance issues
  2. **Clarity**: Property mappings were implicit; now developers must explicitly specify what they need
  3. **Flexibility**: Custom property selection was difficult without extending repository classes
  4. **Consistency**: Unified API across page, article, and snippet loading

  #### Example Usage

See upgrade-3.x.md