### PR TITLE
Replace Sulu Common Dir with Symfony new Share Dir

### DIFF
--- a/.env
+++ b/.env
@@ -5,9 +5,16 @@
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_SECRET=a448d1dfcaa563fce56c2fd9981f662b
+APP_SHARE_DIR=var/share
 #TRUSTED_PROXIES=127.0.0.1,127.0.0.2
 #TRUSTED_HOSTS=localhost,example.com
 ###< symfony/framework-bundle ###
+
+###> symfony/routing ###
+# Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
+# See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
+DEFAULT_URI=http://localhost
+###< symfony/routing ###
 
 ###> cmsig/seal-symfony-bundle ###
 SEAL_DSN=loupe://%kernel.project_dir%/var/indexes

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1186,6 +1186,7 @@ Removed kernel parameters:
 
 - All `sulu_*.class` parameters for services where removed (use compilerpasses to replace class of a service definition)
 - Parameter `%permissions%` was replaced in favor of `%sulu_security.permissions%`
+- The `%sulu.common_cache_dir%` dir was replace by `%kernel.share_dir%`
 
 Removed JavaScript files and methods:
 

--- a/config/packages/routing.yaml
+++ b/config/packages/routing.yaml
@@ -1,10 +1,8 @@
 framework:
     router:
-        utf8: true
-
         # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
         # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
-        #default_uri: http://localhost
+        default_uri: '%env(DEFAULT_URI)%'
 
 when@prod: &prod
     framework:

--- a/packages/article/tests/Application/Kernel.php
+++ b/packages/article/tests/Application/Kernel.php
@@ -74,8 +74,8 @@ class Kernel extends SuluTestKernel
         return parent::getCacheDir() . '/' . $this->config;
     }
 
-    public function getCommonCacheDir(): string
+    public function getShareDir(): string
     {
-        return parent::getCommonCacheDir() . '/' . $this->config;
+        return parent::getShareDir() . '/' . $this->config;
     }
 }

--- a/packages/custom-url/tests/Application/Kernel.php
+++ b/packages/custom-url/tests/Application/Kernel.php
@@ -56,8 +56,8 @@ class Kernel extends SuluTestKernel
         return parent::getCacheDir() . '/' . $this->config;
     }
 
-    public function getCommonCacheDir(): string
+    public function getShareDir(): string
     {
-        return parent::getCommonCacheDir() . '/' . $this->config;
+        return parent::getShareDir() . '/' . $this->config;
     }
 }

--- a/packages/page/tests/Application/Kernel.php
+++ b/packages/page/tests/Application/Kernel.php
@@ -81,8 +81,8 @@ class Kernel extends SuluTestKernel
         return parent::getCacheDir() . '/' . $this->config;
     }
 
-    public function getCommonCacheDir(): string
+    public function getShareDir(): string
     {
-        return parent::getCommonCacheDir() . '/' . $this->config;
+        return parent::getShareDir() . '/' . $this->config;
     }
 }

--- a/packages/route/tests/Application/Kernel.php
+++ b/packages/route/tests/Application/Kernel.php
@@ -102,8 +102,8 @@ class Kernel extends SuluTestKernel implements CompilerPassInterface
         return parent::getCacheDir() . '/' . $this->config;
     }
 
-    public function getCommonCacheDir(): string
+    public function getShareDir(): string
     {
-        return parent::getCommonCacheDir() . '/' . $this->config;
+        return parent::getShareDir() . '/' . $this->config;
     }
 }

--- a/packages/search/tests/Application/Kernel.php
+++ b/packages/search/tests/Application/Kernel.php
@@ -74,8 +74,8 @@ class Kernel extends SuluTestKernel
         return parent::getCacheDir() . '/' . $this->config;
     }
 
-    public function getCommonCacheDir(): string
+    public function getShareDir(): string
     {
-        return parent::getCommonCacheDir() . '/' . $this->config;
+        return parent::getShareDir() . '/' . $this->config;
     }
 }

--- a/packages/snippet/tests/Application/Kernel.php
+++ b/packages/snippet/tests/Application/Kernel.php
@@ -72,8 +72,8 @@ class Kernel extends SuluTestKernel
         return parent::getCacheDir() . '/' . $this->config;
     }
 
-    public function getCommonCacheDir(): string
+    public function getShareDir(): string
     {
-        return parent::getCommonCacheDir() . '/' . $this->config;
+        return parent::getShareDir() . '/' . $this->config;
     }
 }

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -226,7 +226,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                 'framework',
                 [
                     'cache' => [
-                        'directory' => '%sulu.common_cache_dir%/pools',
+                        'directory' => '%kernel.share_dir%/pools',
                     ],
                 ]
             );

--- a/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Cache/SuluHttpCache.php
@@ -48,7 +48,7 @@ class SuluHttpCache extends HttpCache implements CacheInvalidation
     public function __construct(HttpKernelInterface $kernel, $cacheDir = null, ?bool $debug = null)
     {
         if (!$cacheDir && $kernel instanceof SuluKernel) {
-            $cacheDir = $kernel->getCommonCacheDir() . \DIRECTORY_SEPARATOR . 'http_cache';
+            $cacheDir = $kernel->getShareDir() . \DIRECTORY_SEPARATOR . 'http_cache';
         }
 
         parent::__construct($kernel, $cacheDir);

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/Kernel.php
@@ -62,8 +62,8 @@ class Kernel extends SuluTestKernel
         return parent::getCacheDir() . \ltrim('/' . $this->appContext);
     }
 
-    public function getCommonCacheDir(): string
+    public function getShareDir(): string
     {
-        return parent::getCommonCacheDir() . \ltrim('/' . $this->appContext);
+        return parent::getShareDir() . \ltrim('/' . $this->appContext);
     }
 }

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -216,12 +216,31 @@ abstract class SuluKernel extends Kernel
             . $this->environment;
     }
 
-    public function getCommonCacheDir(): string
+    /**
+     * Remove this method when minimum Symfony version is 7.4.
+     */
+    public function getShareDir(): ?string
     {
+        if (\method_exists(parent::class, 'getShareDir')) {
+            return parent::getShareDir();
+        }
+
+        // Remove this method when minimum Symfony version is 7.4.
+        if (null !== $dir = $_SERVER['APP_SHARE_DIR'] ?? null) {
+            if (false === $dir = \filter_var($dir, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? $dir) {
+                return null;
+            }
+
+            if (\is_string($dir)) {
+                return $this->getProjectDir() . \DIRECTORY_SEPARATOR
+                    . $dir . \DIRECTORY_SEPARATOR
+                    . $this->environment;
+            }
+        }
+
         return $this->getProjectDir() . \DIRECTORY_SEPARATOR
             . 'var' . \DIRECTORY_SEPARATOR
-            . 'cache' . \DIRECTORY_SEPARATOR
-            . 'common' . \DIRECTORY_SEPARATOR
+            . 'share' . \DIRECTORY_SEPARATOR
             . $this->environment;
     }
 
@@ -272,8 +291,9 @@ abstract class SuluKernel extends Kernel
             parent::getKernelParameters(),
             [
                 'sulu.context' => $this->context,
-                'sulu.common_cache_dir' => $this->getCommonCacheDir(),
-            ]
+                // remove when minimum Symfony Version is 7.4:
+                ...(($dir = $this->getShareDir()) ? ['kernel.share_dir' => \realpath($dir) ?: $dir] : []),
+            ],
         );
     }
 

--- a/src/Sulu/Component/HttpKernel/SuluKernel.php
+++ b/src/Sulu/Component/HttpKernel/SuluKernel.php
@@ -216,16 +216,12 @@ abstract class SuluKernel extends Kernel
             . $this->environment;
     }
 
-    /**
-     * Remove this method when minimum Symfony version is 7.4.
-     */
     public function getShareDir(): ?string
     {
-        if (\method_exists(parent::class, 'getShareDir')) {
-            return parent::getShareDir();
-        }
+        // Remove this method in favor of Symfony own one when:
+        //  - minimum Symfony version is 7.4.
+        //  - cache dir is no longer context specific
 
-        // Remove this method when minimum Symfony version is 7.4.
         if (null !== $dir = $_SERVER['APP_SHARE_DIR'] ?? null) {
             if (false === $dir = \filter_var($dir, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? $dir) {
                 return null;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Replace Sulu Common Dir with Symfony new Share Dir.

#### Why?

Symfony 7.4 provides the new Share Dir which is similar to our mechanic with Common Dir. Specially used in Upson / Symfony Cloud setup to store shared caches (app cache).