### PR TITLE
Disallow call of doctrine collection clear method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,7 @@
         "scheb/2fa-totp": "^6.0 || ^7.0",
         "scheb/2fa-trusted-device": "^6.0 || ^7.0",
         "shipmonk/composer-dependency-analyser": "^1.8",
+        "spaze/phpstan-disallowed-calls": "^4.7",
         "superbalist/flysystem-google-storage": "^7.1",
         "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
         "symfony/debug-bundle": "^5.4 || ^6.0 || ^7.0",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -7,6 +7,7 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
+    - vendor/spaze/phpstan-disallowed-calls/extension.neon
 
 parameters:
     phpVersion: 80200
@@ -33,6 +34,10 @@ parameters:
         - %currentWorkingDirectory%/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/LegacyResettingControllerTest.php
         - %currentWorkingDirectory%/src/Sulu/Bundle/MarkupBundle/Listener/SwiftMailerListener.php
         - %currentWorkingDirectory%/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Listener/SwiftMailerListenerTest.php
+    disallowedMethodCalls:
+        -
+            method: 'Doctrine\Common\Collections\Collection::clear()'
+            message: 'use add and removeElement methods instead of clear to avoid unintended data loss if domain event listeners reflush during postFlush event'
     symfony:
         containerXmlPath: %currentWorkingDirectory%/var/cache/admin/dev/App_KernelDevDebugContainer.xml
         consoleApplicationLoader: tests/phpstan/console-application.php

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroup.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroup.php
@@ -170,7 +170,9 @@ class TargetGroup implements TargetGroupInterface
 
     public function clearWebspaces()
     {
-        $this->webspaces->clear();
+        foreach ($this->webspaces as $webspace) {
+            $this->removeWebspace($webspace);
+        }
     }
 
     public function getRules()
@@ -194,6 +196,8 @@ class TargetGroup implements TargetGroupInterface
 
     public function clearRules()
     {
-        $this->rules->clear();
+        foreach ($this->rules as $rule) {
+            $this->removeRule($rule);
+        }
     }
 }

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRule.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Entity/TargetGroupRule.php
@@ -120,6 +120,8 @@ class TargetGroupRule implements TargetGroupRuleInterface
 
     public function clearConditions()
     {
-        $this->conditions->clear();
+        foreach ($this->conditions as $condition) {
+            $this->removeCondition($condition);
+        }
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AbstractContactManager.php
@@ -1780,7 +1780,9 @@ abstract class AbstractContactManager implements ContactManagerInterface
     {
         if ($entities && \count($entities) > 0 && \method_exists($entities, 'getValues')) {
             $newEntities = $entities->getValues();
-            $entities->clear();
+            foreach ($entities as $entity) {
+                $entities->removeElement($entity);
+            }
             foreach ($newEntities as $value) {
                 $entities->add($value);
             }

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -504,7 +504,9 @@ class FileVersion implements AuditableInterface
      */
     public function removeTags()
     {
-        $this->tags->clear();
+        foreach ($this->tags as $tag) {
+            $this->tags->removeElement($tag);
+        }
     }
 
     /**
@@ -561,7 +563,7 @@ class FileVersion implements AuditableInterface
                 $newMetaList[] = clone $meta;
             }
 
-            $this->meta->clear();
+            $this->meta->clear(); // @phpstan-ignore-line disallowed.method it saved to call here as it a none persisted entity
             foreach ($newMetaList as $newMeta) {
                 $newMeta->setFileVersion($this);
                 $this->addMeta($newMeta);
@@ -576,7 +578,7 @@ class FileVersion implements AuditableInterface
                 $newContentLanguageList[] = clone $contentLanguage;
             }
 
-            $this->contentLanguages->clear();
+            $this->contentLanguages->clear(); // @phpstan-ignore-line disallowed.method it saved to call here as it a none persisted entity
             foreach ($newContentLanguageList as $newContentLanguage) {
                 $newContentLanguage->setFileVersion($this);
                 $this->addContentLanguage($newContentLanguage);
@@ -587,7 +589,7 @@ class FileVersion implements AuditableInterface
                 $newPublishLanguageList[] = clone $publishLanguage;
             }
 
-            $this->publishLanguages->clear();
+            $this->publishLanguages->clear(); // @phpstan-ignore-line disallowed.method it saved to call here as it a none persisted entity
             foreach ($newPublishLanguageList as $newPublishLanguage) {
                 $newPublishLanguage->setFileVersion($this);
                 $this->addPublishLanguage($newPublishLanguage);
@@ -598,7 +600,7 @@ class FileVersion implements AuditableInterface
                 $newFormatOptionsArray[] = clone $formatOptions;
             }
 
-            $this->formatOptions->clear();
+            $this->formatOptions->clear(); // @phpstan-ignore-line disallowed.method it saved to call here as it a none persisted entity
             foreach ($newFormatOptionsArray as $newFormatOptions) {
                 $newFormatOptions->setFileVersion($this);
                 $this->addFormatOptions($newFormatOptions);
@@ -655,7 +657,9 @@ class FileVersion implements AuditableInterface
      */
     public function removeCategories()
     {
-        $this->categories->clear();
+        foreach ($this->categories as $category) {
+            $this->categories->removeElement($category);
+        }
     }
 
     /**
@@ -681,8 +685,8 @@ class FileVersion implements AuditableInterface
      */
     public function removeTargetGroups()
     {
-        if ($this->targetGroups) {
-            $this->targetGroups->clear();
+        foreach ($this->targetGroups as $targetGroup) {
+            $this->targetGroups->removeElement($targetGroup);
         }
     }
 

--- a/src/Sulu/Bundle/ReferenceBundle/Application/Collector/ReferenceCollector.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Application/Collector/ReferenceCollector.php
@@ -117,7 +117,7 @@ class ReferenceCollector implements ReferenceCollectorInterface
             $this->referenceRepository->add($reference);
         }
 
-        $this->referenceCollection->clear();
+        $this->referenceCollection->clear(); // @phpstan-ignore-line disallowed.method the `referenceCollection` is no entity so we save to use clear here
     }
 
     private function getReference(ReferenceInterface $reference): ?ReferenceInterface

--- a/src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Entity/Analytics.php
@@ -145,7 +145,9 @@ class Analytics implements AnalyticsInterface
 
     public function clearDomains(): AnalyticsInterface
     {
-        $this->domains->clear();
+        foreach ($this->domains as $domain) {
+            $this->domains->removeElement($domain);
+        }
 
         return $this;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/8369
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Disallow call of doctrine collection clear method

#### Why?

Calling `clear` actually triggers a `DELETE ..` query which removes all related entities, as in postFlush the UnitOfWork is not 100% cleanup it ends up in retrigger the delete query even if the values has changed. So basically in a Sulu Setup we should not allow calling the clear method of a already persisted collection.