### PR TITLE
Fix MediaBundle tests without security configured

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/SmartContent/MediaSmartContentProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/SmartContent/MediaSmartContentProvider.php
@@ -91,7 +91,7 @@ readonly class MediaSmartContentProvider implements SmartContentProviderInterfac
         private TranslatorInterface $translator,
         private WebspaceManagerInterface $webspaceManager,
         private AccessControlQueryEnhancer $accessControlQueryEnhancer,
-        private Security $security,
+        private ?Security $security,
         private bool $hasAudienceTargeting = false,
         private ?array $permissions = null,
     ) {
@@ -222,7 +222,7 @@ readonly class MediaSmartContentProvider implements SmartContentProviderInterfac
     ): void {
         $webspace = $this->webspaceManager->findWebspaceByKey($filters['webspaceKey'] ?? null);
         /** @var UserInterface|null $user */
-        $user = $webspace && $webspace->hasWebsiteSecurity() ? $this->security->getUser() : null;
+        $user = $webspace && $webspace->hasWebsiteSecurity() ? $this->security?->getUser() : null;
         /** @var int|null $permission */
         $permission = $webspace && $webspace->hasWebsiteSecurity() && $this->permissions
             ? $this->permissions[PermissionTypes::VIEW]

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -332,7 +332,7 @@
             <argument type="service" id="translator"/>
             <argument type="service" id="sulu_core.webspace.webspace_manager"/>
             <argument type="service" id="sulu_security.access_control_query_enhancer"/>
-            <argument type="service" id="security.helper" on-invalid="ignore"/>
+            <argument type="service" id="security.helper" on-invalid="null"/>
             <argument type="expression">container.hasParameter('sulu_audience_targeting.enabled')</argument>
             <argument>%sulu_security.permissions%</argument>
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix MediaBundle tests without security configured.

#### Why?

When developing bundles you don't want for functional tests setup a whole security with firewall.