### PR TITLE
Use absolute urls for cache invalidation

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriber.php
+++ b/packages/article/src/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriber.php
@@ -18,6 +18,8 @@ use Sulu\Article\Domain\Event\ArticleWorkflowTransitionAppliedEvent;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -36,7 +38,8 @@ class ArticleCacheInvalidationSubscriber implements EventSubscriberInterface
         private ?CacheManagerInterface $cacheManager,
         private RouteRepositoryInterface $routeRepository,
         private ContentAggregatorInterface $contentAggregator,
-        private RouteGeneratorInterface $routeGenerator
+        private RouteGeneratorInterface $routeGenerator,
+        private WebspaceManagerInterface $webspaceManager
     ) {
     }
 
@@ -62,10 +65,13 @@ class ArticleCacheInvalidationSubscriber implements EventSubscriberInterface
         }
 
         $article = $event->getArticle();
-        $uuid = $article->getUuid();
 
-        $this->cacheManager->invalidateTag($uuid);
-        $this->invalidateArticlePaths($uuid, $event->getResourceLocale());
+        $this->cacheManager->invalidateTag($article->getUuid());
+
+        if (!$this->cacheManager->supportsTags()) {
+            $this->invalidateArticlePaths($article, $event->getResourceLocale());
+        }
+
         $this->invalidateArticleExcerpt($article, $event->getResourceLocale());
     }
 
@@ -78,7 +84,7 @@ class ArticleCacheInvalidationSubscriber implements EventSubscriberInterface
         $this->cacheManager->invalidateTag($event->getResourceId());
     }
 
-    private function invalidateArticlePaths(string $uuid, ?string $locale): void
+    private function invalidateArticlePaths(ArticleInterface $article, ?string $locale): void
     {
         if (!$locale || !$this->cacheManager) {
             return;
@@ -86,19 +92,28 @@ class ArticleCacheInvalidationSubscriber implements EventSubscriberInterface
 
         $routes = $this->routeRepository->findBy([
             'resourceKey' => ArticleInterface::RESOURCE_KEY,
-            'resourceId' => $uuid,
+            'resourceId' => $article->getUuid(),
             'locale' => $locale,
         ]);
 
-        foreach ($routes as $route) {
-            $url = $this->routeGenerator->generate(
-                $route->getSlug(),
-                $route->getLocale(),
-                $route->getSite(),
-                UrlGeneratorInterface::ABSOLUTE_URL
-            );
+        /** @var Webspace $webspace */
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
+            if (null === $webspace->getLocalization($locale)) {
+                continue;
+            }
 
-            $this->cacheManager->invalidatePath($url);
+            $webspaceKey = $webspace->getKey();
+
+            foreach ($routes as $route) {
+                $url = $this->routeGenerator->generate(
+                    $route->getSlug(),
+                    $route->getLocale(),
+                    $webspaceKey,
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                );
+
+                $this->cacheManager->invalidatePath($url);
+            }
         }
     }
 

--- a/packages/article/src/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriber.php
+++ b/packages/article/src/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriber.php
@@ -18,6 +18,7 @@ use Sulu\Article\Domain\Event\ArticleWorkflowTransitionAppliedEvent;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -33,7 +34,8 @@ class ArticleCacheInvalidationSubscriber implements EventSubscriberInterface
     public function __construct(
         private ?CacheManagerInterface $cacheManager,
         private RouteRepositoryInterface $routeRepository,
-        private ContentAggregatorInterface $contentAggregator
+        private ContentAggregatorInterface $contentAggregator,
+        private WebspaceManagerInterface $webspaceManager
     ) {
     }
 
@@ -88,7 +90,16 @@ class ArticleCacheInvalidationSubscriber implements EventSubscriberInterface
         ]);
 
         foreach ($routes as $route) {
-            $this->cacheManager->invalidatePath($route->getSlug());
+            $urls = $this->webspaceManager->findUrlsByResourceLocator(
+                $route->getSlug(),
+                null,
+                $route->getLocale(),
+                $route->getSite(),
+            );
+
+            foreach ($urls as $url) {
+                $this->cacheManager->invalidatePath($url);
+            }
         }
     }
 

--- a/packages/article/src/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriber.php
+++ b/packages/article/src/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriber.php
@@ -18,12 +18,13 @@ use Sulu\Article\Domain\Event\ArticleWorkflowTransitionAppliedEvent;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal No BC promise is given for this class. Create your own event subscriber or use the
@@ -35,7 +36,7 @@ class ArticleCacheInvalidationSubscriber implements EventSubscriberInterface
         private ?CacheManagerInterface $cacheManager,
         private RouteRepositoryInterface $routeRepository,
         private ContentAggregatorInterface $contentAggregator,
-        private WebspaceManagerInterface $webspaceManager
+        private RouteGeneratorInterface $routeGenerator
     ) {
     }
 
@@ -90,16 +91,14 @@ class ArticleCacheInvalidationSubscriber implements EventSubscriberInterface
         ]);
 
         foreach ($routes as $route) {
-            $urls = $this->webspaceManager->findUrlsByResourceLocator(
+            $url = $this->routeGenerator->generate(
                 $route->getSlug(),
-                null,
                 $route->getLocale(),
                 $route->getSite(),
+                UrlGeneratorInterface::ABSOLUTE_URL
             );
 
-            foreach ($urls as $url) {
-                $this->cacheManager->invalidatePath($url);
-            }
+            $this->cacheManager->invalidatePath($url);
         }
     }
 

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -397,6 +397,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_route.route_repository'),
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_route.route_generator'),
+                new Reference('sulu_core.webspace.webspace_manager'),
             ])
             ->tag('kernel.event_subscriber');
 

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -396,6 +396,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_http_cache.cache_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 new Reference('sulu_route.route_repository'),
                 new Reference('sulu_content.content_aggregator'),
+                new Reference('sulu_core.webspace.webspace_manager'),
             ])
             ->tag('kernel.event_subscriber');
 

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -396,7 +396,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_http_cache.cache_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 new Reference('sulu_route.route_repository'),
                 new Reference('sulu_content.content_aggregator'),
-                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_route.route_generator'),
             ])
             ->tag('kernel.event_subscriber');
 

--- a/packages/article/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriberTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriberTest.php
@@ -25,12 +25,13 @@ use Sulu\Article\Infrastructure\Sulu\HttpCache\EventSubscriber\ArticleCacheInval
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
 use Sulu\Bundle\TagBundle\Entity\Tag;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Domain\Model\Route;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ArticleCacheInvalidationSubscriberTest extends TestCase
 {
@@ -52,9 +53,9 @@ class ArticleCacheInvalidationSubscriberTest extends TestCase
     private ObjectProphecy $contentAggregator;
 
     /**
-     * @var ObjectProphecy<WebspaceManagerInterface>
+     * @var ObjectProphecy<RouteGeneratorInterface>
      */
-    private ObjectProphecy $webspaceManager;
+    private ObjectProphecy $routeGenerator;
 
     private ArticleCacheInvalidationSubscriber $subscriber;
 
@@ -63,13 +64,13 @@ class ArticleCacheInvalidationSubscriberTest extends TestCase
         $this->cacheManager = $this->prophesize(CacheManagerInterface::class);
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
-        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
 
         $this->subscriber = new ArticleCacheInvalidationSubscriber(
             $this->cacheManager->reveal(),
             $this->routeRepository->reveal(),
             $this->contentAggregator->reveal(),
-            $this->webspaceManager->reveal()
+            $this->routeGenerator->reveal()
         );
     }
 
@@ -124,19 +125,11 @@ class ArticleCacheInvalidationSubscriberTest extends TestCase
             'stage' => 'live',
         ])->willThrow(ContentNotFoundException::class);
 
-        $this->webspaceManager->findUrlsByResourceLocator(
-            '/en/blog/test-article',
-            null,
-            'en',
-            null
-        )->willReturn(['https://example.com/en/blog/test-article']);
+        $this->routeGenerator->generate('/en/blog/test-article', 'en', null, UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/en/blog/test-article');
 
-        $this->webspaceManager->findUrlsByResourceLocator(
-            '/en/news/old-slug',
-            null,
-            'en',
-            null
-        )->willReturn(['https://example.com/en/news/old-slug']);
+        $this->routeGenerator->generate('/en/news/old-slug', 'en', null, UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/en/news/old-slug');
 
         $this->cacheManager->invalidateTag('article-uuid-123')
             ->shouldBeCalled();

--- a/packages/article/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriberTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriberTest.php
@@ -25,6 +25,10 @@ use Sulu\Article\Infrastructure\Sulu\HttpCache\EventSubscriber\ArticleCacheInval
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
 use Sulu\Bundle\TagBundle\Entity\Tag;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -57,20 +61,28 @@ class ArticleCacheInvalidationSubscriberTest extends TestCase
      */
     private ObjectProphecy $routeGenerator;
 
+    /**
+     * @var ObjectProphecy<WebspaceManagerInterface>
+     */
+    private ObjectProphecy $webspaceManager;
+
     private ArticleCacheInvalidationSubscriber $subscriber;
 
     protected function setUp(): void
     {
         $this->cacheManager = $this->prophesize(CacheManagerInterface::class);
+        $this->cacheManager->supportsTags()->willReturn(true); // Default: tags supported, no path invalidation
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
         $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
 
         $this->subscriber = new ArticleCacheInvalidationSubscriber(
             $this->cacheManager->reveal(),
             $this->routeRepository->reveal(),
             $this->contentAggregator->reveal(),
-            $this->routeGenerator->reveal()
+            $this->routeGenerator->reveal(),
+            $this->webspaceManager->reveal()
         );
     }
 
@@ -120,22 +132,53 @@ class ArticleCacheInvalidationSubscriberTest extends TestCase
             'locale' => 'en',
         ])->willReturn([$route1, $route2]);
 
+        $this->cacheManager->supportsTags()->willReturn(false);
+        $localization = $this->prophesize(Localization::class);
+
+        $webspace1 = $this->prophesize(Webspace::class);
+        $webspace1->getLocalization('en')->willReturn($localization->reveal());
+        $webspace1->getKey()->willReturn('sulu_io');
+
+        $webspace2 = $this->prophesize(Webspace::class);
+        $webspace2->getLocalization('en')->willReturn($localization->reveal());
+        $webspace2->getKey()->willReturn('blog');
+
+        $webspace3 = $this->prophesize(Webspace::class);
+        $webspace3->getLocalization('en')->willReturn(null); // Does not support 'en'
+
+        $webspaceCollection = new WebspaceCollection([
+            'sulu_io' => $webspace1->reveal(),
+            'blog' => $webspace2->reveal(),
+            'other' => $webspace3->reveal(),
+        ]);
+
+        $this->webspaceManager->getWebspaceCollection()->willReturn($webspaceCollection);
+
         $this->contentAggregator->aggregate($article, [
             'locale' => 'en',
             'stage' => 'live',
         ])->willThrow(ContentNotFoundException::class);
 
-        $this->routeGenerator->generate('/en/blog/test-article', 'en', null, UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('https://example.com/en/blog/test-article');
+        $this->routeGenerator->generate('/en/blog/test-article', 'en', 'sulu_io', UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://sulu.io/en/blog/test-article');
+        $this->routeGenerator->generate('/en/blog/test-article', 'en', 'blog', UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://blog.example.com/en/blog/test-article');
 
-        $this->routeGenerator->generate('/en/news/old-slug', 'en', null, UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willReturn('https://example.com/en/news/old-slug');
+        $this->routeGenerator->generate('/en/news/old-slug', 'en', 'sulu_io', UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://sulu.io/en/news/old-slug');
+        $this->routeGenerator->generate('/en/news/old-slug', 'en', 'blog', UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://blog.example.com/en/news/old-slug');
 
         $this->cacheManager->invalidateTag('article-uuid-123')
             ->shouldBeCalled();
-        $this->cacheManager->invalidatePath('https://example.com/en/blog/test-article')
+
+        $this->cacheManager->invalidatePath('https://sulu.io/en/blog/test-article')
             ->shouldBeCalled();
-        $this->cacheManager->invalidatePath('https://example.com/en/news/old-slug')
+        $this->cacheManager->invalidatePath('https://blog.example.com/en/blog/test-article')
+            ->shouldBeCalled();
+        $this->cacheManager->invalidatePath('https://sulu.io/en/news/old-slug')
+            ->shouldBeCalled();
+        $this->cacheManager->invalidatePath('https://blog.example.com/en/news/old-slug')
             ->shouldBeCalled();
 
         $this->subscriber->onWorkflowTransition($event);

--- a/packages/article/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriberTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/ArticleCacheInvalidationSubscriberTest.php
@@ -25,6 +25,7 @@ use Sulu\Article\Infrastructure\Sulu\HttpCache\EventSubscriber\ArticleCacheInval
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
 use Sulu\Bundle\TagBundle\Entity\Tag;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -50,6 +51,11 @@ class ArticleCacheInvalidationSubscriberTest extends TestCase
      */
     private ObjectProphecy $contentAggregator;
 
+    /**
+     * @var ObjectProphecy<WebspaceManagerInterface>
+     */
+    private ObjectProphecy $webspaceManager;
+
     private ArticleCacheInvalidationSubscriber $subscriber;
 
     protected function setUp(): void
@@ -57,11 +63,13 @@ class ArticleCacheInvalidationSubscriberTest extends TestCase
         $this->cacheManager = $this->prophesize(CacheManagerInterface::class);
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
 
         $this->subscriber = new ArticleCacheInvalidationSubscriber(
             $this->cacheManager->reveal(),
             $this->routeRepository->reveal(),
-            $this->contentAggregator->reveal()
+            $this->contentAggregator->reveal(),
+            $this->webspaceManager->reveal()
         );
     }
 
@@ -116,11 +124,25 @@ class ArticleCacheInvalidationSubscriberTest extends TestCase
             'stage' => 'live',
         ])->willThrow(ContentNotFoundException::class);
 
+        $this->webspaceManager->findUrlsByResourceLocator(
+            '/en/blog/test-article',
+            null,
+            'en',
+            null
+        )->willReturn(['https://example.com/en/blog/test-article']);
+
+        $this->webspaceManager->findUrlsByResourceLocator(
+            '/en/news/old-slug',
+            null,
+            'en',
+            null
+        )->willReturn(['https://example.com/en/news/old-slug']);
+
         $this->cacheManager->invalidateTag('article-uuid-123')
             ->shouldBeCalled();
-        $this->cacheManager->invalidatePath('/en/blog/test-article')
+        $this->cacheManager->invalidatePath('https://example.com/en/blog/test-article')
             ->shouldBeCalled();
-        $this->cacheManager->invalidatePath('/en/news/old-slug')
+        $this->cacheManager->invalidatePath('https://example.com/en/news/old-slug')
             ->shouldBeCalled();
 
         $this->subscriber->onWorkflowTransition($event);

--- a/packages/page/src/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriber.php
+++ b/packages/page/src/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriber.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Page\Infrastructure\Sulu\HttpCache\EventSubscriber;
 
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -33,7 +34,8 @@ class PageCacheInvalidationSubscriber implements EventSubscriberInterface
     public function __construct(
         private ?CacheManagerInterface $cacheManager,
         private RouteRepositoryInterface $routeRepository,
-        private ContentAggregatorInterface $contentAggregator
+        private ContentAggregatorInterface $contentAggregator,
+        private WebspaceManagerInterface $webspaceManager
     ) {
     }
 
@@ -88,7 +90,16 @@ class PageCacheInvalidationSubscriber implements EventSubscriberInterface
         ]);
 
         foreach ($routes as $route) {
-            $this->cacheManager->invalidatePath($route->getSlug());
+            $urls = $this->webspaceManager->findUrlsByResourceLocator(
+                $route->getSlug(),
+                null,
+                $route->getLocale(),
+                $route->getSite(),
+            );
+
+            foreach ($urls as $url) {
+                $this->cacheManager->invalidatePath($url);
+            }
         }
     }
 

--- a/packages/page/src/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriber.php
+++ b/packages/page/src/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriber.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sulu\Page\Infrastructure\Sulu\HttpCache\EventSubscriber;
 
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -22,8 +21,10 @@ use Sulu\Page\Domain\Event\PageRemovedEvent;
 use Sulu\Page\Domain\Event\PageWorkflowTransitionAppliedEvent;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal No BC promise is given for this class. Create your own event subscriber or use the
@@ -35,7 +36,7 @@ class PageCacheInvalidationSubscriber implements EventSubscriberInterface
         private ?CacheManagerInterface $cacheManager,
         private RouteRepositoryInterface $routeRepository,
         private ContentAggregatorInterface $contentAggregator,
-        private WebspaceManagerInterface $webspaceManager
+        private RouteGeneratorInterface $routeGenerator
     ) {
     }
 
@@ -90,16 +91,14 @@ class PageCacheInvalidationSubscriber implements EventSubscriberInterface
         ]);
 
         foreach ($routes as $route) {
-            $urls = $this->webspaceManager->findUrlsByResourceLocator(
+            $url = $this->routeGenerator->generate(
                 $route->getSlug(),
-                null,
                 $route->getLocale(),
                 $route->getSite(),
+                UrlGeneratorInterface::ABSOLUTE_URL
             );
 
-            foreach ($urls as $url) {
-                $this->cacheManager->invalidatePath($url);
-            }
+            $this->cacheManager->invalidatePath($url);
         }
     }
 

--- a/packages/page/src/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriber.php
+++ b/packages/page/src/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriber.php
@@ -65,7 +65,11 @@ class PageCacheInvalidationSubscriber implements EventSubscriberInterface
         $uuid = $page->getUuid();
 
         $this->cacheManager->invalidateTag($uuid);
-        $this->invalidatePagePaths($uuid, $event->getResourceLocale());
+
+        if (!$this->cacheManager->supportsTags()) {
+            $this->invalidatePagePaths($uuid, $event->getResourceLocale());
+        }
+
         $this->invalidatePageExcerpt($page, $event->getResourceLocale());
     }
 

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -614,6 +614,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_http_cache.cache_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 new Reference('sulu_route.route_repository'),
                 new Reference('sulu_content.content_aggregator'),
+                new Reference('sulu_core.webspace.webspace_manager'),
             ])
             ->tag('kernel.event_subscriber');
     }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -614,7 +614,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_http_cache.cache_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
                 new Reference('sulu_route.route_repository'),
                 new Reference('sulu_content.content_aggregator'),
-                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_route.route_generator'),
             ])
             ->tag('kernel.event_subscriber');
     }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriberTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriberTest.php
@@ -19,6 +19,7 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
 use Sulu\Bundle\TagBundle\Entity\Tag;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -50,6 +51,11 @@ class PageCacheInvalidationSubscriberTest extends TestCase
      */
     private ObjectProphecy $contentAggregator;
 
+    /**
+     * @var ObjectProphecy<WebspaceManagerInterface>
+     */
+    private ObjectProphecy $webspaceManager;
+
     private PageCacheInvalidationSubscriber $subscriber;
 
     protected function setUp(): void
@@ -57,11 +63,13 @@ class PageCacheInvalidationSubscriberTest extends TestCase
         $this->cacheManager = $this->prophesize(CacheManagerInterface::class);
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
 
         $this->subscriber = new PageCacheInvalidationSubscriber(
             $this->cacheManager->reveal(),
             $this->routeRepository->reveal(),
-            $this->contentAggregator->reveal()
+            $this->contentAggregator->reveal(),
+            $this->webspaceManager->reveal()
         );
     }
 
@@ -118,11 +126,25 @@ class PageCacheInvalidationSubscriberTest extends TestCase
             'stage' => 'live',
         ])->willThrow(ContentNotFoundException::class);
 
+        $this->webspaceManager->findUrlsByResourceLocator(
+            '/en/test-page',
+            null,
+            'en',
+            null
+        )->willReturn(['https://example.com/en/test-page']);
+
+        $this->webspaceManager->findUrlsByResourceLocator(
+            '/en/old-url',
+            null,
+            'en',
+            null
+        )->willReturn(['https://example.com/en/old-url']);
+
         $this->cacheManager->invalidateTag('page-uuid-123')
             ->shouldBeCalled();
-        $this->cacheManager->invalidatePath('/en/test-page')
+        $this->cacheManager->invalidatePath('https://example.com/en/test-page')
             ->shouldBeCalled();
-        $this->cacheManager->invalidatePath('/en/old-url')
+        $this->cacheManager->invalidatePath('https://example.com/en/old-url')
             ->shouldBeCalled();
 
         $this->subscriber->onWorkflowTransition($event);

--- a/packages/page/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriberTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriberTest.php
@@ -62,6 +62,7 @@ class PageCacheInvalidationSubscriberTest extends TestCase
     protected function setUp(): void
     {
         $this->cacheManager = $this->prophesize(CacheManagerInterface::class);
+        $this->cacheManager->supportsTags()->willReturn(true);
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
         $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
@@ -121,6 +122,8 @@ class PageCacheInvalidationSubscriberTest extends TestCase
             'resourceId' => 'page-uuid-123',
             'locale' => 'en',
         ])->willReturn([$route1, $route2]);
+
+        $this->cacheManager->supportsTags()->willReturn(false);
 
         $this->contentAggregator->aggregate($page, [
             'locale' => 'en',

--- a/packages/page/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriberTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriberTest.php
@@ -19,7 +19,6 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\HttpCacheBundle\Cache\CacheManagerInterface;
 use Sulu\Bundle\TagBundle\Entity\Tag;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -29,8 +28,10 @@ use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\HttpCache\EventSubscriber\PageCacheInvalidationSubscriber;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Domain\Model\Route;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PageCacheInvalidationSubscriberTest extends TestCase
 {
@@ -52,9 +53,9 @@ class PageCacheInvalidationSubscriberTest extends TestCase
     private ObjectProphecy $contentAggregator;
 
     /**
-     * @var ObjectProphecy<WebspaceManagerInterface>
+     * @var ObjectProphecy<RouteGeneratorInterface>
      */
-    private ObjectProphecy $webspaceManager;
+    private ObjectProphecy $routeGenerator;
 
     private PageCacheInvalidationSubscriber $subscriber;
 
@@ -63,13 +64,13 @@ class PageCacheInvalidationSubscriberTest extends TestCase
         $this->cacheManager = $this->prophesize(CacheManagerInterface::class);
         $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
-        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
 
         $this->subscriber = new PageCacheInvalidationSubscriber(
             $this->cacheManager->reveal(),
             $this->routeRepository->reveal(),
             $this->contentAggregator->reveal(),
-            $this->webspaceManager->reveal()
+            $this->routeGenerator->reveal()
         );
     }
 
@@ -126,19 +127,11 @@ class PageCacheInvalidationSubscriberTest extends TestCase
             'stage' => 'live',
         ])->willThrow(ContentNotFoundException::class);
 
-        $this->webspaceManager->findUrlsByResourceLocator(
-            '/en/test-page',
-            null,
-            'en',
-            null
-        )->willReturn(['https://example.com/en/test-page']);
+        $this->routeGenerator->generate('/en/test-page', 'en', null, UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/en/test-page');
 
-        $this->webspaceManager->findUrlsByResourceLocator(
-            '/en/old-url',
-            null,
-            'en',
-            null
-        )->willReturn(['https://example.com/en/old-url']);
+        $this->routeGenerator->generate('/en/old-url', 'en', null, UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.com/en/old-url');
 
         $this->cacheManager->invalidateTag('page-uuid-123')
             ->shouldBeCalled();


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | License | MIT

  #### What's in this PR?

  This PR fixes cache invalidation failures when using Varnish by resolving Route slugs to full URLs
  with hosts before invalidating cache.

  #### Why?

Sulu 3.0's cache invalidation throws `FOS\HttpCache\Exception\MissingHostException`

  To Do
-  [ ] Test manually with Varnish configuration