### PR TITLE
Never read route directly from the Request method instead from attributes bag

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -286,11 +286,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarAction.php
 
 		-
-			message: "#^Method Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\View\\\\ToolbarAction\\:\\:getOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarAction.php
-
-		-
 			message: "#^Property Sulu\\\\Bundle\\\\AdminBundle\\\\Admin\\\\View\\\\ToolbarAction\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarAction.php
@@ -12452,11 +12447,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$entity of method Sulu\\\\Bundle\\\\MediaBundle\\\\Collection\\\\Manager\\\\CollectionManager\\:\\:getApiEntity\\(\\) expects Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\CollectionInterface, Sulu\\\\Bundle\\\\MediaBundle\\\\Entity\\\\Collection\\|null given\\.$#"
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
-
-		-
-			message: "#^Parameter \\#1 \\$entityName of method Doctrine\\\\ORM\\\\EntityManager\\:\\:getRepository\\(\\) expects class\\-string\\<SuluMediaBundle\\:CollectionType\\>, string given\\.$#"
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
@@ -30863,11 +30853,6 @@ parameters:
 		-
 			message: "#^Cannot access offset 'prefix' on mixed\\.$#"
 			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
-
-		-
-			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\HttpFoundation\\\\Request\\|null\\.$#"
-			count: 3
 			path: src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
 
 		-

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -147,10 +147,10 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
         $request = $this->requestStack->getCurrentRequest();
         $urls = [];
 
-        if ($request->get('_route')) {
+        if ($request && $request->attributes->get('_route')) {
             $portalInformations = $this->webspaceManager->getPortalInformations($this->environment);
-            $routeParams = $request->get('_route_params');
-            $routeName = $request->get('_route');
+            $routeParams = $request->attributes->get('_route_params');
+            $routeName = $request->attributes->get('_route');
 
             foreach ($portalInformations as $portalInformation) {
                 if (

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/TemplateAttributeResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/TemplateAttributeResolverTest.php
@@ -48,7 +48,7 @@ class TemplateAttributeResolverTest extends TestCase
     protected $router;
 
     /**
-     * @var ObjectProphecy<RequestStack>
+     * @var RequestStack
      */
     protected $requestStack;
 
@@ -73,11 +73,6 @@ class TemplateAttributeResolverTest extends TestCase
     protected $portal;
 
     /**
-     * @var ObjectProphecy<Request>
-     */
-    protected $request;
-
-    /**
      * @var TemplateAttributeResolver
      */
     protected $templateAttributeResolver;
@@ -94,8 +89,7 @@ class TemplateAttributeResolverTest extends TestCase
 
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->router = $this->prophesize(RouterInterface::class);
-        $this->requestStack = $this->prophesize(RequestStack::class);
-        $this->request = $this->prophesize(Request::class);
+        $this->requestStack = new RequestStack();
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->webspace = $this->prophesize(Webspace::class);
         $this->portal = $this->prophesize(Portal::class);
@@ -119,8 +113,6 @@ class TemplateAttributeResolverTest extends TestCase
 
         $this->webspaceManager->getPortalInformations($this->environment)->willReturn($this->portalInformations);
 
-        $this->requestStack->getCurrentRequest()->willReturn($this->request);
-
         $this->portal->getKey()->willReturn($webspacePortalKey);
         $this->portal->getName()->willReturn($webspacePortalName);
         $this->portal->getDefaultLocalization()->willReturn(Localization::createFromString('en'));
@@ -134,8 +126,10 @@ class TemplateAttributeResolverTest extends TestCase
         $this->requestAnalyzer->getWebspace()->willReturn($this->webspace->reveal());
         $this->requestAnalyzer->getSegment()->willReturn();
 
-        $this->request->get('_route')->willReturn('test');
-        $this->request->get('_route_params')->willReturn(['host' => 'sulu.io', 'prefix' => '/de']);
+        $request = new Request();
+        $request->attributes->set('_route', 'test');
+        $request->attributes->set('_route_params', ['host' => 'sulu.io', 'prefix' => '/de']);
+        $this->requestStack->push($request);
 
         $this->router->generate('test', ['host' => 'sulu.io', 'prefix' => '/de'], UrlGeneratorInterface::ABSOLUTE_URL)->willReturn('http://sulu.io/de/test');
         $this->router->generate('test', ['host' => 'sulu.io', 'prefix' => '/en'], UrlGeneratorInterface::ABSOLUTE_URL)->willReturn('http://sulu.io/en/test');
@@ -195,8 +189,10 @@ class TemplateAttributeResolverTest extends TestCase
     {
         $templateAttributeResolver = $this->createTemplateAttributeResolver();
 
-        $this->request->get('_route')->willReturn('test_static')->shouldBeCalled();
-        $this->request->get('_route_params')->willReturn(['host' => 'sulu.io', '_locale' => 'de']);
+        $request = new Request();
+        $request->attributes->set('_route', 'test_static');
+        $request->attributes->set('_route_params', ['host' => 'sulu.io', '_locale' => 'de']);
+        $this->requestStack->push($request);
 
         $this->router->generate('test_static', ['host' => 'sulu.io', '_locale' => 'de'], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://sulu.io/de/test')->shouldBeCalledTimes(1);
@@ -246,8 +242,10 @@ class TemplateAttributeResolverTest extends TestCase
 
     public function testResolveStaticRouteWithoutUrls(): void
     {
-        $this->request->get('_route')->willReturn('test_static')->shouldBeCalled();
-        $this->request->get('_route_params')->willReturn(['host' => 'sulu.io', '_locale' => 'de']);
+        $request = new Request();
+        $request->attributes->set('_route', 'test_static');
+        $request->attributes->set('_route_params', ['host' => 'sulu.io', '_locale' => 'de']);
+        $this->requestStack->push($request);
 
         $this->router->generate('test_static', ['host' => 'sulu.io', '_locale' => 'de'], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('http://sulu.io/de/test')->shouldBeCalledTimes(1);
@@ -299,7 +297,7 @@ class TemplateAttributeResolverTest extends TestCase
             $this->requestAnalyzerResolver,
             $this->webspaceManager->reveal(),
             $this->router->reveal(),
-            $this->requestStack->reveal(),
+            $this->requestStack,
             $this->environment,
             $enabledTwigAttributes
         );


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix to never read route directly from the Request instead only from attributes

#### Why?

Could be dangerous but as the priority is different not a real issue.

Also Symfony 7.4 deprecated the `Request::get` method.