### PR TITLE
Remove parameters.yml file from TestBundle

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
@@ -17,11 +17,6 @@ return static function(PhpFileLoader $loader, ContainerBuilder $container) {
     $filesystem = new Filesystem();
 
     $context = $container->getParameter('sulu.context');
-    $path = __DIR__ . \DIRECTORY_SEPARATOR;
-    if (!$filesystem->exists($path . 'parameters.yml')) {
-        $filesystem->copy($path . 'parameters.yml.dist', $path . 'parameters.yml');
-    }
-    $loader->import('parameters.yml');
     $loader->import('context_' . $context . '.yml');
 
     if ('admin' === $context) {

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/parameters.yml.dist
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/parameters.yml.dist
@@ -1,2 +1,0 @@
-parameters:
-    env(DATABASE_URL): mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -1,3 +1,7 @@
+parameters:
+    # Fallback values (used if environmental variables are not set)
+    env(DATABASE_URL): mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.0&charset=utf8mb4
+
 framework:
     secret: secret
     router: { resource: '%kernel.project_dir%/config/routing.yml' }
@@ -16,7 +20,8 @@ doctrine:
         naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
     dbal:
-        url: '%env(DATABASE_URL)%'
+        url: '%env(resolve:DATABASE_URL)%'
+        dbname_suffix: '_test%env(default::TEST_TOKEN)%'
 
 jms_serializer:
     metadata:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove parameters.yml file from TestBundle.

#### Why?

This mechanic actually is not longer required to run the tests. REAL Env can be set or local used.