### PR TITLE
Fix crashing SEO tab on Article with PageTreeRoute

### DIFF
--- a/packages/page/assets/js/containers/Form/fields/SearchResult.js
+++ b/packages/page/assets/js/containers/Form/fields/SearchResult.js
@@ -22,7 +22,7 @@ class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {
         throw new Error('If "url" is defined it must be a string or a object following page tree structure!');
     }
 
-    extractUrlFromPageTreeRoute(url: {}): string {
+    extractUrlFromPageTreeRoute(url: Object): string {
         let urlPath = '';
 
         if (typeof url.page === 'object'

--- a/packages/page/assets/js/containers/Form/fields/SearchResult.js
+++ b/packages/page/assets/js/containers/Form/fields/SearchResult.js
@@ -6,11 +6,27 @@ import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {
-    extractUrlFromPageTreeRoute(url: object): string {
+    extractUrl(url: any): string {
+        if (typeof url === 'string') {
+            return url;
+        }
+
+        if (url === undefined) {
+            return '';
+        }
+
+        if (typeof url === 'object') {
+            return this.extractUrlFromPageTreeRoute(url);
+        }
+
+        throw new Error('If "url" is defined it must be a string or a object following page tree structure!');
+    }
+
+    extractUrlFromPageTreeRoute(url: {}): string {
         let urlPath = '';
 
         if (typeof url.page === 'object'
-            && url.page.path === 'string'
+            && typeof url.page.path === 'string'
         ) {
             urlPath += url.page.path;
         }
@@ -28,7 +44,7 @@ class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {
 
         const description = formInspector.getValueByPath('/ext/seo/description');
         const title = formInspector.getValueByPath('/ext/seo/title');
-        let url = formInspector.getValueByPath('/url');
+        const url = this.extractUrl(formInspector.getValueByPath('/url'));
 
         if (title !== undefined && typeof title !== 'string') {
             throw new Error('If "title" is defined it must be a string!');
@@ -36,18 +52,6 @@ class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {
 
         if (description !== undefined && typeof description !== 'string') {
             throw new Error('If description is defined it must be a string!');
-        }
-
-        if (url === undefined) {
-            url = '';
-        }
-
-        if (typeof url === 'object') {
-            url = this.extractUrlFromPageTreeRoute(url);
-        }
-
-        if (typeof url !== 'string') {
-            throw new Error('If "url" is defined it must be a string!');
         }
 
         return (

--- a/packages/page/assets/js/containers/Form/fields/SearchResult.js
+++ b/packages/page/assets/js/containers/Form/fields/SearchResult.js
@@ -6,13 +6,29 @@ import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {
+    extractUrlFromPageTreeRoute(url: string): string {
+        let urlPath = '';
+
+        if (typeof url.page === 'object'
+            && url.page.path === 'string'
+        ) {
+            urlPath += url.page.path;
+        }
+
+        if (typeof url.suffix === 'object') {
+            urlPath += url.suffix;
+        }
+
+        return urlPath;
+    }
+
     render() {
         const {formInspector} = this.props;
         const locale = formInspector.locale ? formInspector.locale.get() : undefined;
 
         const description = formInspector.getValueByPath('/ext/seo/description');
         const title = formInspector.getValueByPath('/ext/seo/title');
-        const url = formInspector.getValueByPath('/url');
+        let url = formInspector.getValueByPath('/url');
 
         if (title !== undefined && typeof title !== 'string') {
             throw new Error('If "title" is defined it must be a string!');
@@ -22,7 +38,15 @@ class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {
             throw new Error('If description is defined it must be a string!');
         }
 
-        if (url !== undefined && typeof url !== 'string') {
+        if (url === undefined) {
+            url = '';
+        }
+
+        if (typeof url === 'object') {
+            url = this.extractUrlFromPageTreeRoute(url);
+        }
+
+        if (typeof url !== 'string') {
             throw new Error('If "url" is defined it must be a string!');
         }
 

--- a/packages/page/assets/js/containers/Form/fields/SearchResult.js
+++ b/packages/page/assets/js/containers/Form/fields/SearchResult.js
@@ -6,7 +6,7 @@ import type {FieldTypeProps} from 'sulu-admin-bundle/types';
 
 @observer
 class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {
-    extractUrlFromPageTreeRoute(url: string): string {
+    extractUrlFromPageTreeRoute(url: object): string {
         let urlPath = '';
 
         if (typeof url.page === 'object'
@@ -15,7 +15,7 @@ class SearchResult extends React.Component<FieldTypeProps<typeof undefined>> {
             urlPath += url.page.path;
         }
 
-        if (typeof url.suffix === 'object') {
+        if (typeof url.suffix === 'string') {
             urlPath += url.suffix;
         }
 

--- a/packages/page/assets/js/containers/Form/tests/fields/SearchResult.test.js
+++ b/packages/page/assets/js/containers/Form/tests/fields/SearchResult.test.js
@@ -48,6 +48,37 @@ test('Pass correct fields to SearchResult component', () => {
     expect(searchResult.prop('url')).toEqual('www.example.org/url');
 });
 
+test('Pass correct fields to SearchResult component with PageTreeRoute', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    formInspector.getValueByPath.mockImplementation((path) => {
+        switch (path) {
+            case '/ext/seo/description':
+                return 'SEO description';
+            case '/ext/seo/title':
+                return 'SEO title';
+            case '/url':
+                return {
+                    page: {
+                        uuid: '019a9d17-6a7d-7d56-acc0-0068d1cd4040',
+                        path: '/page',
+                    },
+                    suffix: '/article',
+                };
+        }
+    });
+
+    const searchResult = shallow(
+        <SearchResult
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+        />
+    );
+
+    expect(searchResult.prop('description')).toEqual('SEO description');
+    expect(searchResult.prop('title')).toEqual('SEO title');
+    expect(searchResult.prop('url')).toEqual('www.example.org/page/article');
+});
+
 test('Pass correct fields to SearchResult component', () => {
     const formInspector = new FormInspector(
         new ResourceFormStore(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix crashing SEO tab on Article with PageTreeRoute

#### Why?

Because it should not crash.