### PR TITLE
Rename Route::site to Route::webspace

### DIFF
--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
@@ -86,7 +86,7 @@ class ArticleSmartContentProviderTest extends SuluTestCase
 
         // TODO this should not be necessary
         $requestContext = $container->get('router.request_context');
-        $requestContext->setParameter(RequestAttributeEnum::SITE->value, 'sulu-io');
+        $requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, 'sulu-io');
         // TODO this should not be necessary
 
         // Create categories

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/PageTreeArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/PageTreeArticleSmartContentProviderTest.php
@@ -62,7 +62,7 @@ class PageTreeArticleSmartContentProviderTest extends SuluTestCase
         $routeRepository = $container->get('sulu_route.route_repository');
 
         $requestContext = $container->get('router.request_context');
-        $requestContext->setParameter(RequestAttributeEnum::SITE->value, 'sulu-io');
+        $requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, 'sulu-io');
 
         // Create parent pages
         self::$pages['blog'] = self::createPage([

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -43,7 +43,7 @@ class ArticleControllerTest extends SuluTestCase
 
         // TODO this should not be necessary
         $requestContext = self::getContainer()->get('router.request_context');
-        $requestContext->setParameter(RequestAttributeEnum::SITE->value, 'sulu-io');
+        $requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, 'sulu-io');
         // TODO this should not be necessary
     }
 

--- a/packages/content/tests/Functional/Integration/ExampleControllerAvailableAndShadowLocalesTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerAvailableAndShadowLocalesTest.php
@@ -43,7 +43,7 @@ class ExampleControllerAvailableAndShadowLocalesTest extends SuluTestCase
         // TODO this should not be necessary
         $this->client->disableReboot();
         $requestContext = self::getContainer()->get('router.request_context');
-        $requestContext->setParameter(RequestAttributeEnum::SITE->value, 'sulu-io');
+        $requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, 'sulu-io');
         // TODO this should not be necessary
     }
 

--- a/packages/page/src/Domain/Model/PageDimensionContent.php
+++ b/packages/page/src/Domain/Model/PageDimensionContent.php
@@ -92,7 +92,7 @@ class PageDimensionContent implements PageDimensionContentInterface
 
     public function setRoute(Route $route): void
     {
-        $route->setSite($this->getResource()->getWebspaceKey());
+        $route->setWebspace($this->getResource()->getWebspaceKey());
 
         $this->parentSetRoute($route);
     }

--- a/packages/page/src/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriber.php
+++ b/packages/page/src/Infrastructure/Sulu/HttpCache/EventSubscriber/PageCacheInvalidationSubscriber.php
@@ -98,7 +98,7 @@ class PageCacheInvalidationSubscriber implements EventSubscriberInterface
             $url = $this->routeGenerator->generate(
                 $route->getSlug(),
                 $route->getLocale(),
-                $route->getSite(),
+                $route->getWebspace(),
                 UrlGeneratorInterface::ABSOLUTE_URL
             );
 

--- a/packages/page/src/Infrastructure/Sulu/Route/PageWebspaceRouteGenerator.php
+++ b/packages/page/src/Infrastructure/Sulu/Route/PageWebspaceRouteGenerator.php
@@ -12,7 +12,7 @@
 namespace Sulu\Page\Infrastructure\Sulu\Route;
 
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
-use Sulu\Route\Application\Routing\Generator\SiteRouteGeneratorInterface;
+use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
 use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +24,7 @@ use Symfony\Component\Routing\RequestContext;
  *
  * @internal this class is internal and should not be extended or overwritten
  */
-class WebspaceSiteRouteGenerator implements SiteRouteGeneratorInterface
+class PageWebspaceRouteGenerator implements WebspaceRouteGeneratorInterface
 {
     public function __construct(
         private readonly WebspaceManagerInterface $webspaceManager,
@@ -34,18 +34,18 @@ class WebspaceSiteRouteGenerator implements SiteRouteGeneratorInterface
 
     public function generate(RequestContext $requestContext, string $slug, string $locale): string
     {
-        $site = $requestContext->getParameter(RequestAttributeEnum::SITE->value);
+        $site = $requestContext->getParameter(RequestAttributeEnum::WEBSPACE->value);
         if (!\is_string($site)) {
             $currentRequest = $this->requestStack->getCurrentRequest();
 
             if (!$currentRequest instanceof Request) {
-                throw new MissingRequestContextParameterException(RequestAttributeEnum::SITE->value);
+                throw new MissingRequestContextParameterException(RequestAttributeEnum::WEBSPACE->value);
             }
 
-            $site = $currentRequest->attributes->get(RequestAttributeEnum::SITE->value); // TODO the requestContext should be kept in sync via listener with request attributes
+            $site = $currentRequest->attributes->get(RequestAttributeEnum::WEBSPACE->value); // TODO the requestContext should be kept in sync via listener with request attributes
 
             if (!\is_string($site)) {
-                throw new MissingRequestContextParameterException(RequestAttributeEnum::SITE->value);
+                throw new MissingRequestContextParameterException(RequestAttributeEnum::WEBSPACE->value);
             }
         }
 

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -67,7 +67,7 @@ use Sulu\Page\Infrastructure\Sulu\Content\Visitor\PageSmartContentFiltersVisitor
 use Sulu\Page\Infrastructure\Sulu\Content\Visitor\SegmentSmartContentFiltersVisitor;
 use Sulu\Page\Infrastructure\Sulu\HttpCache\EventSubscriber\PageCacheInvalidationSubscriber;
 use Sulu\Page\Infrastructure\Sulu\Reference\PageReferenceRefresher;
-use Sulu\Page\Infrastructure\Sulu\Route\WebspaceSiteRouteGenerator;
+use Sulu\Page\Infrastructure\Sulu\Route\PageWebspaceRouteGenerator;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexContentEnhancer;
@@ -335,13 +335,13 @@ final class SuluPageBundle extends AbstractBundle
             ->tag('sulu.admin');
 
         // Route Integration
-        $services->set('sulu_page.webspace_site_route_generator')
-            ->class(WebspaceSiteRouteGenerator::class)
+        $services->set('sulu_page.page_webspace_route_generator')
+            ->class(PageWebspaceRouteGenerator::class)
             ->args([
                 new Reference('sulu_core.webspace.webspace_manager'),
                 new Reference('request_stack'),
             ])
-            ->tag('sulu_route.site_route_generator', ['site' => '.default']);
+            ->tag('sulu_route.webspace_route_generator', ['webspace' => '.default']);
 
         $services->set('sulu_page.webspace_route_mode_typed_form_metadata_visitor')
             ->class(WebspaceRouteModeTypedFormMetadataVisitor::class)

--- a/packages/page/tests/Unit/Domain/Model/PageDimensionContentTest.php
+++ b/packages/page/tests/Unit/Domain/Model/PageDimensionContentTest.php
@@ -131,7 +131,7 @@ class PageDimensionContentTest extends TestCase
     public function testSetRoute(): void
     {
         $route = $this->prophesize(Route::class);
-        $route->setSite('sulu-io')->shouldBeCalled()->willReturn($route->reveal());
+        $route->setWebspace('sulu-io')->shouldBeCalled()->willReturn($route->reveal());
 
         $this->pageDimensionContent->setRoute($route->reveal());
 

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/ContentPathTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/ContentPathTwigExtensionTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\ContentPathTwigExtension;
 use Sulu\Route\Application\Routing\Generator\RouteGenerator;
-use Sulu\Route\Application\Routing\Generator\SiteRouteGeneratorInterface;
+use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -47,7 +47,7 @@ class ContentPathTwigExtensionTest extends TestCase
             $this->requestContext,
         );
 
-        $websiteRouteGenerator = new class() implements SiteRouteGeneratorInterface {
+        $websiteRouteGenerator = new class() implements WebspaceRouteGeneratorInterface {
             public function generate(RequestContext $requestContext, string $slug, string $locale): string
             {
                 $port = match ($requestContext->getScheme()) {
@@ -67,7 +67,7 @@ class ContentPathTwigExtensionTest extends TestCase
             }
         };
 
-        $intranetRouteGenerator = new class() implements SiteRouteGeneratorInterface {
+        $intranetRouteGenerator = new class() implements WebspaceRouteGeneratorInterface {
             public function generate(RequestContext $requestContext, string $slug, string $locale): string
             {
                 $port = match ($requestContext->getScheme()) {
@@ -117,7 +117,7 @@ class ContentPathTwigExtensionTest extends TestCase
     #[TestWith(['http://intranet.localhost/de/test', '/test', 'intranet', 'de'])]
     public function testSuluContentPath(string $expectedUrl, string $slug, ?string $webspaceKey = null, ?string $locale = null): void
     {
-        $this->requestContext->setParameter(RequestAttributeEnum::SITE->value, 'website');
+        $this->requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, 'website');
 
         $this->assertSame(
             $expectedUrl,
@@ -127,7 +127,7 @@ class ContentPathTwigExtensionTest extends TestCase
 
     public function testSuluContentRootPath(): void
     {
-        $this->requestContext->setParameter(RequestAttributeEnum::SITE->value, 'website');
+        $this->requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, 'website');
 
         $this->assertSame(
             '/en',

--- a/packages/route/config/doctrine/Route/Route.orm.xml
+++ b/packages/route/config/doctrine/Route/Route.orm.xml
@@ -7,7 +7,7 @@
         table="ro_routes"
     ><!-- FIXME change route to `ro_routes` -->
         <unique-constraints>
-            <unique-constraint name="ro_routes_unique" fields="site,locale,slug" />
+            <unique-constraint name="ro_routes_unique" fields="webspace,locale,slug" />
         </unique-constraints>
 
         <indexes>
@@ -18,7 +18,7 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="site" type="string" length="31" nullable="true"/>
+        <field name="webspace" type="string" length="31" nullable="true"/>
         <field name="locale" type="string" length="15"/>
         <field name="slug" type="string" length="144"/>
 

--- a/packages/route/src/Application/ResourceLocator/ResourceLocatorGenerator.php
+++ b/packages/route/src/Application/ResourceLocator/ResourceLocatorGenerator.php
@@ -49,7 +49,7 @@ final readonly class ResourceLocatorGenerator implements ResourceLocatorGenerato
         $uniquePath = $this->createUnique( // TODO own service called during doctrine listener also?
             $parentPath . $path,
             $request->locale,
-            $request->site,
+            $request->webspace,
             $request->resourceKey,
             $request->resourceId,
         );
@@ -64,7 +64,7 @@ final readonly class ResourceLocatorGenerator implements ResourceLocatorGenerato
     private function createUnique(
         string $path,
         string $locale,
-        ?string $site,
+        ?string $webspace,
         string $resourceKey,
         ?string $resourceId,
     ): string {
@@ -74,7 +74,7 @@ final readonly class ResourceLocatorGenerator implements ResourceLocatorGenerato
         while ($this->routeRepository->existBy(
             $resourceId ? [
                 'locale' => $locale,
-                'site' => $site,
+                'webspace' => $webspace,
                 'slug' => $path,
                 'excludeResource' => [
                     'resourceKey' => $resourceKey,
@@ -82,7 +82,7 @@ final readonly class ResourceLocatorGenerator implements ResourceLocatorGenerato
                 ],
             ] : [
                 'locale' => $locale,
-                'site' => $site,
+                'webspace' => $webspace,
                 'slug' => $path,
             ],
         )) {

--- a/packages/route/src/Application/ResourceLocator/ResourceLocatorRequest.php
+++ b/packages/route/src/Application/ResourceLocator/ResourceLocatorRequest.php
@@ -21,7 +21,7 @@ final readonly class ResourceLocatorRequest
     public function __construct(
         public array $parts,
         public string $locale,
-        public ?string $site,
+        public ?string $webspace,
         public string $resourceKey,
         public ?string $resourceId,
         public ?string $parentResourceId,

--- a/packages/route/src/Application/Routing/Generator/RouteGenerator.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGenerator.php
@@ -23,27 +23,27 @@ use Symfony\Component\Translation\LocaleSwitcher;
 final class RouteGenerator implements RouteGeneratorInterface
 {
     public function __construct(
-        private ContainerInterface $siteRouteGeneratorLocator,
+        private ContainerInterface $webspaceRouteGeneratorLocator,
         private RequestContext $requestContext,
         private RequestStack $requestStack,
         private LocaleSwitcher $localeSwitcher,
     ) {
     }
 
-    public function generate(string $slug, ?string $locale = null, ?string $site = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
+    public function generate(string $slug, ?string $locale = null, ?string $webspace = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string
     {
-        if (null === $site) {
-            $requestSite = $this->requestContext->getParameter(RequestAttributeEnum::SITE->value);
+        if (null === $webspace) {
+            $requestWebspace = $this->requestContext->getParameter(RequestAttributeEnum::WEBSPACE->value);
 
-            if (!\is_string($requestSite)) {
-                $requestSite = $this->requestStack->getCurrentRequest()?->attributes->get(RequestAttributeEnum::SITE->value);
+            if (!\is_string($requestWebspace)) {
+                $requestWebspace = $this->requestStack->getCurrentRequest()?->attributes->get(RequestAttributeEnum::WEBSPACE->value);
             }
 
-            if (!\is_string($requestSite)) {
-                throw new MissingRequestContextParameterException(RequestAttributeEnum::SITE->value);
+            if (!\is_string($requestWebspace)) {
+                throw new MissingRequestContextParameterException(RequestAttributeEnum::WEBSPACE->value);
             }
 
-            $site = $requestSite;
+            $webspace = $requestWebspace;
         }
 
         if (null === $locale) {
@@ -55,16 +55,16 @@ final class RouteGenerator implements RouteGeneratorInterface
             }
         }
 
-        $siteRouteGenerator = null;
-        if ($this->siteRouteGeneratorLocator->has($site)) {
-            $siteRouteGenerator = $this->siteRouteGeneratorLocator->get($site);
-        } elseif ($this->siteRouteGeneratorLocator->has('.default')) { // TODO discuss how we should handle this, currently a workaround to avoid register one per webspace
-            $siteRouteGenerator = $this->siteRouteGeneratorLocator->get('.default');
+        $webspaceRouteGenerator = null;
+        if ($this->webspaceRouteGeneratorLocator->has($webspace)) {
+            $webspaceRouteGenerator = $this->webspaceRouteGeneratorLocator->get($webspace);
+        } elseif ($this->webspaceRouteGeneratorLocator->has('.default')) { // TODO discuss how we should handle this, currently a workaround to avoid register one per webspace
+            $webspaceRouteGenerator = $this->webspaceRouteGeneratorLocator->get('.default');
         }
 
-        \assert($siteRouteGenerator instanceof SiteRouteGeneratorInterface, 'The SiteRouteGenerator for "' . $site . '" must implement SiteRouteGeneratorInterface but got: ' . \get_debug_type($siteRouteGenerator));
+        \assert($webspaceRouteGenerator instanceof WebspaceRouteGeneratorInterface, 'The WebspaceRouteGenerator for "' . $webspace . '" must implement WebspaceRouteGeneratorInterface but got: ' . \get_debug_type($webspaceRouteGenerator));
 
-        $generatedUrl = $siteRouteGenerator->generate($this->requestContext, $slug, $locale);
+        $generatedUrl = $webspaceRouteGenerator->generate($this->requestContext, $slug, $locale);
 
         $schemeAndHttpHost = \sprintf(
             '%s://%s%s/',

--- a/packages/route/src/Application/Routing/Generator/RouteGeneratorInterface.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGeneratorInterface.php
@@ -19,5 +19,5 @@ interface RouteGeneratorInterface
     /**
      * @throws MissingRequestContextParameterException
      */
-    public function generate(string $slug, ?string $locale = null, ?string $site = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string;
+    public function generate(string $slug, ?string $locale = null, ?string $webspace = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string;
 }

--- a/packages/route/src/Application/Routing/Generator/WebspaceRouteGeneratorInterface.php
+++ b/packages/route/src/Application/Routing/Generator/WebspaceRouteGeneratorInterface.php
@@ -13,7 +13,7 @@ namespace Sulu\Route\Application\Routing\Generator;
 
 use Symfony\Component\Routing\RequestContext;
 
-interface SiteRouteGeneratorInterface
+interface WebspaceRouteGeneratorInterface
 {
     public function generate(RequestContext $requestContext, string $slug, string $locale): string;
 }

--- a/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
+++ b/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\RouteCollection;
 /**
  * @internal This is an internal class overwrite by decorate the service and use the `RouteCollectionForRequestLoaderInterface` not this class.
  *
- * The RouteLoader requires that a previous request listener has set the site and slug attributes. In case of Sulu
+ * The RouteLoader requires that a previous request listener has set the webspace and slug attributes. In case of Sulu
  * this is done inside the PageBundle via a WebspaceRequestListener.
  */
 final readonly class RouteCollectionForRequestRouteLoader implements RouteCollectionForRequestLoaderInterface
@@ -40,21 +40,21 @@ final readonly class RouteCollectionForRequestRouteLoader implements RouteCollec
     public function getRouteCollectionForRequest(Request $request): RouteCollection
     {
         $locale = $request->getLocale();
-        $site = $request->attributes->get(RequestAttributeEnum::SITE->value);
+        $webspace = $request->attributes->get(RequestAttributeEnum::WEBSPACE->value);
         $slug = $request->attributes->get(RequestAttributeEnum::SLUG->value);
 
-        if (null === $site) {
+        if (null === $webspace) {
             // TODO remove this bridge the routing should not know about webspaces and the sulu routes attributes
             $suluAttribute = $request->attributes->get('_sulu');
             if ($suluAttribute instanceof RequestAttributes) {
                 $portalInformation = $suluAttribute->getAttribute('portalInformation');
 
                 if ($portalInformation instanceof PortalInformation) {
-                    $site = $portalInformation->getWebspaceKey();
+                    $webspace = $portalInformation->getWebspaceKey();
 
-                    if ($site) {
-                        $request->attributes->set(RequestAttributeEnum::SITE->value, $site);
-                        $this->requestContext->setParameter(RequestAttributeEnum::SITE->value, $site);
+                    if ($webspace) {
+                        $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, $webspace);
+                        $this->requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, $webspace);
                     }
                 }
 
@@ -76,17 +76,17 @@ final readonly class RouteCollectionForRequestRouteLoader implements RouteCollec
             }
         }
 
-        if ((null !== $site && !\is_string($site))
+        if ((null !== $webspace && !\is_string($webspace))
             || !\is_string($slug)
         ) {
             return new RouteCollection();
         }
 
         $route = $this->routeRepository->findFirstBy([
-            'siteOrNull' => $site,
+            'webspaceOrNull' => $webspace,
             'locale' => $locale,
             'slug' => $slug,
-        ], ['site' => 'desc']);
+        ], ['webspace' => 'desc']);
 
         if (null === $route) {
             return new RouteCollection();

--- a/packages/route/src/Application/Routing/Matcher/RouteHistoryDefaultsProvider.php
+++ b/packages/route/src/Application/Routing/Matcher/RouteHistoryDefaultsProvider.php
@@ -52,7 +52,7 @@ final readonly class RouteHistoryDefaultsProvider implements RouteDefaultsProvid
             throw new GoneHttpException(\sprintf('The target route with resourceKey "%s" and resourceId "%s" no longer exists.', $resourceKey, $resourceId));
         }
 
-        $url = $this->routeGenerator->generate($targetRoute->getSlug(), $targetRoute->getLocale(), $targetRoute->getSite());
+        $url = $this->routeGenerator->generate($targetRoute->getSlug(), $targetRoute->getLocale(), $targetRoute->getWebspace());
 
         return [
             '_controller' => RedirectController::class,

--- a/packages/route/src/Domain/Model/Route.php
+++ b/packages/route/src/Domain/Model/Route.php
@@ -26,7 +26,7 @@ class Route
 
     private int $id;
 
-    private ?string $site;
+    private ?string $webspace;
 
     private string $locale;
 
@@ -45,13 +45,13 @@ class Route
      */
     private mixed $resourceIdCallable = null;
 
-    public function __construct(string $resourceKey, string $resourceId, string $locale, string $slug, ?string $site = null, ?Route $parentRoute = null)
+    public function __construct(string $resourceKey, string $resourceId, string $locale, string $slug, ?string $webspace = null, ?Route $parentRoute = null)
     {
         $this->resourceKey = $resourceKey;
         $this->resourceId = $resourceId;
         $this->locale = $locale;
         $this->slug = $slug;
-        $this->site = $site;
+        $this->webspace = $webspace;
         $this->parentRoute = $parentRoute;
     }
 
@@ -67,7 +67,7 @@ class Route
      *
      * @param (callable(): string) $resourceIdCallable Example of a callable: fn(): string => (string) $entity->getId()
      */
-    public static function createRouteWithTempId(string $resourceKey, callable $resourceIdCallable, string $locale, string $slug, ?string $site = null, ?Route $parentRoute = null): Route
+    public static function createRouteWithTempId(string $resourceKey, callable $resourceIdCallable, string $locale, string $slug, ?string $webspace = null, ?Route $parentRoute = null): Route
     {
         // to avoid confuses with widely used uuids in our own code we use a not so widely used ULID in base58 format
         $tempId = self::TEMPORARY_RESOURCE_IDENTIFIER . '::' . (new Ulid())->toBase58();
@@ -77,7 +77,7 @@ class Route
             $tempId,
             $locale,
             $slug,
-            $site,
+            $webspace,
             $parentRoute
         );
 
@@ -112,14 +112,14 @@ class Route
         return $this->id;
     }
 
-    public function getSite(): ?string
+    public function getWebspace(): ?string
     {
-        return $this->site;
+        return $this->webspace;
     }
 
-    public function setSite(?string $site): static
+    public function setWebspace(?string $webspace): static
     {
-        $this->site = $site;
+        $this->webspace = $webspace;
 
         return $this;
     }

--- a/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
+++ b/packages/route/src/Domain/Repository/RouteRepositoryInterface.php
@@ -17,8 +17,8 @@ use Sulu\Route\Domain\Model\Route;
 /**
  * @phpstan-type RouteFilter array{
  *     id?: int|null,
- *     site?: string|null,
- *     siteOrNull?: string|null,
+ *     webspace?: string|null,
+ *     webspaceOrNull?: string|null,
  *     locale?: string,
  *     locales?: string[],
  *     slug?: string,
@@ -30,7 +30,7 @@ use Sulu\Route\Domain\Model\Route;
  *     },
  * }
  * @phpstan-type RouteSortBy array{
- *     site?: 'asc'|'desc',
+ *     webspace?: 'asc'|'desc',
  * }
  */
 interface RouteRepositoryInterface

--- a/packages/route/src/Domain/Value/RequestAttributeEnum.php
+++ b/packages/route/src/Domain/Value/RequestAttributeEnum.php
@@ -13,7 +13,7 @@ namespace Sulu\Route\Domain\Value;
 
 enum RequestAttributeEnum: string
 {
-    case SITE = 'site';
+    case WEBSPACE = 'webspace';
 
     case SLUG = 'slug';
 }

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -33,7 +33,7 @@ use Symfony\Contracts\Service\ResetInterface;
 class RouteChangedUpdater implements ResetInterface
 {
     /**
-     * @var array<int, array{oldSlug: string, oldSite: string|null, route: Route}>
+     * @var array<int, array{oldSlug: string, oldWebspace: string|null, route: Route}>
      */
     private array $routeChanges = [];
 
@@ -55,10 +55,10 @@ class RouteChangedUpdater implements ResetInterface
             \assert(\is_string($oldSlug), 'Slug is expected to be always a string.');
         }
 
-        $oldSite = $route->getSite();
-        if ($args->hasChangedField('site')) {
-            $oldSite = $args->getOldValue('site');
-            \assert(\is_string($oldSite) || \is_null($oldSite), 'Site is expected to be always a string or null.');
+        $oldWebspace = $route->getWebspace();
+        if ($args->hasChangedField('webspace')) {
+            $oldWebspace = $args->getOldValue('webspace');
+            \assert(\is_string($oldWebspace) || \is_null($oldWebspace), 'Webspace is expected to be always a string or null.');
         }
 
         if ($oldSlug === $route->getSlug()) {
@@ -67,7 +67,7 @@ class RouteChangedUpdater implements ResetInterface
 
         $this->routeChanges[$route->getId()] = [
             'oldSlug' => $oldSlug,
-            'oldSite' => $oldSite,
+            'oldWebspace' => $oldWebspace,
             'route' => $route,
         ];
     }
@@ -123,21 +123,21 @@ class RouteChangedUpdater implements ResetInterface
         foreach ($this->routeChanges as $routeChange) {
             $route = $routeChange['route'];
             $oldSlug = $routeChange['oldSlug'];
-            $oldSite = $routeChange['oldSite'];
+            $oldWebspace = $routeChange['oldWebspace'];
             $newSlug = $route->getSlug();
             $locale = $route->getLocale();
-            $site = $route->getSite();
+            $webspace = $route->getWebspace();
 
             // select all child and grand routes of oldSlug
             $selectQueryBuilder = $connection->createQueryBuilder()
                 ->from($routesTableName, 'parent')
                 ->select('parent.id AS parent_id')
-                ->addSelect('child.site')
+                ->addSelect('child.webspace')
                 ->addSelect('child.slug')
                 ->addSelect('child.resource_key')
                 ->addSelect('child.resource_id')
                 ->innerJoin('parent', $routesTableName, 'child', 'child.parent_id = parent.id')
-                ->andWhere(\is_string($site) ? 'parent.site = :site' : 'parent.site IS NULL')
+                ->andWhere(\is_string($webspace) ? 'parent.webspace = :webspace' : 'parent.webspace IS NULL')
                 ->andWhere('parent.locale = :locale')
                 ->andWhere('(parent.slug = :newSlug OR parent.slug LIKE :oldSlugSlash)') // direct child is using newSlug already updated as we are in PostFlush, grand child use oldSlugWithSlash as not yet updated
                 ->andWhere('(child.slug LIKE :oldSlugSlash)') // ignore disconnected child routes in case of full tree edit
@@ -145,14 +145,14 @@ class RouteChangedUpdater implements ResetInterface
                 ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
                 ->setParameter('locale', $locale, ParameterType::STRING);
 
-            if (\is_string($site)) {
-                $selectQueryBuilder->setParameter('site', $site, ParameterType::STRING);
+            if (\is_string($webspace)) {
+                $selectQueryBuilder->setParameter('webspace', $webspace, ParameterType::STRING);
             }
 
             /**
              * @var array<int, array{
              *     parent_id: int,
-             *     site: string|null,
+             *     webspace: string|null,
              *     slug: string,
              *     resource_key: string,
              *     resource_id: string,
@@ -168,7 +168,7 @@ class RouteChangedUpdater implements ResetInterface
                     $childAndGrandChildRow['resource_key'] . '::' . $childAndGrandChildRow['resource_id'],
                     $locale,
                     $childAndGrandChildRow['slug'],
-                    $childAndGrandChildRow['site'],
+                    $childAndGrandChildRow['webspace'],
                     null, // history never has parents as they never will be updated
                 );
             }
@@ -181,7 +181,7 @@ class RouteChangedUpdater implements ResetInterface
                 $route->getResourceKey() . '::' . $route->getResourceId(),
                 $locale,
                 $oldSlug,
-                $oldSite,
+                $oldWebspace,
                 null, // history never has parents ad they never will be updated
             );
 
@@ -229,14 +229,14 @@ class RouteChangedUpdater implements ResetInterface
                 $classMetadata->getColumnName('resourceId') => ':resourceId',
                 $classMetadata->getColumnName('locale') => ':locale',
                 $classMetadata->getColumnName('slug') => ':slug',
-                $classMetadata->getColumnName('site') => ':site',
+                $classMetadata->getColumnName('webspace') => ':webspace',
             ])
             ->setParameters([
                 'resourceKey' => $historyRoute->getResourceKey(),
                 'resourceId' => $historyRoute->getResourceId(),
                 'locale' => $historyRoute->getLocale(),
                 'slug' => $historyRoute->getSlug(),
-                'site' => $historyRoute->getSite(),
+                'webspace' => $historyRoute->getWebspace(),
             ]);
 
         if (

--- a/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
+++ b/packages/route/src/Infrastructure/Doctrine/Repository/RouteRepository.php
@@ -109,25 +109,25 @@ class RouteRepository implements RouteRepositoryInterface
     {
         $queryBuilder = $this->repository->createQueryBuilder('route');
 
-        if (\array_key_exists('site', $filters)) {
-            $site = $filters['site'] ?? null;
+        if (\array_key_exists('webspace', $filters)) {
+            $webspace = $filters['webspace'] ?? null;
             $queryBuilder->andWhere(
-                null === $site ? 'route.site IS NULL' : 'route.site = :site'
+                null === $webspace ? 'route.webspace IS NULL' : 'route.webspace = :webspace'
             );
 
-            if (null !== $site) {
-                $queryBuilder->setParameter('site', $site);
+            if (null !== $webspace) {
+                $queryBuilder->setParameter('webspace', $webspace);
             }
         }
 
-        if (\array_key_exists('siteOrNull', $filters)) {
-            $site = $filters['siteOrNull'] ?? null;
+        if (\array_key_exists('webspaceOrNull', $filters)) {
+            $webspace = $filters['webspaceOrNull'] ?? null;
             $queryBuilder->andWhere(
-                null === $site ? 'route.site IS NULL' : '(route.site = :site OR route.site IS NULL)'
+                null === $webspace ? 'route.webspace IS NULL' : '(route.webspace = :webspace OR route.webspace IS NULL)'
             );
 
-            if (null !== $site) {
-                $queryBuilder->setParameter('site', $site);
+            if (null !== $webspace) {
+                $queryBuilder->setParameter('webspace', $webspace);
             }
         }
 
@@ -183,14 +183,14 @@ class RouteRepository implements RouteRepositoryInterface
         if ([] !== $sortBys) {
             foreach ($sortBys as $field => $order) {
                 $order = match (true) {
-                    // if we filter by siteOrNull and order by site we need invert the order for specific platforms
+                    // if we filter by webspaceOrNull and order by webspace we need invert the order for specific platforms
                     // TODO if possible in future use something like ASC NULLS FIRST / DESC NULLS LAST directly
-                    ('site' === $field // @phpstan-ignore-line identical.alwaysTrue
+                    ('webspace' === $field // @phpstan-ignore-line identical.alwaysTrue
                         && (
                             $this->entityManager->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform
                             || $this->entityManager->getConnection()->getDatabasePlatform() instanceof OraclePlatform
                         )
-                        && \array_key_exists('siteOrNull', $filters)
+                        && \array_key_exists('webspaceOrNull', $filters)
                     ) => match ($order) {
                         'asc' => 'desc',
                         'desc' => 'asc',

--- a/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
+++ b/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
@@ -19,7 +19,7 @@ use Sulu\Route\Application\ResourceLocator\PathCleanup\PathCleanupInterface;
 use Sulu\Route\Application\ResourceLocator\ResourceLocatorGenerator;
 use Sulu\Route\Application\Routing\Generator\RouteGenerator;
 use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
-use Sulu\Route\Application\Routing\Generator\SiteRouteGeneratorInterface;
+use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
 use Sulu\Route\Application\Routing\Matcher\RouteCollectionForRequestLoaderInterface;
 use Sulu\Route\Application\Routing\Matcher\RouteCollectionForRequestRouteLoader;
 use Sulu\Route\Application\Routing\Matcher\RouteDefaultsProviderInterface;
@@ -97,7 +97,7 @@ final class SuluRouteBundle extends AbstractBundle
         $services->set('sulu_route.route_generator')
             ->class(RouteGenerator::class)
             ->args([
-                tagged_locator('sulu_route.site_route_generator', 'site', 'getSite'),
+                tagged_locator('sulu_route.webspace_route_generator', 'webspace', 'getWebspace'),
                 new Reference('router.request_context'),
                 new Reference('request_stack'),
                 new Reference('translation.locale_switcher'),
@@ -184,8 +184,8 @@ final class SuluRouteBundle extends AbstractBundle
             ->tag('sulu.admin');
 
         // Extension Points
-        $builder->registerForAutoconfiguration(SiteRouteGeneratorInterface::class)
-            ->addTag('sulu_route.site_route_generator');
+        $builder->registerForAutoconfiguration(WebspaceRouteGeneratorInterface::class)
+            ->addTag('sulu_route.webspace_route_generator');
 
         $builder->registerForAutoconfiguration(RouteCollectionForRequestLoaderInterface::class)
             ->addTag('sulu_route.route_collection_for_request_loader');

--- a/packages/route/src/Userinterface/Controller/Admin/ResourceLocatorGenerateController.php
+++ b/packages/route/src/Userinterface/Controller/Admin/ResourceLocatorGenerateController.php
@@ -45,7 +45,7 @@ final readonly class ResourceLocatorGenerateController
 
         /** @var array<string, string>  $parts */
         $locale = $payload->getString('locale');
-        $site = $payload->getString('webspace') ?: null;
+        $webspace = $payload->getString('webspace') ?: null;
         $resourceKey = $payload->getString('resourceKey');
         $resourceId = $payload->getString('resourceId') ?: null;
         $parentResourceId = $payload->getString('parentId') ?: null;
@@ -56,7 +56,7 @@ final readonly class ResourceLocatorGenerateController
         return new ResourceLocatorRequest(
             $parts,
             $locale,
-            $site,
+            $webspace,
             $resourceKey,
             $resourceId,
             $parentResourceId,

--- a/packages/route/tests/Application/ExampleWebspaceRouteGenerator.php
+++ b/packages/route/tests/Application/ExampleWebspaceRouteGenerator.php
@@ -11,13 +11,13 @@
 
 namespace Sulu\Route\Tests\Application;
 
-use Sulu\Route\Application\Routing\Generator\SiteRouteGeneratorInterface;
+use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 
 /**
  * @internal
  */
-final class ExampleSiteRouteGenerator implements SiteRouteGeneratorInterface
+final class ExampleWebspaceRouteGenerator implements WebspaceRouteGeneratorInterface
 {
     public function generate(RequestContext $requestContext, string $slug, string $locale): string
     {
@@ -37,7 +37,7 @@ final class ExampleSiteRouteGenerator implements SiteRouteGeneratorInterface
         );
     }
 
-    public static function getSite(): string
+    public static function getWebspace(): string
     {
         return 'sulu-io';
     }

--- a/packages/route/tests/Application/Kernel.php
+++ b/packages/route/tests/Application/Kernel.php
@@ -90,7 +90,7 @@ class Kernel extends SuluTestKernel implements CompilerPassInterface
     public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
         if (\str_starts_with($request->getPathInfo(), '/en/')) { // use for the CmfRouteProviderTest
-            $request->attributes->set(RequestAttributeEnum::SITE->value, 'sulu-io');
+            $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, 'sulu-io');
             $request->attributes->set(RequestAttributeEnum::SLUG->value, \substr($request->getPathInfo(), 3));
         }
 

--- a/packages/route/tests/Application/config/config.yml
+++ b/packages/route/tests/Application/config/config.yml
@@ -23,5 +23,5 @@ doctrine:
         url: '%env(DATABASE_URL)%'
 
 services:
-    Sulu\Route\Tests\Application\ExampleSiteRouteGenerator:
+    Sulu\Route\Tests\Application\ExampleWebspaceRouteGenerator:
         autoconfigure: true

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
@@ -22,7 +22,7 @@ use Sulu\Route\Infrastructure\Doctrine\EventListener\RouteChangedUpdater;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
- * @phpstan-type RouteData array{resourceId: string, locale?: string, slug: string, site?: string|null, parentSlug?: string|null, parentSite?: string|null}
+ * @phpstan-type RouteData array{resourceId: string, locale?: string, slug: string, webspace?: string|null, parentSlug?: string|null, parentWebspace?: string|null}
  */
 #[CoversClass(RouteChangedUpdater::class)]
 class RouteChangedUpdaterTest extends KernelTestCase
@@ -116,10 +116,10 @@ class RouteChangedUpdaterTest extends KernelTestCase
         $postParentRouteSetter = [];
         foreach ($routes as $routeData) {
             $route = $this->createRoute($routeData);
-            $uniqueKey = ($route->getSite() ?? '') . $route->getLocale() . $route->getSlug();
+            $uniqueKey = ($route->getWebspace() ?? '') . $route->getLocale() . $route->getSlug();
             $parentRoute = null;
             if (isset($routeData['parentSlug'])) {
-                $parentUniqueKey = ($routeData['parentSite'] ?? $route->getSite() ?? '') . $route->getLocale() . $routeData['parentSlug'];
+                $parentUniqueKey = ($routeData['parentWebspace'] ?? $route->getWebspace() ?? '') . $route->getLocale() . $routeData['parentSlug'];
                 $parentRoute = $createdRoutes[$parentUniqueKey] ?? null;
                 if (null === $parentRoute) { // if parent route was not yet created we set it later see $postParentRouteSetter foreach below
                     $postParentRouteSetter[$parentUniqueKey][] = $route;
@@ -162,14 +162,14 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 'resourceKey' => 'page',
                 'resourceId' => $expectedRoute['resourceId'],
                 'locale' => $expectedRoute['locale'] ?? 'en',
-                'site' => $expectedRoute['site'] ?? null,
+                'webspace' => $expectedRoute['webspace'] ?? null,
             ]);
 
             $this->assertNotNull($route, \sprintf(
-                'Expected route with resourceId "%s", locale "%s" and site "%s" not found.',
+                'Expected route with resourceId "%s", locale "%s" and webspace "%s" not found.',
                 $expectedRoute['resourceId'],
                 $expectedRoute['locale'] ?? 'en',
-                $expectedRoute['site'] ?? 'NULL',
+                $expectedRoute['webspace'] ?? 'NULL',
             ));
 
             $this->assertSame($expectedRoute['slug'], $route->getSlug());
@@ -190,7 +190,7 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 if ($expectedRoute['resourceId'] === $route['resourceId']
                     && $expectedRoute['slug'] !== $route['slug']
                     && ($expectedRoute['locale'] ?? 'en') === ($route['locale'] ?? 'en')
-                    && ($expectedRoute['site'] ?? null) === ($route['site'] ?? null)
+                    && ($expectedRoute['webspace'] ?? null) === ($route['webspace'] ?? null)
                 ) {
                     $expectedHistoryRoutes[] = $route;
                 }
@@ -203,7 +203,7 @@ class RouteChangedUpdaterTest extends KernelTestCase
         foreach ($expectedHistoryRoutes as $expectedHistoryRoute) {
             $route = $repository->findOneBy([
                 'locale' => $expectedHistoryRoute['locale'] ?? 'en',
-                'site' => $expectedHistoryRoute['site'] ?? null,
+                'webspace' => $expectedHistoryRoute['webspace'] ?? null,
                 'slug' => $expectedHistoryRoute['slug'],
             ]);
 
@@ -260,19 +260,19 @@ class RouteChangedUpdaterTest extends KernelTestCase
                     'resourceId' => '1',
                     'slug' => '/test',
                     'locale' => 'en',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test-2',
                     'locale' => 'en',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test-2/child-a',
                     'locale' => 'en',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
             ],
             'changeRoute' => '/test-article',
@@ -281,19 +281,19 @@ class RouteChangedUpdaterTest extends KernelTestCase
                     'resourceId' => '1',
                     'slug' => '/test-article',
                     'locale' => 'en',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test-2',
                     'locale' => 'en',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test-2/child-a',
                     'locale' => 'en',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
             ],
             'expectedChangedRoutes' => 1,
@@ -513,59 +513,59 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test/child-b',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
                 ],
                 [
                     'resourceId' => '4',
                     'slug' => '/test/child-b/grand-child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test/child-b',
                 ],
                 [
                     'resourceId' => '5',
                     'slug' => '/test/child-b/grand-child-b',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test/child-b',
                 ],
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                     'parentSlug' => '/test',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test/child-b',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                     'parentSlug' => '/test',
                 ],
                 [
                     'resourceId' => '4',
                     'slug' => '/test/child-b/grand-child-a',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                     'parentSlug' => '/test/child-b',
                 ],
                 [
                     'resourceId' => '5',
                     'slug' => '/test/child-b/grand-child-b',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                     'parentSlug' => '/test/child-b',
                 ],
             ],
@@ -574,59 +574,59 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test-article',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test-article/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test-article/child-b',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article',
                 ],
                 [
                     'resourceId' => '4',
                     'slug' => '/test-article/child-b/grand-child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article/child-b',
                 ],
                 [
                     'resourceId' => '5',
                     'slug' => '/test-article/child-b/grand-child-b',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article/child-b',
                 ],
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                     'parentSlug' => '/test',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test/child-b',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                     'parentSlug' => '/test',
                 ],
                 [
                     'resourceId' => '4',
                     'slug' => '/test/child-b/grand-child-a',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                     'parentSlug' => '/test/child-b',
                 ],
                 [
                     'resourceId' => '5',
                     'slug' => '/test/child-b/grand-child-b',
-                    'site' => 'intranet',
+                    'webspace' => 'intranet',
                     'parentSlug' => '/test/child-b',
                 ],
             ],
@@ -638,40 +638,40 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test/something-else/child-a',
-                    'site' => null,
+                    'webspace' => null,
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '4',
                     'slug' => '/test/something-else/child-b',
-                    'site' => null,
+                    'webspace' => null,
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '10',
                     'slug' => '/test-2',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '11',
                     'slug' => '/test-2/something-else/child-a',
-                    'site' => null,
+                    'webspace' => null,
                     'parentSlug' => '/test-2',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
             ],
             'changeRoute' => '/test-article',
@@ -679,39 +679,39 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test-article',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test-article/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test-article/something-else/child-a',
-                    'site' => null,
+                    'webspace' => null,
                     'parentSlug' => '/test-article',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '4',
                     'slug' => '/test-article/something-else/child-b',
-                    'site' => null,
+                    'webspace' => null,
                     'parentSlug' => '/test-article',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '10',
                     'slug' => '/test-2',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '11',
                     'slug' => '/test-2/something-else/child-a',
-                    'site' => null,
+                    'webspace' => null,
                     'parentSlug' => '/test-2',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
             ],
             'expectedChangedRoutes' => 4,
@@ -722,14 +722,14 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
             ],
             'changeRoute' => '/test/child-a-edit',
@@ -737,14 +737,14 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a-edit',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
             ],
             'expectedChangedRoutes' => 1,
@@ -755,14 +755,14 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
             ],
             'changeRoute' => '/test-child-a',
@@ -770,14 +770,14 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '2',
                     'slug' => '/test-child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
             ],
             'expectedChangedRoutes' => 1,
@@ -788,21 +788,21 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test-child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test/child-b',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
             ],
             'changeRoute' => '/test-article',
@@ -810,21 +810,21 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test-article',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test-child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test-article/child-b',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
             ],
             'expectedChangedRoutes' => 2,
@@ -835,14 +835,14 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => null,
-                    'parentSite' => null,
+                    'parentWebspace' => null,
                 ],
             ],
             'changeRoute' => '/test-article',
@@ -850,14 +850,14 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test-article',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => null,
-                    'parentSite' => null,
+                    'parentWebspace' => null,
                 ],
             ],
             'expectedChangedRoutes' => 1,
@@ -868,21 +868,21 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test/grand-child-1', // this was before "/test/child-a/grand-child-1"
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test/child-a', // and so still child of "/test-child-a"
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
             ],
             'changeRoute' => '/test-article',
@@ -890,21 +890,21 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 [
                     'resourceId' => '1',
                     'slug' => '/test-article',
-                    'site' => 'website',
+                    'webspace' => 'website',
                 ],
                 [
                     'resourceId' => '2',
                     'slug' => '/test-article/child-a',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
                 [
                     'resourceId' => '3',
                     'slug' => '/test-article/grand-child-1',
-                    'site' => 'website',
+                    'webspace' => 'website',
                     'parentSlug' => '/test-article/child-a',
-                    'parentSite' => 'website',
+                    'parentWebspace' => 'website',
                 ],
             ],
             'expectedChangedRoutes' => 3,
@@ -1000,7 +1000,7 @@ class RouteChangedUpdaterTest extends KernelTestCase
             $route['resourceId'],
             $route['locale'] ?? 'en',
             $route['slug'],
-            $route['site'] ?? null,
+            $route['webspace'] ?? null,
         );
     }
 }

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/Repository/RouteRepositoryTest.php
@@ -40,11 +40,11 @@ class RouteRepositoryTest extends KernelTestCase
         $unexpectedLocalesRouteEs = new Route('example', '1', 'es', '/ejemplo', 'the_site');
         $entityManager->persist($unexpectedLocalesRouteEs);
 
-        $multiSiteRouteEn = new Route('multisite', '1', 'en', '/example', null);
-        $entityManager->persist($multiSiteRouteEn);
+        $multiWebspaceRouteEn = new Route('multisite', '1', 'en', '/example', null);
+        $entityManager->persist($multiWebspaceRouteEn);
 
-        $multiSiteRouteDe = new Route('multisite', '1', 'de', '/beispiel', null);
-        $entityManager->persist($multiSiteRouteDe);
+        $multiWebspaceRouteDe = new Route('multisite', '1', 'de', '/beispiel', null);
+        $entityManager->persist($multiWebspaceRouteDe);
 
         $entityManager->flush();
         $entityManager->clear();
@@ -86,10 +86,10 @@ class RouteRepositoryTest extends KernelTestCase
         $this->assertNull($route);
     }
 
-    public function testFindOneBySiteSlugLocale(): void
+    public function testFindOneByWebspaceSlugLocale(): void
     {
         $route = $this->routeRepository->findOneBy([
-            'site' => 'the_site',
+            'webspace' => 'the_site',
             'slug' => '/test',
             'locale' => 'en',
         ]);
@@ -97,13 +97,13 @@ class RouteRepositoryTest extends KernelTestCase
         $this->assertNotNull($route);
         $this->assertSame('/test', $route->getSlug());
         $this->assertSame('en', $route->getLocale());
-        $this->assertSame('the_site', $route->getSite());
+        $this->assertSame('the_site', $route->getWebspace());
     }
 
-    public function testGetOneBySiteSlugLocale(): void
+    public function testGetOneByWebspaceSlugLocale(): void
     {
         $route = $this->routeRepository->findOneBy([
-            'site' => 'the_site',
+            'webspace' => 'the_site',
             'slug' => '/test',
             'locale' => 'en',
         ]);
@@ -111,7 +111,7 @@ class RouteRepositoryTest extends KernelTestCase
         $this->assertNotNull($route);
         $this->assertSame('/test', $route->getSlug());
         $this->assertSame('en', $route->getLocale());
-        $this->assertSame('the_site', $route->getSite());
+        $this->assertSame('the_site', $route->getWebspace());
     }
 
     public function testFindOneByResourceAndLocale(): void
@@ -128,49 +128,49 @@ class RouteRepositoryTest extends KernelTestCase
         $this->assertSame('example::1', $route->getResourceId());
     }
 
-    public function testFindFirstBySiteOrNullSlugLocale(): void
+    public function testFindFirstByWebspaceOrNullSlugLocale(): void
     {
         $routes = $this->routeRepository->findBy([
-            'siteOrNull' => 'the_site',
+            'webspaceOrNull' => 'the_site',
             'slug' => '/example',
             'locale' => 'en',
-        ], ['site' => 'desc']);
+        ], ['webspace' => 'desc']);
 
         $this->assertGreaterThanOrEqual(2, \count([...$routes]), 'This test requires at least two routes on the same slug and locale.');
 
         $route = $this->routeRepository->findFirstBy([
-            'siteOrNull' => 'the_site',
+            'webspaceOrNull' => 'the_site',
             'slug' => '/example',
             'locale' => 'en',
-        ], ['site' => 'desc']);
+        ], ['webspace' => 'desc']);
 
         $this->assertNotNull($route);
         $this->assertSame('/example', $route->getSlug());
         $this->assertSame('en', $route->getLocale());
-        $this->assertSame('the_site', $route->getSite());
+        $this->assertSame('the_site', $route->getWebspace());
     }
 
-    public function testFindFirstBySiteSlugLocale(): void
+    public function testFindFirstByWebspaceSlugLocale(): void
     {
         $route = $this->routeRepository->findFirstBy([
-            'siteOrNull' => null,
+            'webspaceOrNull' => null,
             'slug' => '/example',
             'locale' => 'en',
-        ], ['site' => 'desc']);
+        ], ['webspace' => 'desc']);
 
         $this->assertNotNull($route);
         $this->assertSame('/example', $route->getSlug());
         $this->assertSame('en', $route->getLocale());
-        $this->assertNull($route->getSite());
+        $this->assertNull($route->getWebspace());
     }
 
     public function testFindFirstByNotExist(): void
     {
         $route = $this->routeRepository->findFirstBy([
-            'siteOrNull' => 'the_site',
+            'webspaceOrNull' => 'the_site',
             'slug' => '/not-exist',
             'locale' => 'en',
-        ], ['site' => 'desc']);
+        ], ['webspace' => 'desc']);
 
         $this->assertNull($route);
     }
@@ -194,21 +194,21 @@ class RouteRepositoryTest extends KernelTestCase
                     'resourceId' => '1',
                     'locale' => 'de',
                     'slug' => '/beispiel',
-                    'site' => 'the_site',
+                    'webspace' => 'the_site',
                 ],
                 [
                     'resourceKey' => 'example',
                     'resourceId' => '1',
                     'locale' => 'en',
                     'slug' => '/example',
-                    'site' => 'the_site',
+                    'webspace' => 'the_site',
                 ],
                 [
                     'resourceKey' => 'example',
                     'resourceId' => '1',
                     'locale' => 'fr',
                     'slug' => '/exemple',
-                    'site' => 'the_site',
+                    'webspace' => 'the_site',
                 ],
             ],
             \array_map(function(Route $route): array {
@@ -217,7 +217,7 @@ class RouteRepositoryTest extends KernelTestCase
                     'resourceId' => $route->getResourceId(),
                     'locale' => $route->getLocale(),
                     'slug' => $route->getSlug(),
-                    'site' => $route->getSite(),
+                    'webspace' => $route->getWebspace(),
                 ];
             }, $routes),
         );
@@ -234,19 +234,19 @@ class RouteRepositoryTest extends KernelTestCase
         $this->assertNull($route);
     }
 
-    public function testExistBySiteSlugLocale(): void
+    public function testExistByWebspaceSlugLocale(): void
     {
         $this->assertTrue($this->routeRepository->existBy([
-            'site' => 'the_site',
+            'webspace' => 'the_site',
             'slug' => '/example',
             'locale' => 'en',
         ]));
     }
 
-    public function testExistBySiteWithExclude(): void
+    public function testExistByWebspaceWithExclude(): void
     {
         $this->assertFalse($this->routeRepository->existBy([
-            'site' => 'the_site',
+            'webspace' => 'the_site',
             'slug' => '/example',
             'locale' => 'en',
             'excludeResource' => [
@@ -256,10 +256,10 @@ class RouteRepositoryTest extends KernelTestCase
         ]));
     }
 
-    public function testExistBySiteSlugLocaleNotFound(): void
+    public function testExistByWebspaceSlugLocaleNotFound(): void
     {
         $this->assertFalse($this->routeRepository->existBy([
-            'site' => 'the_site',
+            'webspace' => 'the_site',
             'slug' => '/example-1',
             'locale' => 'en',
         ]));

--- a/packages/route/tests/Functional/Infrastructure/SymfonyCmf/Routing/CmfRouteProviderTest.php
+++ b/packages/route/tests/Functional/Infrastructure/SymfonyCmf/Routing/CmfRouteProviderTest.php
@@ -74,7 +74,7 @@ class CmfRouteProviderTest extends WebsiteTestCase
         $cmfRouteProvider = self::getContainer()->get('sulu_route.symfony_cmf_route_provider');
 
         $request = Request::create('/en/test-redirect');
-        $request->attributes->set(RequestAttributeEnum::SITE->value, 'sulu-io');
+        $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, 'sulu-io');
         $request->attributes->set(RequestAttributeEnum::SLUG->value, '/test-redirect');
         $request->setLocale('en');
 

--- a/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorGeneratorTest.php
@@ -63,7 +63,7 @@ class ResourceLocatorGeneratorTest extends TestCase
                 'title' => 'Hello World',
             ],
             locale: 'de',
-            site: 'website',
+            webspace: 'website',
             resourceKey: 'articles',
             parentResourceId: 'cff165a7-ae8e-46b4-8f32-f0a339173207',
             parentResourceKey: 'pages',
@@ -74,7 +74,7 @@ class ResourceLocatorGeneratorTest extends TestCase
             resourceId: 'cff165a7-ae8e-46b4-8f32-f0a339173207',
             locale: 'de',
             slug: '/news',
-            site: 'website',
+            webspace: 'website',
         );
         $this->routeRepository->findOneBy([
             'resourceId' => 'cff165a7-ae8e-46b4-8f32-f0a339173207',
@@ -98,19 +98,19 @@ class ResourceLocatorGeneratorTest extends TestCase
         $this->routeRepository->existBy([
             'slug' => '/hello-world',
             'locale' => 'en',
-            'site' => null,
+            'webspace' => null,
         ])->willReturn(true);
 
         $this->routeRepository->existBy([
             'slug' => '/hello-world-1',
             'locale' => 'en',
-            'site' => null,
+            'webspace' => null,
         ])->willReturn(true);
 
         $this->routeRepository->existBy([
             'slug' => '/hello-world-2',
             'locale' => 'en',
-            'site' => null,
+            'webspace' => null,
         ])->willReturn(false);
 
         $this->assertSame('/hello-world-2', $this->resourceLocatorGenerator->generate($request));
@@ -122,7 +122,7 @@ class ResourceLocatorGeneratorTest extends TestCase
     private function createResourceLocatorRequest(
         array $parts = [],
         string $locale = 'en',
-        ?string $site = null,
+        ?string $webspace = null,
         string $resourceKey = 'pages',
         ?string $resourceId = null,
         ?string $parentResourceId = null,
@@ -132,7 +132,7 @@ class ResourceLocatorGeneratorTest extends TestCase
         return new ResourceLocatorRequest(
             parts: $parts,
             locale: $locale,
-            site: $site,
+            webspace: $webspace,
             resourceKey: $resourceKey,
             resourceId: $resourceId,
             parentResourceId: $parentResourceId,
@@ -146,7 +146,7 @@ class ResourceLocatorGeneratorTest extends TestCase
         string $resourceId = '12345',
         string $locale = 'en',
         string $slug = '/',
-        ?string $site = null,
+        ?string $webspace = null,
         ?Route $parentRoute = null,
     ): Route {
         return new Route(
@@ -154,7 +154,7 @@ class ResourceLocatorGeneratorTest extends TestCase
             $resourceId,
             $locale,
             $slug,
-            $site,
+            $webspace,
             $parentRoute,
         );
     }

--- a/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorRequestTest.php
+++ b/packages/route/tests/Unit/Application/ResourceLocator/ResourceLocatorRequestTest.php
@@ -33,11 +33,11 @@ class ResourceLocatorRequestTest extends TestCase
         $this->assertSame('de', $instance->locale);
     }
 
-    public function testSite(): void
+    public function testWebspace(): void
     {
-        $instance = $this->createInstance(site: 'sulu');
+        $instance = $this->createInstance(webspace: 'sulu');
 
-        $this->assertSame('sulu', $instance->site);
+        $this->assertSame('sulu', $instance->webspace);
     }
 
     public function testResourceKey(): void
@@ -90,7 +90,7 @@ class ResourceLocatorRequestTest extends TestCase
     private function createInstance(
         array $parts = [],
         string $locale = 'en',
-        ?string $site = null,
+        ?string $webspace = null,
         string $resourceKey = 'pages',
         ?string $resourceId = null,
         ?string $parentResourceId = null,
@@ -100,7 +100,7 @@ class ResourceLocatorRequestTest extends TestCase
         return new ResourceLocatorRequest(
             parts: $parts,
             locale: $locale,
-            site: $site,
+            webspace: $webspace,
             resourceKey: $resourceKey,
             resourceId: $resourceId,
             parentResourceId: $parentResourceId,

--- a/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
@@ -14,7 +14,7 @@ namespace Sulu\Route\Tests\Unit\Application\Routing\Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Sulu\Route\Application\Routing\Generator\RouteGenerator;
-use Sulu\Route\Application\Routing\Generator\SiteRouteGeneratorInterface;
+use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
 use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -32,7 +32,7 @@ class RouteGeneratorTest extends TestCase
     public function setUp(): void
     {
         $container = new Container();
-        $container->set('the_site', new class() implements SiteRouteGeneratorInterface {
+        $container->set('the_site', new class() implements WebspaceRouteGeneratorInterface {
             public function generate(RequestContext $requestContext, string $slug, string $locale): string
             {
                 $port = match ($requestContext->getScheme()) {
@@ -52,7 +52,7 @@ class RouteGeneratorTest extends TestCase
             }
         });
 
-        $container->set('the_other_side', new class() implements SiteRouteGeneratorInterface {
+        $container->set('the_other_side', new class() implements WebspaceRouteGeneratorInterface {
             public function generate(RequestContext $requestContext, string $slug, string $locale): string
             {
                 return \sprintf(
@@ -133,9 +133,9 @@ class RouteGeneratorTest extends TestCase
         $this->assertSame('/de/test', $result);
     }
 
-    public function testGenerateRequestContextSite(): void
+    public function testGenerateRequestContextWebspace(): void
     {
-        $this->requestContext->setParameter('site', 'the_site');
+        $this->requestContext->setParameter('webspace', 'the_site');
 
         $result = $this->routeGenerator->generate('/test', 'en', null);
         $this->assertSame('/en/test', $result);
@@ -147,10 +147,10 @@ class RouteGeneratorTest extends TestCase
         $this->assertSame('/en/test', $result);
     }
 
-    public function testGenerateRequestContextSiteMissing(): void
+    public function testGenerateRequestContextWebspaceMissing(): void
     {
         $this->expectException(MissingRequestContextParameterException::class);
-        $this->expectExceptionMessage('Missing request context parameter "site".');
+        $this->expectExceptionMessage('Missing request context parameter "webspace".');
 
         $this->routeGenerator->generate('/test', 'en', null);
     }

--- a/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
@@ -63,7 +63,7 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
         );
     }
 
-    public function testGetRouteCollectionForRequestIncorrectSite(): void
+    public function testGetRouteCollectionForRequestIncorrectWebspace(): void
     {
         $request = Request::create('/en/test');
         $request->attributes->set(RequestAttributeEnum::SLUG->value, new \stdClass());
@@ -77,7 +77,7 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
     public function testGetRouteCollectionForRequestNoSlug(): void
     {
         $request = Request::create('/en/test');
-        $request->attributes->set(RequestAttributeEnum::SITE->value, 'the_site');
+        $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, 'the_site');
 
         $this->routeRepository->findFirstBy(Argument::cetera())->shouldNotBeCalled();
         $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
@@ -88,7 +88,7 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
     public function testGetRouteCollectionForRequestNoRoute(): void
     {
         $request = Request::create('/test');
-        $request->attributes->set(RequestAttributeEnum::SITE->value, 'the_site');
+        $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, 'the_site');
         $request->attributes->set(RequestAttributeEnum::SLUG->value, '/test');
 
         $this->routeRepository->findFirstBy(Argument::cetera())->willReturn(null);
@@ -100,7 +100,7 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
     public function testGetRouteCollectionForRequestMatch(): void
     {
         $request = Request::create('/test');
-        $request->attributes->set(RequestAttributeEnum::SITE->value, 'the_site');
+        $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, 'the_site');
         $request->attributes->set(RequestAttributeEnum::SLUG->value, '/test');
 
         $routeModel = new Route('resource_key_example', '1', 'en', '/test', 'the_site');

--- a/packages/route/tests/Unit/Application/Routing/Matcher/RouteHistoryDefaultsProviderTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Matcher/RouteHistoryDefaultsProviderTest.php
@@ -18,7 +18,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Route\Application\Routing\Generator\RouteGenerator;
-use Sulu\Route\Application\Routing\Generator\SiteRouteGeneratorInterface;
+use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
 use Sulu\Route\Application\Routing\Matcher\RouteHistoryDefaultsProvider;
 use Sulu\Route\Domain\Model\Route;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
@@ -52,7 +52,7 @@ class RouteHistoryDefaultsProviderTest extends TestCase
 
         // Use the same setup as in RouteGeneratorTest
         $container = new Container();
-        $container->set('the_site', new class() implements SiteRouteGeneratorInterface {
+        $container->set('the_site', new class() implements WebspaceRouteGeneratorInterface {
             public function generate(RequestContext $requestContext, string $slug, string $locale): string
             {
                 $port = match ($requestContext->getScheme()) {

--- a/packages/route/tests/Unit/Domain/Model/RouteTest.php
+++ b/packages/route/tests/Unit/Domain/Model/RouteTest.php
@@ -100,7 +100,7 @@ class RouteTest extends TestCase
         string $resourceId = '1',
         string $locale = 'en',
         string $slug = '/',
-        ?string $site = null,
+        ?string $webspace = null,
         ?Route $parentRoute = null,
     ): Route {
         return new Route(
@@ -108,7 +108,7 @@ class RouteTest extends TestCase
             $resourceId,
             $locale,
             $slug,
-            $site,
+            $webspace,
             $parentRoute,
         );
     }
@@ -118,7 +118,7 @@ class RouteTest extends TestCase
         ?callable $resourceIdCallable = null,
         string $locale = 'en',
         string $slug = '/',
-        ?string $site = null,
+        ?string $webspace = null,
         ?Route $parentRoute = null,
     ): Route {
         return Route::createRouteWithTempId(
@@ -126,7 +126,7 @@ class RouteTest extends TestCase
             null === $resourceIdCallable ? fn () => '1' : $resourceIdCallable,
             $locale,
             $slug,
-            $site,
+            $webspace,
             $parentRoute,
         );
     }

--- a/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
+++ b/src/Sulu/Bundle/PreviewBundle/Preview/Renderer/PreviewRenderer.php
@@ -90,7 +90,7 @@ class PreviewRenderer implements PreviewRendererInterface
 
         $attributes['preview'] = true;
         $attributes['partial'] = $partial;
-        $attributes[RequestAttributeEnum::SITE->value] = $webspaceKey;
+        $attributes[RequestAttributeEnum::WEBSPACE->value] = $webspaceKey;
         $attributes['_sulu'] = new RequestAttributes(
             [
                 'webspace' => $webspace,

--- a/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
@@ -66,8 +66,8 @@ class RequestListener implements EventSubscriberInterface
             if (!$context->hasParameter('host')) {
                 $context->setParameter('host', $portalInformation->getHost());
             }
-            if (!$context->hasParameter(RequestAttributeEnum::SITE->value)) {
-                $context->setParameter(RequestAttributeEnum::SITE->value, $portalInformation->getWebspace()->getKey());
+            if (!$context->hasParameter(RequestAttributeEnum::WEBSPACE->value)) {
+                $context->setParameter(RequestAttributeEnum::WEBSPACE->value, $portalInformation->getWebspace()->getKey());
             }
         }
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RequestListenerTest.php
@@ -79,7 +79,7 @@ class RequestListenerTest extends TestCase
 
         $this->assertSame('test/', $this->requestContext->getParameter('prefix'));
         $this->assertSame('sulu.io', $this->requestContext->getParameter('host'));
-        $this->assertSame('sulu_io', $this->requestContext->getParameter('site'));
+        $this->assertSame('sulu_io', $this->requestContext->getParameter('webspace'));
     }
 
     public function testRequestAnalyzerSubRequest(): void
@@ -123,7 +123,7 @@ class RequestListenerTest extends TestCase
 
         $this->assertFalse($this->requestContext->hasParameter('prefix'));
         $this->assertFalse($this->requestContext->hasParameter('host'));
-        $this->assertFalse($this->requestContext->hasParameter('site'));
+        $this->assertFalse($this->requestContext->hasParameter('webspace'));
     }
 
     private function createRequestEvent(Request $request, int $requestType = HttpKernelInterface::MAIN_REQUEST): RequestEvent

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
@@ -34,7 +34,7 @@ class AdminRequestProcessor implements RequestProcessorInterface
         $attributes['webspaceKey'] = $request->get('webspace') ?: $request->get('webspaceKey');
         $attributes['locale'] = $request->get('locale', $request->get('language'));
 
-        $request->attributes->set(RequestAttributeEnum::SITE->value, $attributes['webspaceKey']); // TODO move in own request listener
+        $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, $attributes['webspaceKey']); // TODO move in own request listener
 
         if ($attributes['locale']) {
             $attributes['localization'] = Localization::createFromString($attributes['locale']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Rename Route::site to Route::webspace

#### Why?

@chirimoya found it we should name it webspace to avoid confusen between site and webspace.