### PR TITLE
Allow update of dataprovider in WebspaceCopyCommand

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
+++ b/src/Sulu/Bundle/PageBundle/Command/WebspaceCopyCommand.php
@@ -509,7 +509,7 @@ class WebspaceCopyCommand extends Command
                 continue;
             }
 
-            if ('provider' !== $parameter['name'] || 'content' !== $parameter['value']) {
+            if ('provider' !== $parameter['name'] || 'pages' !== $parameter['value']) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/smartcontent.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/smartcontent.xml
@@ -22,7 +22,7 @@
             </meta>
 
             <params>
-                <param name="provider" value="content"/>
+                <param name="provider" value="pages"/>
                 <param name="max_per_page" value="5"/>
                 <param name="page_parameter" value="p"/>
                 <param name="properties" type="collection">


### PR DESCRIPTION

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no yes
| Deprecations? | no
| Fixed tickets | #8353
| License | MIT

#### What's in this PR?

This PR will update the data provider of smart_content - content types to the corresponding new page UUID after copying a webspace.

#### Why?

After copying a webspace, the target webspace did not update the dataprovider to the corresponding page of the target webspace.
