### PR TITLE
Use snapshot version of composer when test against dev versions

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -191,7 +191,7 @@ jobs:
                       phpcr-transport: doctrinedbal
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, imagick'
-                      tools: 'composer:v2'
+                      tools: 'composer:snapshot'
                       composer-stability: 'dev'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
@@ -240,10 +240,6 @@ jobs:
             - name: Set composer stability
               if: ${{ matrix.composer-stability }}
               run: composer config minimum-stability ${{ matrix.composer-stability }}
-
-            - name: Use composer snapshot version
-              if: ${{ matrix.composer-stability == 'dev' }}
-              run: composer self-update --snapshot
 
             - name: Install composer dependencies
               uses: ramsey/composer-install@v3

--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -241,8 +241,12 @@ jobs:
               if: ${{ matrix.composer-stability }}
               run: composer config minimum-stability ${{ matrix.composer-stability }}
 
+            - name: Use composer snapshot version
+              if: ${{ matrix.composer-stability == 'dev' }}
+              run: composer self-update --snapshot
+
             - name: Install composer dependencies
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v3
               with:
                   dependency-versions: ${{matrix.dependency-versions}}
                   composer-options: ${{ matrix.composer-options }}
@@ -295,7 +299,7 @@ jobs:
                   coverage: none
 
             - name: Install composer dependencies
-              uses: ramsey/composer-install@v1
+              uses: ramsey/composer-install@v3
               with:
                   dependency-versions: highest
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use snapshot version of composer when test against dev versions.

#### Why?

We test `@dev` against our dependencies but not composer itself. This way we can give composer early feedback and avoid issues in stable releases like:  https://github.com/composer/composer/discussions/12603