### PR TITLE
Take care of access control in the website page reindex provider

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
@@ -17,12 +17,14 @@ use CmsIg\Seal\Reindex\ReindexConfig;
 use CmsIg\Seal\Reindex\ReindexProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 
 /**
- * @phpstan-type Page array{
+ * @phpstan-type PageData array{
  *     pageId: int,
  *     changed: \DateTimeImmutable,
  *     created: \DateTimeImmutable,
@@ -68,7 +70,7 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
     {
         $pages = $this->loadPages($reindexConfig->getIdentifiers());
 
-        /** @var Page $page */
+        /** @var PageData $page */
         foreach ($pages as $page) {
             $authoredAt = $page['authored'] ?? $page['changed'];
 
@@ -90,13 +92,19 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
     /**
      * @param string[] $identifiers
      *
-     * @return iterable<Page>
+     * @return iterable<PageData>
      */
     private function loadPages(array $identifiers = []): iterable
     {
         $qb = $this->dimensionContentRepository->createQueryBuilder('dimensionContent')
             ->leftJoin('dimensionContent.route', 'route')
             ->leftJoin('dimensionContent.page', 'page')
+            ->leftJoin(
+                AccessControl::class,
+                'accessControl',
+                'WITH',
+                'accessControl.entityId = page.uuid AND accessControl.entityClass = :pageClass'
+            )
             ->select('IDENTITY(dimensionContent.page) AS pageId')
             ->addSelect('dimensionContent.authored')
             ->addSelect('dimensionContent.changed')
@@ -106,11 +114,13 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
             ->addSelect('page.webspaceKey')
             ->where('dimensionContent.stage = :stage')
             ->andWhere('dimensionContent.locale IS NOT NULL')
-            ->andWhere('dimensionContent.version = :version');
+            ->andWhere('dimensionContent.version = :version')
+            ->andWhere('accessControl.id IS NULL');
 
         $parameters = [
             'stage' => DimensionContentInterface::STAGE_LIVE,
             'version' => DimensionContentInterface::CURRENT_VERSION,
+            'pageClass' => Page::class,
         ];
 
         if (0 < \count($identifiers)) {
@@ -140,7 +150,7 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
 
         $qb->setParameters($parameters);
 
-        /** @var iterable<Page> */
+        /** @var iterable<PageData> */
         return $qb->getQuery()->toIterable();
     }
 

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
@@ -15,25 +15,30 @@ namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageReindexProvider;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
 
 class WebsitePageReindexProviderTest extends SuluTestCase
 {
     use CreatePageTrait;
+    use CreatePageWithPermissionsTrait;
     use SetGetPrivatePropertyTrait;
 
     private EntityManagerInterface $entityManager;
     private WebsitePageReindexProvider $provider;
+    private Role $anonymousRole;
 
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
         $this->provider = new WebsitePageReindexProvider($this->entityManager);
         $this->purgeDatabase();
+        $this->anonymousRole = $this->createAnonymousRoleWithWebspacePermissions('sulu-test-secure');
     }
 
     public function testGetIndex(): void
@@ -74,6 +79,18 @@ class WebsitePageReindexProviderTest extends SuluTestCase
                 ],
             ],
         ], 'blog');
+        $page3 = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'No Access',
+                    'url' => '/no-access',
+                    'authored' => '1995-11-29T12:00:00+00:00',
+                ],
+            ],
+        ], 'sulu-io');
+        $this->denyAccessToPage($page3, $this->anonymousRole);
+        $this->entityManager->clear();
 
         $changedDateString1 = '2023-06-01 15:30:00';
         $changedDateString2 = '2024-11-29 15:30:00';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
dd issue number here e.g.: #5730 -->
| Related issues/PRs | #7672
| License | MIT

#### What's in this PR?

Don't add pages with access control to the website search index.

