### PR TITLE
Allow custom Icon Providers in configuration

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -91,7 +91,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')
                         ->validate()
                             ->ifTrue(function($value) {
-                                return !\is_string($value) || !\preg_match('/^([a-z0-9-_]+:\/\//', $value);
+                                return !\is_string($value) || !\preg_match('/^[a-z0-9-_]+:\/\//', $value);
                             })
                             ->thenInvalid('The icon set path must start with "<provider-name>://"')
                         ->end()

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -91,9 +91,9 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')
                         ->validate()
                             ->ifTrue(function($value) {
-                                return !\is_string($value) || !\preg_match('/^(icomoon:\/\/|svg:\/\/)/', $value);
+                                return !\is_string($value) || !\preg_match('/^([a-z0-9-_]+:\/\//', $value);
                             })
-                            ->thenInvalid('The icon set path must start with "icomoon://" or "svg://"')
+                            ->thenInvalid('The icon set path must start with "<provider-name>://"')
                         ->end()
                     ->end()
                 ->end()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

You can already add your own icon providers via the `IconProviderInterface`. However, these providers cannot be set in the configuration due to a strict check on the standard providers. I have therefore modified this check slightly so that custom providers can be entered.