### PR TITLE
Support Default param in SingleSnippetSelection

### DIFF
--- a/packages/snippet/src/Domain/Repository/SnippetAreaRepositoryInterface.php
+++ b/packages/snippet/src/Domain/Repository/SnippetAreaRepositoryInterface.php
@@ -53,6 +53,16 @@ interface SnippetAreaRepositoryInterface
      *     uuids?: string[],
      *     webspaceKey?: string,
      *     areaKey?: string,
+     * } $filters
+     */
+    public function findSnippetUuidBy(array $filters): ?string;
+
+    /**
+     * @param array{
+     *     uuid?: string,
+     *     uuids?: string[],
+     *     webspaceKey?: string,
+     *     areaKey?: string,
      *     page?: int,
      *     limit?: int,
      * } $filters

--- a/packages/snippet/src/Domain/Repository/SnippetAreaRepositoryInterface.php
+++ b/packages/snippet/src/Domain/Repository/SnippetAreaRepositoryInterface.php
@@ -55,7 +55,7 @@ interface SnippetAreaRepositoryInterface
      *     areaKey?: string,
      * } $filters
      */
-    public function findSnippetUuidBy(array $filters): ?string;
+    public function findOneUuidBy(array $filters): ?string;
 
     /**
      * @param array{

--- a/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetAreaRepository.php
+++ b/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetAreaRepository.php
@@ -76,6 +76,20 @@ class SnippetAreaRepository implements SnippetAreaRepositoryInterface
         return $snippetArea;
     }
 
+    public function findSnippetUuidBy(array $filters): ?string
+    {
+        $queryBuilder = $this->createQueryBuilder($filters);
+        $queryBuilder->select('IDENTITY(area.snippet)');
+
+        try {
+            $result = $queryBuilder->getQuery()->getSingleScalarResult();
+
+            return \is_string($result) ? $result : null;
+        } catch (NoResultException $e) {
+            return null;
+        }
+    }
+
     public function countBy(array $filters = []): int
     {
         // The countBy method will ignore any page and limit parameters

--- a/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetAreaRepository.php
+++ b/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetAreaRepository.php
@@ -76,7 +76,7 @@ class SnippetAreaRepository implements SnippetAreaRepositoryInterface
         return $snippetArea;
     }
 
-    public function findSnippetUuidBy(array $filters): ?string
+    public function findOneUuidBy(array $filters): ?string
     {
         $queryBuilder = $this->createQueryBuilder($filters);
         $queryBuilder->select('IDENTITY(area.snippet)');

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
@@ -27,10 +27,21 @@ class SingleSnippetSelectionPropertyResolver implements PropertyResolverInterfac
      * @param array{
      *     resourceLoader?: string,
      *     properties?: array<string, mixed>|null,
+     *     default?: string,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
+        if ((null === $data || '' === $data) && isset($params['default'])) {
+            return ContentView::createSmartResolvable(
+                data: [
+                    'areaKey' => $params['default'],
+                ],
+                resourceLoaderKey: 'snippet_area_default',
+                view: $params,
+            );
+        }
+
         if (!\is_string($data)) {
             return ContentView::create(null, \array_merge(['id' => null], $params));
         }

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolver.php
@@ -53,7 +53,7 @@ class SnippetAreaSmartResolver implements SmartResolverInterface
         }
         $webspaceKey = $webspace->getKey();
 
-        $snippetId = $this->snippetAreaRepository->findSnippetUuidBy([
+        $snippetId = $this->snippetAreaRepository->findOneUuidBy([
             'webspaceKey' => $webspaceKey,
             'areaKey' => $areaKey,
         ]);

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Infrastructure\Sulu\Content\SmartResolver;
+
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
+use Sulu\Content\Application\SmartResolver\Resolver\SmartResolverInterface;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
+use Sulu\Snippet\Domain\Repository\SnippetAreaRepositoryInterface;
+use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
+
+/**
+ * Resolves default snippet from snippet area when SingleSnippetSelection has no selection.
+ *
+ * @internal if you need to override this service, create a new service based on SmartResolverInterface instead of extending this class
+ *
+ * @final
+ */
+class SnippetAreaSmartResolver implements SmartResolverInterface
+{
+    public function __construct(
+        private SnippetAreaRepositoryInterface $snippetAreaRepository,
+        private RequestAnalyzerInterface $requestAnalyzer,
+    ) {
+    }
+
+    public function resolve(SmartResolvable $resolvable, ?string $locale = null): ContentView
+    {
+        /**
+         * @var array{
+         *     areaKey: string,
+         * } $data
+         */
+        $data = $resolvable->getData();
+
+        $areaKey = $data['areaKey'];
+
+        $webspace = $this->requestAnalyzer->getWebspace();
+        if (null === $webspace) { // @phpstan-ignore identical.alwaysFalse
+            return ContentView::create(null, []);
+        }
+        $webspaceKey = $webspace->getKey();
+
+        $snippetId = $this->snippetAreaRepository->findSnippetUuidBy([
+            'webspaceKey' => $webspaceKey,
+            'areaKey' => $areaKey,
+        ]);
+
+        if (null === $snippetId) {
+            return ContentView::create(null, []);
+        }
+
+        return ContentView::createResolvableWithReferences(
+            id: $snippetId,
+            resourceLoaderKey: SnippetResourceLoader::getKey(),
+            resourceKey: SnippetInterface::RESOURCE_KEY,
+            view: [
+                'id' => $snippetId,
+            ],
+            priority: 100,
+        );
+    }
+
+    public static function getType(): string
+    {
+        return 'snippet_area_default';
+    }
+}

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -49,6 +49,7 @@ use Sulu\Snippet\Infrastructure\Sulu\Admin\SnippetAreaAdmin;
 use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SingleSnippetSelectionPropertyResolver;
 use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SnippetSelectionPropertyResolver;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
+use Sulu\Snippet\Infrastructure\Sulu\Content\SmartResolver\SnippetAreaSmartResolver;
 use Sulu\Snippet\Infrastructure\Sulu\Content\SnippetSmartContentProvider;
 use Sulu\Snippet\Infrastructure\Sulu\Reference\SnippetReferenceRefresher;
 use Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetIndexListener;
@@ -320,6 +321,15 @@ final class SuluSnippetBundle extends AbstractBundle
         $services->set('sulu_snippet.snippet_selection_property_resolver')
             ->class(SnippetSelectionPropertyResolver::class)
             ->tag('sulu_content.property_resolver');
+
+        // SmartResolver services
+        $services->set('sulu_snippet.snippet_area_smart_resolver')
+            ->class(SnippetAreaSmartResolver::class)
+            ->args([
+                new Reference('sulu_snippet.snippet_area_repository'),
+                new Reference('sulu_core.webspace.request_analyzer'),
+            ])
+            ->tag('sulu_content.smart_resolver', ['type' => 'snippet_area_default']);
 
         // ResourceLoader services
         $services->set('sulu_snippet.snippet_resource_loader')

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolverTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
 use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SingleSnippetSelectionPropertyResolver;
 
 #[CoversClass(SingleSnippetSelectionPropertyResolver::class)]
@@ -148,5 +149,50 @@ class SingleSnippetSelectionPropertyResolverTest extends TestCase
         $this->assertSame([
             'properties' => null,
         ], $content->getMetadata());
+    }
+
+    public function testResolveWithDefaultParameterWhenDataIsNull(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en', ['default' => 'header']);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(SmartResolvable::class, $content);
+        $this->assertSame('snippet_area_default', $content->getResourceLoaderKey());
+        $this->assertSame(['areaKey' => 'header'], $content->getData());
+        $this->assertSame(['default' => 'header'], $contentView->getView());
+    }
+
+    public function testResolveWithDefaultParameterWhenDataIsEmptyString(): void
+    {
+        $contentView = $this->resolver->resolve('', 'en', ['default' => 'footer']);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(SmartResolvable::class, $content);
+        $this->assertSame('snippet_area_default', $content->getResourceLoaderKey());
+        $this->assertSame(['areaKey' => 'footer'], $content->getData());
+        $this->assertSame(['default' => 'footer'], $contentView->getView());
+    }
+
+    public function testResolveWithDefaultParameterButDataIsSet(): void
+    {
+        $contentView = $this->resolver->resolve('snippet-123', 'en', ['default' => 'header']);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame('snippet-123', $content->getId());
+        $this->assertSame('snippet', $content->getResourceLoaderKey());
+
+        $this->assertSame([
+            'id' => 'snippet-123',
+            'default' => 'header',
+        ], $contentView->getView());
+    }
+
+    public function testResolveWithoutDefaultParameterWhenDataIsNull(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame(['id' => null], $contentView->getView());
     }
 }

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolverTest.php
@@ -73,7 +73,7 @@ class SnippetAreaSmartResolverTest extends TestCase
 
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
-        $this->snippetAreaRepository->findSnippetUuidBy([
+        $this->snippetAreaRepository->findOneUuidBy([
             'webspaceKey' => 'sulu_io',
             'areaKey' => 'header',
         ])->willReturn('snippet-uuid-123');
@@ -100,7 +100,7 @@ class SnippetAreaSmartResolverTest extends TestCase
 
         $this->requestAnalyzer->getWebspace()->willReturn($webspace);
 
-        $this->snippetAreaRepository->findSnippetUuidBy([
+        $this->snippetAreaRepository->findOneUuidBy([
             'webspaceKey' => 'sulu_io',
             'areaKey' => 'footer',
         ])->willReturn(null);
@@ -126,6 +126,6 @@ class SnippetAreaSmartResolverTest extends TestCase
         $this->assertNull($result->getContent());
         $this->assertSame([], $result->getView());
 
-        $this->snippetAreaRepository->findSnippetUuidBy()->shouldNotHaveBeenCalled();
+        $this->snippetAreaRepository->findOneUuidBy()->shouldNotHaveBeenCalled();
     }
 }

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolverTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Infrastructure\Sulu\Content\SmartResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
+use Sulu\Snippet\Domain\Repository\SnippetAreaRepositoryInterface;
+use Sulu\Snippet\Infrastructure\Sulu\Content\SmartResolver\SnippetAreaSmartResolver;
+
+#[CoversClass(SnippetAreaSmartResolver::class)]
+class SnippetAreaSmartResolverTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private SnippetAreaSmartResolver $resolver;
+
+    /** @var ObjectProphecy<SnippetAreaRepositoryInterface> */
+    private ObjectProphecy $snippetAreaRepository;
+
+    /** @var ObjectProphecy<RequestAnalyzerInterface> */
+    private ObjectProphecy $requestAnalyzer;
+
+    protected function setUp(): void
+    {
+        $this->snippetAreaRepository = $this->prophesize(SnippetAreaRepositoryInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->resolver = new SnippetAreaSmartResolver(
+            $this->snippetAreaRepository->reveal(),
+            $this->requestAnalyzer->reveal()
+        );
+    }
+
+    private function createWebspace(string $key): Webspace
+    {
+        $webspace = new Webspace();
+        $webspace->setKey($key);
+
+        return $webspace;
+    }
+
+    public function testGetType(): void
+    {
+        $this->assertSame('snippet_area_default', SnippetAreaSmartResolver::getType());
+    }
+
+    public function testResolveWithSnippet(): void
+    {
+        $smartResolvable = new SmartResolvable(
+            data: ['areaKey' => 'header'],
+            resourceLoaderKey: 'snippet_area_default',
+            priority: 2048
+        );
+
+        $webspace = $this->createWebspace('sulu_io');
+
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->snippetAreaRepository->findSnippetUuidBy([
+            'webspaceKey' => 'sulu_io',
+            'areaKey' => 'header',
+        ])->willReturn('snippet-uuid-123');
+
+        $result = $this->resolver->resolve($smartResolvable, 'en');
+
+        $content = $result->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $content);
+        $this->assertSame('snippet-uuid-123', $content->getId());
+        $this->assertSame('snippet', $content->getResourceLoaderKey());
+        $this->assertSame('snippets', $content->getResourceKey());
+        $this->assertSame(['id' => 'snippet-uuid-123'], $result->getView());
+    }
+
+    public function testResolveWithoutSnippet(): void
+    {
+        $smartResolvable = new SmartResolvable(
+            data: ['areaKey' => 'footer'],
+            resourceLoaderKey: 'snippet_area_default',
+            priority: 2048
+        );
+
+        $webspace = $this->createWebspace('sulu_io');
+
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->snippetAreaRepository->findSnippetUuidBy([
+            'webspaceKey' => 'sulu_io',
+            'areaKey' => 'footer',
+        ])->willReturn(null);
+
+        $result = $this->resolver->resolve($smartResolvable, 'en');
+
+        $this->assertNull($result->getContent());
+        $this->assertSame([], $result->getView());
+    }
+
+    public function testResolveWithoutWebspace(): void
+    {
+        $smartResolvable = new SmartResolvable(
+            data: ['areaKey' => 'sidebar'],
+            resourceLoaderKey: 'snippet_area_default',
+            priority: 2048
+        );
+
+        $this->requestAnalyzer->getWebspace()->willReturn(null);
+
+        $result = $this->resolver->resolve($smartResolvable, 'en');
+
+        $this->assertNull($result->getContent());
+        $this->assertSame([], $result->getView());
+
+        $this->snippetAreaRepository->findSnippetUuidBy()->shouldNotHaveBeenCalled();
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #7672 
| License | MIT

#### What's in this PR?

- adds support for the "default" param in the snippet template.

#### Why?

- this was already supported in Sulu 2.6

#### Example Usage

```twig
        <property name="header" type="single_snippet_selection">
            <meta>
                <title lang="en">Header-Snippet</title>
            </meta>

            <params>
                <param name="default" value="header-area"/>
            </params>
        </property>```
```