### PR TITLE
Rename search index  id separator, from "::" to "__"

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleIndexListener.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleIndexListener.php
@@ -49,10 +49,10 @@ final class AdminArticleIndexListener
             }
 
             foreach ($locales as $locale) {
-                $identifiers[] = ArticleInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+                $identifiers[] = ArticleInterface::RESOURCE_KEY . '__' . $event->getResourceId() . '__' . $locale;
             }
         } elseif ($locale) {
-            $identifiers[] = ArticleInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+            $identifiers[] = ArticleInterface::RESOURCE_KEY . '__' . $event->getResourceId() . '__' . $locale;
         }
 
         if (!$identifiers) {

--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
@@ -86,7 +86,7 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
             }
 
             yield [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . ((string) $article['articleId']) . '::' . $article['locale'],
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . ((string) $article['articleId']) . '__' . $article['locale'],
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => (string) $article['articleId'],
                 'changedAt' => $article['changed']->format('c'),
@@ -127,14 +127,14 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
             $conditions = [];
 
             foreach ($identifiers as $index => $identifier) {
-                $resourceKey = \explode('::', $identifier)[0];
+                $resourceKey = \explode('__', $identifier)[0];
 
                 if (ArticleInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
-                $id = \explode('::', $identifier)[1] ?? '';
-                $locale = \explode('::', $identifier)[2] ?? '';
+                $id = \explode('__', $identifier)[1] ?? '';
+                $locale = \explode('__', $identifier)[2] ?? '';
 
                 $conditions[] = "(dimensionContent.article = :id{$index} AND dimensionContent.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;

--- a/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleIndexListener.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleIndexListener.php
@@ -36,7 +36,7 @@ final class WebsiteArticleIndexListener
         $resourceId = $event->getResourceId();
 
         $identifiers = \array_map(
-            fn (string $locale) => ArticleInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            fn (string $locale) => ArticleInterface::RESOURCE_KEY . '__' . $resourceId . '__' . $locale,
             $this->getLocales($event),
         );
 

--- a/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleReindexProvider.php
@@ -107,7 +107,7 @@ final class WebsiteArticleReindexProvider implements ReindexProviderInterface
             }
 
             yield [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . ((string) $article['articleId']) . '::' . $article['locale'],
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . ((string) $article['articleId']) . '__' . $article['locale'],
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => (string) $article['articleId'],
                 'locale' => $article['locale'],
@@ -152,14 +152,14 @@ final class WebsiteArticleReindexProvider implements ReindexProviderInterface
             $conditions = [];
 
             foreach ($identifiers as $index => $identifier) {
-                $resourceKey = \explode('::', $identifier)[0];
+                $resourceKey = \explode('__', $identifier)[0];
 
                 if (ArticleInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
-                $id = \explode('::', $identifier)[1] ?? '';
-                $locale = \explode('::', $identifier)[2] ?? '';
+                $id = \explode('__', $identifier)[1] ?? '';
+                $locale = \explode('__', $identifier)[2] ?? '';
 
                 $conditions[] = "(dimensionContent.article = :id{$index} AND dimensionContent.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
@@ -117,7 +117,7 @@ class AdminArticleReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article1->getUuid() . '::en',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article1->getUuid() . '__en',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article1->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
@@ -129,7 +129,7 @@ class AdminArticleReindexProviderTest extends SuluTestCase
                 ],
             ],
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article2->getUuid() . '::en',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__en',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -141,7 +141,7 @@ class AdminArticleReindexProviderTest extends SuluTestCase
                 ],
             ],
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article2->getUuid() . '::de',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -229,8 +229,8 @@ class AdminArticleReindexProviderTest extends SuluTestCase
         ]);
 
         $identifiers = [
-            ArticleInterface::RESOURCE_KEY . '::' . $article1->getUuid() . '::en',
-            ArticleInterface::RESOURCE_KEY . '::' . $article2->getUuid() . '::de',
+            ArticleInterface::RESOURCE_KEY . '__' . $article1->getUuid() . '__en',
+            ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
         ];
 
         $config = ReindexConfig::create()

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
@@ -137,7 +137,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article1->getUuid() . '::en',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article1->getUuid() . '__en',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article1->getUuid(),
                 'locale' => 'en',
@@ -149,7 +149,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
             ],
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article2->getUuid() . '::de',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article2->getUuid(),
                 'locale' => 'de',
@@ -161,7 +161,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
             ],
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article2->getUuid() . '::en',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__en',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article2->getUuid(),
                 'locale' => 'en',
@@ -247,7 +247,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article1->getUuid() . '::en',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article1->getUuid() . '__en',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article1->getUuid(),
                 'locale' => 'en',
@@ -259,7 +259,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
             ],
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article2->getUuid() . '::de',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article2->getUuid(),
                 'locale' => 'de',
@@ -271,7 +271,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
             ],
             [
-                'id' => ArticleInterface::RESOURCE_KEY . '::' . $article2->getUuid() . '::en',
+                'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__en',
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => $article2->getUuid(),
                 'locale' => 'en',
@@ -340,8 +340,8 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         ]);
 
         $identifiers = [
-            ArticleInterface::RESOURCE_KEY . '::' . $article1->getUuid() . '::en',
-            ArticleInterface::RESOURCE_KEY . '::' . $article2->getUuid() . '::de',
+            ArticleInterface::RESOURCE_KEY . '__' . $article1->getUuid() . '__en',
+            ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
         ];
 
         $config = ReindexConfig::create()

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/AdminArticleIndexListenerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/AdminArticleIndexListenerTest.php
@@ -56,7 +56,7 @@ class AdminArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::123::en']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__123__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -72,7 +72,7 @@ class AdminArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::456::en']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__456__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -88,7 +88,7 @@ class AdminArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::789::en', ArticleInterface::RESOURCE_KEY . '::789::de']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__789__en', ArticleInterface::RESOURCE_KEY . '__789__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -108,7 +108,7 @@ class AdminArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::222::de']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__222__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -124,7 +124,7 @@ class AdminArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::333::de']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__333__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -140,7 +140,7 @@ class AdminArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::444::de']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__444__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/WebsiteArticleIndexListenerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/WebsiteArticleIndexListenerTest.php
@@ -54,7 +54,7 @@ class WebsiteArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('website')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::123::en']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__123__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -70,7 +70,7 @@ class WebsiteArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('website')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::789::en', ArticleInterface::RESOURCE_KEY . '::789::de']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__789__en', ArticleInterface::RESOURCE_KEY . '__789__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -86,7 +86,7 @@ class WebsiteArticleIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('website')
-            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '::444::de']);
+            ->withIdentifiers([ArticleInterface::RESOURCE_KEY . '__444__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))

--- a/packages/page/src/Infrastructure/Sulu/Search/AdminPageIndexListener.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/AdminPageIndexListener.php
@@ -42,7 +42,7 @@ final class AdminPageIndexListener
         $resourceId = $event->getResourceId();
 
         $identifiers = \array_map(
-            fn (string $locale) => PageInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            fn (string $locale) => PageInterface::RESOURCE_KEY . '__' . $resourceId . '__' . $locale,
             $this->getLocales($event),
         );
 

--- a/packages/page/src/Infrastructure/Sulu/Search/AdminPageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/AdminPageReindexProvider.php
@@ -69,7 +69,7 @@ final class AdminPageReindexProvider implements ReindexProviderInterface
         /** @var Page $page */
         foreach ($pages as $page) {
             yield [
-                'id' => PageInterface::RESOURCE_KEY . '::' . ((string) $page['pageId']) . '::' . $page['locale'],
+                'id' => PageInterface::RESOURCE_KEY . '__' . ((string) $page['pageId']) . '__' . $page['locale'],
                 'resourceKey' => PageInterface::RESOURCE_KEY,
                 'resourceId' => (string) $page['pageId'],
                 'changedAt' => $page['changed']->format('c'),
@@ -111,14 +111,14 @@ final class AdminPageReindexProvider implements ReindexProviderInterface
             $conditions = [];
 
             foreach ($identifiers as $index => $identifier) {
-                $resourceKey = \explode('::', $identifier)[0];
+                $resourceKey = \explode('__', $identifier)[0];
 
                 if (PageInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
-                $id = \explode('::', $identifier)[1] ?? '';
-                $locale = \explode('::', $identifier)[2] ?? '';
+                $id = \explode('__', $identifier)[1] ?? '';
+                $locale = \explode('__', $identifier)[2] ?? '';
 
                 $conditions[] = "(dimensionContent.page = :id{$index} AND dimensionContent.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;

--- a/packages/page/src/Infrastructure/Sulu/Search/WebsitePageIndexListener.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/WebsitePageIndexListener.php
@@ -36,7 +36,7 @@ final class WebsitePageIndexListener
         $resourceId = $event->getResourceId();
 
         $identifiers = \array_map(
-            fn (string $locale) => PageInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            fn (string $locale) => PageInterface::RESOURCE_KEY . '__' . $resourceId . '__' . $locale,
             $this->getLocales($event),
         );
 

--- a/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
@@ -73,7 +73,7 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
             $authoredAt = $page['authored'] ?? $page['changed'];
 
             yield [
-                'id' => PageInterface::RESOURCE_KEY . '::' . ((string) $page['pageId']) . '::' . $page['locale'],
+                'id' => PageInterface::RESOURCE_KEY . '__' . ((string) $page['pageId']) . '__' . $page['locale'],
                 'resourceKey' => PageInterface::RESOURCE_KEY,
                 'resourceId' => (string) $page['pageId'],
                 'locale' => $page['locale'],
@@ -117,14 +117,14 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
             $conditions = [];
 
             foreach ($identifiers as $index => $identifier) {
-                $resourceKey = \explode('::', $identifier)[0];
+                $resourceKey = \explode('__', $identifier)[0];
 
                 if (PageInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
-                $id = \explode('::', $identifier)[1] ?? '';
-                $locale = \explode('::', $identifier)[2] ?? '';
+                $id = \explode('__', $identifier)[1] ?? '';
+                $locale = \explode('__', $identifier)[2] ?? '';
 
                 $conditions[] = "(dimensionContent.page = :id{$index} AND dimensionContent.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/AdminPageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/AdminPageReindexProviderTest.php
@@ -101,7 +101,7 @@ class AdminPageReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::de',
+                'id' => PageInterface::RESOURCE_KEY . '__' . $page2->getUuid() . '__de',
                 'resourceKey' => PageInterface::RESOURCE_KEY,
                 'resourceId' => $page2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -113,7 +113,7 @@ class AdminPageReindexProviderTest extends SuluTestCase
                 ],
             ],
             [
-                'id' => PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::en',
+                'id' => PageInterface::RESOURCE_KEY . '__' . $page1->getUuid() . '__en',
                 'resourceKey' => PageInterface::RESOURCE_KEY,
                 'resourceId' => $page1->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
@@ -125,7 +125,7 @@ class AdminPageReindexProviderTest extends SuluTestCase
                 ],
             ],
             [
-                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
+                'id' => PageInterface::RESOURCE_KEY . '__' . $page2->getUuid() . '__en',
                 'resourceKey' => PageInterface::RESOURCE_KEY,
                 'resourceId' => $page2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -202,8 +202,8 @@ class AdminPageReindexProviderTest extends SuluTestCase
         ]);
 
         $identifiers = [
-            PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::de',
-            PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
+            PageInterface::RESOURCE_KEY . '__' . $page1->getUuid() . '__de',
+            PageInterface::RESOURCE_KEY . '__' . $page2->getUuid() . '__en',
         ];
 
         $config = ReindexConfig::create()

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
@@ -101,7 +101,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => PageInterface::RESOURCE_KEY . '::' . $page1->getUuid() . '::en',
+                'id' => PageInterface::RESOURCE_KEY . '__' . $page1->getUuid() . '__en',
                 'resourceKey' => PageInterface::RESOURCE_KEY,
                 'resourceId' => $page1->getUuid(),
                 'locale' => 'en',
@@ -113,7 +113,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
             ],
             [
-                'id' => PageInterface::RESOURCE_KEY . '::' . $page2->getUuid() . '::en',
+                'id' => PageInterface::RESOURCE_KEY . '__' . $page2->getUuid() . '__en',
                 'resourceKey' => PageInterface::RESOURCE_KEY,
                 'resourceId' => $page2->getUuid(),
                 'locale' => 'en',

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/AdminPageIndexListenerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/AdminPageIndexListenerTest.php
@@ -56,7 +56,7 @@ class AdminPageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::123::en']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__123__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -72,7 +72,7 @@ class AdminPageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::456::en']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__456__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -88,7 +88,7 @@ class AdminPageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::789::en', PageInterface::RESOURCE_KEY . '::789::de']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__789__en', PageInterface::RESOURCE_KEY . '__789__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -108,7 +108,7 @@ class AdminPageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::222::de']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__222__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -124,7 +124,7 @@ class AdminPageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::333::de']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__333__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -140,7 +140,7 @@ class AdminPageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::444::de']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__444__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/WebsitePageIndexListenerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/WebsitePageIndexListenerTest.php
@@ -54,7 +54,7 @@ class WebsitePageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('website')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::123::en']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__123__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -70,7 +70,7 @@ class WebsitePageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('website')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::789::en', PageInterface::RESOURCE_KEY . '::789::de']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__789__en', PageInterface::RESOURCE_KEY . '__789__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -86,7 +86,7 @@ class WebsitePageIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('website')
-            ->withIdentifiers([PageInterface::RESOURCE_KEY . '::444::de']);
+            ->withIdentifiers([PageInterface::RESOURCE_KEY . '__444__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))

--- a/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetIndexListener.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetIndexListener.php
@@ -40,7 +40,7 @@ final class AdminSnippetIndexListener
         $resourceId = $event->getResourceId();
 
         $identifiers = \array_map(
-            fn (string $locale) => SnippetInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            fn (string $locale) => SnippetInterface::RESOURCE_KEY . '__' . $resourceId . '__' . $locale,
             $this->getLocales($event),
         );
 

--- a/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
@@ -68,7 +68,7 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
         /** @var Snippet $snippet */
         foreach ($snippets as $snippet) {
             yield [
-                'id' => SnippetInterface::RESOURCE_KEY . '::' . ((string) $snippet['snippetId']) . '::' . $snippet['locale'],
+                'id' => SnippetInterface::RESOURCE_KEY . '__' . ((string) $snippet['snippetId']) . '__' . $snippet['locale'],
                 'resourceKey' => SnippetInterface::RESOURCE_KEY,
                 'resourceId' => (string) $snippet['snippetId'],
                 'changedAt' => $snippet['changed']->format('c'),
@@ -105,14 +105,14 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
             $conditions = [];
 
             foreach ($identifiers as $index => $identifier) {
-                $resourceKey = \explode('::', $identifier)[0];
+                $resourceKey = \explode('__', $identifier)[0];
 
                 if (SnippetInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
-                $id = \explode('::', $identifier)[1] ?? '';
-                $locale = \explode('::', $identifier)[2] ?? '';
+                $id = \explode('__', $identifier)[1] ?? '';
+                $locale = \explode('__', $identifier)[2] ?? '';
 
                 $conditions[] = "(dimensionContent.snippet = :id{$index} AND dimensionContent.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Search/AdminSnippetReindexProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Search/AdminSnippetReindexProviderTest.php
@@ -98,7 +98,7 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::de',
+                'id' => SnippetInterface::RESOURCE_KEY . '__' . $snippet2->getUuid() . '__de',
                 'resourceKey' => SnippetInterface::RESOURCE_KEY,
                 'resourceId' => $snippet2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -107,7 +107,7 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
                 'locale' => 'de',
             ],
             [
-                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet1->getUuid() . '::en',
+                'id' => SnippetInterface::RESOURCE_KEY . '__' . $snippet1->getUuid() . '__en',
                 'resourceKey' => SnippetInterface::RESOURCE_KEY,
                 'resourceId' => $snippet1->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
@@ -116,7 +116,7 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
                 'locale' => 'en',
             ],
             [
-                'id' => SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::en',
+                'id' => SnippetInterface::RESOURCE_KEY . '__' . $snippet2->getUuid() . '__en',
                 'resourceKey' => SnippetInterface::RESOURCE_KEY,
                 'resourceId' => $snippet2->getUuid(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -186,8 +186,8 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
         ]);
 
         $identifiers = [
-            SnippetInterface::RESOURCE_KEY . '::' . $snippet1->getUuid() . '::de',
-            SnippetInterface::RESOURCE_KEY . '::' . $snippet2->getUuid() . '::en',
+            SnippetInterface::RESOURCE_KEY . '__' . $snippet1->getUuid() . '__de',
+            SnippetInterface::RESOURCE_KEY . '__' . $snippet2->getUuid() . '__en',
         ];
 
         $config = ReindexConfig::create()

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Search/AdminSnippetIndexListenerTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Search/AdminSnippetIndexListenerTest.php
@@ -56,7 +56,7 @@ class AdminSnippetIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '::123::en']);
+            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '__123__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -72,7 +72,7 @@ class AdminSnippetIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '::456::en']);
+            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '__456__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -88,7 +88,7 @@ class AdminSnippetIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '::789::en', SnippetInterface::RESOURCE_KEY . '::789::de']);
+            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '__789__en', SnippetInterface::RESOURCE_KEY . '__789__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -108,7 +108,7 @@ class AdminSnippetIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '::222::de']);
+            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '__222__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -124,7 +124,7 @@ class AdminSnippetIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '::333::de']);
+            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '__333__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -140,7 +140,7 @@ class AdminSnippetIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '::444::de']);
+            ->withIdentifiers([SnippetInterface::RESOURCE_KEY . '__444__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryIndexListener.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryIndexListener.php
@@ -38,7 +38,7 @@ final class AdminCategoryIndexListener
         $resourceId = $event->getResourceId();
 
         $identifiers = \array_map(
-            fn (string $locale) => CategoryInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            fn (string $locale) => CategoryInterface::RESOURCE_KEY . '__' . $resourceId . '__' . $locale,
             $this->getLocales($event),
         );
 

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryReindexProvider.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryReindexProvider.php
@@ -67,7 +67,7 @@ final class AdminCategoryReindexProvider implements ReindexProviderInterface
         /** @var Category $category */
         foreach ($categories as $category) {
             yield [
-                'id' => CategoryInterface::RESOURCE_KEY . '::' . ((string) $category['id']) . '::' . $category['locale'],
+                'id' => CategoryInterface::RESOURCE_KEY . '__' . ((string) $category['id']) . '__' . $category['locale'],
                 'resourceKey' => CategoryInterface::RESOURCE_KEY,
                 'resourceId' => (string) $category['id'],
                 'changedAt' => $category['changed']->format('c'),
@@ -98,14 +98,14 @@ final class AdminCategoryReindexProvider implements ReindexProviderInterface
             $parameters = [];
 
             foreach ($identifiers as $index => $identifier) {
-                $resourceKey = \explode('::', $identifier)[0];
+                $resourceKey = \explode('__', $identifier)[0];
 
                 if (CategoryInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
-                $id = \explode('::', $identifier)[1] ?? '';
-                $locale = \explode('::', $identifier)[2] ?? '';
+                $id = \explode('__', $identifier)[1] ?? '';
+                $locale = \explode('__', $identifier)[2] ?? '';
 
                 $conditions[] = "(category.id = :id{$index} AND translation.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminCategoryReindexProviderTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminCategoryReindexProviderTest.php
@@ -80,7 +80,7 @@ class AdminCategoryReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => CategoryInterface::RESOURCE_KEY . '::' . $category1->getId() . '::' . $category1Translation->getLocale(),
+                'id' => CategoryInterface::RESOURCE_KEY . '__' . $category1->getId() . '__' . $category1Translation->getLocale(),
                 'resourceKey' => CategoryInterface::RESOURCE_KEY,
                 'resourceId' => (string) $category1->getId(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
@@ -89,7 +89,7 @@ class AdminCategoryReindexProviderTest extends SuluTestCase
                 'locale' => $category1Translation->getLocale(),
             ],
             [
-                'id' => CategoryInterface::RESOURCE_KEY . '::' . $category2->getId() . '::' . $category2Translation1->getLocale(),
+                'id' => CategoryInterface::RESOURCE_KEY . '__' . $category2->getId() . '__' . $category2Translation1->getLocale(),
                 'resourceKey' => CategoryInterface::RESOURCE_KEY,
                 'resourceId' => (string) $category2->getId(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -98,7 +98,7 @@ class AdminCategoryReindexProviderTest extends SuluTestCase
                 'locale' => $category2Translation1->getLocale(),
             ],
             [
-                'id' => CategoryInterface::RESOURCE_KEY . '::' . $category2->getId() . '::' . $category2Translation2->getLocale(),
+                'id' => CategoryInterface::RESOURCE_KEY . '__' . $category2->getId() . '__' . $category2Translation2->getLocale(),
                 'resourceKey' => CategoryInterface::RESOURCE_KEY,
                 'resourceId' => (string) $category2->getId(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -146,8 +146,8 @@ class AdminCategoryReindexProviderTest extends SuluTestCase
         ]);
 
         $identifiers = [
-            CategoryInterface::RESOURCE_KEY . '::' . $category1->getId() . '::' . $category1Translation->getLocale(),
-            CategoryInterface::RESOURCE_KEY . '::' . $category2->getId() . '::' . $category2Translation2->getLocale(),
+            CategoryInterface::RESOURCE_KEY . '__' . $category1->getId() . '__' . $category1Translation->getLocale(),
+            CategoryInterface::RESOURCE_KEY . '__' . $category2->getId() . '__' . $category2Translation2->getLocale(),
         ];
 
         $config = ReindexConfig::create()

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminCategoryIndexListenerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminCategoryIndexListenerTest.php
@@ -57,7 +57,7 @@ class AdminCategoryIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::123::en']);
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '__123__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -74,7 +74,7 @@ class AdminCategoryIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::456::en']);
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '__456__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -91,7 +91,7 @@ class AdminCategoryIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::789::en', CategoryInterface::RESOURCE_KEY . '::789::de']);
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '__789__en', CategoryInterface::RESOURCE_KEY . '__789__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -109,7 +109,7 @@ class AdminCategoryIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::111::de']);
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '__111__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -130,7 +130,7 @@ class AdminCategoryIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '::111::en']);
+            ->withIdentifiers([CategoryInterface::RESOURCE_KEY . '__111__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminAccountReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminAccountReindexProvider.php
@@ -58,7 +58,7 @@ final class AdminAccountReindexProvider implements ReindexProviderInterface
         /** @var Account $account */
         foreach ($accounts as $account) {
             yield [
-                'id' => AccountInterface::RESOURCE_KEY . '::' . ((string) $account['id']),
+                'id' => AccountInterface::RESOURCE_KEY . '__' . ((string) $account['id']),
                 'resourceKey' => AccountInterface::RESOURCE_KEY,
                 'resourceId' => (string) $account['id'],
                 'mediaId' => (string) $account['mediaId'],
@@ -85,7 +85,7 @@ final class AdminAccountReindexProvider implements ReindexProviderInterface
 
         if (0 < \count($identifiers)) {
             $qb->where('account.id IN (:ids)')
-                ->setParameter('ids', \array_map(fn ($identifier) => (int) \str_replace(AccountInterface::RESOURCE_KEY . '::', '', $identifier), $identifiers));
+                ->setParameter('ids', \array_map(fn ($identifier) => (int) \str_replace(AccountInterface::RESOURCE_KEY . '__', '', $identifier), $identifiers));
         }
 
         /** @var iterable<Account> */

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactIndexListener.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactIndexListener.php
@@ -43,7 +43,7 @@ final class AdminContactIndexListener
             ReindexConfig::create()
                 ->withIndex('admin')
                 ->withIdentifiers([
-                    AccountInterface::RESOURCE_KEY . '::' . $event->getResourceId(),
+                    AccountInterface::RESOURCE_KEY . '__' . $event->getResourceId(),
                 ]),
         );
     }
@@ -54,7 +54,7 @@ final class AdminContactIndexListener
             ReindexConfig::create()
                 ->withIndex('admin')
                 ->withIdentifiers([
-                    ContactInterface::RESOURCE_KEY . '::' . $event->getResourceId(),
+                    ContactInterface::RESOURCE_KEY . '__' . $event->getResourceId(),
                 ]),
         );
     }

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactReindexProvider.php
@@ -59,7 +59,7 @@ final class AdminContactReindexProvider implements ReindexProviderInterface
         /** @var Contact $contact */
         foreach ($contacts as $contact) {
             yield [
-                'id' => ContactInterface::RESOURCE_KEY . '::' . ((string) $contact['id']),
+                'id' => ContactInterface::RESOURCE_KEY . '__' . ((string) $contact['id']),
                 'resourceKey' => ContactInterface::RESOURCE_KEY,
                 'resourceId' => (string) $contact['id'],
                 'mediaId' => (string) $contact['mediaId'],
@@ -87,7 +87,7 @@ final class AdminContactReindexProvider implements ReindexProviderInterface
 
         if (0 < \count($identifiers)) {
             $qb->where('contact.id IN (:ids)')
-                ->setParameter('ids', \array_map(fn ($identifier) => (int) \str_replace(ContactInterface::RESOURCE_KEY . '::', '', $identifier), $identifiers));
+                ->setParameter('ids', \array_map(fn ($identifier) => (int) \str_replace(ContactInterface::RESOURCE_KEY . '__', '', $identifier), $identifiers));
         }
 
         /** @var iterable<Contact> */

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminAccountReindexProviderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminAccountReindexProviderTest.php
@@ -105,7 +105,7 @@ class AdminAccountReindexProviderTest extends SuluTestCase
         $this->assertSame(
             [
                 [
-                    'id' => AccountInterface::RESOURCE_KEY . '::' . $account1->getId(),
+                    'id' => AccountInterface::RESOURCE_KEY . '__' . $account1->getId(),
                     'resourceKey' => AccountInterface::RESOURCE_KEY,
                     'resourceId' => (string) $account1->getId(),
                     'mediaId' => (string) $account1->getLogo()?->getId(),
@@ -114,7 +114,7 @@ class AdminAccountReindexProviderTest extends SuluTestCase
                     'title' => $account1->getName(),
                 ],
                 [
-                    'id' => AccountInterface::RESOURCE_KEY . '::' . $account2->getId(),
+                    'id' => AccountInterface::RESOURCE_KEY . '__' . $account2->getId(),
                     'resourceKey' => AccountInterface::RESOURCE_KEY,
                     'resourceId' => (string) $account2->getId(),
                     'mediaId' => '',
@@ -136,8 +136,8 @@ class AdminAccountReindexProviderTest extends SuluTestCase
         $this->entityManager->flush();
 
         $identifiers = [
-            AccountInterface::RESOURCE_KEY . '::' . $account1->getId(),
-            AccountInterface::RESOURCE_KEY . '::' . $account3->getId(),
+            AccountInterface::RESOURCE_KEY . '__' . $account1->getId(),
+            AccountInterface::RESOURCE_KEY . '__' . $account3->getId(),
         ];
 
         $config = ReindexConfig::create()

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminContactReindexProviderTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminContactReindexProviderTest.php
@@ -108,7 +108,7 @@ class AdminContactReindexProviderTest extends SuluTestCase
         $this->assertSame(
             [
                 [
-                    'id' => ContactInterface::RESOURCE_KEY . '::' . $contact1->getId(),
+                    'id' => ContactInterface::RESOURCE_KEY . '__' . $contact1->getId(),
                     'resourceKey' => ContactInterface::RESOURCE_KEY,
                     'resourceId' => (string) $contact1->getId(),
                     'mediaId' => (string) $contact1->getAvatar()?->getId(),
@@ -117,7 +117,7 @@ class AdminContactReindexProviderTest extends SuluTestCase
                     'title' => $contact1->getFullName(),
                 ],
                 [
-                    'id' => ContactInterface::RESOURCE_KEY . '::' . $contact2->getId(),
+                    'id' => ContactInterface::RESOURCE_KEY . '__' . $contact2->getId(),
                     'resourceKey' => ContactInterface::RESOURCE_KEY,
                     'resourceId' => (string) $contact2->getId(),
                     'mediaId' => '',
@@ -139,8 +139,8 @@ class AdminContactReindexProviderTest extends SuluTestCase
         $this->entityManager->flush();
 
         $identifiers = [
-            ContactInterface::RESOURCE_KEY . '::' . $contact1->getId(),
-            ContactInterface::RESOURCE_KEY . '::' . $contact3->getId(),
+            ContactInterface::RESOURCE_KEY . '__' . $contact1->getId(),
+            ContactInterface::RESOURCE_KEY . '__' . $contact3->getId(),
         ];
 
         $config = ReindexConfig::create()

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminContactIndexListenerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminContactIndexListenerTest.php
@@ -61,7 +61,7 @@ class AdminContactIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '::123']);
+            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '__123']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -78,7 +78,7 @@ class AdminContactIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '::456']);
+            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '__456']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -96,7 +96,7 @@ class AdminContactIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '::789']);
+            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '__789']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -114,7 +114,7 @@ class AdminContactIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '::789']);
+            ->withIdentifiers([AccountInterface::RESOURCE_KEY . '__789']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -130,7 +130,7 @@ class AdminContactIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ContactInterface::RESOURCE_KEY . '::123']);
+            ->withIdentifiers([ContactInterface::RESOURCE_KEY . '__123']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -146,7 +146,7 @@ class AdminContactIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ContactInterface::RESOURCE_KEY . '::456']);
+            ->withIdentifiers([ContactInterface::RESOURCE_KEY . '__456']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -164,7 +164,7 @@ class AdminContactIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ContactInterface::RESOURCE_KEY . '::789']);
+            ->withIdentifiers([ContactInterface::RESOURCE_KEY . '__789']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -182,7 +182,7 @@ class AdminContactIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([ContactInterface::RESOURCE_KEY . '::789']);
+            ->withIdentifiers([ContactInterface::RESOURCE_KEY . '__789']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionIndexListener.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionIndexListener.php
@@ -33,7 +33,7 @@ final class AdminCollectionIndexListener
         $resourceId = $event->getResourceId();
 
         $identifiers = \array_map(
-            fn (string $locale) => CollectionInterface::RESOURCE_KEY . '::' . $resourceId . '::' . $locale,
+            fn (string $locale) => CollectionInterface::RESOURCE_KEY . '__' . $resourceId . '__' . $locale,
             $this->getLocales($event),
         );
 

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionReindexProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionReindexProvider.php
@@ -59,7 +59,7 @@ final class AdminCollectionReindexProvider implements ReindexProviderInterface
         /** @var Collection $collection */
         foreach ($collections as $collection) {
             yield [
-                'id' => CollectionInterface::RESOURCE_KEY . '::' . ((string) $collection['collectionId']) . '::' . $collection['locale'],
+                'id' => CollectionInterface::RESOURCE_KEY . '__' . ((string) $collection['collectionId']) . '__' . $collection['locale'],
                 'resourceKey' => CollectionInterface::RESOURCE_KEY,
                 'resourceId' => (string) $collection['collectionId'],
                 'changedAt' => $collection['changed']->format('c'),
@@ -90,14 +90,14 @@ final class AdminCollectionReindexProvider implements ReindexProviderInterface
             $parameters = [];
 
             foreach ($identifiers as $index => $identifier) {
-                $resourceKey = \explode('::', $identifier)[0];
+                $resourceKey = \explode('__', $identifier)[0];
 
                 if (CollectionInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
-                $id = \explode('::', $identifier)[1] ?? '';
-                $locale = \explode('::', $identifier)[2] ?? '';
+                $id = \explode('__', $identifier)[1] ?? '';
+                $locale = \explode('__', $identifier)[2] ?? '';
 
                 $conditions[] = "(collection.id = :id{$index} AND collectionMeta.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaIndexListener.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaIndexListener.php
@@ -40,17 +40,17 @@ final class AdminMediaIndexListener
             }
 
             foreach ($locales as $locale) {
-                $identifiers[] = MediaInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+                $identifiers[] = MediaInterface::RESOURCE_KEY . '__' . $event->getResourceId() . '__' . $locale;
             }
         } elseif ($event instanceof MediaRestoredEvent || $event instanceof MediaVersionAddedEvent) {
             $media = $event->getMedia();
             $locales = $this->getLocales($media);
 
             foreach ($locales as $locale) {
-                $identifiers[] = MediaInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+                $identifiers[] = MediaInterface::RESOURCE_KEY . '__' . $event->getResourceId() . '__' . $locale;
             }
         } elseif ($locale) {
-            $identifiers[] = MediaInterface::RESOURCE_KEY . '::' . $event->getResourceId() . '::' . $locale;
+            $identifiers[] = MediaInterface::RESOURCE_KEY . '__' . $event->getResourceId() . '__' . $locale;
         }
 
         if (!$identifiers) {

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaReindexProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaReindexProvider.php
@@ -60,7 +60,7 @@ final class AdminMediaReindexProvider implements ReindexProviderInterface
         /** @var Media $media */
         foreach ($medias as $media) {
             yield [
-                'id' => MediaInterface::RESOURCE_KEY . '::' . ((string) $media['id']) . '::' . $media['locale'],
+                'id' => MediaInterface::RESOURCE_KEY . '__' . ((string) $media['id']) . '__' . $media['locale'],
                 'resourceKey' => MediaInterface::RESOURCE_KEY,
                 'resourceId' => (string) $media['id'],
                 'mediaId' => (string) $media['id'],
@@ -96,14 +96,14 @@ final class AdminMediaReindexProvider implements ReindexProviderInterface
             $parameters = [];
 
             foreach ($identifiers as $index => $identifier) {
-                $resourceKey = \explode('::', $identifier)[0];
+                $resourceKey = \explode('__', $identifier)[0];
 
                 if (MediaInterface::RESOURCE_KEY !== $resourceKey) {
                     continue;
                 }
 
-                $id = \explode('::', $identifier)[1] ?? '';
-                $locale = \explode('::', $identifier)[2] ?? '';
+                $id = \explode('__', $identifier)[1] ?? '';
+                $locale = \explode('__', $identifier)[2] ?? '';
 
                 $conditions[] = "(media.id = :id{$index} AND meta.locale = :locale{$index})";
                 $parameters["id{$index}"] = $id;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminCollectionReindexProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminCollectionReindexProviderTest.php
@@ -105,7 +105,7 @@ class AdminCollectionReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => CollectionInterface::RESOURCE_KEY . '::' . $collection1->getId() . '::en',
+                'id' => CollectionInterface::RESOURCE_KEY . '__' . $collection1->getId() . '__en',
                 'resourceKey' => CollectionInterface::RESOURCE_KEY,
                 'resourceId' => (string) $collection1->getId(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString1))->format('c'),
@@ -114,7 +114,7 @@ class AdminCollectionReindexProviderTest extends SuluTestCase
                 'locale' => 'en',
             ],
             [
-                'id' => CollectionInterface::RESOURCE_KEY . '::' . $collection2->getId() . '::de',
+                'id' => CollectionInterface::RESOURCE_KEY . '__' . $collection2->getId() . '__de',
                 'resourceKey' => CollectionInterface::RESOURCE_KEY,
                 'resourceId' => (string) $collection2->getId(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -124,7 +124,7 @@ class AdminCollectionReindexProviderTest extends SuluTestCase
             ],
 
             [
-                'id' => CollectionInterface::RESOURCE_KEY . '::' . $collection2->getId() . '::en',
+                'id' => CollectionInterface::RESOURCE_KEY . '__' . $collection2->getId() . '__en',
                 'resourceKey' => CollectionInterface::RESOURCE_KEY,
                 'resourceId' => (string) $collection2->getId(),
                 'changedAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
@@ -172,8 +172,8 @@ class AdminCollectionReindexProviderTest extends SuluTestCase
         $this->entityManager->flush();
 
         $identifiers = [
-            CollectionInterface::RESOURCE_KEY . '::' . $collection1->getId() . '::en',
-            CollectionInterface::RESOURCE_KEY . '::' . $collection2->getId() . '::de',
+            CollectionInterface::RESOURCE_KEY . '__' . $collection1->getId() . '__en',
+            CollectionInterface::RESOURCE_KEY . '__' . $collection2->getId() . '__de',
         ];
 
         $config = ReindexConfig::create()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminMediaReindexProviderTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Infrastructure/Sulu/Search/AdminMediaReindexProviderTest.php
@@ -95,7 +95,7 @@ class AdminMediaReindexProviderTest extends SuluTestCase
 
         $expectedResult = [
             [
-                'id' => MediaInterface::RESOURCE_KEY . '::' . $media1->getId() . '::en',
+                'id' => MediaInterface::RESOURCE_KEY . '__' . $media1->getId() . '__en',
                 'resourceKey' => MediaInterface::RESOURCE_KEY,
                 'resourceId' => (string) $media1->getId(),
                 'mediaId' => (string) $media1->getId(),
@@ -105,7 +105,7 @@ class AdminMediaReindexProviderTest extends SuluTestCase
                 'locale' => 'en',
             ],
             [
-                'id' => MediaInterface::RESOURCE_KEY . '::' . $media2->getId() . '::de',
+                'id' => MediaInterface::RESOURCE_KEY . '__' . $media2->getId() . '__de',
                 'resourceKey' => MediaInterface::RESOURCE_KEY,
                 'resourceId' => (string) $media2->getId(),
                 'mediaId' => (string) $media2->getId(),
@@ -132,8 +132,8 @@ class AdminMediaReindexProviderTest extends SuluTestCase
         $media3 = $this->createMedia('Cool Media EN 2');
 
         $identifiers = [
-            MediaInterface::RESOURCE_KEY . '::' . $media1->getId() . '::en',
-            MediaInterface::RESOURCE_KEY . '::' . $media2->getId() . '::de',
+            MediaInterface::RESOURCE_KEY . '__' . $media1->getId() . '__en',
+            MediaInterface::RESOURCE_KEY . '__' . $media2->getId() . '__de',
         ];
 
         $config = ReindexConfig::create()

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminCollectionIndexListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminCollectionIndexListenerTest.php
@@ -56,7 +56,7 @@ class AdminCollectionIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CollectionInterface::RESOURCE_KEY . '::' . $collection->getId() . '::en']);
+            ->withIdentifiers([CollectionInterface::RESOURCE_KEY . '__' . $collection->getId() . '__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -73,7 +73,7 @@ class AdminCollectionIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CollectionInterface::RESOURCE_KEY . '::' . $collection->getId() . '::en']);
+            ->withIdentifiers([CollectionInterface::RESOURCE_KEY . '__' . $collection->getId() . '__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -90,7 +90,7 @@ class AdminCollectionIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CollectionInterface::RESOURCE_KEY . '::' . $collection->getId() . '::en', CollectionInterface::RESOURCE_KEY . '::' . $collection->getId() . '::de']);
+            ->withIdentifiers([CollectionInterface::RESOURCE_KEY . '__' . $collection->getId() . '__en', CollectionInterface::RESOURCE_KEY . '__' . $collection->getId() . '__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -106,7 +106,7 @@ class AdminCollectionIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([CollectionInterface::RESOURCE_KEY . '::' . $collection->getId() . '::en']);
+            ->withIdentifiers([CollectionInterface::RESOURCE_KEY . '__' . $collection->getId() . '__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminMediaIndexListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Search/AdminMediaIndexListenerTest.php
@@ -72,7 +72,7 @@ class AdminMediaIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '::' . $media->getId() . '::en']);
+            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '__' . $media->getId() . '__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -88,7 +88,7 @@ class AdminMediaIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '::' . $media->getId() . '::en']);
+            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '__' . $media->getId() . '__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -105,7 +105,7 @@ class AdminMediaIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '::' . $media->getId() . '::en', MediaInterface::RESOURCE_KEY . '::' . $media->getId() . '::de']);
+            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '__' . $media->getId() . '__en', MediaInterface::RESOURCE_KEY . '__' . $media->getId() . '__de']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -121,7 +121,7 @@ class AdminMediaIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '::' . $media->getId() . '::en']);
+            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '__' . $media->getId() . '__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))
@@ -138,7 +138,7 @@ class AdminMediaIndexListenerTest extends TestCase
 
         $expectedConfig = ReindexConfig::create()
             ->withIndex('admin')
-            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '::' . $media->getId() . '::en']);
+            ->withIdentifiers([MediaInterface::RESOURCE_KEY . '__' . $media->getId() . '__en']);
 
         $this->messageBus->dispatch($expectedConfig)
             ->willReturn(new Envelope($expectedConfig))


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8354
| Related issues/PRs | #7672
| License | MIT


#### What's in this PR?

Refactor search index id separator form `::` to `__` to fix Meilisearch issue.  See https://github.com/sulu/sulu/issues/8354
