### PR TITLE
Fix vanishing many to many relations

### DIFF
--- a/packages/article/tests/Functional/Integration/responses/article_post_restore.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post_restore.json
@@ -21,7 +21,10 @@
     "excerptImage": null,
     "excerptMore": "Excerpt More 2",
     "excerptSegment": "updated-segment",
-    "excerptTags": [],
+    "excerptTags": [
+        "Tag 3",
+        "Tag 4"
+    ],
     "excerptTitle": "Excerpt Title 2",
     "ghostLocale": "de",
     "id": "@string@",

--- a/packages/content/src/Domain/Model/ExcerptTrait.php
+++ b/packages/content/src/Domain/Model/ExcerptTrait.php
@@ -125,10 +125,17 @@ trait ExcerptTrait
     public function setExcerptCategories(array $excerptCategories): void
     {
         $this->initializeCategories();
-        $this->excerptCategories->clear();
 
-        foreach ($excerptCategories as $excerptCategory) {
-            $this->excerptCategories->add($excerptCategory);
+        foreach ($this->excerptCategories as $existingCategory) {
+            if (!\in_array($existingCategory, $excerptCategories, true)) {
+                $this->excerptCategories->removeElement($existingCategory);
+            }
+        }
+
+        foreach ($excerptCategories as $newCategory) {
+            if (!$this->excerptCategories->contains($newCategory)) {
+                $this->excerptCategories->add($newCategory);
+            }
         }
     }
 
@@ -162,10 +169,17 @@ trait ExcerptTrait
     public function setExcerptTags(array $excerptTags): void
     {
         $this->initializeTags();
-        $this->excerptTags->clear();
 
-        foreach ($excerptTags as $excerptTag) {
-            $this->excerptTags->add($excerptTag);
+        foreach ($this->excerptTags as $existingTag) {
+            if (!\in_array($existingTag, $excerptTags, true)) {
+                $this->excerptTags->removeElement($existingTag);
+            }
+        }
+
+        foreach ($excerptTags as $newTag) {
+            if (!$this->excerptTags->contains($newTag)) {
+                $this->excerptTags->add($newTag);
+            }
         }
     }
 
@@ -190,10 +204,19 @@ trait ExcerptTrait
     public function setExcerptAudienceTargetGroups(array $excerptAudienceTargetGroups): void
     {
         $this->initializeAudienceTargetGroups();
-        $this->excerptAudienceTargetGroups->clear();
 
-        foreach ($excerptAudienceTargetGroups as $excerptAudienceTargetGroup) {
-            $this->excerptAudienceTargetGroups->add($excerptAudienceTargetGroup);
+        // Remove target groups no longer in the new list
+        foreach ($this->excerptAudienceTargetGroups as $existingTargetGroup) {
+            if (!\in_array($existingTargetGroup, $excerptAudienceTargetGroups, true)) {
+                $this->excerptAudienceTargetGroups->removeElement($existingTargetGroup);
+            }
+        }
+
+        // Add new target groups
+        foreach ($excerptAudienceTargetGroups as $newTargetGroup) {
+            if (!$this->excerptAudienceTargetGroups->contains($newTargetGroup)) {
+                $this->excerptAudienceTargetGroups->add($newTargetGroup);
+            }
         }
     }
 

--- a/packages/content/tests/Functional/Integration/ExampleControllerTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerTest.php
@@ -23,6 +23,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Tests\Application\AppCache;
 use Sulu\Content\Tests\Application\CacheTagsKernel;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Repository\ExampleRepository;
 use Sulu\Content\Tests\Functional\Traits\CreateCategoryTrait;
 use Sulu\Content\Tests\Functional\Traits\CreateMediaTrait;
 use Sulu\Content\Tests\Functional\Traits\CreateTagTrait;
@@ -1030,6 +1031,86 @@ class ExampleControllerTest extends SuluTestCase
         $this->assertSame(3, $totalReferenceCount);
 
         return $id;
+    }
+
+    public function testPublishPreservesDimensionContentTagRelations(): void
+    {
+        self::purgeDatabase();
+
+        $category = $this->createCategory(['key' => 'test-category']);
+        $this->createCategoryTranslation($category, ['title' => 'Test Category', 'locale' => 'en']);
+        self::getEntityManager()->flush();
+
+        /** @var ExampleRepository $exampleRepository */
+        $exampleRepository = self::getContainer()->get('example_test.example_repository');
+        $this->client->request('POST', '/admin/api/examples?locale=en', [], [], [], \json_encode([
+            'template' => 'default',
+            'title' => 'Tag Test Example',
+            'excerptTags' => ['Test Tag 1', 'Test Tag 2'],
+            'excerptCategories' => [$category->getId()],
+            'url' => '/test-example',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+        $this->assertArrayHasKey('id', $content);
+        $id = $content['id'];
+        $this->assertIsInt($id);
+
+        $example = $exampleRepository->findOneBy(['uuid' => $id]);
+        $this->assertNotNull($example);
+
+        $localizedDraft = null;
+        foreach ($example->getDimensionContents() as $dimensionContent) {
+            if ('draft' === $dimensionContent->getStage() && 'en' === $dimensionContent->getLocale() && 0 === $dimensionContent->getVersion()) {
+                $localizedDraft = $dimensionContent;
+                break;
+            }
+        }
+
+        $this->assertNotNull($localizedDraft, 'Localized draft should exist before publish');
+        $this->assertCount(2, $localizedDraft->getExcerptTags(), 'Localized draft should have 2 tags before publish');
+        $this->assertCount(1, $localizedDraft->getExcerptCategories(), 'Localized draft should have 1 category before publish');
+
+        self::getEntityManager()->clear();
+        $this->client->request('PUT', '/admin/api/examples/' . $id . '?locale=en&action=publish', [], [], [], \json_encode($content) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $example = $exampleRepository->findOneBy(['uuid' => $id]);
+        $this->assertNotNull($example);
+
+        $draftVersion0 = null;
+        $draftVersioned = null;
+        $liveVersion0 = null;
+
+        foreach ($example->getDimensionContents() as $dimensionContent) {
+            if ('en' !== $dimensionContent->getLocale()) {
+                continue;
+            }
+
+            if ('draft' === $dimensionContent->getStage() && 0 === $dimensionContent->getVersion()) {
+                $draftVersion0 = $dimensionContent;
+            } elseif ('draft' === $dimensionContent->getStage() && $dimensionContent->getVersion() > 0) {
+                $draftVersioned = $dimensionContent;
+            } elseif ('live' === $dimensionContent->getStage() && 0 === $dimensionContent->getVersion()) {
+                $liveVersion0 = $dimensionContent;
+            }
+        }
+
+        $this->assertNotNull($draftVersion0, 'Draft version=0 dimension content should exist');
+        $this->assertNotNull($draftVersioned, 'Draft versioned dimension content should exist');
+        $this->assertNotNull($liveVersion0, 'Live version=0 dimension content should exist');
+
+        $this->assertCount(2, $draftVersion0->getExcerptTags(), 'Draft version=0 should have 2 tags');
+        $this->assertCount(2, $draftVersioned->getExcerptTags(), 'Draft versioned should have 2 tags');
+        $this->assertCount(2, $liveVersion0->getExcerptTags(), 'Live version=0 should have 2 tags');
+
+        $this->assertCount(1, $draftVersion0->getExcerptCategories(), 'Draft version=0 should have 1 category');
+        $this->assertCount(1, $draftVersioned->getExcerptCategories(), 'Draft versioned should have 1 category');
+        $this->assertCount(1, $liveVersion0->getExcerptCategories(), 'Live version=0 should have 1 category');
     }
 
     protected function getSnapshotFolder(): string

--- a/packages/content/tests/Unit/Content/Domain/Model/ExcerptTraitTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Model/ExcerptTraitTest.php
@@ -160,6 +160,96 @@ class ExcerptTraitTest extends TestCase
         $this->assertSame([3, 4], $model->getExcerptCategoryIds());
     }
 
+    public function testSetExcerptTagsSynchronizesCollection(): void
+    {
+        $tag1 = $this->createTag(1);
+        $tag2 = $this->createTag(2);
+        $tag3 = $this->createTag(3);
+
+        $model = $this->getExcerptInstance();
+
+        $model->setExcerptTags([$tag1, $tag2]);
+        $this->assertSame([1, 2], \array_values(\array_map(function(TagInterface $tag) {
+            return $tag->getId();
+        }, $model->getExcerptTags())));
+
+        $model->setExcerptTags([$tag1, $tag3]);
+        $this->assertSame([1, 3], \array_values(\array_map(function(TagInterface $tag) {
+            return $tag->getId();
+        }, $model->getExcerptTags())));
+
+        $this->assertCount(2, $model->getExcerptTags());
+    }
+
+    public function testSetExcerptCategoriesSynchronizesCollection(): void
+    {
+        $category1 = $this->createCategory(1);
+        $category2 = $this->createCategory(2);
+        $category3 = $this->createCategory(3);
+
+        $model = $this->getExcerptInstance();
+
+        $model->setExcerptCategories([$category1, $category2]);
+        $this->assertSame([1, 2], \array_values(\array_map(function(CategoryInterface $category) {
+            return $category->getId();
+        }, $model->getExcerptCategories())));
+
+        $model->setExcerptCategories([$category1, $category3]);
+        $this->assertSame([1, 3], \array_values(\array_map(function(CategoryInterface $category) {
+            return $category->getId();
+        }, $model->getExcerptCategories())));
+
+        $this->assertCount(2, $model->getExcerptCategories());
+    }
+
+    public function testSetExcerptAudienceTargetGroupsSynchronizesCollection(): void
+    {
+        $targetGroup1 = $this->createTargetGroup(1);
+        $targetGroup2 = $this->createTargetGroup(2);
+        $targetGroup3 = $this->createTargetGroup(3);
+
+        $model = $this->getExcerptInstance();
+
+        $model->setExcerptAudienceTargetGroups([$targetGroup1, $targetGroup2]);
+        $this->assertSame([1, 2], \array_values(\array_map(function(TargetGroupInterface $targetGroup) {
+            return $targetGroup->getId();
+        }, $model->getExcerptAudienceTargetGroups())));
+
+        $model->setExcerptAudienceTargetGroups([$targetGroup1, $targetGroup3]);
+        $this->assertSame([1, 3], \array_values(\array_map(function(TargetGroupInterface $targetGroup) {
+            return $targetGroup->getId();
+        }, $model->getExcerptAudienceTargetGroups())));
+
+        $this->assertCount(2, $model->getExcerptAudienceTargetGroups());
+    }
+
+    public function testSharedTagInstancesAcrossMultipleModels(): void
+    {
+        $tag1 = $this->createTag(1);
+        $tag2 = $this->createTag(2);
+
+        $model1 = $this->getExcerptInstance();
+        $model2 = $this->getExcerptInstance();
+
+        $model1->setExcerptTags([$tag1, $tag2]);
+        $model2->setExcerptTags([$tag1, $tag2]);
+
+        $this->assertCount(2, $model1->getExcerptTags());
+        $this->assertCount(2, $model2->getExcerptTags());
+
+        $model2->setExcerptTags([$tag1]);
+
+        $this->assertCount(2, $model1->getExcerptTags());
+        $this->assertSame([1, 2], \array_values(\array_map(function(TagInterface $tag) {
+            return $tag->getId();
+        }, $model1->getExcerptTags())));
+
+        $this->assertCount(1, $model2->getExcerptTags());
+        $this->assertSame([1], \array_values(\array_map(function(TagInterface $tag) {
+            return $tag->getId();
+        }, $model2->getExcerptTags())));
+    }
+
     private function createTag(int $id): TagInterface
     {
         $tag = new Tag();

--- a/packages/page/tests/Functional/Integration/responses/page_get_after_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get_after_restore.json
@@ -28,7 +28,10 @@
     "excerptMore" : "Excerpt More",
     "excerptTags" : [ "Tag 1", "Tag 2" ],
     "excerptTitle" : "Excerpt Title",
-    "excerptAudienceTargetGroups" : [],
+    "excerptAudienceTargetGroups": [
+        "@integer@",
+        "@integer@"
+    ],
     "excerptSegment" : { "sulu-io" : "@string@" },
     "ghostLocale" : "en",
     "id" : "@string@",

--- a/packages/page/tests/Functional/Integration/responses/page_post_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_restore.json
@@ -19,7 +19,6 @@
     "linkData": null,
     "changed": "@datetime@",
     "changer": "@integer@",
-
     "contentLocales": [
         "en",
         "de"
@@ -27,7 +26,10 @@
     "created": "@datetime@",
     "creator": "@integer@",
     "description": "<p>Test Page 2</p>",
-    "excerptAudienceTargetGroups": [],
+    "excerptAudienceTargetGroups": [
+        "@integer@",
+        "@integer@"
+    ],
     "excerptCategories": [],
     "excerptDescription": "Excerpt Description 2",
     "excerptIcon": null,
@@ -36,7 +38,10 @@
     "excerptSegment": {
         "sulu-io": "updated-segment"
     },
-    "excerptTags": [],
+    "excerptTags": [
+        "Tag 3",
+        "Tag 4"
+    ],
     "excerptTitle": "Excerpt Title 2",
     "ghostLocale": "de",
     "id": "@uuid@",

--- a/packages/page/tests/Functional/Integration/responses/page_post_trigger_unpublish.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_trigger_unpublish.json
@@ -35,7 +35,10 @@
         "Tag 2"
     ],
     "excerptTitle": "Excerpt Title",
-    "excerptAudienceTargetGroups": [],
+    "excerptAudienceTargetGroups": [
+        "@integer@",
+        "@integer@"
+    ],
     "excerptSegment": {
         "sulu-io": "@string@"
     },

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -20,7 +20,9 @@ use PHPUnit\Framework\Attributes\Depends;
 use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
+use Sulu\Content\Tests\Functional\Traits\CreateCategoryTrait;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
+use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
@@ -30,6 +32,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 class SnippetControllerTest extends SuluTestCase
 {
     use AssertSnapshotTrait;
+    use CreateCategoryTrait;
 
     /**
      * @var KernelBrowser
@@ -382,6 +385,84 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('GET', '/admin/api/snippets/' . $trashItem->getResourceId() . '?locale=en');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('snippet_post_restore.json', $response, 200);
+    }
+
+    public function testPublishPreservesDimensionContentTagRelations(): void
+    {
+        self::purgeDatabase();
+
+        $category = $this->createCategory(['key' => 'test-category']);
+        $this->createCategoryTranslation($category, ['title' => 'Test Category', 'locale' => 'en']);
+        self::getEntityManager()->flush();
+
+        $snippetRepository = self::getContainer()->get(SnippetRepositoryInterface::class);
+        $this->client->request('POST', '/admin/api/snippets?locale=en', [], [], [], \json_encode([
+            'template' => 'snippet',
+            'title' => 'Tag Test Snippet',
+            'excerptTags' => ['Test Tag 1', 'Test Tag 2'],
+            'excerptCategories' => [$category->getId()],
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+        $this->assertArrayHasKey('id', $content);
+        $id = $content['id'];
+        $this->assertIsString($id);
+
+        $snippet = $snippetRepository->findOneBy(['uuid' => $id]);
+        $this->assertNotNull($snippet);
+
+        $localizedDraft = null;
+        foreach ($snippet->getDimensionContents() as $dimensionContent) {
+            if ('draft' === $dimensionContent->getStage() && 'en' === $dimensionContent->getLocale() && 0 === $dimensionContent->getVersion()) {
+                $localizedDraft = $dimensionContent;
+                break;
+            }
+        }
+
+        $this->assertNotNull($localizedDraft, 'Localized draft should exist before publish');
+        $this->assertCount(2, $localizedDraft->getExcerptTags(), 'Localized draft should have 2 tags before publish');
+        $this->assertCount(1, $localizedDraft->getExcerptCategories(), 'Localized draft should have 1 category before publish');
+
+        self::getEntityManager()->clear();
+        $this->client->request('PUT', '/admin/api/snippets/' . $id . '?locale=en&action=publish', [], [], [], \json_encode($content) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $snippet = $snippetRepository->findOneBy(['uuid' => $id]);
+        $this->assertNotNull($snippet);
+
+        $draftVersion0 = null;
+        $draftVersioned = null;
+        $liveVersion0 = null;
+
+        foreach ($snippet->getDimensionContents() as $dimensionContent) {
+            if ('en' !== $dimensionContent->getLocale()) {
+                continue;
+            }
+
+            if ('draft' === $dimensionContent->getStage() && 0 === $dimensionContent->getVersion()) {
+                $draftVersion0 = $dimensionContent;
+            } elseif ('draft' === $dimensionContent->getStage() && $dimensionContent->getVersion() > 0) {
+                $draftVersioned = $dimensionContent;
+            } elseif ('live' === $dimensionContent->getStage() && 0 === $dimensionContent->getVersion()) {
+                $liveVersion0 = $dimensionContent;
+            }
+        }
+
+        $this->assertNotNull($draftVersion0, 'Draft version=0 dimension content should exist');
+        $this->assertNotNull($draftVersioned, 'Draft versioned dimension content should exist');
+        $this->assertNotNull($liveVersion0, 'Live version=0 dimension content should exist');
+
+        $this->assertCount(2, $draftVersion0->getExcerptTags(), 'Draft version=0 should have 2 tags');
+        $this->assertCount(2, $draftVersioned->getExcerptTags(), 'Draft versioned should have 2 tags');
+        $this->assertCount(2, $liveVersion0->getExcerptTags(), 'Live version=0 should have 2 tags');
+
+        $this->assertCount(1, $draftVersion0->getExcerptCategories(), 'Draft version=0 should have 1 category');
+        $this->assertCount(1, $draftVersioned->getExcerptCategories(), 'Draft versioned should have 1 category');
+        $this->assertCount(1, $liveVersion0->getExcerptCategories(), 'Live version=0 should have 1 category');
     }
 
     protected function getSnapshotFolder(): string

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -22,7 +22,6 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
 use Sulu\Content\Tests\Functional\Traits\CreateCategoryTrait;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
-use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
@@ -385,84 +384,6 @@ class SnippetControllerTest extends SuluTestCase
         $this->client->request('GET', '/admin/api/snippets/' . $trashItem->getResourceId() . '?locale=en');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('snippet_post_restore.json', $response, 200);
-    }
-
-    public function testPublishPreservesDimensionContentTagRelations(): void
-    {
-        self::purgeDatabase();
-
-        $category = $this->createCategory(['key' => 'test-category']);
-        $this->createCategoryTranslation($category, ['title' => 'Test Category', 'locale' => 'en']);
-        self::getEntityManager()->flush();
-
-        $snippetRepository = self::getContainer()->get(SnippetRepositoryInterface::class);
-        $this->client->request('POST', '/admin/api/snippets?locale=en', [], [], [], \json_encode([
-            'template' => 'snippet',
-            'title' => 'Tag Test Snippet',
-            'excerptTags' => ['Test Tag 1', 'Test Tag 2'],
-            'excerptCategories' => [$category->getId()],
-        ]) ?: null);
-
-        $response = $this->client->getResponse();
-        $this->assertHttpStatusCode(201, $response);
-        $content = \json_decode((string) $response->getContent(), true);
-        $this->assertIsArray($content);
-        $this->assertArrayHasKey('id', $content);
-        $id = $content['id'];
-        $this->assertIsString($id);
-
-        $snippet = $snippetRepository->findOneBy(['uuid' => $id]);
-        $this->assertNotNull($snippet);
-
-        $localizedDraft = null;
-        foreach ($snippet->getDimensionContents() as $dimensionContent) {
-            if ('draft' === $dimensionContent->getStage() && 'en' === $dimensionContent->getLocale() && 0 === $dimensionContent->getVersion()) {
-                $localizedDraft = $dimensionContent;
-                break;
-            }
-        }
-
-        $this->assertNotNull($localizedDraft, 'Localized draft should exist before publish');
-        $this->assertCount(2, $localizedDraft->getExcerptTags(), 'Localized draft should have 2 tags before publish');
-        $this->assertCount(1, $localizedDraft->getExcerptCategories(), 'Localized draft should have 1 category before publish');
-
-        self::getEntityManager()->clear();
-        $this->client->request('PUT', '/admin/api/snippets/' . $id . '?locale=en&action=publish', [], [], [], \json_encode($content) ?: null);
-        $response = $this->client->getResponse();
-        $this->assertHttpStatusCode(200, $response);
-
-        $snippet = $snippetRepository->findOneBy(['uuid' => $id]);
-        $this->assertNotNull($snippet);
-
-        $draftVersion0 = null;
-        $draftVersioned = null;
-        $liveVersion0 = null;
-
-        foreach ($snippet->getDimensionContents() as $dimensionContent) {
-            if ('en' !== $dimensionContent->getLocale()) {
-                continue;
-            }
-
-            if ('draft' === $dimensionContent->getStage() && 0 === $dimensionContent->getVersion()) {
-                $draftVersion0 = $dimensionContent;
-            } elseif ('draft' === $dimensionContent->getStage() && $dimensionContent->getVersion() > 0) {
-                $draftVersioned = $dimensionContent;
-            } elseif ('live' === $dimensionContent->getStage() && 0 === $dimensionContent->getVersion()) {
-                $liveVersion0 = $dimensionContent;
-            }
-        }
-
-        $this->assertNotNull($draftVersion0, 'Draft version=0 dimension content should exist');
-        $this->assertNotNull($draftVersioned, 'Draft versioned dimension content should exist');
-        $this->assertNotNull($liveVersion0, 'Live version=0 dimension content should exist');
-
-        $this->assertCount(2, $draftVersion0->getExcerptTags(), 'Draft version=0 should have 2 tags');
-        $this->assertCount(2, $draftVersioned->getExcerptTags(), 'Draft versioned should have 2 tags');
-        $this->assertCount(2, $liveVersion0->getExcerptTags(), 'Live version=0 should have 2 tags');
-
-        $this->assertCount(1, $draftVersion0->getExcerptCategories(), 'Draft version=0 should have 1 category');
-        $this->assertCount(1, $draftVersioned->getExcerptCategories(), 'Draft versioned should have 1 category');
-        $this->assertCount(1, $liveVersion0->getExcerptCategories(), 'Live version=0 should have 1 category');
     }
 
     protected function getSnapshotFolder(): string

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -20,7 +20,6 @@ use PHPUnit\Framework\Attributes\Depends;
 use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
-use Sulu\Content\Tests\Functional\Traits\CreateCategoryTrait;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
@@ -31,7 +30,6 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 class SnippetControllerTest extends SuluTestCase
 {
     use AssertSnapshotTrait;
-    use CreateCategoryTrait;
 
     /**
      * @var KernelBrowser

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
@@ -15,7 +15,10 @@
     "excerptImage": null,
     "excerptMore": "Excerpt More 2",
     "excerptSegment": null,
-    "excerptTags": [],
+    "excerptTags": [
+        "Tag 3",
+        "Tag 4"
+    ],
     "excerptTitle": "Excerpt Title 2",
     "ghostLocale": "de",
     "id": "@string@",


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | License | MIT

  #### What's in this PR?

  This PR fixes a critical bug in the dimension content architecture where excerpt tags, categories,
  and audience target groups were being lost from the original draft (version=0) dimension content
  after publishing a snippet, article, or page.

  #### Why?

  When publishing content (snippets, articles, pages), the system creates multiple dimension content
  records:
  1. Original draft (version=0) - should keep its excerpt data
  2. Versioned draft (version=timestamp) - copy of the data
  3. Live content (version=0) - published copy

  However, the **original draft was losing its excerpt tags, categories, and target groups** in the
  database after publish.

  **Root Cause:**

  During the publish workflow, when copying data to new dimension contents:
  1. The same Tag/Category entity instances are shared across multiple dimension contents (from
  TagFactory)
  2. When setExcerptTags() is called on a new dimension content, clear() removes ALL associations from
   Doctrine's Unit of Work
  3. This inadvertently deletes join table entries for the original draft dimension content