### PR TITLE
Add default param to SnippetSelectionPropertyResolver

### DIFF
--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
@@ -27,10 +27,21 @@ class SnippetSelectionPropertyResolver implements PropertyResolverInterface
      * @param array{
      *     resourceLoader?: string,
      *     properties?: array<string, mixed>|null,
+     *     default?: string,
      * } $params
      */
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
+        if ((null === $data || [] === $data) && isset($params['default'])) {
+            return ContentView::createSmartResolvable(
+                data: [
+                    'areaKey' => [$params['default']],
+                ],
+                resourceLoaderKey: 'snippet_area_default',
+                view: $params,
+            );
+        }
+
         if (
             !\is_array($data)
             || !\array_is_list($data)

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolver.php
@@ -22,7 +22,8 @@ use Sulu\Snippet\Domain\Repository\SnippetAreaRepositoryInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
 
 /**
- * Resolves default snippet from snippet area when SingleSnippetSelection has no selection.
+ * Resolves default snippet from snippet area when snippet selection has no selection.
+ * Supports both single area key (string) and multiple area keys (array).
  *
  * @internal if you need to override this service, create a new service based on SmartResolverInterface instead of extending this class
  *
@@ -40,23 +41,27 @@ class SnippetAreaSmartResolver implements SmartResolverInterface
     {
         /**
          * @var array{
-         *     areaKey: string,
+         *     areaKey: string|array<string>,
          * } $data
          */
         $data = $resolvable->getData();
-
         $areaKey = $data['areaKey'];
 
         $webspace = $this->requestAnalyzer->getWebspace();
         if (null === $webspace) { // @phpstan-ignore identical.alwaysFalse
-            return ContentView::create(null, []);
+            return \is_array($areaKey)
+                ? ContentView::create([], ['ids' => []])
+                : ContentView::create(null, []);
         }
-        $webspaceKey = $webspace->getKey();
 
-        $snippetId = $this->snippetAreaRepository->findOneUuidBy([
-            'webspaceKey' => $webspaceKey,
-            'areaKey' => $areaKey,
-        ]);
+        return \is_array($areaKey)
+            ? $this->resolveMultipleAreas($areaKey, $webspace->getKey())
+            : $this->resolveSingleArea($areaKey, $webspace->getKey());
+    }
+
+    private function resolveSingleArea(string $areaKey, string $webspaceKey): ContentView
+    {
+        $snippetId = $this->fetchSnippetId($areaKey, $webspaceKey);
 
         if (null === $snippetId) {
             return ContentView::create(null, []);
@@ -66,11 +71,57 @@ class SnippetAreaSmartResolver implements SmartResolverInterface
             id: $snippetId,
             resourceLoaderKey: SnippetResourceLoader::getKey(),
             resourceKey: SnippetInterface::RESOURCE_KEY,
-            view: [
-                'id' => $snippetId,
-            ],
+            view: ['id' => $snippetId],
             priority: 100,
         );
+    }
+
+    /**
+     * @param array<string> $areaKeys
+     */
+    private function resolveMultipleAreas(array $areaKeys, string $webspaceKey): ContentView
+    {
+        $snippetIds = $this->fetchSnippetIds($areaKeys, $webspaceKey);
+
+        if ([] === $snippetIds) {
+            return ContentView::create([], ['ids' => []]);
+        }
+
+        return ContentView::createResolvablesWithReferences(
+            ids: $snippetIds,
+            resourceLoaderKey: SnippetResourceLoader::getKey(),
+            resourceKey: SnippetInterface::RESOURCE_KEY,
+            view: ['ids' => $snippetIds],
+            priority: 100,
+        );
+    }
+
+    private function fetchSnippetId(string $areaKey, string $webspaceKey): ?string
+    {
+        return $this->snippetAreaRepository->findOneUuidBy([
+            'webspaceKey' => $webspaceKey,
+            'areaKey' => $areaKey,
+        ]);
+    }
+
+    /**
+     * @param array<string> $areaKeys
+     *
+     * @return array<string>
+     */
+    private function fetchSnippetIds(array $areaKeys, string $webspaceKey): array
+    {
+        $snippetIds = [];
+
+        foreach ($areaKeys as $key) {
+            $snippetId = $this->fetchSnippetId($key, $webspaceKey);
+
+            if (null !== $snippetId) {
+                $snippetIds[] = $snippetId;
+            }
+        }
+
+        return $snippetIds;
     }
 
     public static function getType(): string

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
 use Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver\SnippetSelectionPropertyResolver;
 
 #[CoversClass(SnippetSelectionPropertyResolver::class)]
@@ -169,5 +170,48 @@ class SnippetSelectionPropertyResolverTest extends TestCase
         $this->assertSame([
             'properties' => null,
         ], $content[0]->getMetadata());
+    }
+
+    public function testResolveDefaultWithEmptyArray(): void
+    {
+        $contentView = $this->resolver->resolve([], 'en', ['default' => 'footer']);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(SmartResolvable::class, $content);
+        $this->assertSame('snippet_area_default', $content->getResourceLoaderKey());
+        $this->assertSame(['areaKey' => ['footer']], $content->getData());
+        $this->assertSame(['default' => 'footer'], $contentView->getView());
+    }
+
+    public function testResolveDefaultWithNull(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en', ['default' => 'header']);
+
+        $content = $contentView->getContent();
+        $this->assertInstanceOf(SmartResolvable::class, $content);
+        $this->assertSame('snippet_area_default', $content->getResourceLoaderKey());
+        $this->assertSame(['areaKey' => ['header']], $content->getData());
+        $this->assertSame(['default' => 'header'], $contentView->getView());
+    }
+
+    public function testResolveDefaultWithData(): void
+    {
+        $contentView = $this->resolver->resolve(['1', '2'], 'en', ['default' => 'footer']);
+
+        $content = $contentView->getContent();
+        $this->assertIsArray($content);
+        $this->assertCount(2, $content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+        $this->assertSame('1', $content[0]->getId());
+        $this->assertInstanceOf(ResolvableResource::class, $content[1]);
+        $this->assertSame('2', $content[1]->getId());
+    }
+
+    public function testResolveWithoutDefault(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertEmpty($contentView->getContent());
+        $this->assertSame(['ids' => []], $contentView->getView());
     }
 }

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolverTest.php
@@ -128,4 +128,108 @@ class SnippetAreaSmartResolverTest extends TestCase
 
         $this->snippetAreaRepository->findOneUuidBy()->shouldNotHaveBeenCalled();
     }
+
+    public function testResolveWithArrayAndSingleSnippet(): void
+    {
+        $smartResolvable = new SmartResolvable(
+            data: ['areaKey' => ['header']],
+            resourceLoaderKey: 'snippet_area_default',
+            priority: 2048
+        );
+
+        $webspace = $this->createWebspace('sulu_io');
+
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->snippetAreaRepository->findOneUuidBy([
+            'webspaceKey' => 'sulu_io',
+            'areaKey' => 'header',
+        ])->willReturn('snippet-uuid-123');
+
+        $result = $this->resolver->resolve($smartResolvable, 'en');
+
+        $content = $result->getContent();
+        $this->assertIsArray($content);
+        $this->assertCount(1, $content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+        $this->assertSame('snippet-uuid-123', $content[0]->getId());
+        $this->assertSame('snippet', $content[0]->getResourceLoaderKey());
+        $this->assertSame('snippets', $content[0]->getResourceKey());
+        $this->assertSame(['ids' => ['snippet-uuid-123']], $result->getView());
+    }
+
+    public function testResolveWithArrayAndMultipleSnippets(): void
+    {
+        $smartResolvable = new SmartResolvable(
+            data: ['areaKey' => ['header', 'footer']],
+            resourceLoaderKey: 'snippet_area_default',
+            priority: 2048
+        );
+
+        $webspace = $this->createWebspace('sulu_io');
+
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->snippetAreaRepository->findOneUuidBy([
+            'webspaceKey' => 'sulu_io',
+            'areaKey' => 'header',
+        ])->willReturn('snippet-uuid-header');
+
+        $this->snippetAreaRepository->findOneUuidBy([
+            'webspaceKey' => 'sulu_io',
+            'areaKey' => 'footer',
+        ])->willReturn('snippet-uuid-footer');
+
+        $result = $this->resolver->resolve($smartResolvable, 'en');
+
+        $content = $result->getContent();
+        $this->assertIsArray($content);
+        $this->assertCount(2, $content);
+        $this->assertInstanceOf(ResolvableResource::class, $content[0]);
+        $this->assertSame('snippet-uuid-header', $content[0]->getId());
+        $this->assertInstanceOf(ResolvableResource::class, $content[1]);
+        $this->assertSame('snippet-uuid-footer', $content[1]->getId());
+        $this->assertSame(['ids' => ['snippet-uuid-header', 'snippet-uuid-footer']], $result->getView());
+    }
+
+    public function testResolveWithArrayAndNoSnippet(): void
+    {
+        $smartResolvable = new SmartResolvable(
+            data: ['areaKey' => ['footer']],
+            resourceLoaderKey: 'snippet_area_default',
+            priority: 2048
+        );
+
+        $webspace = $this->createWebspace('sulu_io');
+
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->snippetAreaRepository->findOneUuidBy([
+            'webspaceKey' => 'sulu_io',
+            'areaKey' => 'footer',
+        ])->willReturn(null);
+
+        $result = $this->resolver->resolve($smartResolvable, 'en');
+
+        $this->assertSame([], $result->getContent());
+        $this->assertSame(['ids' => []], $result->getView());
+    }
+
+    public function testResolveWithArrayAndNoWebspace(): void
+    {
+        $smartResolvable = new SmartResolvable(
+            data: ['areaKey' => ['sidebar']],
+            resourceLoaderKey: 'snippet_area_default',
+            priority: 2048
+        );
+
+        $this->requestAnalyzer->getWebspace()->willReturn(null);
+
+        $result = $this->resolver->resolve($smartResolvable, 'en');
+
+        $this->assertSame([], $result->getContent());
+        $this->assertSame(['ids' => []], $result->getView());
+
+        $this->snippetAreaRepository->findOneUuidBy()->shouldNotHaveBeenCalled();
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/SmartContentQueryEnhancer.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/SmartContentQueryEnhancer.php
@@ -14,7 +14,7 @@ namespace Sulu\Bundle\AdminBundle\SmartContent;
 use Doctrine\ORM\Query\Expr\OrderBy;
 use Doctrine\ORM\QueryBuilder;
 
-class SmartContentQueryEnhancer
+final class SmartContentQueryEnhancer
 {
     public function addPagination(QueryBuilder $queryBuilder, int $offset, ?int $limit = null): void
     {


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | <!-- if there's an issue, add it here -->
  | Related issues/PRs | #8324
  | License | MIT

  #### What's in this PR?

  This PR adds support for the `default` parameter to `SnippetSelectionPropertyResolver`, bringing it to feature parity with `SingleSnippetSelectionPropertyResolver` (#8324).

  #### Why?

  Missing feature from Sulu 2.6 in Sulu 3.0