### PR TITLE
Fix store/restore translation for page/article/snippet

### DIFF
--- a/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
@@ -17,6 +17,7 @@ use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface;
 
 /**
  * @experimental
@@ -29,6 +30,7 @@ final class RemoveArticleTranslationMessageHandler
     public function __construct(
         private ArticleRepositoryInterface $articleRepository,
         private DomainEventCollectorInterface $domainEventCollector,
+        private ?TrashManagerInterface $trashManager = null,
     ) {
     }
 
@@ -36,6 +38,8 @@ final class RemoveArticleTranslationMessageHandler
     {
         $article = $this->articleRepository->getOneBy($message->getIdentifier());
         $locale = $message->getLocale();
+
+        $this->trashManager?->store($article::RESOURCE_KEY, $article, ['locale' => $locale]);
 
         $dimensionContents = $article->getDimensionContents();
 

--- a/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
@@ -39,7 +39,9 @@ final class RemoveArticleTranslationMessageHandler
         $article = $this->articleRepository->getOneBy($message->getIdentifier());
         $locale = $message->getLocale();
 
-        $this->trashManager?->store($article::RESOURCE_KEY, $article, ['locale' => $locale]);
+        /** @var string $resourceKey */
+        $resourceKey = $article::RESOURCE_KEY;
+        $this->trashManager?->store($resourceKey, $article, ['locale' => $locale]);
 
         $dimensionContents = $article->getDimensionContents();
 

--- a/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
+++ b/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
@@ -100,17 +100,20 @@ final class ArticleTrashItemHandler implements
         Assert::notNull($unlocalizedDimensionContent, 'Expected to find an unlocalized dimension content for the article.');
         Assert::notEmpty($localizedDimensionContents, 'Expected to find at least one localized dimension content for the article.');
 
-        // sort dimensionContents after the availableLocales from the unlocalizedDimension
+        // Reorder localized dimension contents to match the order defined in availableLocales.
         $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
         Assert::isArray($availableLocales, 'Expected availableLocales to be an array');
         /** @var array<string, ArticleDimensionContentInterface> $localizedDimensionContents */
         $localizedDimensionContents = \array_merge(
-            \array_flip(\array_filter($availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents))),
+            \array_flip(
+                \array_filter(
+                    $availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents)
+                )
+            ),
             $localizedDimensionContents,
         );
 
         foreach ($localizedDimensionContents as $locale => $localizedDimensionContent) {
-            /** @var array<int, ArticleDimensionContent> $dimensionContents */
             $dimensionContents = [$unlocalizedDimensionContent, $localizedDimensionContent];
 
             $mergedDimensionContent = $this->contentMerger->merge(
@@ -155,29 +158,29 @@ final class ArticleTrashItemHandler implements
     {
         $restoreData = $trashItem->getRestoreData();
         $articleUuid = $trashItem->getResourceId();
-        $restoreTranslation = true;
 
         $article = $this->articleRepository->findOneBy(['uuid' => $articleUuid]);
-
         if (!$article) {
             $article = $this->articleRepository->createNew($articleUuid);
-            $restoreTranslation = false;
+            $this->articleRepository->add($article);
         }
 
-        $this->articleRepository->add($article);
-
         $dimensionContents = $restoreData['dimensionContents'] ?? [];
+        /** @var list<string> $allLocales */
         $allLocales = [];
+        /** @var string|null $articleTitle */
         $articleTitle = null;
         Assert::isArray($dimensionContents, 'Expected dimensionContents to be an array');
-        /** @var array<string, mixed> $dimensionContentData */
         foreach ($dimensionContents as $dimensionContentData) {
-            if (!$articleTitle && \array_key_exists('title', $dimensionContentData) && $dimensionContentData['title']) {
-                /** @var string $articleTitle */
+            Assert::isArray($dimensionContentData, 'Expected dimensionContentData to be an array');
+            /** @var array<string, mixed> $dimensionContentData */
+            if (null === $articleTitle && \array_key_exists('title', $dimensionContentData) && $dimensionContentData['title']) {
+                Assert::string($dimensionContentData['title']);
                 $articleTitle = $dimensionContentData['title'];
             }
 
             if (\array_key_exists('locale', $dimensionContentData) && $dimensionContentData['locale']) {
+                Assert::string($dimensionContentData['locale']);
                 $allLocales[] = $dimensionContentData['locale'];
             }
 
@@ -186,11 +189,9 @@ final class ArticleTrashItemHandler implements
             }
         }
 
-        /** @var array{locales?: string[]} $context */
         $context = $allLocales ? ['locales' => $allLocales] : [];
 
-        if ($restoreTranslation) {
-            /** @var string $locale */
+        if ('translation' === $trashItem->getRestoreType()) {
             foreach ($allLocales as $locale) {
                 $this->domainEventCollector->collect(new ArticleTranslationRestoredEvent(
                     $article,
@@ -198,14 +199,16 @@ final class ArticleTrashItemHandler implements
                     $restoreData,
                 ));
             }
-        } else {
-            $this->domainEventCollector->collect(new ArticleRestoredEvent(
-                $article,
-                $articleTitle,
-                $context,
-                $restoreData,
-            ));
+
+            return $article;
         }
+
+        $this->domainEventCollector->collect(new ArticleRestoredEvent(
+            $article,
+            $articleTitle,
+            $context,
+            $restoreData,
+        ));
 
         return $article;
     }

--- a/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
+++ b/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
@@ -70,7 +70,7 @@ final class ArticleTrashItemHandler implements
             'dimensionContents' => [],
         ];
 
-        $restoreType = $options['locales'] ?? null ? 'translation' : null;
+        $restoreType = $options['locale'] ?? null ? 'translation' : null;
 
         $titles = [];
         /** @var array<string, ArticleDimensionContentInterface> $localizedDimensionContents */
@@ -80,13 +80,17 @@ final class ArticleTrashItemHandler implements
         foreach ($article->getDimensionContents() as $dimensionContent) {
             if (
                 DimensionContentInterface::CURRENT_VERSION !== $dimensionContent->getVersion()
-                && DimensionContentInterface::STAGE_LIVE !== $dimensionContent->getStage()
+                || DimensionContentInterface::STAGE_DRAFT !== $dimensionContent->getStage()
             ) {
                 continue;
             }
 
             if (null === $dimensionContent->getLocale()) {
                 $unlocalizedDimensionContent = $dimensionContent;
+                continue;
+            }
+
+            if ('translation' === $restoreType && $dimensionContent->getLocale() !== $options['locale']) {
                 continue;
             }
 
@@ -101,7 +105,7 @@ final class ArticleTrashItemHandler implements
         Assert::isArray($availableLocales, 'Expected availableLocales to be an array');
         /** @var array<string, ArticleDimensionContentInterface> $localizedDimensionContents */
         $localizedDimensionContents = \array_merge(
-            \array_flip($availableLocales),
+            \array_flip(\array_filter($availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents))),
             $localizedDimensionContents,
         );
 
@@ -168,8 +172,6 @@ final class ArticleTrashItemHandler implements
         Assert::isArray($dimensionContents, 'Expected dimensionContents to be an array');
         /** @var array<string, mixed> $dimensionContentData */
         foreach ($dimensionContents as $dimensionContentData) {
-            unset($dimensionContentData['url']); // TODO old route is not removed on delete?
-
             if (!$articleTitle && \array_key_exists('title', $dimensionContentData) && $dimensionContentData['title']) {
                 /** @var string $articleTitle */
                 $articleTitle = $dimensionContentData['title'];

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -196,6 +196,7 @@ final class SuluArticleBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_article.article_repository'),
                 new Reference('sulu_activity.domain_event_collector'),
+                new Reference('sulu_trash.trash_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
             ->tag('messenger.message_handler');
 

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -447,6 +447,7 @@ class ArticleControllerTest extends SuluTestCase
         $trashItem = $trashRepository->findOneBy([
             'resourceKey' => ArticleInterface::RESOURCE_KEY,
             'resourceId' => $id,
+            'restoreType' => null,
         ]);
         $this->assertNotNull($trashItem);
         $id = $trashItem->getId();

--- a/packages/article/tests/Functional/Integration/responses/article_post_restore.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post_restore.json
@@ -48,6 +48,6 @@
     "template": "article",
     "title": "Test Article 2",
     "version": 0,
-    "url": null,
+    "url": "/my-article-2",
     "workflowPlace": "unpublished"
 }

--- a/packages/page/src/Application/MessageHandler/RemovePageTranslationMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageTranslationMessageHandler.php
@@ -39,7 +39,9 @@ final class RemovePageTranslationMessageHandler
         $page = $this->pageRepository->getOneBy($message->getIdentifier());
         $locale = $message->getLocale();
 
-        $this->trashManager?->store($page::RESOURCE_KEY, $page, ['locale' => $locale]);
+        /** @var string $resourceKey */
+        $resourceKey = $page::RESOURCE_KEY;
+        $this->trashManager?->store($resourceKey, $page, ['locale' => $locale]);
 
         $dimensionContents = $page->getDimensionContents();
 

--- a/packages/page/src/Application/MessageHandler/RemovePageTranslationMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageTranslationMessageHandler.php
@@ -12,6 +12,7 @@
 namespace Sulu\Page\Application\MessageHandler;
 
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface;
 use Sulu\Page\Application\Message\RemovePageTranslationMessage;
 use Sulu\Page\Domain\Event\PageTranslationRemovedEvent;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
@@ -29,6 +30,7 @@ final class RemovePageTranslationMessageHandler
     public function __construct(
         private PageRepositoryInterface $pageRepository,
         private DomainEventCollectorInterface $domainEventCollector,
+        private ?TrashManagerInterface $trashManager = null,
     ) {
     }
 
@@ -36,6 +38,8 @@ final class RemovePageTranslationMessageHandler
     {
         $page = $this->pageRepository->getOneBy($message->getIdentifier());
         $locale = $message->getLocale();
+
+        $this->trashManager?->store($page::RESOURCE_KEY, $page, ['locale' => $locale]);
 
         $dimensionContents = $page->getDimensionContents();
 

--- a/packages/page/src/Infrastructure/Sulu/Trash/PageTrashItemHandler.php
+++ b/packages/page/src/Infrastructure/Sulu/Trash/PageTrashItemHandler.php
@@ -63,7 +63,6 @@ final class PageTrashItemHandler implements
     public function store(object $resource, array $options = []): TrashItemInterface
     {
         Assert::isInstanceOf($resource, PageInterface::class);
-
         $page = $resource;
 
         $data = [
@@ -75,9 +74,7 @@ final class PageTrashItemHandler implements
         $restoreType = $options['locale'] ?? null ? 'translation' : null;
 
         $titles = [];
-        /** @var array<string, PageDimensionContentInterface> $localizedDimensionContents */
         $localizedDimensionContents = [];
-        /** @var PageDimensionContentInterface|null $unlocalizedDimensionContent */
         $unlocalizedDimensionContent = null;
         foreach ($page->getDimensionContents() as $dimensionContent) {
             if (
@@ -102,17 +99,20 @@ final class PageTrashItemHandler implements
         Assert::notNull($unlocalizedDimensionContent, 'Expected to find an unlocalized dimension content for the page.');
         Assert::notEmpty($localizedDimensionContents, 'Expected to find at least one localized dimension content for the page.');
 
-        // sort dimensionContents after the availableLocales from the unlocalizedDimension
+        // Reorder localized dimension contents to match the order defined in availableLocales.
         $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
         Assert::isArray($availableLocales, 'Expected availableLocales to be an array');
         /** @var array<string, PageDimensionContentInterface> $localizedDimensionContents */
         $localizedDimensionContents = \array_merge(
-            \array_flip(\array_filter($availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents))),
+            \array_flip(
+                \array_filter(
+                    $availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents)
+                )
+            ),
             $localizedDimensionContents,
         );
 
         foreach ($localizedDimensionContents as $locale => $localizedDimensionContent) {
-            /** @var array<int, PageDimensionContent> $dimensionContents */
             $dimensionContents = [$unlocalizedDimensionContent, $localizedDimensionContent];
 
             $mergedDimensionContent = $this->contentMerger->merge(
@@ -159,18 +159,16 @@ final class PageTrashItemHandler implements
     {
         $restoreData = $trashItem->getRestoreData();
         $pageUuid = $trashItem->getResourceId();
-        $restoreTranslation = true;
 
         $page = $this->pageRepository->findOneBy(['uuid' => $pageUuid]);
-
         if (!$page) {
-            // Create the page
             $page = $this->pageRepository->createNew($pageUuid);
+            $this->pageRepository->add($page);
+
             $webspaceKey = $restoreData['webspaceKey'];
             Assert::string($webspaceKey, 'Expected webspaceKey to be a string');
             $page->setWebspaceKey($webspaceKey);
 
-            // Set parent if exists
             $parentUuid = $restoreFormData['parentId'] ?? $restoreData['parentUuid'];
             if ($parentUuid) {
                 Assert::string($parentUuid, 'Expected parentUuid to be a string');
@@ -179,11 +177,7 @@ final class PageTrashItemHandler implements
                     $page->setParent($parent);
                 }
             }
-
-            $restoreTranslation = false;
         }
-
-        $this->pageRepository->add($page);
 
         $dimensionContents = $restoreData['dimensionContents'] ?? [];
         $allLocales = [];
@@ -209,7 +203,7 @@ final class PageTrashItemHandler implements
         /** @var array{locales?: string[]} $context */
         $context = $allLocales ? ['locales' => $allLocales] : [];
 
-        if ($restoreTranslation) {
+        if ('translation' === $trashItem->getRestoreType()) {
             /** @var string $locale */
             foreach ($allLocales as $locale) {
                 $this->domainEventCollector->collect(new PageTranslationRestoredEvent(
@@ -218,6 +212,8 @@ final class PageTrashItemHandler implements
                     $restoreData,
                 ));
             }
+
+            return $page;
         } else {
             $this->domainEventCollector->collect(new PageRestoredEvent(
                 $page,
@@ -236,7 +232,7 @@ final class PageTrashItemHandler implements
             'restore_page',
             PageAdmin::EDIT_FORM_VIEW,
             ['id' => 'id', 'webspace' => 'webspace'],
-            null, // TODO serialization group?
+            null,
         );
     }
 }

--- a/packages/page/src/Infrastructure/Sulu/Trash/PageTrashItemHandler.php
+++ b/packages/page/src/Infrastructure/Sulu/Trash/PageTrashItemHandler.php
@@ -72,7 +72,7 @@ final class PageTrashItemHandler implements
             'dimensionContents' => [],
         ];
 
-        $restoreType = $options['locales'] ?? null ? 'translation' : null;
+        $restoreType = $options['locale'] ?? null ? 'translation' : null;
 
         $titles = [];
         /** @var array<string, PageDimensionContentInterface> $localizedDimensionContents */
@@ -82,13 +82,17 @@ final class PageTrashItemHandler implements
         foreach ($page->getDimensionContents() as $dimensionContent) {
             if (
                 DimensionContentInterface::CURRENT_VERSION !== $dimensionContent->getVersion()
-                && DimensionContentInterface::STAGE_LIVE !== $dimensionContent->getStage()
+                || DimensionContentInterface::STAGE_DRAFT !== $dimensionContent->getStage()
             ) {
                 continue;
             }
 
             if (null === $dimensionContent->getLocale()) {
                 $unlocalizedDimensionContent = $dimensionContent;
+                continue;
+            }
+
+            if ('translation' === $restoreType && $dimensionContent->getLocale() !== $options['locale']) {
                 continue;
             }
 
@@ -103,7 +107,7 @@ final class PageTrashItemHandler implements
         Assert::isArray($availableLocales, 'Expected availableLocales to be an array');
         /** @var array<string, PageDimensionContentInterface> $localizedDimensionContents */
         $localizedDimensionContents = \array_merge(
-            \array_flip($availableLocales),
+            \array_flip(\array_filter($availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents))),
             $localizedDimensionContents,
         );
 
@@ -197,7 +201,6 @@ final class PageTrashItemHandler implements
                 $allLocales[] = $dimensionContentData['locale'];
             }
 
-            unset($dimensionContentData['url']); // TODO old route is not removed on delete?
             foreach ($this->pageMappers as $pageMapper) {
                 $pageMapper->mapPageData($page, $dimensionContentData);
             }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -186,6 +186,7 @@ final class SuluPageBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_activity.domain_event_collector'),
+                new Reference('sulu_trash.trash_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
             ->tag('messenger.message_handler');
 

--- a/packages/page/tests/Functional/Integration/responses/page_post_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_restore.json
@@ -61,7 +61,7 @@
     "stage": "draft",
     "template": "default",
     "title": "Test Page 2",
-    "url": null,
+    "url": "/my-page-2",
     "version": 0,
     "webspace": "sulu-io",
     "workflowPlace": "unpublished"

--- a/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
@@ -12,6 +12,7 @@
 namespace Sulu\Snippet\Application\MessageHandler;
 
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\TrashBundle\Application\TrashManager\TrashManagerInterface;
 use Sulu\Snippet\Application\Message\RemoveSnippetTranslationMessage;
 use Sulu\Snippet\Domain\Event\SnippetTranslationRemovedEvent;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
@@ -29,6 +30,7 @@ final class RemoveSnippetTranslationMessageHandler
     public function __construct(
         private SnippetRepositoryInterface $snippetRepository,
         private DomainEventCollectorInterface $domainEventCollector,
+        private ?TrashManagerInterface $trashManager = null,
     ) {
     }
 
@@ -36,6 +38,8 @@ final class RemoveSnippetTranslationMessageHandler
     {
         $snippet = $this->snippetRepository->getOneBy($message->getIdentifier());
         $locale = $message->getLocale();
+
+        $this->trashManager?->store($snippet::RESOURCE_KEY, $snippet, ['locale' => $locale]);
 
         $dimensionContents = $snippet->getDimensionContents();
 

--- a/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
@@ -39,7 +39,9 @@ final class RemoveSnippetTranslationMessageHandler
         $snippet = $this->snippetRepository->getOneBy($message->getIdentifier());
         $locale = $message->getLocale();
 
-        $this->trashManager?->store($snippet::RESOURCE_KEY, $snippet, ['locale' => $locale]);
+        /** @var string $resourceKey */
+        $resourceKey = $snippet::RESOURCE_KEY;
+        $this->trashManager?->store($resourceKey, $snippet, ['locale' => $locale]);
 
         $dimensionContents = $snippet->getDimensionContents();
 

--- a/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
@@ -100,17 +100,20 @@ final class SnippetTrashItemHandler implements
         Assert::notNull($unlocalizedDimensionContent, 'Expected to find an unlocalized dimension content for the snippet.');
         Assert::notEmpty($localizedDimensionContents, 'Expected to find at least one localized dimension content for the snippet.');
 
-        // sort dimensionContents after the availableLocales from the unlocalizedDimension
+        // Reorder localized dimension contents to match the order defined in availableLocales.
         $availableLocales = $unlocalizedDimensionContent->getAvailableLocales();
         Assert::isArray($availableLocales, 'Expected availableLocales to be an array');
         /** @var array<string, SnippetDimensionContentInterface> $localizedDimensionContents */
         $localizedDimensionContents = \array_merge(
-            \array_flip(\array_filter($availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents))),
+            \array_flip(
+                \array_filter(
+                    $availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents)
+                )
+            ),
             $localizedDimensionContents
         );
 
         foreach ($localizedDimensionContents as $locale => $localizedDimensionContent) {
-            /** @var array<int, SnippetDimensionContent> $dimensionContents */
             $dimensionContents = [$unlocalizedDimensionContent, $localizedDimensionContent];
 
             $mergedDimensionContent = $this->contentMerger->merge(
@@ -155,29 +158,29 @@ final class SnippetTrashItemHandler implements
     {
         $restoreData = $trashItem->getRestoreData();
         $snippetUuid = $trashItem->getResourceId();
-        $restoreTranslation = true;
 
         $snippet = $this->snippetRepository->findOneBy(['uuid' => $snippetUuid]);
-
         if (!$snippet) {
             $snippet = $this->snippetRepository->createNew($snippetUuid);
-            $restoreTranslation = false;
+            $this->snippetRepository->add($snippet);
         }
 
-        $this->snippetRepository->add($snippet);
-
         $dimensionContents = $restoreData['dimensionContents'] ?? [];
+        /** @var list<string> $allLocales */
         $allLocales = [];
+        /** @var string|null $snippetTitle */
         $snippetTitle = null;
         Assert::isArray($dimensionContents, 'Expected dimensionContents to be an array');
-        /** @var array<string, mixed> $dimensionContentData */
         foreach ($dimensionContents as $dimensionContentData) {
-            if (!$snippetTitle && \array_key_exists('title', $dimensionContentData) && $dimensionContentData['title']) {
-                /** @var string $snippetTitle */
+            Assert::isArray($dimensionContentData, 'Expected dimensionContentData to be an array');
+            /** @var array<string, mixed> $dimensionContentData */
+            if (null === $snippetTitle && \array_key_exists('title', $dimensionContentData) && $dimensionContentData['title']) {
+                Assert::string($dimensionContentData['title']);
                 $snippetTitle = $dimensionContentData['title'];
             }
 
             if (\array_key_exists('locale', $dimensionContentData) && $dimensionContentData['locale']) {
+                Assert::string($dimensionContentData['locale']);
                 $allLocales[] = $dimensionContentData['locale'];
             }
 
@@ -186,11 +189,9 @@ final class SnippetTrashItemHandler implements
             }
         }
 
-        /** @var array{locales?: string[]} $context */
         $context = $allLocales ? ['locales' => $allLocales] : [];
 
-        if ($restoreTranslation) {
-            /** @var string $locale */
+        if ('translation' === $trashItem->getRestoreType()) {
             foreach ($allLocales as $locale) {
                 $this->domainEventCollector->collect(new SnippetTranslationRestoredEvent(
                     $snippet,
@@ -198,14 +199,16 @@ final class SnippetTrashItemHandler implements
                     $restoreData,
                 ));
             }
-        } else {
-            $this->domainEventCollector->collect(new SnippetRestoredEvent(
-                $snippet,
-                $snippetTitle,
-                $context,
-                $restoreData,
-            ));
+
+            return $snippet;
         }
+
+        $this->domainEventCollector->collect(new SnippetRestoredEvent(
+            $snippet,
+            $snippetTitle,
+            $context,
+            $restoreData,
+        ));
 
         return $snippet;
     }

--- a/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
@@ -70,7 +70,7 @@ final class SnippetTrashItemHandler implements
             'dimensionContents' => [],
         ];
 
-        $restoreType = $options['locales'] ?? null ? 'translation' : null;
+        $restoreType = $options['locale'] ?? null ? 'translation' : null;
 
         $titles = [];
         /** @var array<string, SnippetDimensionContentInterface> $localizedDimensionContents */
@@ -80,13 +80,17 @@ final class SnippetTrashItemHandler implements
         foreach ($snippet->getDimensionContents() as $dimensionContent) {
             if (
                 DimensionContentInterface::CURRENT_VERSION !== $dimensionContent->getVersion()
-                && DimensionContentInterface::STAGE_LIVE !== $dimensionContent->getStage()
+                || DimensionContentInterface::STAGE_DRAFT !== $dimensionContent->getStage()
             ) {
                 continue;
             }
 
             if (null === $dimensionContent->getLocale()) {
                 $unlocalizedDimensionContent = $dimensionContent;
+                continue;
+            }
+
+            if ('translation' === $restoreType && $dimensionContent->getLocale() !== $options['locale']) {
                 continue;
             }
 
@@ -101,7 +105,7 @@ final class SnippetTrashItemHandler implements
         Assert::isArray($availableLocales, 'Expected availableLocales to be an array');
         /** @var array<string, SnippetDimensionContentInterface> $localizedDimensionContents */
         $localizedDimensionContents = \array_merge(
-            \array_flip($availableLocales),
+            \array_flip(\array_filter($availableLocales, static fn ($locale) => \array_key_exists($locale, $localizedDimensionContents))),
             $localizedDimensionContents
         );
 
@@ -168,8 +172,6 @@ final class SnippetTrashItemHandler implements
         Assert::isArray($dimensionContents, 'Expected dimensionContents to be an array');
         /** @var array<string, mixed> $dimensionContentData */
         foreach ($dimensionContents as $dimensionContentData) {
-            unset($dimensionContentData['url']); // TODO old route is not removed on delete?
-
             if (!$snippetTitle && \array_key_exists('title', $dimensionContentData) && $dimensionContentData['title']) {
                 /** @var string $snippetTitle */
                 $snippetTitle = $dimensionContentData['title'];

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -165,6 +165,7 @@ final class SuluSnippetBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_snippet.snippet_repository'),
                 new Reference('sulu_activity.domain_event_collector'),
+                new Reference('sulu_trash.trash_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
             ->tag('messenger.message_handler');
 

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -360,6 +360,7 @@ class SnippetControllerTest extends SuluTestCase
         $trashItem = $trashRepository->findOneBy([
             'resourceKey' => SnippetInterface::RESOURCE_KEY,
             'resourceId' => $id,
+            'restoreType' => null,
         ]);
         $this->assertNotNull($trashItem);
         $id = $trashItem->getId();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add store and restore of single translations.

#### Why?

Restore of single translation not working.


#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md

<!--

Dear Contributors,

Thank you for contributing to the Sulu ecosystem!

We appreciate your effort to improve our project.  
If you need assistance or have questions about your pull request, our team is here to help.  
Please join our Slack channel for support: https://sulu.io/services/support#chat.

Best Regards, 
The Sulu Core Team

-->
