### PR TITLE
Add support for DescendantProviderInterface for pages

### DIFF
--- a/packages/article/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
+++ b/packages/article/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
@@ -165,10 +165,10 @@ class ArticleRepository implements ArticleRepositoryInterface
             $queryBuilder->addSelect(\explode(' ', $orderBy->getParts()[0])[0]);
         }
 
-        /** @var iterable<string> $identifiers */
-        $identifiers = $queryBuilder->getQuery()->getResult();
+        /** @var array<array{uuid: string}> $result */
+        $result = $queryBuilder->getQuery()->getResult();
 
-        return $identifiers;
+        return \array_column($result, 'uuid');
     }
 
     public function add(ArticleInterface $article): void

--- a/packages/page/src/Application/Message/RemovePageMessage.php
+++ b/packages/page/src/Application/Message/RemovePageMessage.php
@@ -19,7 +19,8 @@ class RemovePageMessage
     public function __construct(
         /** @var array{ uuid?: string } $identifier */
         private array $identifier,
-        private string $locale
+        private string $locale,
+        private bool $forceRemoveChildren = false
     ) {
     }
 
@@ -36,5 +37,10 @@ class RemovePageMessage
     public function getLocale(): string
     {
         return $this->locale;
+    }
+
+    public function getForceRemoveChildren(): bool
+    {
+        return $this->forceRemoveChildren;
     }
 }

--- a/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
@@ -12,22 +12,15 @@
 namespace Sulu\Page\Application\MessageHandler;
 
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
-use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface;
-use Sulu\Component\Rest\Exception\InsufficientDescendantPermissionsException;
-use Sulu\Component\Security\Authentication\UserInterface;
-use Sulu\Component\Security\Authorization\AccessControl\AccessControlRepositoryInterface;
-use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Page\Application\Message\RemovePageMessage;
 use Sulu\Page\Domain\Event\PageRemovedEvent;
 use Sulu\Page\Domain\Exception\RemovePageDependantResourcesFoundException;
-use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
-use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @experimental
@@ -37,16 +30,9 @@ use Symfony\Bundle\SecurityBundle\Security;
  */
 final class RemovePageMessageHandler
 {
-    /**
-     * @param array<string, int> $permissions
-     */
     public function __construct(
         private PageRepositoryInterface $pageRepository,
         private DomainEventCollectorInterface $domainEventCollector,
-        private AccessControlRepositoryInterface $accessControlRepository,
-        private SystemStoreInterface $systemStore,
-        private ?Security $security,
-        private array $permissions,
         private ?TrashManagerInterface $trashManager = null,
     ) {
     }
@@ -54,8 +40,6 @@ final class RemovePageMessageHandler
     public function __invoke(RemovePageMessage $message): void
     {
         $page = $this->pageRepository->getOneBy($message->getIdentifier());
-
-        $this->checkPermissionsForDescendants($page);
 
         if (!$message->getForceRemoveChildren()) {
             $this->checkDescendantsForDependencyWarning($page);
@@ -92,36 +76,6 @@ final class RemovePageMessageHandler
             $title,
             $context
         ));
-    }
-
-    private function checkPermissionsForDescendants(PageInterface $page): void
-    {
-        $user = $this->getCurrentUser();
-        if (null === $user) {
-            return;
-        }
-
-        $descendantIds = $this->pageRepository->findDescendantIdsById($page->getUuid());
-        if (empty($descendantIds)) {
-            return;
-        }
-
-        $authorizedDescendantIds = $this->accessControlRepository->findIdsWithGrantedPermissions(
-            $user,
-            $this->permissions[PermissionTypes::DELETE],
-            Page::class,
-            $descendantIds,
-            $this->systemStore->getSystem(),
-            null
-        );
-
-        $unauthorizedDescendantIds = \array_diff($descendantIds, $authorizedDescendantIds);
-        if (!empty($unauthorizedDescendantIds)) {
-            throw new InsufficientDescendantPermissionsException(
-                \count($unauthorizedDescendantIds),
-                PermissionTypes::DELETE
-            );
-        }
     }
 
     private function checkDescendantsForDependencyWarning(PageInterface $page): void
@@ -178,17 +132,5 @@ final class RemovePageMessageHandler
         \krsort($grouped);
 
         return \array_values($grouped);
-    }
-
-    private function getCurrentUser(): ?UserInterface
-    {
-        if (null === $this->security) {
-            return null;
-        }
-
-        /** @var UserInterface|null $user */
-        $user = $this->security->getUser();
-
-        return $user;
     }
 }

--- a/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
@@ -12,13 +12,22 @@
 namespace Sulu\Page\Application\MessageHandler;
 
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface;
+use Sulu\Component\Rest\Exception\InsufficientDescendantPermissionsException;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\AccessControl\AccessControlRepositoryInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Page\Application\Message\RemovePageMessage;
 use Sulu\Page\Domain\Event\PageRemovedEvent;
+use Sulu\Page\Domain\Exception\RemovePageDependantResourcesFoundException;
+use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 
 /**
  * @experimental
@@ -28,9 +37,16 @@ use Sulu\Page\Domain\Repository\PageRepositoryInterface;
  */
 final class RemovePageMessageHandler
 {
+    /**
+     * @param array<string, int> $permissions
+     */
     public function __construct(
         private PageRepositoryInterface $pageRepository,
         private DomainEventCollectorInterface $domainEventCollector,
+        private AccessControlRepositoryInterface $accessControlRepository,
+        private SystemStoreInterface $systemStore,
+        private ?Security $security,
+        private array $permissions,
         private ?TrashManagerInterface $trashManager = null,
     ) {
     }
@@ -38,6 +54,12 @@ final class RemovePageMessageHandler
     public function __invoke(RemovePageMessage $message): void
     {
         $page = $this->pageRepository->getOneBy($message->getIdentifier());
+
+        $this->checkPermissionsForDescendants($page);
+
+        if (!$message->getForceRemoveChildren()) {
+            $this->checkDescendantsForDependencyWarning($page);
+        }
 
         $this->pageRepository->remove($page);
 
@@ -70,5 +92,103 @@ final class RemovePageMessageHandler
             $title,
             $context
         ));
+    }
+
+    private function checkPermissionsForDescendants(PageInterface $page): void
+    {
+        $user = $this->getCurrentUser();
+        if (null === $user) {
+            return;
+        }
+
+        $descendantIds = $this->pageRepository->findDescendantIdsById($page->getUuid());
+        if (empty($descendantIds)) {
+            return;
+        }
+
+        $authorizedDescendantIds = $this->accessControlRepository->findIdsWithGrantedPermissions(
+            $user,
+            $this->permissions[PermissionTypes::DELETE],
+            Page::class,
+            $descendantIds,
+            $this->systemStore->getSystem(),
+            null
+        );
+
+        $unauthorizedDescendantIds = \array_diff($descendantIds, $authorizedDescendantIds);
+        if (!empty($unauthorizedDescendantIds)) {
+            throw new InsufficientDescendantPermissionsException(
+                \count($unauthorizedDescendantIds),
+                PermissionTypes::DELETE
+            );
+        }
+    }
+
+    private function checkDescendantsForDependencyWarning(PageInterface $page): void
+    {
+        $descendantIds = $this->pageRepository->findDescendantIdsById($page->getUuid());
+
+        if (empty($descendantIds)) {
+            return;
+        }
+
+        /** @var array<string> $descendantIds */
+        $descendants = $this->pageRepository->findBy(['uuids' => $descendantIds]);
+        $descendantResources = [];
+        foreach ($descendants as $descendant) {
+            $descendantResources[] = [
+                'uuid' => $descendant->getUuid(),
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'depth' => $descendant->getDepth(),
+            ];
+        }
+
+        throw new RemovePageDependantResourcesFoundException(
+            [
+                'id' => $page->getUuid(),
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+            ],
+            $this->groupResourcesByDepth($descendantResources),
+            \count($descendantResources)
+        );
+    }
+
+    /**
+     * @param array<array{uuid: string, resourceKey: string, depth: int}> $resources
+     *
+     * @return array<int, array<array{id: string, resourceKey: string}>>
+     */
+    private function groupResourcesByDepth(array $resources): array
+    {
+        $grouped = [];
+
+        foreach ($resources as $resource) {
+            $depth = $resource['depth'];
+
+            if (!isset($grouped[$depth])) {
+                $grouped[$depth] = [];
+            }
+
+            $grouped[$depth][] = [
+                'id' => $resource['uuid'],
+                'resourceKey' => $resource['resourceKey'],
+            ];
+        }
+
+        \krsort($grouped);
+
+        return \array_values($grouped);
+    }
+
+    private function getCurrentUser(): ?UserInterface
+    {
+        if (null === $this->security) {
+            return null;
+        }
+
+        /** @var UserInterface|null $user */
+        $user = $this->security->getUser();
+
+        return $user;
     }
 }

--- a/packages/page/src/Domain/Exception/RemovePageDependantResourcesFoundException.php
+++ b/packages/page/src/Domain/Exception/RemovePageDependantResourcesFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Domain\Exception;
+
+use Sulu\Component\Rest\Exception\RemoveDependantResourcesFoundException;
+
+class RemovePageDependantResourcesFoundException extends RemoveDependantResourcesFoundException
+{
+    public function getTitleTranslationKey(): string
+    {
+        return 'sulu_page.delete_page_dependant_warning_title';
+    }
+
+    public function getDetailTranslationKey(): string
+    {
+        return 'sulu_page.delete_page_dependant_warning_detail';
+    }
+}

--- a/packages/page/src/Domain/Repository/PageRepositoryInterface.php
+++ b/packages/page/src/Domain/Repository/PageRepositoryInterface.php
@@ -12,6 +12,7 @@
 namespace Sulu\Page\Domain\Repository;
 
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\AccessControl\DescendantProviderInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Exception\PageNotFoundException;
 use Sulu\Page\Domain\Model\PageInterface;
@@ -21,7 +22,7 @@ use Sulu\Page\Domain\Model\PageInterface;
  *
  * @see Sulu\Page\Infrastructure\Doctrine\Repository\PageRepository
  */
-interface PageRepositoryInterface
+interface PageRepositoryInterface extends DescendantProviderInterface
 {
     /**
      * Groups are used in controllers and represents serialization / resolver group,
@@ -45,6 +46,8 @@ interface PageRepositoryInterface
      *     uuids?: string[],
      *     locale?: string,
      *     stage?: string,
+     *     parentId?: string|null,
+     *     descendantOfId?: string,
      *     load_ghost_content?: bool,
      *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
@@ -64,6 +67,8 @@ interface PageRepositoryInterface
      *     uuids?: string[],
      *     locale?: string,
      *     stage?: string,
+     *     parentId?: string|null,
+     *     descendantOfId?: string,
      *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      * @param array{
@@ -87,6 +92,8 @@ interface PageRepositoryInterface
      *     tagNames?: string[],
      *     tagOperator?: 'AND'|'OR',
      *     templateKeys?: string[],
+     *     parentId?: string|null,
+     *     descendantOfId?: string,
      *     page?: int,
      *     limit?: int,
      *     navigationContexts?: string[],
@@ -120,6 +127,8 @@ interface PageRepositoryInterface
      *     tagNames?: string[],
      *     tagOperator?: 'AND'|'OR',
      *     templateKeys?: string[],
+     *     parentId?: string|null,
+     *     descendantOfId?: string,
      *     page?: int,
      *     limit?: int,
      *     navigationContexts?: string[],
@@ -153,6 +162,8 @@ interface PageRepositoryInterface
      *     tagNames?: string[],
      *     tagOperator?: 'AND'|'OR',
      *     templateKeys?: string[],
+     *     parentId?: string|null,
+     *     descendantOfId?: string,
      *     page?: int,
      *     limit?: int,
      *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
@@ -179,6 +190,8 @@ interface PageRepositoryInterface
      *     tagNames?: string[],
      *     tagOperator?: 'AND'|'OR',
      *     templateKeys?: string[],
+     *     parentId?: string|null,
+     *     descendantOfId?: string,
      *     accessControl?: array{user?: UserInterface|null, permission?: int|null},
      * } $filters
      */

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -181,10 +181,10 @@ class PageRepository implements PageRepositoryInterface
             $queryBuilder->addSelect(\explode(' ', $orderBy->getParts()[0])[0]);
         }
 
-        /** @var iterable<string> $identifiers */
-        $identifiers = $queryBuilder->getQuery()->getResult();
+        /** @var array<array{uuid: string}> $result */
+        $result = $queryBuilder->getQuery()->getResult();
 
-        return $identifiers;
+        return \array_column($result, 'uuid');
     }
 
     public function add(PageInterface $page): void
@@ -266,6 +266,7 @@ class PageRepository implements PageRepositoryInterface
      *     templateKeys?: string[],
      *     loadGhost?: bool,
      *     parentId?: string|null,
+     *     descendantOfId?: string,
      *     webspaceKey?: string,
      *     page?: int,
      *     limit?: int,
@@ -330,6 +331,20 @@ class PageRepository implements PageRepositoryInterface
                 default => $queryBuilder->andWhere('page.parent = :parentId')
                     ->setParameter('parentId', $parentId),
             };
+        }
+
+        $descendantOfId = $filters['descendantOfId'] ?? null;
+        if (null !== $descendantOfId) {
+            Assert::string($descendantOfId); // @phpstan-ignore staticMethod.alreadyNarrowedType
+            $queryBuilder
+                ->innerJoin(
+                    PageInterface::class,
+                    'ancestorPage',
+                    Join::WITH,
+                    'page.lft > ancestorPage.lft AND page.rgt < ancestorPage.rgt'
+                )
+                ->andWhere('ancestorPage.uuid = :descendantOfId')
+                ->setParameter('descendantOfId', $descendantOfId);
         }
 
         $depth = $filters['depth'] ?? null;
@@ -436,5 +451,25 @@ class PageRepository implements PageRepositoryInterface
         if (!$hasJoin) {
             $queryBuilder->leftJoin('page.dimensionContents', 'dimensionContent');
         }
+    }
+
+    public function findDescendantIdsById($id): array
+    {
+        /** @var string $id */
+        $descendants = $this->findIdentifiersBy(['descendantOfId' => $id]);
+
+        /** @var array<string> $result */
+        $result = [...$descendants];
+
+        return $result;
+    }
+
+    public function supportsDescendantType(string $type): bool
+    {
+        if (!\class_exists($type) && !\interface_exists($type)) {
+            return false;
+        }
+
+        return \is_a($type, PageInterface::class, true);
     }
 }

--- a/packages/page/src/Infrastructure/Sulu/Security/PageDescendantSecurityListener.php
+++ b/packages/page/src/Infrastructure/Sulu/Security/PageDescendantSecurityListener.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Security;
+
+use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
+use Sulu\Component\Rest\Exception\InsufficientDescendantPermissionsException;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\AccessControl\AccessControlRepositoryInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @internal this listener should not be extended by a project
+ */
+final class PageDescendantSecurityListener implements EventSubscriberInterface
+{
+    /**
+     * @param array<string, int> $permissions
+     */
+    public function __construct(
+        private PageRepositoryInterface $pageRepository,
+        private AccessControlRepositoryInterface $accessControlRepository,
+        private SystemStoreInterface $systemStore,
+        private ?Security $security,
+        private array $permissions,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => ['onKernelController', -10], // After SuluSecurityListener (priority 0)
+        ];
+    }
+
+    public function onKernelController(ControllerEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if ('sulu_page.delete_page' !== $request->attributes->get('_route')) {
+            return;
+        }
+
+        if (null === $this->security) {
+            return;
+        }
+
+        if ($request->query->getBoolean('deleteLocale', false)) {
+            return;
+        }
+
+        $id = $request->attributes->get('id');
+        if (null === $id || !\is_string($id)) {
+            return;
+        }
+
+        $page = $this->pageRepository->getOneBy(['uuid' => $id]);
+
+        $this->checkPermissionsForDescendants($page);
+    }
+
+    private function checkPermissionsForDescendants(PageInterface $page): void
+    {
+        /** @var UserInterface|null $user */
+        $user = $this->security?->getUser();
+        if (null === $user) {
+            return;
+        }
+
+        $descendantIds = $this->pageRepository->findDescendantIdsById($page->getUuid());
+        if (empty($descendantIds)) {
+            return;
+        }
+
+        $authorizedDescendantIds = $this->accessControlRepository->findIdsWithGrantedPermissions(
+            $user,
+            $this->permissions[PermissionTypes::DELETE],
+            Page::class,
+            $descendantIds,
+            $this->systemStore->getSystem(),
+            null
+        );
+
+        $unauthorizedDescendantIds = \array_diff($descendantIds, $authorizedDescendantIds);
+        if (!empty($unauthorizedDescendantIds)) {
+            throw new InsufficientDescendantPermissionsException(
+                \count($unauthorizedDescendantIds),
+                PermissionTypes::DELETE
+            );
+        }
+    }
+}

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -69,6 +69,7 @@ use Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageIndexListener;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageReindexProvider;
+use Sulu\Page\Infrastructure\Sulu\Security\PageDescendantSecurityListener;
 use Sulu\Page\Infrastructure\Sulu\Security\PageSecurityListener;
 use Sulu\Page\Infrastructure\Sulu\Sitemap\PagesSitemapProvider;
 use Sulu\Page\Infrastructure\Sulu\Trash\PageTrashItemHandler;
@@ -172,10 +173,6 @@ final class SuluPageBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_activity.domain_event_collector'),
-                new Reference('sulu.repository.access_control'),
-                new Reference('sulu_security.system_store'),
-                new Reference('security.helper', ContainerInterface::NULL_ON_INVALID_REFERENCE),
-                param('sulu_security.permissions'),
                 new Reference('sulu_trash.trash_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
             ->tag('messenger.message_handler');
@@ -590,6 +587,17 @@ final class SuluPageBundle extends AbstractBundle
             ->class(PageSecurityListener::class)
             ->args([
                 new Reference('sulu_security.security_checker', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+            ])
+            ->tag('kernel.event_subscriber');
+
+        $services->set('sulu_page.page_descendant_security_listener')
+            ->class(PageDescendantSecurityListener::class)
+            ->args([
+                new Reference('sulu_page.page_repository'),
+                new Reference('sulu.repository.access_control'),
+                new Reference('sulu_security.system_store'),
+                new Reference('security.helper', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                param('sulu_security.permissions'),
             ])
             ->tag('kernel.event_subscriber');
     }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -172,6 +172,10 @@ final class SuluPageBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_activity.domain_event_collector'),
+                new Reference('sulu.repository.access_control'),
+                new Reference('sulu_security.system_store'),
+                new Reference('security.helper', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                param('sulu_security.permissions'),
                 new Reference('sulu_trash.trash_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
             ->tag('messenger.message_handler');
@@ -347,7 +351,8 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_content.dimension_content_query_enhancer'),
                 new Reference('sulu_security.access_control_query_enhancer'),
-            ]);
+            ])
+            ->tag('sulu.descendant_provider');
 
         $services->alias(PageRepositoryInterface::class, 'sulu_page.page_repository');
 

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -223,6 +223,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
     public function deleteAction(Request $request, string $id): Response // TODO route should be a uuid
     {
         $deleteLocale = $request->query->getBoolean('deleteLocale', false);
+        $forceRemoveChildren = $request->query->getBoolean('force', false);
         $locale = $this->getLocale($request);
 
         if ($deleteLocale) {
@@ -233,7 +234,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
             return new Response('', 204);
         }
 
-        $message = new RemovePageMessage(['uuid' => $id], $locale);
+        $message = new RemovePageMessage(['uuid' => $id], $locale, $forceRemoveChildren);
         /** @see Sulu\Page\Application\MessageHandler\RemovePageMessageHandler */
         $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/PageRepositoryTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/PageRepositoryTest.php
@@ -18,11 +18,12 @@ use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
 use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
 
-class PageRepositoryPermissionTest extends SuluTestCase
+class PageRepositoryTest extends SuluTestCase
 {
     use CreatePageTrait;
     use CreatePageWithPermissionsTrait;
@@ -83,9 +84,7 @@ class PageRepositoryPermissionTest extends SuluTestCase
             'stage' => 'live',
         ]);
 
-        /** @var array<array{uuid: string}> $resultArray */
-        $resultArray = \iterator_to_array($result);
-        $resultUuids = \array_column($resultArray, 'uuid');
+        $resultUuids = [...$result];
 
         $this->assertCount(3, $resultUuids);
         $this->assertContains($page1->getUuid(), $resultUuids);
@@ -122,7 +121,7 @@ class PageRepositoryPermissionTest extends SuluTestCase
             ]
         );
 
-        $resultUuids = \array_column(\iterator_to_array($result), 'uuid');
+        $resultUuids = [...$result];
 
         $this->assertContains($allowedPage->getUuid(), $resultUuids);
         $this->assertNotContains($deniedPage1->getUuid(), $resultUuids);
@@ -160,9 +159,7 @@ class PageRepositoryPermissionTest extends SuluTestCase
             ]
         );
 
-        /** @var array<array{uuid: string}> $resultArray */
-        $resultArray = \iterator_to_array($result);
-        $resultUuids = \array_column($resultArray, 'uuid');
+        $resultUuids = [...$result];
 
         $this->assertCount(2, $resultUuids);
         $this->assertContains($allowed1->getUuid(), $resultUuids);
@@ -224,9 +221,204 @@ class PageRepositoryPermissionTest extends SuluTestCase
             ]
         );
 
-        $resultUuids = \array_column(\iterator_to_array($result), 'uuid');
+        $resultUuids = [...$result];
 
         $this->assertContains($pageWithoutAcl->getUuid(), $resultUuids);
+    }
+
+    public function testFindDescendantIdsById(): void
+    {
+        $parent = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Parent',
+                    'url' => '/parent',
+                    'template' => 'default',
+                ],
+            ],
+        ]);
+
+        $child1 = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Child 1',
+                    'url' => '/parent/child1',
+                    'template' => 'default',
+                    'parentId' => $parent->getUuid(),
+                ],
+            ],
+        ]);
+
+        $child2 = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Child 2',
+                    'url' => '/parent/child2',
+                    'template' => 'default',
+                    'parentId' => $parent->getUuid(),
+                ],
+            ],
+        ]);
+
+        $grandchild = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Grandchild',
+                    'url' => '/parent/child1/grandchild',
+                    'template' => 'default',
+                    'parentId' => $child1->getUuid(),
+                ],
+            ],
+        ]);
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $descendantIds = $this->pageRepository->findDescendantIdsById($parent->getUuid());
+
+        $this->assertCount(3, $descendantIds);
+        $this->assertContains($child1->getUuid(), $descendantIds);
+        $this->assertContains($child2->getUuid(), $descendantIds);
+        $this->assertContains($grandchild->getUuid(), $descendantIds);
+    }
+
+    public function testFindDescendantIdsByIdWithNoChildren(): void
+    {
+        $page = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Single Page',
+                    'url' => '/single',
+                    'template' => 'default',
+                ],
+            ],
+        ]);
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $descendantIds = $this->pageRepository->findDescendantIdsById($page->getUuid());
+
+        $this->assertEmpty($descendantIds);
+    }
+
+    public function testSupportsDescendantType(): void
+    {
+        $this->assertTrue($this->pageRepository->supportsDescendantType(PageInterface::class));
+        $this->assertTrue($this->pageRepository->supportsDescendantType(Page::class));
+        $this->assertFalse($this->pageRepository->supportsDescendantType('SomeOtherClass'));
+    }
+
+    public function testFindDescendantIdsByIdWithDeepNesting(): void
+    {
+        $parent = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Parent',
+                    'url' => '/parent',
+                    'template' => 'default',
+                ],
+            ],
+        ]);
+
+        $child = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Child',
+                    'url' => '/parent/child',
+                    'template' => 'default',
+                    'parentId' => $parent->getUuid(),
+                ],
+            ],
+        ]);
+
+        $grandchild = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Grandchild',
+                    'url' => '/parent/child/grandchild',
+                    'template' => 'default',
+                    'parentId' => $child->getUuid(),
+                ],
+            ],
+        ]);
+
+        $greatGrandchild = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Great Grandchild',
+                    'url' => '/parent/child/grandchild/great',
+                    'template' => 'default',
+                    'parentId' => $grandchild->getUuid(),
+                ],
+            ],
+        ]);
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $descendantIds = $this->pageRepository->findDescendantIdsById($parent->getUuid());
+
+        $this->assertCount(3, $descendantIds);
+        $this->assertContains($child->getUuid(), $descendantIds);
+        $this->assertContains($grandchild->getUuid(), $descendantIds);
+        $this->assertContains($greatGrandchild->getUuid(), $descendantIds);
+    }
+
+    public function testFindDescendantIdsByIdWithMultipleSiblings(): void
+    {
+        $parent = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Parent',
+                    'url' => '/parent',
+                    'template' => 'default',
+                ],
+            ],
+        ]);
+
+        $child1 = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Child 1',
+                    'url' => '/parent/child1',
+                    'template' => 'default',
+                    'parentId' => $parent->getUuid(),
+                ],
+            ],
+        ]);
+
+        $child2 = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Child 2',
+                    'url' => '/parent/child2',
+                    'template' => 'default',
+                    'parentId' => $parent->getUuid(),
+                ],
+            ],
+        ]);
+
+        $child3 = self::createPage([
+            'en' => [
+                'draft' => [
+                    'title' => 'Child 3',
+                    'url' => '/parent/child3',
+                    'template' => 'default',
+                    'parentId' => $parent->getUuid(),
+                ],
+            ],
+        ]);
+
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $descendantIds = $this->pageRepository->findDescendantIdsById($parent->getUuid());
+
+        $this->assertCount(3, $descendantIds);
+        $this->assertContains($child1->getUuid(), $descendantIds);
+        $this->assertContains($child2->getUuid(), $descendantIds);
+        $this->assertContains($child3->getUuid(), $descendantIds);
     }
 
     /**

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -23,6 +23,7 @@ use Sulu\Page\Application\Message\CreatePageMessage;
 use Sulu\Page\Application\Message\ModifyPageMessage;
 use Sulu\Page\Application\MessageHandler\CreatePageMessageHandler;
 use Sulu\Page\Application\MessageHandler\ModifyPageMessageHandler;
+use Sulu\Page\Domain\Exception\RemovePageDependantResourcesFoundException;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
@@ -794,7 +795,7 @@ class PageControllerTest extends SuluTestCase
     #[Depends('testOrderPages')]
     public function testDelete(string $id): int
     {
-        $this->client->request('DELETE', '/admin/api/pages/' . $id . '?locale=en');
+        $this->client->request('DELETE', '/admin/api/pages/' . $id . '?locale=en&force=true');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(204, $response);
 
@@ -833,5 +834,80 @@ class PageControllerTest extends SuluTestCase
     protected function getSnapshotFolder(): string
     {
         return 'responses';
+    }
+
+    /* --- The following tests are independent tests and purge the database on their own --- */
+    public function testDeletePageWithDescendantsWithoutForceReturnsConflict(): void
+    {
+        $this->purgeDatabase();
+        $homepage = $this->createHomepage('homepage-uuid', 'sulu_io');
+
+        $parentPage = $this->createPage('homepage-uuid', [
+            'title' => 'Parent Page',
+            'template' => 'default',
+            'url' => '/parent',
+        ]);
+
+        $childPage = $this->createPage($parentPage->getUuid(), [
+            'title' => 'Child Page',
+            'template' => 'default',
+            'url' => '/parent/child',
+        ]);
+
+        $parentUuid = $parentPage->getUuid();
+        self::getEntityManager()->clear();
+
+        $this->client->request('DELETE', '/admin/api/pages/' . $parentUuid . '?locale=en');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(409, $response);
+
+        /** @var array{code: int, message: string} $responseData */
+        $responseData = \json_decode((string) $response->getContent(), true);
+
+        $this->assertEquals(RemovePageDependantResourcesFoundException::EXCEPTION_CODE_DEPENDANT_RESOURCES_FOUND, $responseData['code']);
+
+        $this->client->request('DELETE', '/admin/api/pages/' . $parentUuid . '?locale=en&force=true');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(204, $response);
+    }
+
+    public function testDeletePageWithDescendantsWithForceSucceeds(): void
+    {
+        $this->purgeDatabase();
+        $homepage = $this->createHomepage('homepage-uuid-2', 'sulu_io');
+
+        $parentPage = $this->createPage('homepage-uuid-2', [
+            'title' => 'Parent Page',
+            'template' => 'default',
+            'url' => '/parent',
+        ]);
+
+        $child = $this->createPage($parentPage->getUuid(), [
+            'title' => 'Child Page',
+            'template' => 'default',
+            'url' => '/parent/child',
+        ]);
+
+        $grandchild = $this->createPage($child->getUuid(), [
+            'title' => 'Grandchild Page',
+            'template' => 'default',
+            'url' => '/parent/child/grandchild',
+        ]);
+
+        $parentUuid = $parentPage->getUuid();
+        $childUuid = $child->getUuid();
+        $grandchildUuid = $grandchild->getUuid();
+
+        self::getEntityManager()->clear();
+
+        $this->client->request('DELETE', '/admin/api/pages/' . $parentUuid . '?locale=en&force=true');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(204, $response);
+
+        $pageRepository = $this->getContainer()->get('sulu_page.page_repository');
+        $this->assertNull($pageRepository->findOneBy(['uuid' => $parentUuid]));
+        $this->assertNull($pageRepository->findOneBy(['uuid' => $childUuid]));
+        $this->assertNull($pageRepository->findOneBy(['uuid' => $grandchildUuid]));
     }
 }

--- a/packages/page/translations/admin.de.json
+++ b/packages/page/translations/admin.de.json
@@ -31,6 +31,8 @@
     "sulu_page.delete_draft": "Entwurf löschen",
     "sulu_page.delete_draft_warning_title": "Entwurf löschen?",
     "sulu_page.delete_draft_warning_text": "Soll der Entwurf wirklich gelöscht werden? Alle Daten gehen dadurch verloren. Die veröffentlichte Seite bleibt unverändert bestehen.",
+    "sulu_page.delete_page_dependant_warning_title": "{1}Eine Unterseite löschen?|]1,Inf[%count% Unterseiten löschen?",
+    "sulu_page.delete_page_dependant_warning_detail": "{1}Sind Sie sich sicher, dass Sie zusätzlich eine Unterseiten löschen möchten?|]1,Inf[Sind Sie sich sicher, dass Sie zusätzlich %count% Unterseiten löschen möchten?",
     "sulu_page.unpublish_warning_title": "Nicht mehr veröffentlichen?",
     "sulu_page.unpublish_warning_text": "Soll die Seite wirklich nicht mehr veröffentlicht werden? Dadurch gehen sämtliche Verknüpfungen auf der Website verloren. Dieser Status kann jederzeit ohne Datenverlust geändert werden.",
     "sulu_page.unpublish": "Nicht mehr veröffentlichen",

--- a/packages/page/translations/admin.en.json
+++ b/packages/page/translations/admin.en.json
@@ -31,6 +31,8 @@
     "sulu_page.delete_draft": "Delete draft",
     "sulu_page.delete_draft_warning_title": "Delete Draft?",
     "sulu_page.delete_draft_warning_text": "Do you really want to delete the draft? All data will be lost. The published page will not be changed.",
+    "sulu_page.delete_page_dependant_warning_title": "{1}Delete one subpage?|]1,Inf[Delete %count% subpages?",
+    "sulu_page.delete_page_dependant_warning_detail": "{1}Are you sure that you also want to delete one subpage?|]1,Inf[Are you sure that you also want to delete %count% subpages?",
     "sulu_page.unpublish_warning_title": "Set to unpublished?",
     "sulu_page.unpublish_warning_text": "Do you really want to unpublish the page? All website links will be lost. This setting can be changed at any time without data loss.",
     "sulu_page.unpublish": "Set to unpublished",

--- a/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetRepository.php
+++ b/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetRepository.php
@@ -165,10 +165,10 @@ class SnippetRepository implements SnippetRepositoryInterface
             $queryBuilder->addSelect(\explode(' ', $orderBy->getParts()[0])[0]);
         }
 
-        /** @var iterable<string> $identifiers */
-        $identifiers = $queryBuilder->getQuery()->getResult();
+        /** @var array<array{uuid: string}> $result */
+        $result = $queryBuilder->getQuery()->getResult();
 
-        return $identifiers;
+        return \array_column($result, 'uuid');
     }
 
     public function add(SnippetInterface $snippet): void


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | Related issues/PRs | #7672 
  | License | MIT

  #### What's in this PR?

  This PR implements `DescendantProviderInterface` support for pages, adding:
  - Permission checks for all descendant pages when deleting a parent page
  - Warning dialog when attempting to delete pages with children (requires `force=true` to proceed)
  - `findDescendantIdsById()` method in PageRepository for querying page hierarchies

  #### Why?

Missing feature from Sulu 3.0