### PR TITLE
Add default template visitor for pages

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Admin/MetadataVisitor/DefaultTemplateTypedFormMetadataVisitor.php
+++ b/packages/page/src/Infrastructure/Sulu/Admin/MetadataVisitor/DefaultTemplateTypedFormMetadataVisitor.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Admin\MetadataVisitor;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+
+/**
+ * @internal no backwards compatibility promise is given for this class it could be removed or changed at any time.
+ *           create your own service based on `TypedFormMetadataVisitorInterface` to customize the behavior if needed.
+ */
+final class DefaultTemplateTypedFormMetadataVisitor implements TypedFormMetadataVisitorInterface
+{
+    public function __construct(private WebspaceManagerInterface $webspaceManager)
+    {
+    }
+
+    /**
+     * @param array{webspace?: string} $metadataOptions
+     */
+    public function visitTypedFormMetadata(TypedFormMetadata $formMetadata, string $key, string $locale, array $metadataOptions = []): void
+    {
+        $webspaceKey = $metadataOptions['webspace'] ?? null;
+        if (null === $webspaceKey) {
+            return;
+        }
+        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+        $defaultTemplate = $webspace?->getDefaultTemplate('page');
+        if (null === $defaultTemplate) {
+            return;
+        }
+
+        $formMetadata->setDefaultType($defaultTemplate);
+    }
+}

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -45,6 +45,7 @@ use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Infrastructure\Doctrine\Repository\NavigationRepository;
 use Sulu\Page\Infrastructure\Doctrine\Repository\PageRepository;
 use Sulu\Page\Infrastructure\JMS\Serializer\WebspaceSerializeEventSubscriber;
+use Sulu\Page\Infrastructure\Sulu\Admin\MetadataVisitor\DefaultTemplateTypedFormMetadataVisitor;
 use Sulu\Page\Infrastructure\Sulu\Admin\MetadataVisitor\WebspaceRouteModeTypedFormMetadataVisitor;
 use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Sulu\Page\Infrastructure\Sulu\Admin\PropertyMetadataMapper\PageTreeRoutePropertyMetadataMapper;
@@ -342,6 +343,13 @@ final class SuluPageBundle extends AbstractBundle
 
         $services->set('sulu_page.webspace_route_mode_typed_form_metadata_visitor')
             ->class(WebspaceRouteModeTypedFormMetadataVisitor::class)
+            ->args([
+                new Reference('sulu_core.webspace.webspace_manager'),
+            ])
+            ->tag('sulu_admin.typed_form_metadata_visitor');
+
+        $services->set('sulu_page.default_template_typed_form_metadata_visitor')
+            ->class(DefaultTemplateTypedFormMetadataVisitor::class)
             ->args([
                 new Reference('sulu_core.webspace.webspace_manager'),
             ])

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Admin/MetadataVisitor/DefaultTemplateTypedFormMetadataVisitorTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Admin/MetadataVisitor/DefaultTemplateTypedFormMetadataVisitorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Admin\MetadataVisitor;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Page\Infrastructure\Sulu\Admin\MetadataVisitor\DefaultTemplateTypedFormMetadataVisitor;
+
+class DefaultTemplateTypedFormMetadataVisitorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private Webspace $webspace;
+
+    private DefaultTemplateTypedFormMetadataVisitor $defaultTemplateTypedFormMetadataVisitor;
+
+    public function setUp(): void
+    {
+        $this->webspace = new Webspace();
+
+        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $webspaceManager->findWebspaceByKey(Argument::cetera())
+            ->willReturn($this->webspace);
+
+        $this->defaultTemplateTypedFormMetadataVisitor = new DefaultTemplateTypedFormMetadataVisitor(
+            $webspaceManager->reveal(),
+        );
+    }
+
+    public function testDefaultTemplateSet(): void
+    {
+        $this->webspace->addDefaultTemplate('page', 'homepage');
+
+        $typedFormMetadata = new TypedFormMetadata();
+
+        $this->defaultTemplateTypedFormMetadataVisitor->visitTypedFormMetadata(
+            $typedFormMetadata,
+            'page',
+            'en',
+            ['webspace' => 'example'],
+        );
+
+        $this->assertSame('homepage', $typedFormMetadata->getDefaultType());
+    }
+
+    public function testDefaultTemplateNotSetForNoWebspace(): void
+    {
+        $this->webspace->addDefaultTemplate('page', 'homepage');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->setDefaultType('default');
+
+        $this->defaultTemplateTypedFormMetadataVisitor->visitTypedFormMetadata(
+            $typedFormMetadata,
+            'page',
+            'en',
+        );
+
+        $this->assertSame('default', $typedFormMetadata->getDefaultType());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Adds a default template visitor for pages that sets the correct default template per webspace.

#### Why?

Missing feature in Sulu 3.0
