### PR TITLE
Add Changelog fieldtype in the settings tab

### DIFF
--- a/packages/content/config/forms/content_settings_changelog.xml
+++ b/packages/content/config/forms/content_settings_changelog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>content_settings_changelog</key>
+
+    <tag name="sulu_content.content_settings_form" instanceOf="Sulu\Content\Domain\Model\AuditableInterface" priority="-100"/>
+
+    <properties>
+        <property name="changelog" type="changelog_line">
+            <meta>
+                <title>sulu_content.changelog</title>
+            </meta>
+        </property>
+    </properties>
+</form>

--- a/packages/content/translations/admin.de.json
+++ b/packages/content/translations/admin.de.json
@@ -37,5 +37,6 @@
     "sulu_content.hide_block_description": "Dieser Block wird nicht veröffentlicht, kann aber weiterhin im Admin bearbeitet werden.",
     "sulu_content.schedules_label": "Zeitfenster zuweisen",
     "sulu_content.schedules_description": "Der Block wird nur angezeigt, wenn mindestens einer der Bedingungen erfüllt wird.",
-    "sulu_content.add_schedule": "Zeitfenster hinzufügen"
+    "sulu_content.add_schedule": "Zeitfenster hinzufügen",
+    "sulu_content.changelog": "Änderungshistorie"
 }

--- a/packages/content/translations/admin.en.json
+++ b/packages/content/translations/admin.en.json
@@ -37,5 +37,6 @@
     "sulu_content.hide_block_description": "This block will not be published, but remains editable in the admin.",
     "sulu_content.schedules_label": "Assign time schedule",
     "sulu_content.schedules_description": "The block will only be visible if at least one condition is valid.",
-    "sulu_content.add_schedule": "Add schedule"
+    "sulu_content.add_schedule": "Add schedule",
+    "sulu_content.changelog": "Changelog"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Adds missing Changelog to the settings tab.

#### Why?

Sulu 3.0 need feature parity with 2.6