### PR TITLE
Add RouteCleanupListener

### DIFF
--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -433,7 +433,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(204, $response);
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(5, $routeRepository->findBy([])); // TODO we need tackle this
+        $this->assertCount(0, $routeRepository->findBy([]));
 
         $trashRepository = self::getContainer()->get(TrashItemRepositoryInterface::class);
         $trashItem = $trashRepository->findOneBy([

--- a/packages/content/src/Infrastructure/Doctrine/EventListener/RouteCleanupListener.php
+++ b/packages/content/src/Infrastructure/Doctrine/EventListener/RouteCleanupListener.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Doctrine\EventListener;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\OnClearEventArgs;
+use Sulu\Content\Domain\Model\ContentRichEntityInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\RoutableInterface;
+use Sulu\Route\Domain\Model\Route;
+use Symfony\Contracts\Service\ResetInterface;
+
+class RouteCleanupListener implements ResetInterface
+{
+    /**
+     * @var array<DimensionContentInterface<ContentRichEntityInterface>&RoutableInterface>
+     */
+    private array $removedDimensionContents = [];  // @phpstan-ignore-line missingType.generics
+
+    /**
+     * @var array<array{resourceKey: string, resourceId: string}>
+     */
+    private array $removedContentRichEntityIds = [];
+
+    /**
+     * @var array<class-string, string|null>
+     */
+    private array $resourceFieldNameCache = [];
+
+    public function preRemove(LifecycleEventArgs $args): void // @phpstan-ignore-line missingType.generics
+    {
+        $object = $args->getObject();
+
+        if ($object instanceof DimensionContentInterface && $object instanceof RoutableInterface) {
+            if (DimensionContentInterface::CURRENT_VERSION !== $object->getVersion()) {
+                return;
+            }
+
+            if (null === $object->getLocale()) {
+                return;
+            }
+
+            $this->removedDimensionContents[] = $object;
+        } elseif ($object instanceof ContentRichEntityInterface) {
+            $dimensionContentClass = $object->createDimensionContent()::class;
+            if (!\is_subclass_of($dimensionContentClass, RoutableInterface::class)) {
+                return;
+            }
+
+            $this->removedContentRichEntityIds[] = [
+                'resourceKey' => $dimensionContentClass::getResourceKey(),
+                'resourceId' => (string) $object->getId(),
+            ];
+        }
+    }
+
+    public function onClear(OnClearEventArgs $args): void // @phpstan-ignore-line missingType.generics
+    {
+        $this->reset();
+    }
+
+    public function postFlush(PostFlushEventArgs $args): void // @phpstan-ignore-line missingType.generics
+    {
+        if (0 === \count($this->removedDimensionContents) && 0 === \count($this->removedContentRichEntityIds)) {
+            return;
+        }
+
+        $objectManager = $args->getObjectManager();
+        $connection = $objectManager->getConnection();
+
+        $classMetadata = $objectManager->getClassMetadata(Route::class);
+        $routesTableName = $classMetadata->getTableName();
+
+        $this->handleDimensionContentRemovals($objectManager, $connection, $routesTableName);
+        $this->handleContentRichEntityRemovals($connection, $routesTableName);
+
+        $this->reset();
+    }
+
+    public function reset(): void
+    {
+        $this->removedDimensionContents = [];
+        $this->removedContentRichEntityIds = [];
+        $this->resourceFieldNameCache = [];
+    }
+
+    private function handleDimensionContentRemovals(
+        EntityManagerInterface $objectManager,
+        Connection $connection,
+        string $routesTableName
+    ): void {
+        if (0 === \count($this->removedDimensionContents)) {
+            return;
+        }
+
+        $toDelete = [];
+        foreach ($this->removedDimensionContents as $dimensionContent) {
+            $resourceId = $dimensionContent->getResource()->getId();
+
+            // Locale is guaranteed to be non-null due to filtering in preRemove
+            $locale = $dimensionContent->getLocale();
+            \assert(\is_string($locale));
+
+            if (!$this->hasRemainingDimensions($objectManager, $dimensionContent, $resourceId, $locale)) {
+                $resourceKey = $dimensionContent::getResourceKey();
+                $toDelete[$resourceKey][$locale][] = (string) $resourceId;
+            }
+        }
+
+        foreach ($toDelete as $resourceKey => $locales) {
+            foreach ($locales as $locale => $resourceIds) {
+                $this->deleteRoutesBatch($connection, $routesTableName, $resourceKey, $resourceIds, $locale);
+            }
+        }
+    }
+
+    private function handleContentRichEntityRemovals(
+        Connection $connection,
+        string $routesTableName
+    ): void {
+        if (0 === \count($this->removedContentRichEntityIds)) {
+            return;
+        }
+
+        $groupedByResourceKey = [];
+        foreach ($this->removedContentRichEntityIds as $entityInfo) {
+            $groupedByResourceKey[$entityInfo['resourceKey']][] = $entityInfo['resourceId'];
+        }
+
+        foreach ($groupedByResourceKey as $resourceKey => $resourceIds) {
+            $this->deleteRoutesBatch($connection, $routesTableName, $resourceKey, $resourceIds);
+        }
+    }
+
+    /**
+     * @param array<string> $resourceIds
+     */
+    private function deleteRoutesBatch(
+        Connection $connection,
+        string $routesTableName,
+        string $resourceKey,
+        array $resourceIds,
+        ?string $locale = null
+    ): void {
+        if (0 === \count($resourceIds)) {
+            return;
+        }
+
+        // Delete main routes
+        $this->executeRouteDeletion($connection, $routesTableName, $resourceKey, $resourceIds, $locale);
+
+        // Delete history routes
+        $historyResourceIds = \array_map(fn (string $id): string => $resourceKey . '::' . $id, $resourceIds);
+        $this->executeRouteDeletion($connection, $routesTableName, Route::HISTORY_RESOURCE_KEY, $historyResourceIds, $locale);
+    }
+
+    /**
+     * @param array<string> $resourceIds
+     */
+    private function executeRouteDeletion(
+        Connection $connection,
+        string $table,
+        string $resourceKey,
+        array $resourceIds,
+        ?string $locale
+    ): void {
+        $queryBuilder = $connection->createQueryBuilder()
+            ->delete($table)
+            ->where('resource_key = :resourceKey')
+            ->andWhere('resource_id IN (:resourceIds)')
+            ->setParameter('resourceKey', $resourceKey)
+            ->setParameter('resourceIds', $resourceIds, ArrayParameterType::STRING);
+
+        if (null !== $locale) {
+            $queryBuilder
+                ->andWhere('locale = :locale')
+                ->setParameter('locale', $locale);
+        }
+
+        $queryBuilder->executeStatement();
+    }
+
+    /**
+     * @template T of ContentRichEntityInterface
+     *
+     * @param DimensionContentInterface<T> $dimensionContent
+     */
+    private function hasRemainingDimensions(
+        EntityManagerInterface $objectManager,
+        DimensionContentInterface $dimensionContent,
+        mixed $resourceId,
+        string $locale
+    ): bool {
+        $resourceFieldName = $this->getResourceFieldName($objectManager, $dimensionContent::class);
+
+        if (null === $resourceFieldName) {
+            return false;
+        }
+
+        $queryBuilder = $objectManager->createQueryBuilder()
+            ->select('COUNT(dimensionContent.id)')
+            ->from($dimensionContent::class, 'dimensionContent')
+            ->where('dimensionContent.' . $resourceFieldName . ' = :resourceId')
+            ->andWhere('dimensionContent.locale = :locale')
+            ->andWhere('dimensionContent.version = :version')
+            ->setParameter('resourceId', $resourceId)
+            ->setParameter('locale', $locale)
+            ->setParameter('version', DimensionContentInterface::CURRENT_VERSION);
+
+        return (int) $queryBuilder->getQuery()->getSingleScalarResult() > 0;
+    }
+
+    /**
+     * @param class-string $dimensionContentClass
+     */
+    private function getResourceFieldName(
+        EntityManagerInterface $objectManager,
+        string $dimensionContentClass
+    ): ?string {
+        if (\array_key_exists($dimensionContentClass, $this->resourceFieldNameCache)) {
+            return $this->resourceFieldNameCache[$dimensionContentClass];
+        }
+
+        $metadata = $objectManager->getClassMetadata($dimensionContentClass);
+        $resourceFieldName = null;
+
+        foreach ($metadata->getAssociationMappings() as $fieldName => $mapping) {
+            if (\is_a($mapping['targetEntity'], ContentRichEntityInterface::class, true)) {
+                $resourceFieldName = $fieldName;
+                break;
+            }
+        }
+
+        $this->resourceFieldNameCache[$dimensionContentClass] = $resourceFieldName;
+
+        return $resourceFieldName;
+    }
+}

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
@@ -16,6 +16,7 @@ namespace Sulu\Content\Infrastructure\Symfony\HttpKernel;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Infrastructure\Doctrine\EventListener\RouteCleanupListener;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\ResourceLoaderCacheCompilerPass;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\SettingsFormPass;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -58,6 +59,15 @@ final class SuluContentBundle extends AbstractBundle
         $loader->load('resolvers.xml');
         $loader->load('resource-loader.xml');
         $loader->load('reference.xml');
+
+        $services = $container->services();
+
+        $services->set('sulu_content.doctrine_route_cleanup_listener')
+            ->class(RouteCleanupListener::class)
+            ->tag('doctrine.event_listener', ['event' => 'preRemove', 'method' => 'preRemove'])
+            ->tag('doctrine.event_listener', ['event' => 'postFlush', 'method' => 'postFlush'])
+            ->tag('doctrine.event_listener', ['event' => 'onClear', 'method' => 'onClear'])
+            ->tag('kernel.reset', ['method' => 'reset']);
     }
 
     /**

--- a/packages/content/tests/Functional/Infrastructure/Doctrine/EventListener/RouteCleanupListenerTest.php
+++ b/packages/content/tests/Functional/Infrastructure/Doctrine/EventListener/RouteCleanupListenerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Functional\Infrastructure\Doctrine\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+use Sulu\Content\Tests\Traits\CreateExampleTrait;
+use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+
+class RouteCleanupListenerTest extends SuluTestCase
+{
+    use CreateExampleTrait;
+
+    private EntityManagerInterface $entityManager;
+    private RouteRepositoryInterface $routeRepository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        self::purgeDatabase();
+
+        $this->entityManager = self::getEntityManager();
+        $this->routeRepository = self::getContainer()->get('sulu_route.route_repository');
+    }
+
+    public function testDeleteDimensionContentKeepsRoutesWhenOtherDimensionsExist(): void
+    {
+        $example = self::createExample([
+            'en' => [
+                'draft' => ['title' => 'Draft', 'url' => '/draft'],
+                'live' => ['title' => 'Live', 'url' => '/live'],
+            ],
+        ], ['create_route' => true]);
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $example = $this->entityManager->find(Example::class, $example->getId());
+        $this->assertInstanceOf(Example::class, $example);
+
+        $draftDimension = null;
+        foreach ($example->getDimensionContents() as $dimensionContent) {
+            if (DimensionContentInterface::STAGE_DRAFT === $dimensionContent->getStage()
+                && 'en' === $dimensionContent->getLocale()
+            ) {
+                $draftDimension = $dimensionContent;
+                break;
+            }
+        }
+
+        $this->assertInstanceOf(ExampleDimensionContent::class, $draftDimension);
+        $this->entityManager->remove($draftDimension);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $routes = $this->routeRepository->findBy([
+            'resourceKey' => Example::RESOURCE_KEY,
+            'resourceId' => (string) $example->getId(),
+            'locale' => 'en',
+        ]);
+        $this->assertCount(1, $routes);
+    }
+
+    public function testDeleteLastDimensionContentForLocaleDeletesRoutes(): void
+    {
+        $example = self::createExample([
+            'en' => [
+                'live' => ['title' => 'English', 'url' => '/english'],
+            ],
+        ], ['create_route' => true]);
+
+        $this->entityManager->flush();
+        $exampleId = $example->getId();
+        $this->entityManager->clear();
+
+        $routes = $this->routeRepository->findBy([
+            'resourceKey' => Example::RESOURCE_KEY,
+            'resourceId' => (string) $exampleId,
+            'locale' => 'en',
+        ]);
+        $this->assertCount(1, $routes);
+
+        $example = $this->entityManager->find(Example::class, $exampleId);
+        $this->assertInstanceOf(Example::class, $example);
+
+        $englishDimensions = [];
+        foreach ($example->getDimensionContents() as $dimensionContent) {
+            if ('en' === $dimensionContent->getLocale()) {
+                $englishDimensions[] = $dimensionContent;
+            }
+        }
+
+        $this->assertNotEmpty($englishDimensions);
+        foreach ($englishDimensions as $dimension) {
+            $this->entityManager->remove($dimension);
+        }
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $routes = $this->routeRepository->findBy([
+            'resourceKey' => Example::RESOURCE_KEY,
+            'resourceId' => (string) $exampleId,
+            'locale' => 'en',
+        ]);
+        $this->assertCount(0, $routes);
+    }
+
+    public function testDeleteContentRichEntityDeletesAllRoutes(): void
+    {
+        $example = self::createExample([
+            'en' => [
+                'live' => ['title' => 'English', 'url' => '/english'],
+            ],
+            'de' => [
+                'live' => ['title' => 'German', 'url' => '/german'],
+            ],
+        ], ['create_route' => true]);
+
+        $this->entityManager->flush();
+        $exampleId = $example->getId();
+        $this->entityManager->clear();
+
+        $example = $this->entityManager->find(Example::class, $exampleId);
+        $this->assertInstanceOf(Example::class, $example);
+        $this->entityManager->remove($example);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $allRoutes = $this->routeRepository->findBy([
+            'resourceKey' => Example::RESOURCE_KEY,
+            'resourceId' => (string) $exampleId,
+        ]);
+        $this->assertCount(0, $allRoutes);
+    }
+
+    public function testHistoryRoutesDeletedWithMainRoutes(): void
+    {
+        $example = self::createExample([
+            'en' => [
+                'live' => ['title' => 'Test Example', 'url' => '/test-example'],
+            ],
+        ], ['create_route' => true]);
+
+        $this->entityManager->flush();
+        $exampleId = $example->getId();
+
+        $historyRoute = new Route(
+            Route::HISTORY_RESOURCE_KEY,
+            Example::RESOURCE_KEY . '::' . $exampleId,
+            'en',
+            '/old-url'
+        );
+        $this->entityManager->persist($historyRoute);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $example = $this->entityManager->find(Example::class, $exampleId);
+        $this->assertInstanceOf(Example::class, $example);
+        $this->entityManager->remove($example);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $mainRoutes = $this->routeRepository->findBy([
+            'resourceKey' => Example::RESOURCE_KEY,
+            'resourceId' => (string) $exampleId,
+        ]);
+        $this->assertCount(0, $mainRoutes);
+
+        $historyRoutes = $this->routeRepository->findBy([
+            'resourceKey' => Route::HISTORY_RESOURCE_KEY,
+            'resourceId' => Example::RESOURCE_KEY . '::' . $exampleId,
+        ]);
+        $this->assertCount(0, $historyRoutes);
+    }
+
+    public function testMultipleLocalesIndependentCleanup(): void
+    {
+        $example = self::createExample([
+            'en' => [
+                'live' => ['title' => 'English', 'url' => '/english'],
+            ],
+            'de' => [
+                'live' => ['title' => 'German', 'url' => '/german'],
+            ],
+        ], ['create_route' => true]);
+
+        $this->entityManager->flush();
+        $exampleId = $example->getId();
+        $this->entityManager->clear();
+
+        $example = $this->entityManager->find(Example::class, $exampleId);
+        $this->assertInstanceOf(Example::class, $example);
+
+        $germanDimensions = [];
+        foreach ($example->getDimensionContents() as $dimensionContent) {
+            if ('de' === $dimensionContent->getLocale()) {
+                $germanDimensions[] = $dimensionContent;
+            }
+        }
+
+        $this->assertNotEmpty($germanDimensions);
+        foreach ($germanDimensions as $dimension) {
+            $this->entityManager->remove($dimension);
+        }
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $deRoutes = $this->routeRepository->findBy([
+            'resourceKey' => Example::RESOURCE_KEY,
+            'resourceId' => (string) $exampleId,
+            'locale' => 'de',
+        ]);
+        $this->assertCount(0, $deRoutes);
+
+        $enRoutes = $this->routeRepository->findBy([
+            'resourceKey' => Example::RESOURCE_KEY,
+            'resourceId' => (string) $exampleId,
+            'locale' => 'en',
+        ]);
+        $this->assertCount(1, $enRoutes);
+    }
+}

--- a/packages/content/tests/Functional/Integration/ExampleControllerTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerTest.php
@@ -462,7 +462,7 @@ class ExampleControllerTest extends SuluTestCase
     public function testDelete(int $id): void
     {
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(3, $routeRepository->findBy([])); // TODO we need tackle this
+        $this->assertCount(3, $routeRepository->findBy([]));
     }
 
     public function testReferencesCreatedWithMediaReferences(): int

--- a/packages/content/tests/Unit/Infrastructure/Doctrine/EventListener/RouteCleanupListenerTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Doctrine/EventListener/RouteCleanupListenerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Infrastructure\Doctrine\EventListener;
+
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Content\Domain\Model\ContentRichEntityInterface;
+use Sulu\Content\Domain\Model\ContentRichEntityTrait;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\DimensionContentTrait;
+use Sulu\Content\Domain\Model\RoutableInterface;
+use Sulu\Content\Domain\Model\RoutableTrait;
+use Sulu\Content\Infrastructure\Doctrine\EventListener\RouteCleanupListener;
+
+class RouteCleanupListenerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private RouteCleanupListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->listener = new RouteCleanupListener();
+    }
+
+    public function testPreRemoveIgnoresNonRoutableDimensionContent(): void
+    {
+        $dimensionContent = new class() implements DimensionContentInterface {
+            use DimensionContentTrait;
+
+            private TestEntity $entity;
+
+            public function __construct()
+            {
+                $this->entity = new TestEntity();
+            }
+
+            public function getResource(): ContentRichEntityInterface // @phpstan-ignore-line missingType.generics
+            {
+                return $this->entity;
+            }
+
+            public static function getResourceKey(): string
+            {
+                return 'test';
+            }
+        };
+
+        $event = $this->prophesize(LifecycleEventArgs::class);
+        $event->getObject()->willReturn($dimensionContent);
+
+        $this->listener->preRemove($event->reveal());
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testPreRemoveIgnoresOldVersions(): void
+    {
+        $dimensionContent = new TestRoutableDimensionContent();
+        $dimensionContent->setVersion(1);
+
+        $event = $this->prophesize(LifecycleEventArgs::class);
+        $event->getObject()->willReturn($dimensionContent);
+
+        $this->listener->preRemove($event->reveal());
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testPreRemoveIgnoresUnlocalizedDimensionContent(): void
+    {
+        $dimensionContent = new TestRoutableDimensionContent();
+        $dimensionContent->setVersion(DimensionContentInterface::CURRENT_VERSION);
+        $dimensionContent->setLocale(null);
+
+        $event = $this->prophesize(LifecycleEventArgs::class);
+        $event->getObject()->willReturn($dimensionContent);
+
+        $this->listener->preRemove($event->reveal());
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testPreRemoveTracksDraftDimensionContent(): void
+    {
+        $dimensionContent = new TestRoutableDimensionContent();
+        $dimensionContent->setVersion(DimensionContentInterface::CURRENT_VERSION);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_DRAFT);
+
+        $event = $this->prophesize(LifecycleEventArgs::class);
+        $event->getObject()->willReturn($dimensionContent);
+
+        $this->listener->preRemove($event->reveal());
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testPreRemoveTracksLiveDimensionContent(): void
+    {
+        $dimensionContent = new TestRoutableDimensionContent();
+        $dimensionContent->setVersion(DimensionContentInterface::CURRENT_VERSION);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setStage(DimensionContentInterface::STAGE_LIVE);
+
+        $event = $this->prophesize(LifecycleEventArgs::class);
+        $event->getObject()->willReturn($dimensionContent);
+
+        $this->listener->preRemove($event->reveal());
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testPreRemoveTracksContentRichEntity(): void
+    {
+        $entity = new TestEntity();
+
+        $event = $this->prophesize(LifecycleEventArgs::class);
+        $event->getObject()->willReturn($entity);
+
+        $this->listener->preRemove($event->reveal());
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testResetClearsState(): void
+    {
+        $dimensionContent = new TestRoutableDimensionContent();
+        $dimensionContent->setVersion(DimensionContentInterface::CURRENT_VERSION);
+        $dimensionContent->setLocale('en');
+
+        $event = $this->prophesize(LifecycleEventArgs::class);
+        $event->getObject()->willReturn($dimensionContent);
+        $this->listener->preRemove($event->reveal());
+
+        $this->listener->reset();
+
+        $this->expectNotToPerformAssertions();
+    }
+}
+
+/**
+ * Test stub for ContentRichEntity.
+ *
+ * @implements ContentRichEntityInterface<TestRoutableDimensionContent>
+ */
+class TestEntity implements ContentRichEntityInterface
+{
+    /**
+     * @phpstan-use ContentRichEntityTrait<TestRoutableDimensionContent>
+     */
+    use ContentRichEntityTrait;
+
+    private int $id = 1;
+
+    public function __construct()
+    {
+        $this->initializeDimensionContents();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function createDimensionContent(): DimensionContentInterface
+    {
+        return new TestRoutableDimensionContent();
+    }
+}
+
+/**
+ * Test stub for RoutableDimensionContent.
+ *
+ * @implements DimensionContentInterface<TestEntity>
+ */
+class TestRoutableDimensionContent implements DimensionContentInterface, RoutableInterface
+{
+    use DimensionContentTrait;
+    use RoutableTrait;
+
+    private TestEntity $entity;
+
+    public function __construct()
+    {
+        $this->entity = new TestEntity();
+    }
+
+    public function getResource(): ContentRichEntityInterface
+    {
+        return $this->entity;
+    }
+
+    public static function getResourceKey(): string
+    {
+        return 'tests';
+    }
+}

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -799,7 +799,7 @@ class PageControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(204, $response);
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(12, $routeRepository->findBy([])); // TODO we need tackle this
+        $this->assertCount(9, $routeRepository->findBy([]));
 
         $trashRepository = self::getContainer()->get(TrashItemRepositoryInterface::class);
         $trashItem = $trashRepository->findOneBy([


### PR DESCRIPTION
  | Q                  | A               |
  |--------------------|-----------------|
  | Bug fix?           | yes             |
  | New feature?       | yes             |
  | BC breaks?         | no              |
  | Deprecations?      | no              |
  | Related issues/PRs | #7672                |
  | License            | MIT             |
  | Documentation PR   | sulu/sulu-docs# |

  What's in this PR?

  This PR adds a new RouteCleanupListener that automatically cleans up orphaned routes when dimension content or content-rich entities are removed.

  - Routes are deleted when the last dimension content for a locale is removed
  - All routes (including history routes) are deleted when a content-rich entity is removed
  - Routes are kept intact when other dimensions still exist for the same locale

  Why?

When dimension content or content-rich entities were deleted, their associated routes remained in the database as orphaned records.