### PR TITLE
Update data types for new bundles

### DIFF
--- a/packages/article/src/Domain/Model/Article.php
+++ b/packages/article/src/Domain/Model/Article.php
@@ -27,15 +27,13 @@ class Article implements ArticleInterface
     use ContentRichEntityTrait;
     use AuditableTrait;
 
-    /**
-     * @var string
-     */
-    protected $uuid;
+    protected string $uuid;
 
     public function __construct(
         ?string $uuid = null
     ) {
         $this->uuid = $uuid ?: Uuid::v7()->toRfc4122();
+        $this->initializeDimensionContents();
     }
 
     public function getId(): string // TODO should be replaced by uuid

--- a/packages/article/src/Domain/Model/ArticleDimensionContent.php
+++ b/packages/article/src/Domain/Model/ArticleDimensionContent.php
@@ -47,25 +47,13 @@ class ArticleDimensionContent implements ArticleDimensionContentInterface
     use WebspaceTrait;
     use WorkflowTrait;
 
-    /**
-     * @var int
-     */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @var ArticleInterface
-     */
-    protected $article;
+    protected ArticleInterface $article;
 
-    /**
-     * @var string|null
-     */
-    protected $title;
+    protected ?string $title = null;
 
-    /**
-     * @var bool
-     */
-    private $customizeWebspaceSettings = false;
+    private bool $customizeWebspaceSettings = false;
 
     /**
      * @var Collection<int, ArticleDimensionContentAdditionalWebspace>

--- a/packages/content/src/Domain/Model/AuthorTrait.php
+++ b/packages/content/src/Domain/Model/AuthorTrait.php
@@ -20,20 +20,11 @@ use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
  */
 trait AuthorTrait
 {
-    /**
-     * @var ContactInterface|null
-     */
-    private $author;
+    private ?ContactInterface $author = null;
 
-    /**
-     * @var \DateTimeImmutable|null
-     */
-    private $authored;
+    private ?\DateTimeImmutable $authored = null;
 
-    /**
-     * @var \DateTimeImmutable|null
-     */
-    private $lastModified;
+    private ?\DateTimeImmutable $lastModified = null;
 
     public function getAuthor(): ?ContactInterface
     {

--- a/packages/content/src/Domain/Model/DimensionContentCollection.php
+++ b/packages/content/src/Domain/Model/DimensionContentCollection.php
@@ -26,22 +26,22 @@ class DimensionContentCollection implements DimensionContentCollectionInterface
     /**
      * @var Collection<int, T>
      */
-    private $dimensionContents;
+    private Collection $dimensionContents;
 
     /**
      * @var mixed[]
      */
-    private $dimensionAttributes;
+    private array $dimensionAttributes;
 
     /**
      * @var class-string<T>
      */
-    private $dimensionContentClass;
+    private string $dimensionContentClass;
 
     /**
      * @var mixed[]
      */
-    private $defaultDimensionAttributes;
+    private array $defaultDimensionAttributes;
 
     /**
      * DimensionContentCollection constructor.

--- a/packages/content/src/Domain/Model/DimensionContentTrait.php
+++ b/packages/content/src/Domain/Model/DimensionContentTrait.php
@@ -15,30 +15,18 @@ namespace Sulu\Content\Domain\Model;
 
 trait DimensionContentTrait
 {
-    /**
-     * @var string|null
-     */
-    protected $locale;
+    protected ?string $locale = null;
 
-    /**
-     * @var string|null
-     */
-    protected $ghostLocale;
+    protected ?string $ghostLocale = null;
 
     /**
      * @var string[]|null
      */
-    protected $availableLocales;
+    protected ?array $availableLocales = null;
 
-    /**
-     * @var string
-     */
-    protected $stage = DimensionContentInterface::STAGE_DRAFT;
+    protected string $stage = DimensionContentInterface::STAGE_DRAFT;
 
-    /**
-     * @var bool
-     */
-    private $isMerged = false;
+    private bool $isMerged = false;
 
     private int $version = DimensionContentInterface::CURRENT_VERSION;
 

--- a/packages/content/src/Domain/Model/ExcerptTrait.php
+++ b/packages/content/src/Domain/Model/ExcerptTrait.php
@@ -15,30 +15,15 @@ namespace Sulu\Content\Domain\Model;
 
 trait ExcerptTrait
 {
-    /**
-     * @var string|null
-     */
-    private $excerptTitle;
+    private ?string $excerptTitle = null;
 
-    /**
-     * @var string|null
-     */
-    private $excerptDescription;
+    private ?string $excerptDescription = null;
 
-    /**
-     * @var string|null
-     */
-    private $excerptMore;
+    private ?string $excerptMore = null;
 
-    /**
-     * @var int|null
-     */
-    private $excerptImageId;
+    private ?int $excerptImageId = null;
 
-    /**
-     * @var int|null
-     */
-    private $excerptIconId;
+    private ?int $excerptIconId = null;
 
     public function getExcerptTitle(): ?string
     {

--- a/packages/content/src/Domain/Model/SeoTrait.php
+++ b/packages/content/src/Domain/Model/SeoTrait.php
@@ -15,40 +15,19 @@ namespace Sulu\Content\Domain\Model;
 
 trait SeoTrait
 {
-    /**
-     * @var string|null
-     */
-    private $seoTitle;
+    private ?string $seoTitle = null;
 
-    /**
-     * @var string|null
-     */
-    private $seoDescription;
+    private ?string $seoDescription = null;
 
-    /**
-     * @var string|null
-     */
-    private $seoKeywords;
+    private ?string $seoKeywords = null;
 
-    /**
-     * @var string|null
-     */
-    private $seoCanonicalUrl;
+    private ?string $seoCanonicalUrl = null;
 
-    /**
-     * @var bool
-     */
-    private $seoNoIndex = false;
+    private bool $seoNoIndex = false;
 
-    /**
-     * @var bool
-     */
-    private $seoNoFollow = false;
+    private bool $seoNoFollow = false;
 
-    /**
-     * @var bool
-     */
-    private $seoHideInSitemap = false;
+    private bool $seoHideInSitemap = false;
 
     public function getSeoTitle(): ?string
     {

--- a/packages/content/src/Domain/Model/ShadowTrait.php
+++ b/packages/content/src/Domain/Model/ShadowTrait.php
@@ -15,15 +15,12 @@ namespace Sulu\Content\Domain\Model;
 
 trait ShadowTrait
 {
-    /**
-     * @var string|null
-     */
-    protected $shadowLocale;
+    protected ?string $shadowLocale = null;
 
     /**
      * @var array<string, string>|null
      */
-    protected $shadowLocales;
+    protected ?array $shadowLocales = null;
 
     /**
      * @internal should only be set by content bundle services not from outside

--- a/packages/content/src/Domain/Model/TaxonomyTrait.php
+++ b/packages/content/src/Domain/Model/TaxonomyTrait.php
@@ -35,10 +35,7 @@ trait TaxonomyTrait
      */
     private $excerptAudienceTargetGroups;
 
-    /**
-     * @var string|null
-     */
-    private $excerptSegment;
+    private ?string $excerptSegment = null;
 
     /**
      * @return int[]
@@ -167,7 +164,7 @@ trait TaxonomyTrait
 
     public function getExcerptSegment(): ?string
     {
-        return $this->excerptSegment ?? null;
+        return $this->excerptSegment;
     }
 
     public function setExcerptSegment(?string $excerptSegment): void

--- a/packages/content/src/Domain/Model/TemplateTrait.php
+++ b/packages/content/src/Domain/Model/TemplateTrait.php
@@ -18,15 +18,12 @@ namespace Sulu\Content\Domain\Model;
  */
 trait TemplateTrait
 {
-    /**
-     * @var string|null
-     */
-    private $templateKey;
+    private ?string $templateKey = null;
 
     /**
      * @var array<string, mixed>
      */
-    private $templateData = [];
+    private array $templateData = [];
 
     public function getTemplateKey(): ?string
     {

--- a/packages/content/src/Domain/Model/WebspaceTrait.php
+++ b/packages/content/src/Domain/Model/WebspaceTrait.php
@@ -15,10 +15,7 @@ namespace Sulu\Content\Domain\Model;
 
 trait WebspaceTrait
 {
-    /**
-     * @var string|null
-     */
-    protected $mainWebspace;
+    protected ?string $mainWebspace = null;
 
     public function getMainWebspace(): ?string
     {

--- a/packages/content/src/Domain/Model/WorkflowTrait.php
+++ b/packages/content/src/Domain/Model/WorkflowTrait.php
@@ -15,15 +15,9 @@ namespace Sulu\Content\Domain\Model;
 
 trait WorkflowTrait
 {
-    /**
-     * @var string|null
-     */
-    protected $workflowPlace;
+    protected ?string $workflowPlace = null;
 
-    /**
-     * @var \DateTimeImmutable|null
-     */
-    protected $workflowPublished;
+    protected ?\DateTimeImmutable $workflowPublished = null;
 
     public static function getWorkflowName(): string
     {

--- a/packages/custom-url/src/Domain/Model/CustomUrlRoute.php
+++ b/packages/custom-url/src/Domain/Model/CustomUrlRoute.php
@@ -33,7 +33,7 @@ class CustomUrlRoute implements CustomUrlRouteInterface
         $this->uuid = Uuid::v7()->__toString();
     }
 
-    public function getUuid(): ?string
+    public function getUuid(): string
     {
         return $this->uuid;
     }

--- a/packages/custom-url/tests/Unit/Domain/Model/CustomUrlRouteTest.php
+++ b/packages/custom-url/tests/Unit/Domain/Model/CustomUrlRouteTest.php
@@ -38,7 +38,6 @@ class CustomUrlRouteTest extends TestCase
 
         $uuid = $route->getUuid();
 
-        $this->assertNotNull($uuid);
         // UUID v7 format: xxxxxxxx-xxxx-7xxx-xxxx-xxxxxxxxxxxx
         $this->assertMatchesRegularExpression(
             '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i',

--- a/packages/snippet/src/Domain/Model/Snippet.php
+++ b/packages/snippet/src/Domain/Model/Snippet.php
@@ -27,15 +27,13 @@ class Snippet implements SnippetInterface
     use ContentRichEntityTrait;
     use AuditableTrait;
 
-    /**
-     * @var string
-     */
-    protected $uuid;
+    protected string $uuid;
 
     public function __construct(
         ?string $uuid = null
     ) {
         $this->uuid = $uuid ?: Uuid::v7()->__toString();
+        $this->initializeDimensionContents();
     }
 
     public function getId(): string // TODO should be replaced by uuid

--- a/packages/snippet/src/Domain/Model/SnippetDimensionContent.php
+++ b/packages/snippet/src/Domain/Model/SnippetDimensionContent.php
@@ -33,20 +33,11 @@ class SnippetDimensionContent implements SnippetDimensionContentInterface
     use TaxonomyTrait;
     use AuditableTrait;
 
-    /**
-     * @var int
-     */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @var SnippetInterface
-     */
-    protected $snippet;
+    protected SnippetInterface $snippet;
 
-    /**
-     * @var string|null
-     */
-    protected $title;
+    protected ?string $title = null;
 
     public function __construct(SnippetInterface $snippet)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds native php types instead of phpdoc types for entities in the refactored bundles.

#### Why?

Better type safety.