### PR TITLE
Add support for url reference types in new route generator

### DIFF
--- a/packages/route/src/Application/Routing/Generator/RouteGenerator.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGenerator.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Translation\LocaleSwitcher;
 
@@ -28,7 +29,7 @@ final class RouteGenerator implements RouteGeneratorInterface
     ) {
     }
 
-    public function generate(string $slug, ?string $locale = null, ?string $site = null): string
+    public function generate(string $slug, ?string $locale = null, ?string $site = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         if (null === $site) {
             $requestSite = $this->requestContext->getParameter(RequestAttributeEnum::SITE->value);
@@ -75,10 +76,13 @@ final class RouteGenerator implements RouteGeneratorInterface
             },
         );
 
-        if (\str_starts_with($generatedUrl, $schemeAndHttpHost)) {
-            return \substr($generatedUrl, \strlen($schemeAndHttpHost) - 1);
-        }
-
-        return $generatedUrl;
+        return match (true) {
+            UrlGeneratorInterface::NETWORK_PATH === $referenceType && \str_starts_with($generatedUrl, $this->requestContext->getScheme()) => \substr($generatedUrl, \strlen($this->requestContext->getScheme()) + 1),
+            (
+                UrlGeneratorInterface::ABSOLUTE_PATH === $referenceType
+                || UrlGeneratorInterface::RELATIVE_PATH === $referenceType // currently relative path behaves like absolute path
+            ) && \str_starts_with($generatedUrl, $schemeAndHttpHost) => \substr($generatedUrl, \strlen($schemeAndHttpHost) - 1),
+            default => $generatedUrl,
+        };
     }
 }

--- a/packages/route/src/Application/Routing/Generator/RouteGenerator.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGenerator.php
@@ -78,7 +78,7 @@ final class RouteGenerator implements RouteGeneratorInterface
         );
 
         return match (true) {
-            UrlGeneratorInterface::NETWORK_PATH === $referenceType && \str_starts_with($generatedUrl, $this->requestContext->getScheme()) => \substr($generatedUrl, \strlen($this->requestContext->getScheme()) + 1),
+            UrlGeneratorInterface::NETWORK_PATH === $referenceType && \str_starts_with($generatedUrl, $this->requestContext->getScheme() . '://') => \substr($generatedUrl, \strlen($this->requestContext->getScheme()) + 1),
             UrlGeneratorInterface::ABSOLUTE_PATH === $referenceType && \str_starts_with($generatedUrl, $schemeAndHttpHost) => \substr($generatedUrl, \strlen($schemeAndHttpHost) - 1),
             UrlGeneratorInterface::RELATIVE_PATH === $referenceType && \str_starts_with($generatedUrl, $schemeAndHttpHost) => UrlGenerator::getRelativePath($this->requestContext->getPathInfo(), \substr($generatedUrl, \strlen($schemeAndHttpHost) - 1)),
             default => $generatedUrl,

--- a/packages/route/src/Application/Routing/Generator/RouteGenerator.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGenerator.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Translation\LocaleSwitcher;
@@ -78,10 +79,8 @@ final class RouteGenerator implements RouteGeneratorInterface
 
         return match (true) {
             UrlGeneratorInterface::NETWORK_PATH === $referenceType && \str_starts_with($generatedUrl, $this->requestContext->getScheme()) => \substr($generatedUrl, \strlen($this->requestContext->getScheme()) + 1),
-            (
-                UrlGeneratorInterface::ABSOLUTE_PATH === $referenceType
-                || UrlGeneratorInterface::RELATIVE_PATH === $referenceType // currently relative path behaves like absolute path
-            ) && \str_starts_with($generatedUrl, $schemeAndHttpHost) => \substr($generatedUrl, \strlen($schemeAndHttpHost) - 1),
+            UrlGeneratorInterface::ABSOLUTE_PATH === $referenceType && \str_starts_with($generatedUrl, $schemeAndHttpHost) => \substr($generatedUrl, \strlen($schemeAndHttpHost) - 1),
+            UrlGeneratorInterface::RELATIVE_PATH === $referenceType && \str_starts_with($generatedUrl, $schemeAndHttpHost) => UrlGenerator::getRelativePath($this->requestContext->getPathInfo(), \substr($generatedUrl, \strlen($schemeAndHttpHost) - 1)),
             default => $generatedUrl,
         };
     }

--- a/packages/route/src/Application/Routing/Generator/RouteGeneratorInterface.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGeneratorInterface.php
@@ -12,11 +12,12 @@
 namespace Sulu\Route\Application\Routing\Generator;
 
 use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 interface RouteGeneratorInterface
 {
     /**
      * @throws MissingRequestContextParameterException
      */
-    public function generate(string $slug, ?string $locale = null, ?string $site = null): string;
+    public function generate(string $slug, ?string $locale = null, ?string $site = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string;
 }

--- a/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
@@ -87,10 +87,10 @@ class RouteGeneratorTest extends TestCase
 
     public function testGenerateRelativePath(): void
     {
-        $this->requestContext->setPathInfo('/en');
+        $this->requestContext->setPathInfo('/en/world/test');
 
         $result = $this->routeGenerator->generate('/test', 'en', 'the_site', UrlGeneratorInterface::RELATIVE_PATH);
-        $this->assertSame('/en/test', $result); // currently we handle RELATIVE_PATH like ABSOLUTE_PATH
+        $this->assertSame('../test', $result);
     }
 
     public function testGenerateAbsolutePath(): void
@@ -98,7 +98,7 @@ class RouteGeneratorTest extends TestCase
         $this->requestContext->setPathInfo('/en');
 
         $result = $this->routeGenerator->generate('/test', 'en', 'the_site', UrlGeneratorInterface::ABSOLUTE_PATH);
-        $this->assertSame('/en/test', $result); // currently we handle RELATIVE_PATH like ABSOLUTE_PATH
+        $this->assertSame('/en/test', $result);
     }
 
     public function testGenerateOther(): void

--- a/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
@@ -18,6 +18,7 @@ use Sulu\Route\Application\Routing\Generator\SiteRouteGeneratorInterface;
 use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Translation\LocaleSwitcher;
 
@@ -72,9 +73,43 @@ class RouteGeneratorTest extends TestCase
         $this->assertSame('/en/test', $result);
     }
 
+    public function testGenerateAbsoluteUrl(): void
+    {
+        $result = $this->routeGenerator->generate('/test', 'en', 'the_site', UrlGeneratorInterface::ABSOLUTE_URL);
+        $this->assertSame('http://localhost/en/test', $result);
+    }
+
+    public function testGenerateNetworkPath(): void
+    {
+        $result = $this->routeGenerator->generate('/test', 'en', 'the_site', UrlGeneratorInterface::NETWORK_PATH);
+        $this->assertSame('//localhost/en/test', $result);
+    }
+
+    public function testGenerateRelativePath(): void
+    {
+        $this->requestContext->setPathInfo('/en');
+
+        $result = $this->routeGenerator->generate('/test', 'en', 'the_site', UrlGeneratorInterface::RELATIVE_PATH);
+        $this->assertSame('/en/test', $result); // currently we handle RELATIVE_PATH like ABSOLUTE_PATH
+    }
+
+    public function testGenerateAbsolutePath(): void
+    {
+        $this->requestContext->setPathInfo('/en');
+
+        $result = $this->routeGenerator->generate('/test', 'en', 'the_site', UrlGeneratorInterface::ABSOLUTE_PATH);
+        $this->assertSame('/en/test', $result); // currently we handle RELATIVE_PATH like ABSOLUTE_PATH
+    }
+
     public function testGenerateOther(): void
     {
         $result = $this->routeGenerator->generate('/test', 'en', 'the_other_side');
+        $this->assertSame('https://example.org/en/test', $result);
+    }
+
+    public function testGenerateOtherAbsolutePath(): void
+    {
+        $result = $this->routeGenerator->generate('/test', 'en', 'the_other_side', UrlGeneratorInterface::ABSOLUTE_PATH);
         $this->assertSame('https://example.org/en/test', $result);
     }
 

--- a/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
@@ -113,6 +113,18 @@ class RouteGeneratorTest extends TestCase
         $this->assertSame('https://example.org/en/test', $result);
     }
 
+    public function testGenerateOtherRelativePath(): void
+    {
+        $result = $this->routeGenerator->generate('/test', 'en', 'the_other_side', UrlGeneratorInterface::RELATIVE_PATH);
+        $this->assertSame('https://example.org/en/test', $result);
+    }
+
+    public function testGenerateOtherNetworkPath(): void
+    {
+        $result = $this->routeGenerator->generate('/test', 'en', 'the_other_side', UrlGeneratorInterface::NETWORK_PATH);
+        $this->assertSame('https://example.org/en/test', $result);
+    }
+
     public function testGenerateRequestContextLocale(): void
     {
         $this->requestContext->setParameter('_locale', 'de');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? |  yes
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add support for route reference types in Url Generators. https://github.com/symfony/symfony/blob/4d91dfc4501c0b2e21caa0ea4eb8a8dacd618872/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php#L34-L55

#### Why?

Usage to clear the http cache via URL.