### PR TITLE
Remove unnecessary else statement in PageTrashItemHandler

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Trash/PageTrashItemHandler.php
+++ b/packages/page/src/Infrastructure/Sulu/Trash/PageTrashItemHandler.php
@@ -214,14 +214,14 @@ final class PageTrashItemHandler implements
             }
 
             return $page;
-        } else {
-            $this->domainEventCollector->collect(new PageRestoredEvent(
-                $page,
-                $pageTitle,
-                $context,
-                $restoreData,
-            ));
         }
+
+        $this->domainEventCollector->collect(new PageRestoredEvent(
+            $page,
+            $pageTitle,
+            $context,
+            $restoreData,
+        ));
 
         return $page;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove unnecessary else statement in PageTrashItemHandler as the if is doing a early return.

#### Why?

Missed to apply in: https://github.com/sulu/sulu/pull/8368