### PR TITLE
Fix array-like filters

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectFieldFilterType.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {computed} from 'mobx';
+import {computed, isArrayLike} from 'mobx';
 import Checkbox, {CheckboxGroup} from '../../../components/Checkbox';
 import {translate} from '../../../utils/Translator';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
@@ -13,7 +13,19 @@ class SelectFieldFilterType extends AbstractFieldFilterType<?Array<string>> {
             throw new Error('The "SelectFieldFilterType" needs some parameters to work!');
         }
 
-        const {options} = parameters;
+        let {options} = parameters;
+
+        // Handle both array and object formats from backend
+        // Backend may send array for numeric keys: ["value0", "value1", "value2"]
+        // Convert to object: {"0": "value0", "1": "value1", "2": "value2"}
+        if (isArrayLike(options)) {
+            const optionsObject = {};
+            // $FlowFixMe: isArrayLike ensures options is array-like and has forEach
+            options.forEach((value, index) => {
+                optionsObject[String(index)] = value;
+            });
+            options = optionsObject;
+        }
 
         if (typeof options !== 'object' || options === null) {
             throw new Error('The "options" parameter must be an object!');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectFieldFilterType.test.js
@@ -1,5 +1,6 @@
 // @flow
 import {mount, render} from 'enzyme';
+import {observable} from 'mobx';
 import SelectFieldFilterType from '../../fieldFilterTypes/SelectFieldFilterType';
 
 jest.mock('../../../../utils/Translator', () => ({
@@ -93,5 +94,43 @@ test.each([
 
     return valueNodePromise.then((valueNode) => {
         expect(valueNode).toEqual(expectedValueNode);
+    });
+});
+
+test('Handle observable array options with numeric keys', () => {
+    const observableOptions = observable(['app.job.jobSource.0', 'app.job.jobSource.1', 'app.job.jobSource.2']);
+    const selectFieldFilterType = new SelectFieldFilterType(
+        jest.fn(),
+        {options: observableOptions},
+        undefined
+    );
+
+    const selectFieldFilterTypeForm = mount(selectFieldFilterType.getFormNode());
+
+    expect(selectFieldFilterTypeForm.find('Checkbox')).toHaveLength(3);
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(0).prop('value')).toEqual('0');
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(0).text()).toEqual('app.job.jobSource.0');
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(1).prop('value')).toEqual('1');
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(1).text()).toEqual('app.job.jobSource.1');
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(2).prop('value')).toEqual('2');
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(2).text()).toEqual('app.job.jobSource.2');
+});
+
+test('Return value node observable array options', () => {
+    const observableOptions = observable(['Option Zero', 'Option One', 'Option Two']);
+    const selectFieldFilterType = new SelectFieldFilterType(
+        jest.fn(),
+        {options: observableOptions},
+        undefined
+    );
+
+    const valueNodePromise = selectFieldFilterType.getValueNode(['0', '2']);
+
+    if (!valueNodePromise) {
+        throw new Error('The getValueNode function must return a promise!');
+    }
+
+    return valueNodePromise.then((valueNode) => {
+        expect(valueNode).toEqual('Option Zero, Option Two');
     });
 });


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #8340
  | License | MIT

  #### What's in this PR?

  This PR fixes a bug in the `SelectFieldFilterType` component where filter options with numeric keys starting from `0` would cause the filter GUI to break and display no options.

  #### Why?

  When list filters use numeric keys starting from `0` in their XML configuration, PHP's `json_encode()` serializes the parameters as a JSON array `["value0", "value1"]` instead of an object `{"0": "value0",
  "1": "value1"}`.

  The JavaScript `SelectFieldFilterType` component expected only objects, causing the filter to render with no options when receiving an array.