### PR TITLE
Remove array support for DimensionContentCollection

### DIFF
--- a/packages/article/src/Application/MessageHandler/RemoveArticleMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/RemoveArticleMessageHandler.php
@@ -45,7 +45,7 @@ final class RemoveArticleMessageHandler
         $resourceKey = $article::RESOURCE_KEY;
         $this->trashManager?->store($resourceKey, $article);
 
-        $dimensionContentCollection = new DimensionContentCollection($article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($article->getDimensionContents(), [], ArticleDimensionContent::class);
         /** @var ArticleDimensionContentInterface|null $localizedDimensionContent */
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $message->getLocale()]);
         $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);

--- a/packages/article/src/Domain/Event/ArticleCreatedEvent.php
+++ b/packages/article/src/Domain/Event/ArticleCreatedEvent.php
@@ -64,7 +64,7 @@ class ArticleCreatedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Domain/Event/ArticleModifiedEvent.php
+++ b/packages/article/src/Domain/Event/ArticleModifiedEvent.php
@@ -64,7 +64,7 @@ class ArticleModifiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Domain/Event/ArticleOrderedEvent.php
+++ b/packages/article/src/Domain/Event/ArticleOrderedEvent.php
@@ -58,7 +58,7 @@ class ArticleOrderedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Domain/Event/ArticleTranslationAddedEvent.php
+++ b/packages/article/src/Domain/Event/ArticleTranslationAddedEvent.php
@@ -64,7 +64,7 @@ class ArticleTranslationAddedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Domain/Event/ArticleTranslationCopiedEvent.php
+++ b/packages/article/src/Domain/Event/ArticleTranslationCopiedEvent.php
@@ -72,7 +72,7 @@ class ArticleTranslationCopiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Domain/Event/ArticleTranslationRemovedEvent.php
+++ b/packages/article/src/Domain/Event/ArticleTranslationRemovedEvent.php
@@ -55,7 +55,7 @@ class ArticleTranslationRemovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Domain/Event/ArticleTranslationRestoredEvent.php
+++ b/packages/article/src/Domain/Event/ArticleTranslationRestoredEvent.php
@@ -64,7 +64,7 @@ class ArticleTranslationRestoredEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Domain/Event/ArticleVersionRestoredEvent.php
+++ b/packages/article/src/Domain/Event/ArticleVersionRestoredEvent.php
@@ -63,7 +63,7 @@ class ArticleVersionRestoredEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Domain/Event/ArticleWorkflowTransitionAppliedEvent.php
+++ b/packages/article/src/Domain/Event/ArticleWorkflowTransitionAppliedEvent.php
@@ -61,7 +61,7 @@ class ArticleWorkflowTransitionAppliedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents()->toArray(), [], ArticleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/article/src/Infrastructure/Sulu/Reference/ArticleReferenceRefresher.php
+++ b/packages/article/src/Infrastructure/Sulu/Reference/ArticleReferenceRefresher.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Article\Infrastructure\Sulu\Reference;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
@@ -190,7 +191,7 @@ class ArticleReferenceRefresher implements ReferenceRefresherInterface
                     }
                     yield $this->contentMerger->merge(
                         new DimensionContentCollection(
-                            $unlocalizedDimensionContent ? [$articleDimensionContent, $unlocalizedDimensionContent] : [$articleDimensionContent],
+                            new ArrayCollection($unlocalizedDimensionContent ? [$articleDimensionContent, $unlocalizedDimensionContent] : [$articleDimensionContent]),
                             $articleDimensionContent::getEffectiveDimensionAttributes(['locale' => $locale, 'stage' => $stage]),
                             ArticleDimensionContent::class
                         )

--- a/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
+++ b/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Trash;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sulu\Article\Application\Mapper\ArticleMapperInterface;
 use Sulu\Article\Domain\Event\ArticleRestoredEvent;
 use Sulu\Article\Domain\Event\ArticleTranslationRestoredEvent;
@@ -114,11 +115,9 @@ final class ArticleTrashItemHandler implements
         );
 
         foreach ($localizedDimensionContents as $locale => $localizedDimensionContent) {
-            $dimensionContents = [$unlocalizedDimensionContent, $localizedDimensionContent];
-
             $mergedDimensionContent = $this->contentMerger->merge(
                 new DimensionContentCollection(
-                    $dimensionContents,
+                    new ArrayCollection([$unlocalizedDimensionContent, $localizedDimensionContent]),
                     [
                         'locale' => $locale,
                         'stage' => DimensionContentInterface::STAGE_DRAFT,

--- a/packages/content/src/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactory.php
+++ b/packages/content/src/Application/DimensionContentCollectionFactory/DimensionContentCollectionFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Application\DimensionContentCollectionFactory;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sulu\Content\Application\ContentDataMapper\ContentDataMapperInterface;
 use Sulu\Content\Application\ContentMetadataInspector\ContentMetadataInspectorInterface;
 use Sulu\Content\Domain\Factory\DimensionContentCollectionFactoryInterface;
@@ -85,10 +86,10 @@ class DimensionContentCollectionFactory implements DimensionContentCollectionFac
         }
 
         $dimensionContentCollection = new DimensionContentCollection(
-            \array_filter([
+            new ArrayCollection(\array_filter([
                 $unlocalizedDimensionContent,
                 $localizedDimensionContent,
-            ]),
+            ])),
             $dimensionAttributes,
             $dimensionContentCollection->getDimensionContentClass()
         );

--- a/packages/content/src/Domain/Model/DimensionContentCollection.php
+++ b/packages/content/src/Domain/Model/DimensionContentCollection.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Domain\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 
@@ -47,12 +46,12 @@ class DimensionContentCollection implements DimensionContentCollectionInterface
     /**
      * DimensionContentCollection constructor.
      *
-     * @param array<int, T>|Collection<int, T> $dimensionContents
+     * @param Collection<int, T> $dimensionContents
      * @param mixed[] $dimensionAttributes
      * @param class-string<T> $dimensionContentClass
      */
     public function __construct(
-        array|Collection $dimensionContents,
+        Collection $dimensionContents,
         array $dimensionAttributes,
         string $dimensionContentClass
     ) {
@@ -60,8 +59,7 @@ class DimensionContentCollection implements DimensionContentCollectionInterface
         $this->defaultDimensionAttributes = $dimensionContentClass::getDefaultDimensionAttributes();
         $this->dimensionAttributes = $dimensionContentClass::getEffectiveDimensionAttributes($dimensionAttributes);
 
-        // TODO remove the array conversion
-        $this->dimensionContents = $dimensionContents instanceof Collection ? $dimensionContents : new ArrayCollection($dimensionContents);
+        $this->dimensionContents = $dimensionContents;
     }
 
     public function getDimensionContentClass(): string

--- a/packages/content/src/Infrastructure/Doctrine/DimensionContentRepository.php
+++ b/packages/content/src/Infrastructure/Doctrine/DimensionContentRepository.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Infrastructure\Doctrine;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Content\Application\ContentMetadataInspector\ContentMetadataInspectorInterface;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
@@ -81,7 +82,7 @@ class DimensionContentRepository implements DimensionContentRepositoryInterface
         $dimensionContents = $queryBuilder->getQuery()->getResult();
 
         return new DimensionContentCollection(
-            $dimensionContents,
+            new ArrayCollection($dimensionContents),
             $dimensionAttributes,
             $dimensionContentClass
         );

--- a/packages/content/tests/Application/ExampleTestBundle/Reference/ExampleReferenceRefresher.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Reference/ExampleReferenceRefresher.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Application\ExampleTestBundle\Reference;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
@@ -184,7 +185,7 @@ class ExampleReferenceRefresher implements ReferenceRefresherInterface
                     }
                     yield $this->contentMerger->merge(
                         new DimensionContentCollection(
-                            $unlocalizedDimensionContent ? [$exampleDimensionContent, $unlocalizedDimensionContent] : [$exampleDimensionContent],
+                            new ArrayCollection($unlocalizedDimensionContent ? [$exampleDimensionContent, $unlocalizedDimensionContent] : [$exampleDimensionContent]),
                             $exampleDimensionContent::getEffectiveDimensionAttributes(['locale' => $locale, 'stage' => $stage]),
                             ExampleDimensionContent::class
                         )

--- a/packages/content/tests/Functional/Infrastructure/Doctrine/DimensionContentQueryEnhancerTest.php
+++ b/packages/content/tests/Functional/Infrastructure/Doctrine/DimensionContentQueryEnhancerTest.php
@@ -140,7 +140,7 @@ class DimensionContentQueryEnhancerTest extends SuluTestCase
             [ExampleRepository::GROUP_SELECT_EXAMPLE_ADMIN => true]
         );
         $dimensionContentCollection = new DimensionContentCollection(
-            \iterator_to_array($example->getDimensionContents()),
+            $example->getDimensionContents(),
             $dimensionAttributes,
             ExampleDimensionContent::class
         );
@@ -180,7 +180,7 @@ class DimensionContentQueryEnhancerTest extends SuluTestCase
             [ExampleRepository::GROUP_SELECT_EXAMPLE_WEBSITE => true]
         );
         $dimensionContentCollection = new DimensionContentCollection(
-            \iterator_to_array($example->getDimensionContents()),
+            $example->getDimensionContents(),
             $dimensionAttributes,
             ExampleDimensionContent::class
         );
@@ -220,7 +220,7 @@ class DimensionContentQueryEnhancerTest extends SuluTestCase
             ]
         );
         $dimensionContentCollection = new DimensionContentCollection(
-            \iterator_to_array($example->getDimensionContents()),
+            $example->getDimensionContents(),
             $dimensionAttributes,
             ExampleDimensionContent::class
         );

--- a/packages/content/tests/Traits/CreateExampleTrait.php
+++ b/packages/content/tests/Traits/CreateExampleTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Traits;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Content\Application\ContentDataMapper\ContentDataMapper;
@@ -91,7 +92,7 @@ trait CreateExampleTrait
 
             // Map Draft Data
             $draftDimensionContentCollection = new DimensionContentCollection(
-                [$draftUnlocalizedDimension, $draftLocalizedDimension],
+                new ArrayCollection([$draftUnlocalizedDimension, $draftLocalizedDimension]),
                 ['stage' => DimensionContentInterface::STAGE_DRAFT, 'locale' => $locale],
                 ExampleDimensionContent::class
             );
@@ -131,7 +132,7 @@ trait CreateExampleTrait
 
                 // map data
                 $liveDimensionContentCollection = new DimensionContentCollection(
-                    \array_filter([$liveUnlocalizedDimension, $liveLocalizedDimension]),
+                    new ArrayCollection(\array_filter([$liveUnlocalizedDimension, $liveLocalizedDimension])),
                     ['stage' => DimensionContentInterface::STAGE_LIVE, 'locale' => $locale],
                     ExampleDimensionContent::class
                 );

--- a/packages/content/tests/Unit/Content/Application/ContentAggregator/ContentAggregatorTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentAggregator/ContentAggregatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentAggregator;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -62,10 +63,10 @@ class ContentAggregatorTest extends TestCase
         ];
 
         $dimensionContentCollection = new DimensionContentCollection(
-            [
+            new ArrayCollection([
                 $dimensionContent1,
                 $dimensionContent2,
-            ],
+            ]),
             $expectedAttributes,
             ExampleDimensionContent::class
         );
@@ -107,7 +108,7 @@ class ContentAggregatorTest extends TestCase
         ];
 
         $dimensionContentCollection = new DimensionContentCollection(
-            [],
+            new ArrayCollection([]),
             $expectedAttributes,
             ExampleDimensionContent::class
         );

--- a/packages/content/tests/Unit/Content/Application/ContentMerger/ContentMergerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentMerger/ContentMergerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentMerger;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Sulu\Content\Application\ContentMerger\ContentMerger;
 use Sulu\Content\Application\ContentMerger\ContentMergerInterface;
@@ -77,10 +78,10 @@ class ContentMergerTest extends TestCase
         $mergedDimensionContent->setVersion(ExampleDimensionContent::CURRENT_VERSION)
             ->shouldBeCalled();
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $dimensionContent1,
             $dimensionContent2,
-        ], [
+        ]), [
             'locale' => 'en',
             'stage' => 'draft',
         ], $dimensionContent1::class);
@@ -104,7 +105,7 @@ class ContentMergerTest extends TestCase
             $merger2->reveal(),
         ]);
 
-        $dimensionContentCollection = new DimensionContentCollection([], [], ExampleDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([]), [], ExampleDimensionContent::class);
 
         $contentMerger->merge($dimensionContentCollection);
     }
@@ -150,10 +151,10 @@ class ContentMergerTest extends TestCase
         $unlocalizedDimension->setLocale(null);
         $unlocalizedDimension->setStage('draft');
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $localizedDimension,
             $unlocalizedDimension,
-        ], [
+        ]), [
             'locale' => 'de',
             'stage' => 'draft',
         ], ExampleDimensionContent::class);
@@ -210,11 +211,11 @@ class ContentMergerTest extends TestCase
         $deDimension->setLocale('de');
         $deDimension->setStage('draft');
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $enDimension,
             $unlocalizedDimension,
             $deDimension,
-        ], [
+        ]), [
             'locale' => 'de',
             'stage' => 'draft',
         ], ExampleDimensionContent::class);
@@ -254,10 +255,10 @@ class ContentMergerTest extends TestCase
         $unlocalizedDimension->setStage('draft');
         $unlocalizedDimension->setTemplateData(['title' => 'Unlocalized Title']);
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $localizedDimension,
             $unlocalizedDimension,
-        ], [
+        ]), [
             'locale' => 'de',
             'stage' => 'draft',
         ], ExampleDimensionContent::class);

--- a/packages/content/tests/Unit/Content/Application/ContentPersister/ContentPersisterTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentPersister/ContentPersisterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentPersister;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Sulu\Content\Application\ContentMerger\ContentMergerInterface;
 use Sulu\Content\Application\ContentPersister\ContentPersister;
@@ -58,10 +59,10 @@ class ContentPersisterTest extends TestCase
         $dimensionContent2->setLocale('de');
         $dimensionContent2->setStage(DimensionContentInterface::STAGE_DRAFT);
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $dimensionContent1,
             $dimensionContent2,
-        ], $expectedAttributes, ExampleDimensionContent::class);
+        ]), $expectedAttributes, ExampleDimensionContent::class);
 
         $dimensionContentCollectionFactory = $this->prophesize(DimensionContentCollectionFactoryInterface::class);
         $dimensionContentCollectionFactory->create($example, $attributes, $data)

--- a/packages/content/tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentWorkflow/ContentWorkflowTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentWorkflow;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -105,10 +106,10 @@ class ContentWorkflowTest extends TestCase
             \get_class($dimensionContent2->reveal()))
         );
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $dimensionContent1->reveal(),
             $dimensionContent2->reveal(),
-        ], $dimensionAttributes, ExampleDimensionContent::class);
+        ]), $dimensionAttributes, ExampleDimensionContent::class);
 
         $dimensionContentRepository->load($contentRichEntity->reveal(), $dimensionAttributes)
             ->willReturn($dimensionContentCollection)
@@ -141,9 +142,9 @@ class ContentWorkflowTest extends TestCase
         $dimensionContent1->getLocale()->willReturn(null);
         $dimensionContent1->getStage()->willReturn('draft');
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $dimensionContent1->reveal(),
-        ], $dimensionAttributes, ExampleDimensionContent::class);
+        ]), $dimensionAttributes, ExampleDimensionContent::class);
 
         $dimensionContentRepository->load($contentRichEntity->reveal(), $dimensionAttributes)
             ->willReturn($dimensionContentCollection)
@@ -190,10 +191,10 @@ class ContentWorkflowTest extends TestCase
             ->willReturn('unpublished')
             ->shouldBeCalled();
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $this->wrapWorkflowMock($dimensionContent1),
             $this->wrapWorkflowMock($dimensionContent2),
-        ], $dimensionAttributes, ExampleDimensionContent::class);
+        ]), $dimensionAttributes, ExampleDimensionContent::class);
 
         $dimensionContentRepository->load($contentRichEntity->reveal(), $dimensionAttributes)
             ->willReturn($dimensionContentCollection)
@@ -248,10 +249,10 @@ class ContentWorkflowTest extends TestCase
                 ->shouldBeCalled();
         }
 
-        $dimensionContentCollection = new DimensionContentCollection([
+        $dimensionContentCollection = new DimensionContentCollection(new ArrayCollection([
             $this->wrapWorkflowMock($dimensionContent1),
             $this->wrapWorkflowMock($dimensionContent2),
-        ], $dimensionAttributes, ExampleDimensionContent::class);
+        ]), $dimensionAttributes, ExampleDimensionContent::class);
 
         $dimensionContentRepository->load($contentRichEntity->reveal(), $dimensionAttributes)
             ->willReturn($dimensionContentCollection)

--- a/packages/content/tests/Unit/Content/Domain/Model/DimensionContentCollectionTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Model/DimensionContentCollectionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Unit\Content\Domain\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Sulu\Content\Domain\Model\DimensionContentCollection;
 use Sulu\Content\Domain\Model\DimensionContentCollectionInterface;
@@ -32,7 +33,7 @@ class DimensionContentCollectionTest extends TestCase
         array $dimensionContents,
         array $dimensionAttributes
     ): DimensionContentCollectionInterface {
-        return new DimensionContentCollection($dimensionContents, $dimensionAttributes, ExampleDimensionContent::class);
+        return new DimensionContentCollection(new ArrayCollection($dimensionContents), $dimensionAttributes, ExampleDimensionContent::class);
     }
 
     public function testCount(): void

--- a/packages/page/src/Application/MessageHandler/CopyPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/CopyPageMessageHandler.php
@@ -75,7 +75,7 @@ final class CopyPageMessageHandler
             );
         }
 
-        $dimensionContentCollection = new DimensionContentCollection($sourcePage->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($sourcePage->getDimensionContents(), [], PageDimensionContent::class);
         /** @var PageDimensionContent $localizedDimensionContent */
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $message->getLocale()]);
 

--- a/packages/page/src/Application/MessageHandler/MovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/MovePageMessageHandler.php
@@ -51,7 +51,7 @@ class MovePageMessageHandler
             return;
         }
 
-        $previousParentDimensionContentCollection = new DimensionContentCollection($previousParent->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $previousParentDimensionContentCollection = new DimensionContentCollection($previousParent->getDimensionContents(), [], PageDimensionContent::class);
         /** @var PageDimensionContent $previousParentLocalizedDimensionContent */
         $previousParentLocalizedDimensionContent = $previousParentDimensionContentCollection->getDimensionContent(['locale' => $message->getLocale()]);
 

--- a/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/RemovePageMessageHandler.php
@@ -51,7 +51,7 @@ final class RemovePageMessageHandler
         $resourceKey = $page::RESOURCE_KEY;
         $this->trashManager?->store($resourceKey, $page);
 
-        $dimensionContentCollection = new DimensionContentCollection($page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($page->getDimensionContents(), [], PageDimensionContent::class);
         /** @var PageDimensionContentInterface|null $localizedDimensionContent */
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $message->getLocale()]);
         $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);

--- a/packages/page/src/Domain/Event/PageCreatedEvent.php
+++ b/packages/page/src/Domain/Event/PageCreatedEvent.php
@@ -69,7 +69,7 @@ class PageCreatedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageModifiedEvent.php
+++ b/packages/page/src/Domain/Event/PageModifiedEvent.php
@@ -69,7 +69,7 @@ class PageModifiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageMovedEvent.php
+++ b/packages/page/src/Domain/Event/PageMovedEvent.php
@@ -61,7 +61,7 @@ class PageMovedEvent extends DomainEvent
             return $eventContext;
         }
 
-        $newParentDimensionContentCollection = new DimensionContentCollection($newParent->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $newParentDimensionContentCollection = new DimensionContentCollection($newParent->getDimensionContents(), [], PageDimensionContent::class);
         $newParentLocalizedDimensionContent = $newParentDimensionContentCollection->getDimensionContent(['locale' => $this->locale]);
 
         return \array_merge($eventContext, [
@@ -89,7 +89,7 @@ class PageMovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageOrderedEvent.php
+++ b/packages/page/src/Domain/Event/PageOrderedEvent.php
@@ -63,7 +63,7 @@ class PageOrderedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageTranslationAddedEvent.php
+++ b/packages/page/src/Domain/Event/PageTranslationAddedEvent.php
@@ -69,7 +69,7 @@ class PageTranslationAddedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageTranslationCopiedEvent.php
+++ b/packages/page/src/Domain/Event/PageTranslationCopiedEvent.php
@@ -77,7 +77,7 @@ class PageTranslationCopiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageTranslationRemovedEvent.php
+++ b/packages/page/src/Domain/Event/PageTranslationRemovedEvent.php
@@ -60,7 +60,7 @@ class PageTranslationRemovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageTranslationRestoredEvent.php
+++ b/packages/page/src/Domain/Event/PageTranslationRestoredEvent.php
@@ -69,7 +69,7 @@ class PageTranslationRestoredEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageVersionRestoredEvent.php
+++ b/packages/page/src/Domain/Event/PageVersionRestoredEvent.php
@@ -68,7 +68,7 @@ class PageVersionRestoredEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Domain/Event/PageWorkflowTransitionAppliedEvent.php
+++ b/packages/page/src/Domain/Event/PageWorkflowTransitionAppliedEvent.php
@@ -66,7 +66,7 @@ class PageWorkflowTransitionAppliedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->page->getDimensionContents(), [], PageDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/page/src/Infrastructure/Sulu/Reference/PageReferenceRefresher.php
+++ b/packages/page/src/Infrastructure/Sulu/Reference/PageReferenceRefresher.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Page\Infrastructure\Sulu\Reference;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
@@ -191,7 +192,7 @@ class PageReferenceRefresher implements ReferenceRefresherInterface
                     }
                     yield $this->contentMerger->merge(
                         new DimensionContentCollection(
-                            $unlocalizedDimensionContent ? [$pageDimensionContent, $unlocalizedDimensionContent] : [$pageDimensionContent],
+                            new ArrayCollection($unlocalizedDimensionContent ? [$pageDimensionContent, $unlocalizedDimensionContent] : [$pageDimensionContent]),
                             $pageDimensionContent::getEffectiveDimensionAttributes(['locale' => $locale, 'stage' => $stage]),
                             PageDimensionContent::class
                         )

--- a/packages/page/src/Infrastructure/Sulu/Search/AdminPageIndexListener.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/AdminPageIndexListener.php
@@ -68,7 +68,7 @@ final class AdminPageIndexListener
 
         if ($event instanceof PageRestoredEvent) {
             $page = $event->getPage();
-            $dimensionContentCollection = new DimensionContentCollection($page->getDimensionContents()->toArray(), [], PageDimensionContent::class);
+            $dimensionContentCollection = new DimensionContentCollection($page->getDimensionContents(), [], PageDimensionContent::class);
             $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);
 
             return $unlocalizedDimensionContent ? ($unlocalizedDimensionContent->getAvailableLocales() ?? []) : [];

--- a/packages/page/src/Infrastructure/Sulu/Trash/PageTrashItemHandler.php
+++ b/packages/page/src/Infrastructure/Sulu/Trash/PageTrashItemHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Infrastructure\Sulu\Trash;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
@@ -113,11 +114,9 @@ final class PageTrashItemHandler implements
         );
 
         foreach ($localizedDimensionContents as $locale => $localizedDimensionContent) {
-            $dimensionContents = [$unlocalizedDimensionContent, $localizedDimensionContent];
-
             $mergedDimensionContent = $this->contentMerger->merge(
                 new DimensionContentCollection(
-                    $dimensionContents,
+                    new ArrayCollection([$unlocalizedDimensionContent, $localizedDimensionContent]),
                     [
                         'locale' => $locale,
                         'stage' => DimensionContentInterface::STAGE_DRAFT,

--- a/packages/snippet/src/Application/MessageHandler/RemoveSnippetMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/RemoveSnippetMessageHandler.php
@@ -45,7 +45,7 @@ final class RemoveSnippetMessageHandler
         $resourceKey = $snippet::RESOURCE_KEY;
         $this->trashManager?->store($resourceKey, $snippet);
 
-        $dimensionContentCollection = new DimensionContentCollection($snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($snippet->getDimensionContents(), [], SnippetDimensionContent::class);
         /** @var SnippetDimensionContentInterface|null $localizedDimensionContent */
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $message->getLocale()]);
         $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null, 'stage' => 'draft']);

--- a/packages/snippet/src/Domain/Event/SnippetCreatedEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetCreatedEvent.php
@@ -64,7 +64,7 @@ class SnippetCreatedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Domain/Event/SnippetModifiedEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetModifiedEvent.php
@@ -64,7 +64,7 @@ class SnippetModifiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Domain/Event/SnippetOrderedEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetOrderedEvent.php
@@ -58,7 +58,7 @@ class SnippetOrderedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Domain/Event/SnippetTranslationAddedEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetTranslationAddedEvent.php
@@ -64,7 +64,7 @@ class SnippetTranslationAddedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Domain/Event/SnippetTranslationCopiedEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetTranslationCopiedEvent.php
@@ -72,7 +72,7 @@ class SnippetTranslationCopiedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Domain/Event/SnippetTranslationRemovedEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetTranslationRemovedEvent.php
@@ -55,7 +55,7 @@ class SnippetTranslationRemovedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Domain/Event/SnippetTranslationRestoredEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetTranslationRestoredEvent.php
@@ -64,7 +64,7 @@ class SnippetTranslationRestoredEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Domain/Event/SnippetVersionRestoredEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetVersionRestoredEvent.php
@@ -63,7 +63,7 @@ class SnippetVersionRestoredEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Domain/Event/SnippetWorkflowTransitionAppliedEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetWorkflowTransitionAppliedEvent.php
@@ -61,7 +61,7 @@ class SnippetWorkflowTransitionAppliedEvent extends DomainEvent
 
     public function getResourceTitle(): ?string
     {
-        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents()->toArray(), [], SnippetDimensionContent::class);
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
 
         return $dimensionContentCollection->getDimensionContent(['locale' => $this->locale])?->getTitle();
     }

--- a/packages/snippet/src/Infrastructure/Sulu/Reference/SnippetReferenceRefresher.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Reference/SnippetReferenceRefresher.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Snippet\Infrastructure\Sulu\Reference;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
@@ -190,7 +191,7 @@ class SnippetReferenceRefresher implements ReferenceRefresherInterface
                     }
                     yield $this->contentMerger->merge(
                         new DimensionContentCollection(
-                            $unlocalizedDimensionContent ? [$snippetDimensionContent, $unlocalizedDimensionContent] : [$snippetDimensionContent],
+                            new ArrayCollection($unlocalizedDimensionContent ? [$snippetDimensionContent, $unlocalizedDimensionContent] : [$snippetDimensionContent]),
                             $snippetDimensionContent::getEffectiveDimensionAttributes(['locale' => $locale, 'stage' => $stage]),
                             SnippetDimensionContent::class
                         )

--- a/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Snippet\Infrastructure\Sulu\Trash;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
@@ -114,11 +115,9 @@ final class SnippetTrashItemHandler implements
         );
 
         foreach ($localizedDimensionContents as $locale => $localizedDimensionContent) {
-            $dimensionContents = [$unlocalizedDimensionContent, $localizedDimensionContent];
-
             $mergedDimensionContent = $this->contentMerger->merge(
                 new DimensionContentCollection(
-                    $dimensionContents,
+                    new ArrayCollection([$unlocalizedDimensionContent, $localizedDimensionContent]),
                     [
                         'locale' => $locale,
                         'stage' => DimensionContentInterface::STAGE_DRAFT,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| License | MIT

#### What's in this PR?

Removes the support for arrays in the DimensionContentCollection

#### Why?

Using a collection is more performant and allows to build optimized queries via doctrine criteria filtering.
