### PR TITLE
Add internal/external link indicators for Sulu 3.0

### DIFF
--- a/packages/page/config/lists/pages.xml
+++ b/packages/page/config/lists/pages.xml
@@ -228,5 +228,10 @@
             <field-name>workflowPlace</field-name>
             <entity-name>dimensionContent</entity-name>
         </property>
+
+        <property name="linkProvider" visibility="never">
+            <field-name>linkProvider</field-name>
+            <entity-name>dimensionContent</entity-name>
+        </property>
     </properties>
 </list>

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -98,7 +98,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
             $filters['shadowLocale'] = null;
         }
 
-        $includedFields = ['locale', 'ghostLocale', 'shadowLocale', 'webspaceKey', 'template', 'publishedState'];
+        $includedFields = ['locale', 'ghostLocale', 'shadowLocale', 'webspaceKey', 'template', 'publishedState', 'linkProvider'];
 
         // TODO this should be handled by PageRepository, currently copied from
         //      https://github.com/handcraftedinthealps/SuluResourceBundle

--- a/packages/page/tests/Functional/Integration/responses/page_cget.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget.json
@@ -16,6 +16,7 @@
             "webspaceKey" : "sulu-io",
             "template" : null,
             "version" : null,
+            "linkProvider": null,
             "hasChildren" : true,
             "_embedded" : {
                 "pages" : [ {
@@ -34,6 +35,7 @@
                     "webspaceKey" : "sulu-io",
                     "template" : "default",
                     "version" : 0,
+                    "linkProvider": null,
                     "hasChildren" : false
                 } ]
             }

--- a/packages/page/tests/Functional/Integration/responses/page_cget_after_copy.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget_after_copy.json
@@ -16,6 +16,7 @@
                 "webspaceKey": "sulu-io",
                 "template": null,
                 "publishedState": false,
+                "linkProvider": null,
                 "hasChildren": true,
                 "_hasPermissions": false,
                 "_embedded": {
@@ -35,6 +36,7 @@
                             "webspaceKey": "sulu-io",
                             "template": "default",
                             "publishedState": false,
+                            "linkProvider": null,
                             "hasChildren": true,
                             "_hasPermissions": false
                         },
@@ -53,6 +55,7 @@
                             "webspaceKey": "sulu-io",
                             "template": "default",
                             "publishedState": true,
+                            "linkProvider": null,
                             "hasChildren": true,
                             "_hasPermissions": false,
                             "_embedded": {
@@ -72,6 +75,7 @@
                                         "webspaceKey": "sulu-io",
                                         "template": "default",
                                         "publishedState": false,
+                                        "linkProvider": null,
                                         "hasChildren": false,
                                         "_hasPermissions": false
                                     }

--- a/packages/page/tests/Functional/Integration/responses/page_cget_after_move.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget_after_move.json
@@ -16,6 +16,7 @@
                 "template": null,
                 "version": null,
                 "publishedState": false,
+                "linkProvider": null,
                 "hasChildren": true,
                 "_hasPermissions": false,
                 "_embedded": {
@@ -35,6 +36,7 @@
                             "template": "default",
                             "version" : 0,
                             "publishedState": false,
+                            "linkProvider": null,
                             "hasChildren": true,
                             "_hasPermissions": false
                         },
@@ -53,6 +55,7 @@
                             "template": "default",
                             "version" : 0,
                             "publishedState": true,
+                            "linkProvider": null,
                             "hasChildren": false,
                             "_hasPermissions": false
                         },
@@ -71,6 +74,7 @@
                             "template": "default",
                             "version" : 0,
                             "publishedState": false,
+                            "linkProvider": null,
                             "hasChildren": false,
                             "_hasPermissions": false
                         }

--- a/packages/page/tests/Functional/Integration/responses/page_cget_exclude_ghost_shadow.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget_exclude_ghost_shadow.json
@@ -17,6 +17,7 @@
                 "webspaceKey": "sulu-io",
                 "template": null,
                 "publishedState": false,
+                "linkProvider": null,
                 "hasChildren": true,
                 "_embedded": {
                     "pages": [
@@ -30,6 +31,7 @@
                             "ghostLocale": null,
                             "hasChildren": true,
                             "id": "@string@",
+                            "linkProvider": null,
                             "version" : 0,
                             "locale": "de",
                             "publishedState": false,

--- a/packages/page/tests/Functional/Integration/responses/page_cget_ghost_shadow.json
+++ b/packages/page/tests/Functional/Integration/responses/page_cget_ghost_shadow.json
@@ -16,6 +16,7 @@
                 "webspaceKey": "sulu-io",
                 "template": null,
                 "publishedState": false,
+                "linkProvider": null,
                 "hasChildren": true,
                 "_hasPermissions": false,
                 "_embedded": {
@@ -35,6 +36,7 @@
                             "webspaceKey": "sulu-io",
                             "template": "default",
                             "publishedState": false,
+                            "linkProvider": null,
                             "hasChildren": true,
                             "_hasPermissions": false,
                             "_embedded": {
@@ -54,6 +56,7 @@
                                         "webspaceKey": "sulu-io",
                                         "template": null,
                                         "publishedState": false,
+                                        "linkProvider": null,
                                         "hasChildren": false,
                                         "_hasPermissions": false
                                     },
@@ -72,6 +75,7 @@
                                         "webspaceKey": "sulu-io",
                                         "template": null,
                                         "publishedState": false,
+                                        "linkProvider": null,
                                         "hasChildren": false,
                                         "_hasPermissions": false
                                     },
@@ -90,6 +94,7 @@
                                         "webspaceKey": "sulu-io",
                                         "template": null,
                                         "publishedState": false,
+                                        "linkProvider": null,
                                         "hasChildren": false,
                                         "_hasPermissions": false
                                     },
@@ -103,6 +108,7 @@
                                         "ghostLocale": null,
                                         "hasChildren": false,
                                         "id": "@string@",
+                                        "linkProvider": null,
                                         "locale": "de",
                                         "publishedState": false,
                                         "shadowLocale": "en",

--- a/packages/page/tests/Functional/Integration/responses/page_post_before_order_list.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_before_order_list.json
@@ -16,6 +16,7 @@
                 "webspaceKey": "sulu-io",
                 "template": null,
                 "version": null,
+                "linkProvider": null,
                 "hasChildren": true,
                 "_hasPermissions": false,
                 "_embedded": {
@@ -35,6 +36,7 @@
                             "webspaceKey": "sulu-io",
                             "template": "default",
                             "version" : 0,
+                            "linkProvider": null,
                             "hasChildren": true,
                             "_hasPermissions": false,
                             "_embedded": {
@@ -54,6 +56,7 @@
                                         "webspaceKey": "sulu-io",
                                         "template": "default",
                                         "version" : 0,
+                                        "linkProvider": null,
                                         "hasChildren": false,
                                         "_hasPermissions": false
                                     },
@@ -72,6 +75,7 @@
                                         "webspaceKey": "sulu-io",
                                         "template": "default",
                                         "version" : 0,
+                                        "linkProvider": null,
                                         "hasChildren": false,
                                         "_hasPermissions": false
                                     },
@@ -90,6 +94,7 @@
                                         "webspaceKey": "sulu-io",
                                         "template": "default",
                                         "version" : 0,
+                                        "linkProvider": null,
                                         "hasChildren": false,
                                         "_hasPermissions": false
                                     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/adapters/ColumnListAdapter.js
@@ -112,10 +112,11 @@ class ColumnListAdapter extends AbstractAdapter {
             indicators.push(<Icon key="permissions" name="su-permissions" />);
         }
 
-        if (item.linked === 'internal') {
-            indicators.push(<Icon key="internal" name="su-link2" />);
-        } else if (item.linked === 'external') {
+        if (item.linkProvider === 'external') {
             indicators.push(<Icon key="external" name="su-link" />);
+        }
+        else if (item.linkProvider !== undefined) {
+            indicators.push(<Icon key="internal" name="su-link2" />);
         } else if (item.shadowLocale) {
             indicators.push(<Icon key="shadow" name="su-shadow-page" />);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js
@@ -31,7 +31,7 @@ test('Render different kind of data with edit button', () => {
                 hasChildren: false,
                 publishedState: false,
                 published: '2017-08-23',
-                linked: 'internal',
+                linkProvider: 'page',
             },
             {
                 id: 7,
@@ -39,7 +39,7 @@ test('Render different kind of data with edit button', () => {
                 hasChildren: false,
                 publishedState: true,
                 published: '2017-08-23',
-                linked: 'internal',
+                linkProvider: 'page',
             },
         ],
         [
@@ -63,7 +63,7 @@ test('Render different kind of data with edit button', () => {
                 hasChildren: false,
                 publishedState: false,
                 published: '2017-08-23',
-                linked: 'external',
+                linkProvider: 'external',
             },
             {
                 id: 9,
@@ -71,7 +71,7 @@ test('Render different kind of data with edit button', () => {
                 hasChildren: false,
                 publishedState: true,
                 published: '2017-08-23',
-                linked: 'external',
+                linkProvider: 'external',
             },
         ],
         [


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes # <!-- add issue number here if applicable -->
  | Related issues/PRs | # <!-- add issue or PR number here if applicable -->
  | License | MIT
  | Documentation PR | sulu/sulu-docs# <!-- add docs PR number here if needed -->

  #### What's in this PR?

  This PR fixes the display of internal/external link indicators in the page list by updating the frontend to use the `linkProvider` property instead of the deprecated `linked` property.

  **Backend changes:**
  - Added `linkProvider` field to pages list configuration (`packages/page/config/lists/pages.xml`)
  - Included `linkProvider` in the page list response fields (`PageController.php`)

  **Frontend changes:**
  - Updated `ColumnListAdapter.js` to check `item.linkProvider` instead of `item.linked`
  - Now displays external link icon (`su-link`) when `linkProvider === 'external'`
  - Displays internal link icon (`su-link2`) when `linkProvider` is set to any other value (e.g., `page`, `media`, etc.)

  #### Why?

  This mismatch caused the internal/external link indicators to not display correctly in the page list, breaking the visual feedback that was working in Sulu 2.6.