### PR TITLE
Fix @see deep class references for PHPStorm

### DIFF
--- a/packages/article/src/Domain/Repository/ArticleRepositoryInterface.php
+++ b/packages/article/src/Domain/Repository/ArticleRepositoryInterface.php
@@ -18,7 +18,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 /**
  * Implementation can be found in the following class:.
  *
- * @see Sulu\Article\Infrastructure\Doctrine\Repository\ArticleRepository
+ * @see \Sulu\Article\Infrastructure\Doctrine\Repository\ArticleRepository
  */
 interface ArticleRepositoryInterface
 {

--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -198,7 +198,7 @@ final class ArticleController
     {
         $message = new CreateArticleMessage($this->getData($request));
 
-        /** @see Sulu\Article\Application\MessageHandler\CreateArticleMessageHandler */
+        /** @see \Sulu\Article\Application\MessageHandler\CreateArticleMessageHandler */
         /** @var ArticleInterface $article */
         $article = $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         $uuid = $article->getUuid();
@@ -213,7 +213,7 @@ final class ArticleController
     public function putAction(Request $request, string $id): Response // TODO route should be a uuid?
     {
         $message = new ModifyArticleMessage(['uuid' => $id], $this->getData($request));
-        /** @see Sulu\Article\Application\MessageHandler\ModifyArticleMessageHandler */
+        /** @see \Sulu\Article\Application\MessageHandler\ModifyArticleMessageHandler */
         $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
         $this->handleAction($request, $id);
@@ -235,14 +235,14 @@ final class ArticleController
 
         if ($deleteLocale) {
             $message = new RemoveArticleTranslationMessage(['uuid' => $id], $locale);
-            /** @see Sulu\Article\Application\MessageHandler\RemoveArticleTranslationMessageHandler */
+            /** @see \Sulu\Article\Application\MessageHandler\RemoveArticleTranslationMessageHandler */
             $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
             return new Response('', 204);
         }
 
         $message = new RemoveArticleMessage(['uuid' => $id], $locale);
-        /** @see Sulu\Article\Application\MessageHandler\RemoveArticleMessageHandler */
+        /** @see \Sulu\Article\Application\MessageHandler\RemoveArticleMessageHandler */
         $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
         return new Response('', 204);
@@ -281,7 +281,7 @@ final class ArticleController
                 (string) $request->query->get('dest'),
             );
 
-            /** @see Sulu\Article\Application\MessageHandler\CopyLocaleArticleMessageHandler */
+            /** @see \Sulu\Article\Application\MessageHandler\CopyLocaleArticleMessageHandler */
             /** @var ArticleInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('restore' === $action) {
@@ -297,13 +297,13 @@ final class ArticleController
                 $request->query->all(),
             );
 
-            /** @see Sulu\Article\Application\MessageHandler\RestoreArticleVersionMessageHandler */
+            /** @see \Sulu\Article\Application\MessageHandler\RestoreArticleVersionMessageHandler */
             /** @var ArticleInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         }
         $message = new ApplyWorkflowTransitionArticleMessage(['uuid' => $uuid], $this->getLocale($request), $action);
 
-        /** @see Sulu\Article\Application\MessageHandler\ApplyWorkflowTransitionArticleMessageHandler */
+        /** @see \Sulu\Article\Application\MessageHandler\ApplyWorkflowTransitionArticleMessageHandler */
         /** @var null */
         return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
     }

--- a/packages/custom-url/src/UserInterface/Controller/Admin/CustomUrlController.php
+++ b/packages/custom-url/src/UserInterface/Controller/Admin/CustomUrlController.php
@@ -102,7 +102,7 @@ class CustomUrlController implements SecuredControllerInterface
     {
         $requestData = $request->request->all();
         try {
-            /** @see Sulu\CustomUrl\Application\MessageHandler\CreateCustomUrlMessageHandler */
+            /** @see \Sulu\CustomUrl\Application\MessageHandler\CreateCustomUrlMessageHandler */
             /** @var CustomUrlInterface $customUrl */
             $customUrl = $this->handle(new Envelope(
                 new CreateCustomUrlMessage(
@@ -133,7 +133,7 @@ class CustomUrlController implements SecuredControllerInterface
         unset($requestData['creator'], $requestData['changer'], $requestData['created'], $requestData['updated']);
 
         try {
-            /** @see Sulu\CustomUrl\Application\MessageHandler\ModifyCustomUrlMessageHandler */
+            /** @see \Sulu\CustomUrl\Application\MessageHandler\ModifyCustomUrlMessageHandler */
             /** @var CustomUrlInterface $customUrl */
             $customUrl = $this->handle(new Envelope(
                 new ModifyCustomUrlMessage(
@@ -161,7 +161,7 @@ class CustomUrlController implements SecuredControllerInterface
 
     public function deleteAction(string $webspace, string $id): Response
     {
-        /** @see Sulu\CustomUrl\Application\MessageHandler\RemoveCustomUrlMessageHandler */
+        /** @see \Sulu\CustomUrl\Application\MessageHandler\RemoveCustomUrlMessageHandler */
         /** @var CustomUrlInterface $customUrl */
         $customUrl = $this->handle(new Envelope(
             new RemoveCustomUrlMessage(uuid: $id, webspaceKey: $webspace),
@@ -177,7 +177,7 @@ class CustomUrlController implements SecuredControllerInterface
 
         // TODO: bulk delete should either be more efficient or just fall back to calling the delete endpoint in code
         foreach ($ids as $id) {
-            /** @see Sulu\CustomUrl\Application\MessageHandler\RemoveCustomUrlMessageHandler */
+            /** @see \Sulu\CustomUrl\Application\MessageHandler\RemoveCustomUrlMessageHandler */
             $this->handle(new Envelope(
                 new RemoveCustomUrlMessage(uuid: $id, webspaceKey: $webspace),
                 [new EnableFlushStamp()],

--- a/packages/page/src/Domain/Repository/PageRepositoryInterface.php
+++ b/packages/page/src/Domain/Repository/PageRepositoryInterface.php
@@ -20,7 +20,7 @@ use Sulu\Page\Domain\Model\PageInterface;
 /**
  * Implementation can be found in the following class:.
  *
- * @see Sulu\Page\Infrastructure\Doctrine\Repository\PageRepository
+ * @see \Sulu\Page\Infrastructure\Doctrine\Repository\PageRepository
  */
 interface PageRepositoryInterface extends DescendantProviderInterface
 {

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -190,7 +190,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         $parentId = $request->query->getString('parentId');
         $message = new CreatePageMessage($webspaceKey, $parentId, $this->getData($request));
 
-        /** @see Sulu\Page\Application\MessageHandler\CreatePageMessageHandler */
+        /** @see \Sulu\Page\Application\MessageHandler\CreatePageMessageHandler */
         /** @var PageInterface $page */
         $page = $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         $uuid = $page->getUuid();
@@ -205,7 +205,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
     public function putAction(Request $request, string $id): Response // TODO route should be a uuid?
     {
         $message = new ModifyPageMessage(['uuid' => $id], $this->getData($request));
-        /** @see Sulu\Page\Application\MessageHandler\ModifyPageMessageHandler */
+        /** @see \Sulu\Page\Application\MessageHandler\ModifyPageMessageHandler */
         $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
         $this->handleAction($request, $id);
@@ -228,14 +228,14 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
 
         if ($deleteLocale) {
             $message = new RemovePageTranslationMessage(['uuid' => $id], $locale);
-            /** @see Sulu\Page\Application\MessageHandler\RemovePageTranslationMessageHandler */
+            /** @see \Sulu\Page\Application\MessageHandler\RemovePageTranslationMessageHandler */
             $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
             return new Response('', 204);
         }
 
         $message = new RemovePageMessage(['uuid' => $id], $locale, $forceRemoveChildren);
-        /** @see Sulu\Page\Application\MessageHandler\RemovePageMessageHandler */
+        /** @see \Sulu\Page\Application\MessageHandler\RemovePageMessageHandler */
         $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
         return new Response('', 204);
@@ -274,21 +274,21 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
                 (string) $request->query->get('dest'),
             );
 
-            /** @see Sulu\Page\Application\MessageHandler\CopyLocalePageMessageHandler */
+            /** @see \Sulu\Page\Application\MessageHandler\CopyLocalePageMessageHandler */
             /** @var PageInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('move' === $action) {
             $destinationUuid = $request->query->getString('destination');
             $message = new MovePageMessage(['uuid' => $uuid], ['uuid' => $destinationUuid], $this->getLocale($request));
 
-            /** @see Sulu\Page\Application\MessageHandler\MovePageMessageHandler */
+            /** @see \Sulu\Page\Application\MessageHandler\MovePageMessageHandler */
             /** @var PageInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('copy' == $action) {
             $destinationUuid = $request->query->getString('destination');
             $message = new CopyPageMessage(['uuid' => $uuid], ['uuid' => $destinationUuid], $this->getLocale($request));
 
-            /** @see Sulu\Page\Application\MessageHandler\CopyPageMessageHandler */
+            /** @see \Sulu\Page\Application\MessageHandler\CopyPageMessageHandler */
             /** @var PageInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('order' === $action) {
@@ -299,7 +299,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
                 $this->getLocale($request),
             );
 
-            /** @see Sulu\Page\Application\MessageHandler\OrderPageMessageHandler */
+            /** @see \Sulu\Page\Application\MessageHandler\OrderPageMessageHandler */
             /** @var PageInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('restore' === $action) {
@@ -315,14 +315,14 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
                 $request->query->all(),
             );
 
-            /** @see Sulu\Page\Application\MessageHandler\RestorePageVersionMessageHandler */
+            /** @see \Sulu\Page\Application\MessageHandler\RestorePageVersionMessageHandler */
             /** @var PageInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         }
 
         $message = new ApplyWorkflowTransitionPageMessage(['uuid' => $uuid], $this->getLocale($request), $action);
 
-        /** @see Sulu\Page\Application\MessageHandler\ApplyWorkflowTransitionPageMessageHandler */
+        /** @see \Sulu\Page\Application\MessageHandler\ApplyWorkflowTransitionPageMessageHandler */
         /** @var PageInterface|null */
         return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
     }

--- a/packages/snippet/src/Domain/Repository/SnippetAreaRepositoryInterface.php
+++ b/packages/snippet/src/Domain/Repository/SnippetAreaRepositoryInterface.php
@@ -19,7 +19,7 @@ use Sulu\Snippet\Domain\Model\SnippetAreaInterface;
 /**
  * Implementation can be found in the following class.
  *
- * @see Sulu\Snippet\Infrastructure\Doctrine\Repository\SnippetAreaRepository
+ * @see \Sulu\Snippet\Infrastructure\Doctrine\Repository\SnippetAreaRepository
  */
 interface SnippetAreaRepositoryInterface
 {

--- a/packages/snippet/src/Domain/Repository/SnippetRepositoryInterface.php
+++ b/packages/snippet/src/Domain/Repository/SnippetRepositoryInterface.php
@@ -18,7 +18,7 @@ use Sulu\Snippet\Domain\Model\SnippetInterface;
 /**
  * Implementation can be found in the following class:.
  *
- * @see Sulu\Snippet\Infrastructure\Doctrine\Repository\SnippetRepository
+ * @see \Sulu\Snippet\Infrastructure\Doctrine\Repository\SnippetRepository
  */
 interface SnippetRepositoryInterface
 {

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -212,7 +212,7 @@ final class SnippetController
     {
         $message = new CreateSnippetMessage($this->getData($request));
 
-        /** @see Sulu\Snippet\Application\MessageHandler\CreateSnippetMessageHandler */
+        /** @see \Sulu\Snippet\Application\MessageHandler\CreateSnippetMessageHandler */
         /** @var SnippetInterface $snippet */
         $snippet = $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         $uuid = $snippet->getUuid();
@@ -227,7 +227,7 @@ final class SnippetController
     public function putAction(Request $request, string $id): Response // TODO route should be a uuid?
     {
         $message = new ModifySnippetMessage(['uuid' => $id], $this->getData($request));
-        /** @see Sulu\Snippet\Application\MessageHandler\ModifySnippetMessageHandler */
+        /** @see \Sulu\Snippet\Application\MessageHandler\ModifySnippetMessageHandler */
         $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
         $this->handleAction($request, $id);
@@ -249,14 +249,14 @@ final class SnippetController
 
         if ($deleteLocale) {
             $message = new RemoveSnippetTranslationMessage(['uuid' => $id], $locale);
-            /** @see Sulu\Snippet\Application\MessageHandler\RemoveSnippetTranslationMessageHandler */
+            /** @see \Sulu\Snippet\Application\MessageHandler\RemoveSnippetTranslationMessageHandler */
             $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
             return new Response('', 204);
         }
 
         $message = new RemoveSnippetMessage(['uuid' => $id], $locale);
-        /** @see Sulu\Snippet\Application\MessageHandler\RemoveSnippetMessageHandler */
+        /** @see \Sulu\Snippet\Application\MessageHandler\RemoveSnippetMessageHandler */
         $this->handle(new Envelope($message, [new EnableFlushStamp()]));
 
         return new Response('', 204);
@@ -295,7 +295,7 @@ final class SnippetController
                 (string) $request->query->get('dest')
             );
 
-            /** @see Sulu\Snippet\Application\MessageHandler\CopyLocaleSnippetMessageHandler */
+            /** @see \Sulu\Snippet\Application\MessageHandler\CopyLocaleSnippetMessageHandler */
             /** @var null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('restore' === $action) {
@@ -311,13 +311,13 @@ final class SnippetController
                 $request->query->all(),
             );
 
-            /** @see Sulu\Snippet\Application\MessageHandler\RestoreSnippetVersionMessageHandler */
+            /** @see \Sulu\Snippet\Application\MessageHandler\RestoreSnippetVersionMessageHandler */
             /** @var SnippetInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } else {
             $message = new ApplyWorkflowTransitionSnippetMessage(['uuid' => $uuid], $this->getLocale($request), $action);
 
-            /** @see Sulu\Snippet\Application\MessageHandler\ApplyWorkflowTransitionSnippetMessageHandler */
+            /** @see \Sulu\Snippet\Application\MessageHandler\ApplyWorkflowTransitionSnippetMessageHandler */
             /** @var null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix @see deep class references for PHPStorm

#### Why?

PHPStorm did detect only "parts" of the reference example in `Sulu\Article\Infrastructure\Doctrine\Repository\ArticleRepository` it detected `Sulu\Article\Infrastructure\Doctrine` as namespace but failed at `Sulu\Article\Infrastructure\Doctrine\Repository` which didn't allow to navigate to the class. With the leading `\` slash all works in IDE.