### PR TITLE
Remove doctrine cache in favor of Symfony cache

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1056,6 +1056,7 @@ Removed classes / services / interfaces / traits:
 - `Sulu\Bundle\WebsiteBundle\ReferenceStore\WebspaceReferenceStore`
 - `Sulu\Bundle\MediaBundle\DependencyInjection\ImageTransformationCompilerPass` (replaced by `tagged_locator`)
 - `Sulu\Bundle\PreviewBundle\Preview\PreviewCache` -> (using Symfony cache now)
+- `sulu_contact.twig.cache`, `sulu_core.cache.memoize.cache`, `sulu_security.twig_extension.user.cache` -> ArrayAdapter of Symfony caching
 
 Removed deprecated functions and properties:
 

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -71,7 +71,6 @@ return $config
     ->ignoreErrorsOnPackages(
         [
             'symfony/yaml', // we use yaml configurations
-            'symfony/cache', // we use cache via psr/cache interface
         ],
         [ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV],
     )

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "cmsig/seal": "^0.12.4",
         "cmsig/seal-symfony-bundle": "^0.12",
         "contao/imagine-svg": "^1.0",
-        "doctrine/cache": "^1.12.1 || ^2.0",
         "doctrine/collections": "^1.6 || ^2.0",
         "doctrine/data-fixtures": "^1.4 || ^2.0",
         "doctrine/dbal": "^3.6",

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
@@ -42,7 +42,7 @@ class CategoryTwigExtensionTest extends TestCase
      */
     private function getMemoizeCache()
     {
-        return new Memoize(DoctrineProvider::wrap(new ArrayAdapter()), 0);
+        return new Memoize(new ArrayAdapter(), 0);
     }
 
     /**

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Twig;
 
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use JMS\Serializer\SerializationContext;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -50,14 +50,8 @@
         </service>
 
         <service id="sulu_contact.twig.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
-
-        <service id="sulu_contact.twig.cache" class="Doctrine\Common\Cache\Cache">
-            <factory class="Doctrine\Common\Cache\Psr6\DoctrineProvider" method="wrap"/>
-            <argument type="service" id="sulu_contact.twig.cache_adapter" />
-        </service>
-
         <service id="sulu_contact.twig" class="Sulu\Bundle\ContactBundle\Twig\ContactTwigExtension">
-            <argument type="service" id="sulu_contact.twig.cache"/>
+            <argument type="service" id="sulu_contact.twig.cache_adapter"/>
             <argument type="service" id="sulu.repository.contact"/>
 
             <tag name="twig.extension"/>

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\ContactBundle\Tests\Unit;
 
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -25,15 +23,7 @@ class ContactTwigExtensionTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ContactTwigExtension
-     */
-    private $extension;
-
-    /**
-     * @var Cache
-     */
-    private $cache;
+    private ContactTwigExtension $extension;
 
     /**
      * @var ObjectProphecy<ContactRepository>
@@ -42,10 +32,9 @@ class ContactTwigExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->cache = DoctrineProvider::wrap(new ArrayAdapter());
         $this->contactRepository = $this->prophesize(ContactRepository::class);
 
-        $this->extension = new ContactTwigExtension($this->cache, $this->contactRepository->reveal());
+        $this->extension = new ContactTwigExtension(new ArrayAdapter(), $this->contactRepository->reveal());
     }
 
     public function testResolveContactFunction(): void
@@ -62,10 +51,10 @@ class ContactTwigExtensionTest extends TestCase
         $this->contactRepository->find(2)->willReturn($contact2);
 
         $contact = $this->extension->resolveContactFunction(1);
-        $this->assertEquals('Hikaru Sulu', $contact->getFullName());
+        $this->assertEquals('Hikaru Sulu', $contact?->getFullName());
 
         $contact = $this->extension->resolveContactFunction(2);
-        $this->assertEquals('John Cho', $contact->getFullName());
+        $this->assertEquals('John Cho', $contact?->getFullName());
     }
 
     public function testResolveContactFunctionNonExisting(): void

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
@@ -51,10 +51,12 @@ class ContactTwigExtensionTest extends TestCase
         $this->contactRepository->find(2)->willReturn($contact2);
 
         $contact = $this->extension->resolveContactFunction(1);
-        $this->assertEquals('Hikaru Sulu', $contact?->getFullName());
+        $this->assertEquals('Hikaru', $contact?->getFirstName());
+        $this->assertEquals('Sulu', $contact?->getLastName());
 
         $contact = $this->extension->resolveContactFunction(2);
-        $this->assertEquals('John Cho', $contact?->getFullName());
+        $this->assertEquals('John', $contact?->getFirstName());
+        $this->assertEquals('Cho', $contact?->getLastName());
     }
 
     public function testResolveContactFunctionNonExisting(): void

--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
@@ -40,15 +40,15 @@ class ContactTwigExtension extends AbstractExtension
     }
 
     /**
-     * @param string $id id to resolve
+     * @param string|int $id id to resolve
      *
      * @return ContactInterface|null
      *
      * @throws InvalidArgumentException
      */
-    public function resolveContactFunction(string $id)
+    public function resolveContactFunction($id)
     {
-        return $this->cache->get($id, function() use ($id) {
+        return $this->cache->get((string) $id, function() use ($id) {
             return $this->contactRepository->find($id);
         });
     }

--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
@@ -11,9 +11,10 @@
 
 namespace Sulu\Bundle\ContactBundle\Twig;
 
-use Doctrine\Common\Cache\Cache;
+use Psr\Cache\InvalidArgumentException;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,7 +24,7 @@ use Twig\TwigFunction;
 class ContactTwigExtension extends AbstractExtension
 {
     public function __construct(
-        private Cache $cache,
+        private ArrayAdapter $cache,
         private ContactRepository $contactRepository,
     ) {
     }
@@ -34,28 +35,21 @@ class ContactTwigExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_resolve_contact', [$this, 'resolveContactFunction']),
+            new TwigFunction('sulu_resolve_contact', $this->resolveContactFunction(...)),
         ];
     }
 
     /**
-     * @param int $id id to resolve
+     * @param string $id id to resolve
      *
      * @return ContactInterface|null
+     *
+     * @throws InvalidArgumentException
      */
-    public function resolveContactFunction($id)
+    public function resolveContactFunction(string $id)
     {
-        if ($this->cache->contains($id)) {
-            return $this->cache->fetch($id);
-        }
-
-        $contact = $this->contactRepository->find($id);
-        if (null === $contact) {
-            return null;
-        }
-
-        $this->cache->save($id, $contact);
-
-        return $contact;
+        return $this->cache->get($id, function() use ($id) {
+            return $this->contactRepository->find($id);
+        });
     }
 }

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/cache.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/cache.xml
@@ -6,11 +6,6 @@
     <services>
         <service id="sulu_core.cache.memoize.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
 
-        <service id="sulu_core.cache.memoize.cache" class="Doctrine\Common\Cache\CacheProvider">
-            <factory class="Doctrine\Common\Cache\Psr6\DoctrineProvider" method="wrap"/>
-            <argument type="service" id="sulu_core.cache.memoize.cache_adapter" />
-        </service>
-
         <service id="sulu_core.cache.memoize" class="Sulu\Component\Cache\Memoize">
             <argument type="service" id="sulu_core.cache.memoize.cache"/>
             <argument type="string">%sulu_core.cache.memoize.default_lifetime%</argument>

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/cache.xml
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/cache.xml
@@ -7,7 +7,7 @@
         <service id="sulu_core.cache.memoize.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
 
         <service id="sulu_core.cache.memoize" class="Sulu\Component\Cache\Memoize">
-            <argument type="service" id="sulu_core.cache.memoize.cache"/>
+            <argument type="service" id="sulu_core.cache.memoize.cache_adapter"/>
             <argument type="string">%sulu_core.cache.memoize.default_lifetime%</argument>
             <tag name="kernel.reset" method="reset" />
         </service>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -220,13 +220,9 @@
         </service>
 
         <service id="sulu_security.twig_extension.user.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
-        <service id="sulu_security.twig_extension.user.cache" class="Sulu\Bundle\ContactBundle\Entity\PositionRepository">
-            <factory class="Doctrine\Common\Cache\Psr6\DoctrineProvider" method="wrap"/>
-            <argument type="service" id="sulu_security.twig_extension.user.cache_adapter" />
-        </service>
 
         <service id="sulu_security.twig_extension.user" class="Sulu\Bundle\SecurityBundle\Twig\UserTwigExtension">
-            <argument type="service" id="sulu_security.twig_extension.user.cache"/>
+            <argument type="service" id="sulu_security.twig_extension.user.cache_adapter"/>
             <argument type="service" id="sulu.repository.user"/>
 
             <tag name="twig.extension"/>

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
@@ -52,10 +52,10 @@ class UserTwigExtensionTest extends TestCase
         $this->userRepository->findUserById(2)->willReturn($user2);
 
         $user = $this->extension->resolveUserFunction(1);
-        $this->assertEquals('hikaru', $user->getUserIdentifier());
+        $this->assertEquals('hikaru', $user?->getUserIdentifier());
 
         $user = $this->extension->resolveUserFunction(2);
-        $this->assertEquals('sulu', $user->getUserIdentifier());
+        $this->assertEquals('sulu', $user?->getUserIdentifier());
     }
 
     public function testResolveUserFunctionNonExisting(): void

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
@@ -52,10 +52,10 @@ class UserTwigExtensionTest extends TestCase
         $this->userRepository->findUserById(2)->willReturn($user2);
 
         $user = $this->extension->resolveUserFunction(1);
-        $this->assertEquals('hikaru', $user->getUsername());
+        $this->assertEquals('hikaru', $user->getUserIdentifier());
 
         $user = $this->extension->resolveUserFunction(2);
-        $this->assertEquals('sulu', $user->getUsername());
+        $this->assertEquals('sulu', $user->getUserIdentifier());
     }
 
     public function testResolveUserFunctionNonExisting(): void

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Unit\Twig;
 
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Twig/UserTwigExtensionTest.php
@@ -25,24 +25,18 @@ class UserTwigExtensionTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var UserTwigExtension
-     */
-    private $extension;
+    private UserTwigExtension $extension;
 
-    /**
-     * @var Cache
-     */
-    private $cache;
+    private ArrayAdapter $cache;
 
     /**
      * @var ObjectProphecy<UserRepository>
      */
-    private $userRepository;
+    private ObjectProphecy $userRepository;
 
     protected function setUp(): void
     {
-        $this->cache = DoctrineProvider::wrap(new ArrayAdapter());
+        $this->cache = new ArrayAdapter();
         $this->userRepository = $this->prophesize(UserRepository::class);
 
         $this->extension = new UserTwigExtension($this->cache, $this->userRepository->reveal());

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\SecurityBundle\Twig;
 use Doctrine\Common\Cache\Cache;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -22,7 +23,7 @@ use Twig\TwigFunction;
  */
 class UserTwigExtension extends AbstractExtension
 {
-    public function __construct(private Cache $cache, private UserRepository $userRepository)
+    public function __construct(private ArrayAdapter $cache, private UserRepository $userRepository)
     {
     }
 
@@ -32,7 +33,7 @@ class UserTwigExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('sulu_resolve_user', [$this, 'resolveUserFunction']),
+            new TwigFunction('sulu_resolve_user', $this->resolveUserFunction(...)),
         ];
     }
 
@@ -43,19 +44,10 @@ class UserTwigExtension extends AbstractExtension
      *
      * @return User
      */
-    public function resolveUserFunction($id)
+    public function resolveUserFunction(string $id)
     {
-        if ($this->cache->contains($id)) {
-            return $this->cache->fetch($id);
-        }
-
-        $user = $this->userRepository->findUserById($id);
-        if (null === $user) {
-            return;
-        }
-
-        $this->cache->save($id, $user);
-
-        return $user;
+        return $this->cache->get($id, function() use ($id) {
+            return $this->userRepository->findUserById($id);
+        });
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -44,9 +44,9 @@ class UserTwigExtension extends AbstractExtension
      *
      * @return User
      */
-    public function resolveUserFunction(string $id)
+    public function resolveUserFunction($id)
     {
-        return $this->cache->get($id, function() use ($id) {
+        return $this->cache->get((string) $id, function() use ($id) {
             return $this->userRepository->findUserById($id);
         });
     }

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -11,9 +11,9 @@
 
 namespace Sulu\Bundle\SecurityBundle\Twig;
 
-use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -41,7 +41,7 @@ class UserTwigExtension extends AbstractExtension
      *
      * @param int $id id to resolve
      *
-     * @return User
+     * @return UserInterface|null
      */
     public function resolveUserFunction($id)
     {

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\SecurityBundle\Twig;
 
-use Doctrine\Common\Cache\Cache;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
@@ -51,7 +51,7 @@ class TagTwigExtensionTest extends TestCase
      */
     private function getMemoizeCache()
     {
-        return new Memoize(DoctrineProvider::wrap(new ArrayAdapter()), 0);
+        return new Memoize(new ArrayAdapter(), 0);
     }
 
     public static function getProvider()

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\TagBundle\Tests\Unit\Twig;
 
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use JMS\Serializer\SerializationContext;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Component/Cache/Memoize.php
+++ b/src/Sulu/Component/Cache/Memoize.php
@@ -13,6 +13,7 @@ namespace Sulu\Component\Cache;
 
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\FlushableCache;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -21,10 +22,10 @@ use Symfony\Contracts\Service\ResetInterface;
 class Memoize implements MemoizeInterface, ResetInterface
 {
     /**
-     * @param Cache $cache should also include FlushableCache to reset in other runtimes like FrankenPHP correctly
+     * @param ArrayAdapter $cache should also include FlushableCache to reset in other runtimes like FrankenPHP correctly
      * @param int $defaultLifeTime
      */
-    public function __construct(protected Cache $cache, protected $defaultLifeTime)
+    public function __construct(protected ArrayAdapter $cache, protected $defaultLifeTime)
     {
     }
 
@@ -40,14 +41,17 @@ class Memoize implements MemoizeInterface, ResetInterface
 
         // memoize pattern: save result for arguments once and
         // return the value from cache if it is called more than once
-        if ($this->cache->contains($id)) {
-            return $this->cache->fetch($id);
-        } else {
-            $value = \call_user_func_array($compute, $arguments);
-            $this->cache->save($id, $value, $lifeTime);
-
-            return $value;
+        $item = $this->cache->getItem($id);
+        if ($item->isHit()) {
+            return $item->get();
         }
+
+        $value = \call_user_func_array($compute, $arguments);
+        $item->set($value);
+        $item->expiresAfter($lifeTime);
+        $this->cache->save($item);
+
+        return $value;
     }
 
     /**
@@ -55,8 +59,7 @@ class Memoize implements MemoizeInterface, ResetInterface
      */
     public function reset()
     {
-        if ($this->cache instanceof FlushableCache) {
-            $this->cache->flushAll();
-        }
+        // This is not necessary as the cache flushes itself on reset.
+        $this->cache->clear();
     }
 }

--- a/src/Sulu/Component/Cache/Memoize.php
+++ b/src/Sulu/Component/Cache/Memoize.php
@@ -39,9 +39,9 @@ class Memoize implements MemoizeInterface, ResetInterface
 
         return $this->cache->get($id, function($item) use ($compute, $arguments, $lifeTime) {
             $value = \call_user_func_array($compute, $arguments);
-        
+
             $item->expiresAfter($lifeTime);
-            
+
             return $value;
         });
     }

--- a/src/Sulu/Component/Cache/Memoize.php
+++ b/src/Sulu/Component/Cache/Memoize.php
@@ -11,8 +11,6 @@
 
 namespace Sulu\Component\Cache;
 
-use Doctrine\Common\Cache\Cache;
-use Doctrine\Common\Cache\FlushableCache;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -39,19 +37,13 @@ class Memoize implements MemoizeInterface, ResetInterface
         // determine cache key
         $id = \md5(\sprintf('%s(%s)', $id, \serialize($arguments)));
 
-        // memoize pattern: save result for arguments once and
-        // return the value from cache if it is called more than once
-        $item = $this->cache->getItem($id);
-        if ($item->isHit()) {
-            return $item->get();
-        }
-
-        $value = \call_user_func_array($compute, $arguments);
-        $item->set($value);
-        $item->expiresAfter($lifeTime);
-        $this->cache->save($item);
-
-        return $value;
+        return $this->cache->get($id, function($item) use ($compute, $arguments, $lifeTime) {
+            $value = \call_user_func_array($compute, $arguments);
+        
+            $item->expiresAfter($lifeTime);
+            
+            return $value;
+        });
     }
 
     /**

--- a/src/Sulu/Component/Cache/MemoizeInterface.php
+++ b/src/Sulu/Component/Cache/MemoizeInterface.php
@@ -20,9 +20,10 @@ interface MemoizeInterface
      * Returns the value stored in the cache or uses the passed function to compute the value and save to cache
      * This function uses the given key for the caching mechanism.
      *
+     * @param string|int $id cache key
      * @param array $arguments array of parameter to call compute function
      * @param callable $compute
-     * @param int $lifeTime cache lifetime
+     * @param int|null $lifeTime cache lifetime
      */
     public function memoizeById($id, $arguments, $compute, $lifeTime = null);
 }

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTest.php
@@ -9,41 +9,24 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Cache\Tests\Unit;
+namespace Sulu\Component\Cache\Tests\Unit\Cache;
 
-use Doctrine\Common\Cache\CacheProvider;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Sulu\Component\Cache\Memoize;
 use Sulu\Component\Cache\MemoizeInterface;
 
 class MemoizeTest extends TestCase
 {
-    use ProphecyTrait;
+    private MemoizeInterface $mem;
 
-    /**
-     * @var MemoizeInterface
-     */
-    private $mem;
-
-    /**
-     * @var ObjectProphecy<CacheProvider>
-     */
-    private $cache;
-
-    /**
-     * @var int
-     */
-    private $defaultLifeTime = 600;
+    private int $defaultLifeTime = 600;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->cache = $this->prophesize(CacheProvider::class);
-
-        $this->mem = new Memoize($this->cache->reveal(), $this->defaultLifeTime);
+        $this->mem = new Memoize(new ArrayAdapter(), $this->defaultLifeTime);
     }
 
     public function testMemoizeByIdFirstCall(): void
@@ -61,15 +44,6 @@ class MemoizeTest extends TestCase
                 }
             );
         };
-
-        $id12 = \md5(\sprintf('mem(%s)', \serialize([1, 2])));
-        $id23 = \md5(\sprintf('mem(%s)', \serialize([2, 3])));
-
-        $this->cache->save($id12, 3, $this->defaultLifeTime)->willReturn(null);
-        $this->cache->contains($id12)->willReturn(false);
-
-        $this->cache->save($id23, 5, $this->defaultLifeTime)->willReturn(null);
-        $this->cache->contains($id23)->willReturn(false);
 
         $v1 = $closure(1, 2);
         $v2 = $closure(2, 3);
@@ -97,15 +71,6 @@ class MemoizeTest extends TestCase
             );
         };
 
-        $id12 = \md5(\sprintf('mem(%s)', \serialize([1, 2])));
-        $id23 = \md5(\sprintf('mem(%s)', \serialize([2, 3])));
-
-        $this->cache->save($id12, 3, 100)->willReturn(null);
-        $this->cache->contains($id12)->willReturn(false);
-
-        $this->cache->save($id23, 5, 100)->willReturn(null);
-        $this->cache->contains($id23)->willReturn(false);
-
         $v1 = $closure(1, 2);
         $v2 = $closure(2, 3);
 
@@ -131,21 +96,19 @@ class MemoizeTest extends TestCase
             );
         };
 
-        $id12 = \md5(\sprintf('mem(%s)', \serialize([1, 2])));
-        $id23 = \md5(\sprintf('mem(%s)', \serialize([2, 3])));
+        // First call - should execute the closure and cache the result.
+        $v1First = $closure(1, 2);
+        $v2First = $closure(2, 3);
 
-        $this->cache->fetch($id12)->wilLReturn(3);
-        $this->cache->contains($id12)->willReturn(true);
+        $this->assertEquals(2, $called);
 
-        $this->cache->fetch($id23)->wilLReturn(5);
-        $this->cache->contains($id23)->willReturn(true);
+        // Second call - should use cached values, closure should not be called.
+        $called = 0;
+        $v1Second = $closure(1, 2);
+        $v2Second = $closure(2, 3);
 
-        $v1 = $closure(1, 2);
-        $v2 = $closure(2, 3);
-
-        $this->assertEquals(3, $v1);
-        $this->assertEquals(5, $v2);
-
+        $this->assertEquals(3, $v1Second);
+        $this->assertEquals(5, $v2Second);
         $this->assertEquals(0, $called);
     }
 }

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTest.php
@@ -12,9 +12,9 @@
 namespace Sulu\Component\Cache\Tests\Unit\Cache;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Sulu\Component\Cache\Memoize;
 use Sulu\Component\Cache\MemoizeInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class MemoizeTest extends TestCase
 {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing the last remains of the doctrine cache integration

#### Why?
The bundle has been replaced by the Symfony version.