### PR TITLE
Deal with absent default meta

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -940,7 +940,7 @@ class Media extends ApiWrapper
     /**
      * @param bool $create
      *
-     * @return FileVersionMeta
+     * @return ($create is true ? FileVersionMeta : FileVersionMeta|null)
      */
     private function getMeta($create = false)
     {

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -533,7 +533,7 @@ class FileVersion implements AuditableInterface
     /**
      * Get defaultMeta.
      *
-     * @return FileVersionMeta
+     * @return FileVersionMeta|null
      */
     public function getDefaultMeta()
     {

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -549,7 +549,7 @@ class FileVersion implements AuditableInterface
             $this->id = null;
             /** @var FileVersionMeta[] $newMetaList */
             $newMetaList = [];
-            $defaultMetaLocale = $this->getDefaultMeta()->getLocale();
+            $defaultMetaLocale = $this->getDefaultMeta()?->getLocale();
             /** @var FileVersionContentLanguage[] $newContentLanguageList */
             $newContentLanguageList = [];
             /** @var FileVersionPublishLanguage[] $newPublishLanguageList */

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Trash/MediaTrashItemHandlerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Trash/MediaTrashItemHandlerTest.php
@@ -260,7 +260,7 @@ class MediaTrashItemHandlerTest extends SuluTestCase
         static::assertSame([], $restoredFile1Version1->getProperties());
         static::assertSame(101, $restoredFile1Version1->getFocusPointX());
         static::assertSame(202, $restoredFile1Version1->getFocusPointY());
-        static::assertSame('de', $restoredFile1Version1->getDefaultMeta()->getLocale());
+        static::assertSame('de', $restoredFile1Version1->getDefaultMeta()?->getLocale());
         static::assertCount(0, $restoredFile1Version1->getTags());
         static::assertCount(0, $restoredFile1Version1->getCategories());
         static::assertCount(0, $restoredFile1Version1->getTargetGroups());
@@ -286,7 +286,7 @@ class MediaTrashItemHandlerTest extends SuluTestCase
         static::assertSame(35, $restoredFile1Version2->getFocusPointX());
         static::assertSame(45, $restoredFile1Version2->getFocusPointY());
         static::assertCount(2, $restoredFile1Version2->getMeta());
-        static::assertSame('de', $restoredFile1Version2->getDefaultMeta()->getLocale());
+        static::assertSame('de', $restoredFile1Version2->getDefaultMeta()?->getLocale());
         static::assertCount(2, $restoredFile1Version2->getFormatOptions());
 
         static::assertCount(2, $restoredFile1Version2->getTags());

--- a/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
+++ b/src/Sulu/Bundle/MediaBundle/Trash/MediaTrashItemHandler.php
@@ -114,7 +114,7 @@ final class MediaTrashItemHandler implements
                     'contentLanguageLocales' => [],
                     'publishLanguageLocales' => [],
                     'meta' => [],
-                    'defaultMetaLocale' => $fileVersion->getDefaultMeta()->getLocale(),
+                    'defaultMetaLocale' => $fileVersion->getDefaultMeta()?->getLocale(),
                     'formatOptions' => [],
                     'tagIds' => [],
                     'categoryIds' => [],
@@ -262,7 +262,9 @@ final class MediaTrashItemHandler implements
                     $meta->setFileVersion($fileVersion);
                     $fileVersion->addMeta($meta);
 
-                    if ($metaData['locale'] === $fileVersionData['defaultMetaLocale']) {
+                    if ($metaData['locale'] === $fileVersionData['defaultMetaLocale']
+                        || !$fileVersion->getDefaultMeta()
+                    ) {
                         $fileVersion->setDefaultMeta($meta);
                     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This change fixes the functionality for uploading a new file version in the Media bundle.

#### Why?

Technically (and in our database in practice too!), the default file meta is not necessarily available for every media file. If you upload a new version, the current code in `__clone` expects to find a default meta and calls `getLocale()` on it. It should deal with the fact that the return value of `getDefaultMeta()` may be `null`.
