### PR TITLE
Disable NavigationContext for homepage

### DIFF
--- a/packages/page/config/forms/content_settings_page_settings.xml
+++ b/packages/page/config/forms/content_settings_page_settings.xml
@@ -8,7 +8,7 @@
     <tag name="sulu_content.content_settings_form" instanceOf="Sulu\Page\Domain\Model\PageDimensionContentInterface" priority="100"/>
 
     <properties>
-        <section name="content_settings_page_settings" visibleCondition="shadowOn == false">
+        <section name="content_settings_page_settings" visibleCondition="shadowOn == false AND url != '/'">
             <meta>
                 <title>sulu_content.page_settings</title>
             </meta>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Disable NavigationContext for Homepage.

#### Why?

Homepage must not be part of the NavigationContext.