### PR TITLE
Remove deprecated media title generation

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1170,6 +1170,7 @@ and some parameters have been removed)
 - `Sulu\Bundle\TagBundle\Tag\TagManager::findAll` (use repository instead)
 - `Sulu\Bundle\TagBundle\Tag\TagManagerInterface::resolveTagIds` (use the Repository)
 - `Sulu\Bundle\TagBundle\Tag\TagManagerInterface::resolveTagNames` (use the Repository)
+- `Sulu\Bundle\MediaBundle\Controller\AbstractMediaController::getTitleFromUpload` (use MediaManager function)
 
 Removed unused arguments:
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
@@ -30,34 +30,10 @@ abstract class AbstractMediaController extends AbstractRestController
         $data = $request->request->all();
         $data['locale'] = $request->get('locale', $fallback ? $this->getLocale($request) : null);
         $data['collection'] = $request->get('collection');
-
-        // @deprecated Just prefill from request here and let the MediaManager set the default title
-        $data['title'] = $request->get('title', $fallback ? $this->getTitleFromUpload($request) : null);
+        $data['title'] = $request->get('title');
         $data['formats'] = $request->get('formats', []);
 
         return $data;
-    }
-
-    /**
-     * @deprecated If you want to customize this please change the MediaManager::getTitleFromUpload
-     *
-     * @param Request $request
-     *
-     * @return string|null
-     */
-    protected function getTitleFromUpload($request)
-    {
-        $uploadedFile = $this->getUploadedFile($request, 'fileVersion');
-
-        if ($uploadedFile) {
-            if (false === \strpos($uploadedFile->getClientOriginalName(), '.')) {
-                return $uploadedFile->getClientOriginalName();
-            }
-
-            return \implode('.', \explode('.', $uploadedFile->getClientOriginalName(), -1));
-        }
-
-        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManagerInterface.php
@@ -49,6 +49,8 @@ interface MediaManagerInterface
      * @param string $locale the locale which the object will be returned
      *
      * @return Media
+     *
+     * @throws MediaNotFoundException
      */
     public function getById($id, $locale);
 
@@ -58,6 +60,8 @@ interface MediaManagerInterface
      * @param int $id
      *
      * @return MediaInterface
+     *
+     * @throws MediaNotFoundException
      */
     public function getEntityById($id);
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Remove deprecated function to generate media in controller.

#### Why?
This should be part of the manager now.
