### PR TITLE
Remove Custom url tab if not defined

### DIFF
--- a/packages/custom-url/src/Infrastructure/Sulu/Admin/CustomUrlAdmin.php
+++ b/packages/custom-url/src/Infrastructure/Sulu/Admin/CustomUrlAdmin.php
@@ -138,7 +138,7 @@ class CustomUrlAdmin extends Admin
         foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
             foreach ($webspace->getPortals() as $portal) {
                 $environment = $portal->getEnvironment($this->environment);
-                if ($environment && \count($environment->getCustomUrls()) > 0) {
+                if (\count($environment->getCustomUrls()) > 0) {
                     return true;
                 }
             }

--- a/packages/custom-url/src/Infrastructure/Sulu/Admin/CustomUrlAdmin.php
+++ b/packages/custom-url/src/Infrastructure/Sulu/Admin/CustomUrlAdmin.php
@@ -44,7 +44,8 @@ class CustomUrlAdmin extends Admin
     public function __construct(
         private WebspaceManagerInterface $webspaceManager,
         private ViewBuilderFactoryInterface $viewBuilderFactory,
-        private SecurityCheckerInterface $securityChecker
+        private SecurityCheckerInterface $securityChecker,
+        private string $environment
     ) {
     }
 
@@ -55,7 +56,7 @@ class CustomUrlAdmin extends Admin
             new ToolbarAction('sulu_admin.delete'),
         ];
 
-        if ($this->hasSomeWebspaceCustomUrlPermission()) {
+        if ($this->hasSomeWebspaceCustomUrlPermission() && $this->hasAnyWebspaceWithCustomUrls()) {
             $viewCollection->add(
                 $this->viewBuilderFactory
                     ->createFormOverlayListViewBuilder(self::LIST_VIEW, '/custom-urls')
@@ -126,6 +127,20 @@ class CustomUrlAdmin extends Admin
 
             if ($hasWebspacePermission) {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasAnyWebspaceWithCustomUrls(): bool
+    {
+        foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
+            foreach ($webspace->getPortals() as $portal) {
+                $environment = $portal->getEnvironment($this->environment);
+                if ($environment && \count($environment->getCustomUrls()) > 0) {
+                    return true;
+                }
             }
         }
 

--- a/packages/custom-url/src/Infrastructure/Symfony/HttpKernel/SuluCustomUrlBundle.php
+++ b/packages/custom-url/src/Infrastructure/Symfony/HttpKernel/SuluCustomUrlBundle.php
@@ -158,6 +158,7 @@ final class SuluCustomUrlBundle extends AbstractBundle
                 service(WebspaceManagerInterface::class),
                 service(ViewBuilderFactoryInterface::class),
                 service(SecurityCheckerInterface::class),
+                '%kernel.environment%',
             ])
             ->tag('sulu.admin')
             ->tag('sulu.context', ['context' => 'admin']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7672 
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR add a condition to hide the custom-url tab when no custom-url is configured.