### PR TITLE
Move default title for media implementation

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,5 +1,9 @@
 # Upgrade
 
+## 2.5.32
+
+* Deprecated \Sulu\Bundle\MediaBundle\Controller\AbstractMediaController::getTitleFromUpload -> MediaManager::getTitleFromUpload
+
 ## 2.5.23
 
 ### Doctrine incompatibility with Symfony 6.3

--- a/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
@@ -32,6 +32,8 @@ abstract class AbstractMediaController extends AbstractRestController
         $data['collection'] = $request->get('collection');
         $data['contentLanguages'] = $request->get('contentLanguages', []);
         $data['publishLanguages'] = $request->get('publishLanguages', []);
+
+        // @deprecated Just prefill from request here and let the MediaManager set the default title
         $data['title'] = $request->get('title', $fallback ? $this->getTitleFromUpload($request) : null);
         $data['formats'] = $request->get('formats', []);
 
@@ -39,6 +41,8 @@ abstract class AbstractMediaController extends AbstractRestController
     }
 
     /**
+     * @deprecated If you want to customize this please change the MediaManager::getTitleFromUpload
+     *
      * @param Request $request
      *
      * @return string|null

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -405,11 +405,25 @@ class MediaManager implements MediaManagerInterface
         $data['size'] = $uploadedFile->getSize();
         $data['mimeType'] = $uploadedFile->getMimeType();
         $data['properties'] = $this->getProperties($uploadedFile);
+        $data['title'] ??= $this->getTitleFromUpload($uploadedFile);
         $data['type'] = [
             'id' => $this->typeManager->getMediaType($uploadedFile->getMimeType()),
         ];
 
         return $this->createMedia($data, $user);
+    }
+
+    /**
+     * Gets the default media title based on the uploaded file.
+     * This implementation just removes the extension.
+     */
+    protected function getTitleFromUpload(UploadedFile $file): string
+    {
+        if (!\str_contains($file->getClientOriginalName(), '.')) {
+            return $file->getClientOriginalName();
+        }
+
+        return \implode('.', \explode('.', $file->getClientOriginalName(), -1));
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | -
| Related issues/PRs | #8330
| License | MIT
| Documentation PR | -

#### What's in this PR?
Moving the default title generation to the MediaManager.

#### Why?
If you want to use the media manager in isolation it should produce media with the same defaults as the controller would.
