### PR TITLE
Disable preview for non available locales

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
 use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\PreviewFormViewBuilder;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -210,7 +211,11 @@ class ArticleAdmin extends Admin
             return;
         }
 
+        $previewCondition = 'availableLocales && locale in availableLocales';
         foreach ($viewBuilders as $viewBuilder) {
+            if ($viewBuilder instanceof PreviewFormViewBuilder) {
+                $viewBuilder->setPreviewCondition($previewCondition);
+            }
             $viewCollection->add($viewBuilder);
         }
 

--- a/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
+++ b/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
@@ -230,8 +230,8 @@ class PageAdmin extends Admin
                 toolbarActions: $formToolbarActionsWithType
             );
 
-            // Preview only available for content pages
-            $previewCondition = 'linkOn == false && shadowOn == false';
+            // Preview only available for content pages and existing locales
+            $previewCondition = 'linkOn == false && shadowOn == false && availableLocales && locale in availableLocales';
 
             // Content and SEO tabs only for content pages
             $contentTabCondition = 'linkOn == false && shadowOn == false';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Disables preview for locales that do not have an existing dimensionContent (e.g. when you copy a locale)

#### Why?

Behind the copy overlay an error was visible in the preview.