### PR TITLE
Fix removal of entity with ghost locale

### DIFF
--- a/packages/article/src/Application/MessageHandler/RemoveArticleMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/RemoveArticleMessageHandler.php
@@ -14,6 +14,7 @@ namespace Sulu\Article\Application\MessageHandler;
 use Sulu\Article\Application\Message\RemoveArticleMessage;
 use Sulu\Article\Domain\Event\ArticleRemovedEvent;
 use Sulu\Article\Domain\Model\ArticleDimensionContent;
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface;
@@ -45,10 +46,24 @@ final class RemoveArticleMessageHandler
         $this->trashManager?->store($resourceKey, $article);
 
         $dimensionContentCollection = new DimensionContentCollection($article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        /** @var ArticleDimensionContentInterface|null $localizedDimensionContent */
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $message->getLocale()]);
         $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);
         $context = $unlocalizedDimensionContent?->getAvailableLocales() ? ['locales' => $unlocalizedDimensionContent->getAvailableLocales()] : [];
 
-        $this->domainEventCollector->collect(new ArticleRemovedEvent($article->getId(), $localizedDimensionContent?->getTitle(), $context));
+        // Try to get title from the removed locale first, fallback to any available locale if null
+        $title = $localizedDimensionContent?->getTitle();
+        if (null === $title && $unlocalizedDimensionContent) {
+            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
+            foreach ($availableLocales as $availableLocale) {
+                $fallbackDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $availableLocale]);
+                if ($fallbackDimensionContent instanceof ArticleDimensionContentInterface && null !== $fallbackDimensionContent->getTitle()) {
+                    $title = $fallbackDimensionContent->getTitle();
+                    break;
+                }
+            }
+        }
+
+        $this->domainEventCollector->collect(new ArticleRemovedEvent($article->getId(), $title, $context));
     }
 }

--- a/packages/article/src/Application/MessageHandler/RemoveArticleMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/RemoveArticleMessageHandler.php
@@ -54,7 +54,7 @@ final class RemoveArticleMessageHandler
         // Try to get title from the removed locale first, fallback to any available locale if null
         $title = $localizedDimensionContent?->getTitle();
         if (null === $title && $unlocalizedDimensionContent) {
-            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
+            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales() ?? [];
             foreach ($availableLocales as $availableLocale) {
                 $fallbackDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $availableLocale]);
                 if ($fallbackDimensionContent instanceof ArticleDimensionContentInterface && null !== $fallbackDimensionContent->getTitle()) {

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -337,7 +337,7 @@ class ArticleControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
-    public function testDeleteSingleLocale(string $id): void
+    public function testDeleteSingleLocale(string $id): string
     {
         $this->client->request('GET', '/admin/api/articles/' . $id . '?locale=en');
         $response = $this->client->getResponse();
@@ -395,6 +395,33 @@ class ArticleControllerTest extends SuluTestCase
         $availableLocales = $content['availableLocales'];
         $this->assertContains('en', $availableLocales);
         $this->assertNotContains('de', $availableLocales);
+
+        return $id;
+    }
+
+    #[Depends('testDeleteSingleLocale')]
+    public function testRecreateDeletedLocale(string $id): string
+    {
+        $this->client->request('PUT', '/admin/api/articles/' . $id . '?locale=de', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'Recreated Test Article (DE)',
+            'url' => '/de/recreated-my-article',
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        /** @var array<int, string> $contentLocales */
+        $contentLocales = $content['contentLocales'];
+        $this->assertContains('en', $availableLocales);
+        $this->assertContains('de', $availableLocales);
+        $this->assertContains('en', $contentLocales);
+        $this->assertContains('de', $contentLocales);
+
+        return $id;
     }
 
     #[Depends('testPost')]
@@ -406,7 +433,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(204, $response);
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(4, $routeRepository->findBy([])); // TODO we need tackle this
+        $this->assertCount(5, $routeRepository->findBy([])); // TODO we need tackle this
 
         $trashRepository = self::getContainer()->get(TrashItemRepositoryInterface::class);
         $trashItem = $trashRepository->findOneBy([

--- a/packages/article/tests/Functional/Integration/responses/article_post_restore.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post_restore.json
@@ -2,12 +2,14 @@
     "author": null,
     "authored": "2020-06-09T00:00:00+00:00",
     "availableLocales": [
-        "en"
+        "en",
+        "de"
     ],
     "changed": "@datetime@",
     "changer": "@integer@",
     "contentLocales": [
-        "en"
+        "en",
+        "de"
     ],
     "created": "@datetime@",
     "creator": "@integer@",
@@ -21,7 +23,7 @@
     "excerptSegment": "updated-segment",
     "excerptTags": [],
     "excerptTitle": "Excerpt Title 2",
-    "ghostLocale": "en",
+    "ghostLocale": "de",
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
@@ -17,6 +17,7 @@ use Sulu\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Page\Application\Message\RemovePageMessage;
 use Sulu\Page\Domain\Event\PageRemovedEvent;
 use Sulu\Page\Domain\Model\PageDimensionContent;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 
 /**
@@ -45,14 +46,29 @@ final class RemovePageMessageHandler
         $this->trashManager?->store($resourceKey, $page);
 
         $dimensionContentCollection = new DimensionContentCollection($page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
-        /** @var PageDimensionContent $localizedDimensionContent */
+        /** @var PageDimensionContentInterface|null $localizedDimensionContent */
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $message->getLocale()]);
+        $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);
+        $context = $unlocalizedDimensionContent?->getAvailableLocales() ? ['locales' => $unlocalizedDimensionContent->getAvailableLocales()] : [];
+
+        // Try to get title from the removed locale first, fallback to any available locale if null
+        $title = $localizedDimensionContent?->getTitle();
+        if (null === $title && $unlocalizedDimensionContent) {
+            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
+            foreach ($availableLocales as $availableLocale) {
+                $fallbackDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $availableLocale]);
+                if ($fallbackDimensionContent instanceof PageDimensionContentInterface && null !== $fallbackDimensionContent->getTitle()) {
+                    $title = $fallbackDimensionContent->getTitle();
+                    break;
+                }
+            }
+        }
 
         $this->domainEventCollector->collect(new PageRemovedEvent(
             $page->getUuid(),
             $page->getWebspaceKey(),
-            $localizedDimensionContent->getTitle(),
-            []
+            $title,
+            $context
         ));
     }
 }

--- a/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
@@ -54,7 +54,7 @@ final class RemovePageMessageHandler
         // Try to get title from the removed locale first, fallback to any available locale if null
         $title = $localizedDimensionContent?->getTitle();
         if (null === $title && $unlocalizedDimensionContent) {
-            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
+            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales() ?? [];
             foreach ($availableLocales as $availableLocale) {
                 $fallbackDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $availableLocale]);
                 if ($fallbackDimensionContent instanceof PageDimensionContentInterface && null !== $fallbackDimensionContent->getTitle()) {

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -703,7 +703,7 @@ class PageControllerTest extends SuluTestCase
     }
 
     #[Depends('testMove')]
-    public function testDeleteSingleLocale(string $id): void
+    public function testDeleteSingleLocale(string $id): string
     {
         $this->client->request('GET', '/admin/api/pages/' . $id . '?locale=en');
         $response = $this->client->getResponse();
@@ -761,6 +761,33 @@ class PageControllerTest extends SuluTestCase
         $availableLocales = $content['availableLocales'];
         $this->assertContains('de', $availableLocales);
         $this->assertNotContains('en', $availableLocales);
+
+        return $id;
+    }
+
+    #[Depends('testDeleteSingleLocale')]
+    public function testRecreateDeletedLocale(string $id): string
+    {
+        $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=en', [], [], [], \json_encode([
+            'template' => 'default',
+            'title' => 'Recreated Test Page (EN)',
+            'url' => '/recreated-my-page',
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        /** @var array<int, string> $contentLocales */
+        $contentLocales = $content['contentLocales'];
+        $this->assertContains('en', $availableLocales);
+        $this->assertContains('de', $availableLocales);
+        $this->assertContains('en', $contentLocales);
+        $this->assertContains('de', $contentLocales);
+
+        return $id;
     }
 
     #[Depends('testPost')]
@@ -772,7 +799,7 @@ class PageControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(204, $response);
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(11, $routeRepository->findBy([])); // TODO we need tackle this
+        $this->assertCount(12, $routeRepository->findBy([])); // TODO we need tackle this
 
         $trashRepository = self::getContainer()->get(TrashItemRepositoryInterface::class);
         $trashItem = $trashRepository->findOneBy([

--- a/packages/snippet/src/Application/MessageHandler/RemoveSnippetMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/RemoveSnippetMessageHandler.php
@@ -17,6 +17,7 @@ use Sulu\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Snippet\Application\Message\RemoveSnippetMessage;
 use Sulu\Snippet\Domain\Event\SnippetRemovedEvent;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContent;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 
 /**
@@ -45,11 +46,24 @@ final class RemoveSnippetMessageHandler
         $this->trashManager?->store($resourceKey, $snippet);
 
         $dimensionContentCollection = new DimensionContentCollection($snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
-        /** @var SnippetDimensionContent $localizedDimensionContent */
+        /** @var SnippetDimensionContentInterface|null $localizedDimensionContent */
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $message->getLocale()]);
         $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);
         $context = $unlocalizedDimensionContent?->getAvailableLocales() ? ['locales' => $unlocalizedDimensionContent->getAvailableLocales()] : [];
 
-        $this->domainEventCollector->collect(new SnippetRemovedEvent($snippet->getId(), $localizedDimensionContent->getTitle(), $context));
+        // Try to get title from the removed locale first, fallback to any available locale if null
+        $title = $localizedDimensionContent?->getTitle();
+        if (null === $title && $unlocalizedDimensionContent) {
+            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
+            foreach ($availableLocales as $availableLocale) {
+                $fallbackDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $availableLocale]);
+                if ($fallbackDimensionContent instanceof SnippetDimensionContentInterface && null !== $fallbackDimensionContent->getTitle()) {
+                    $title = $fallbackDimensionContent->getTitle();
+                    break;
+                }
+            }
+        }
+
+        $this->domainEventCollector->collect(new SnippetRemovedEvent($snippet->getId(), $title, $context));
     }
 }

--- a/packages/snippet/src/Application/MessageHandler/RemoveSnippetMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/RemoveSnippetMessageHandler.php
@@ -54,7 +54,7 @@ final class RemoveSnippetMessageHandler
         // Try to get title from the removed locale first, fallback to any available locale if null
         $title = $localizedDimensionContent?->getTitle();
         if (null === $title && $unlocalizedDimensionContent) {
-            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
+            $availableLocales = $unlocalizedDimensionContent->getAvailableLocales() ?? [];
             foreach ($availableLocales as $availableLocale) {
                 $fallbackDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $availableLocale]);
                 if ($fallbackDimensionContent instanceof SnippetDimensionContentInterface && null !== $fallbackDimensionContent->getTitle()) {

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -260,7 +260,7 @@ class SnippetControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
-    public function testDeleteSingleLocale(string $id): void
+    public function testDeleteSingleLocale(string $id): string
     {
         $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=en');
         $response = $this->client->getResponse();
@@ -309,6 +309,35 @@ class SnippetControllerTest extends SuluTestCase
         $availableLocales = $content['availableLocales'];
         $this->assertContains('en', $availableLocales);
         $this->assertNotContains('de', $availableLocales);
+
+        return $id;
+    }
+
+    #[Depends('testDeleteSingleLocale')]
+    public function testRecreateDeletedLocale(string $id): string
+    {
+        $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{template: string, title: string} $snippetData */
+        $snippetData = \json_decode((string) $response->getContent(), true);
+
+        $this->client->request('PUT', '/admin/api/snippets/' . $id . '?locale=de', [], [], [], \json_encode([
+            'template' => $snippetData['template'],
+            'title' => 'Recreated Test Snippet (DE)',
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        /** @var array<int, string> $availableLocales */
+        $availableLocales = $content['availableLocales'];
+        $this->assertContains('en', $availableLocales);
+        $this->assertContains('de', $availableLocales);
+
+        return $id;
     }
 
     #[Depends('testPost')]

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
@@ -1,6 +1,7 @@
 {
     "availableLocales": [
-        "en"
+        "en",
+        "de"
     ],
     "changed": "@datetime@",
     "changer" : "@integer@",
@@ -16,7 +17,7 @@
     "excerptSegment": null,
     "excerptTags": [],
     "excerptTitle": "Excerpt Title 2",
-    "ghostLocale": "en",
+    "ghostLocale": "de",
     "id": "@string@",
     "image": null,
     "locale": "en",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #8316 
| License | MIT

#### What's in this PR?

- Fixes an issue when a page/article/snippet was removed via the ghost locale
- Added an additional test to verify that the recreation of a removed locale is working as expected.

#### Why?

- Removing a ghost locale should not result in an error.