### PR TITLE
Add 404 response on missing entity

### DIFF
--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -18,9 +18,11 @@ use Sulu\Article\Application\Message\ModifyArticleMessage;
 use Sulu\Article\Application\Message\RemoveArticleMessage;
 use Sulu\Article\Application\Message\RemoveArticleTranslationMessage;
 use Sulu\Article\Application\Message\RestoreArticleVersionMessage;
+use Sulu\Article\Domain\Exception\ArticleNotFoundException;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
+use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
@@ -169,18 +171,27 @@ final class ArticleController
             'stage' => DimensionContentInterface::STAGE_DRAFT,
         ];
 
-        $article = $this->articleRepository->getOneBy(
-            \array_merge(
+        try {
+            $article = $this->articleRepository->getOneBy(
+                \array_merge(
+                    [
+                        'uuid' => $id,
+                        'loadGhost' => true,
+                    ],
+                    $dimensionAttributes,
+                ),
                 [
-                    'uuid' => $id,
-                    'loadGhost' => true,
+                    ArticleRepositoryInterface::GROUP_SELECT_ARTICLE_ADMIN => true,
                 ],
-                $dimensionAttributes,
-            ),
-            [
-                ArticleRepositoryInterface::GROUP_SELECT_ARTICLE_ADMIN => true,
-            ],
-        );
+            );
+        } catch (ArticleNotFoundException $e) {
+            $exception = new EntityNotFoundException($e->getModel(), $id, $e);
+
+            return new JsonResponse(
+                $exception->toArray(),
+                404
+            );
+        }
 
         // TODO the `$article` should just be serialized
         //      Instead of calling the content resolver service which triggers an additional query.

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -47,6 +47,14 @@ class ArticleControllerTest extends SuluTestCase
         // TODO this should not be necessary
     }
 
+    public function testInvalidIdGet(): void
+    {
+        $this->client->request('GET', '/admin/api/articles/invalid-id?locale=en');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(404, $response);
+    }
+
     public function testPostPublish(): string
     {
         self::purgeDatabase();

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -12,6 +12,7 @@
 namespace Sulu\Page\UserInterface\Controller\Admin;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
@@ -39,6 +40,7 @@ use Sulu\Page\Application\Message\OrderPageMessage;
 use Sulu\Page\Application\Message\RemovePageMessage;
 use Sulu\Page\Application\Message\RemovePageTranslationMessage;
 use Sulu\Page\Application\Message\RestorePageVersionMessage;
+use Sulu\Page\Domain\Exception\PageNotFoundException;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
@@ -159,18 +161,27 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
             'stage' => DimensionContentInterface::STAGE_DRAFT,
         ];
 
-        $page = $this->pageRepository->getOneBy(
-            \array_merge(
+        try {
+            $page = $this->pageRepository->getOneBy(
+                \array_merge(
+                    [
+                        'uuid' => $id,
+                        'loadGhost' => true,
+                    ],
+                    $dimensionAttributes,
+                ),
                 [
-                    'uuid' => $id,
-                    'loadGhost' => true,
+                    PageRepositoryInterface::GROUP_SELECT_PAGE_ADMIN => true,
                 ],
-                $dimensionAttributes,
-            ),
-            [
-                PageRepositoryInterface::GROUP_SELECT_PAGE_ADMIN => true,
-            ],
-        );
+            );
+        } catch (PageNotFoundException $e) {
+            $exception = new EntityNotFoundException($e->getModel(), $id, $e);
+
+            return new JsonResponse(
+                $exception->toArray(),
+                404
+            );
+        }
 
         // TODO the `$page` should just be serialized
         //      Instead of calling the content resolver service which triggers an additional query.

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -143,6 +143,14 @@ class PageControllerTest extends SuluTestCase
         return $page;
     }
 
+    public function testInvalidIdGet(): void
+    {
+        $this->client->request('GET', '/admin/api/pages/invalid-id?locale=en');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(404, $response);
+    }
+
     public function testPostPublish(): string
     {
         self::purgeDatabase();

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Snippet\UserInterface\Controller\Admin;
 
+use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
@@ -28,6 +29,7 @@ use Sulu\Snippet\Application\Message\ModifySnippetMessage;
 use Sulu\Snippet\Application\Message\RemoveSnippetMessage;
 use Sulu\Snippet\Application\Message\RemoveSnippetTranslationMessage;
 use Sulu\Snippet\Application\Message\RestoreSnippetVersionMessage;
+use Sulu\Snippet\Domain\Exception\SnippetNotFoundException;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 use Sulu\Snippet\Infrastructure\Symfony\CompilerPass\SnippetAreaCompilerPass;
@@ -183,18 +185,27 @@ final class SnippetController
             'stage' => DimensionContentInterface::STAGE_DRAFT,
         ];
 
-        $snippet = $this->snippetRepository->getOneBy(
-            \array_merge(
+        try {
+            $snippet = $this->snippetRepository->getOneBy(
+                \array_merge(
+                    [
+                        'uuid' => $id,
+                        'loadGhost' => true,
+                    ],
+                    $dimensionAttributes,
+                ),
                 [
-                    'uuid' => $id,
-                    'loadGhost' => true,
-                ],
-                $dimensionAttributes,
-            ),
-            [
-                SnippetRepositoryInterface::GROUP_SELECT_SNIPPET_ADMIN => true,
-            ]
-        );
+                    SnippetRepositoryInterface::GROUP_SELECT_SNIPPET_ADMIN => true,
+                ]
+            );
+        } catch (SnippetNotFoundException $e) {
+            $exception = new EntityNotFoundException($e->getModel(), $id, $e);
+
+            return new JsonResponse(
+                $exception->toArray(),
+                404
+            );
+        }
 
         // TODO the `$snippet` should just be serialized
         //      Instead of calling the content resolver service which triggers an additional query.

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -50,6 +50,14 @@ class SnippetControllerTest extends SuluTestCase
         $schemaTool->updateSchema($classes, false);
     }
 
+    public function testInvalidIdGet(): void
+    {
+        $this->client->request('GET', '/admin/api/snippets/invalid-id?locale=en');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(404, $response);
+    }
+
     public function testPostPublish(): string
     {
         self::purgeDatabase();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Adds a 404 response from the EntityControllers to prevent frontend field-types to crash.

#### Why?

Frontend field types like selections did completely crash when a 500 error was returned. E.g. when a used parent-page was removed.

