### PR TITLE
Adjust one-to-one to many-to-one relation

### DIFF
--- a/packages/snippet/config/doctrine/Snippet/SnippetArea.orm.xml
+++ b/packages/snippet/config/doctrine/Snippet/SnippetArea.orm.xml
@@ -13,8 +13,8 @@
         <field name="webspaceKey" type="string" />
         <field name="areaKey" type="string" />
 
-        <one-to-one field="snippet" target-entity="Sulu\Snippet\Domain\Model\SnippetInterface">
+        <many-to-one field="snippet" target-entity="Sulu\Snippet\Domain\Model\SnippetInterface">
             <join-column name="idSnippet" referenced-column-name="uuid" on-delete="CASCADE" nullable="true"/>
-        </one-to-one>
+        </many-to-one>
     </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
 | Q                  | A               |
  |--------------------|-----------------|
  | Bug fix?           | no              |
  | New feature?       | yes             |
  | BC breaks?         | no              |
  | Deprecations?      | no              |
  | Fixed tickets      | fixes #         |
  | Related issues/PRs | #               |
  | License            | MIT             |
  | Documentation PR   | sulu/sulu-docs# |

  What's in this PR?

  Changes the Doctrine relationship between SnippetArea and Snippet from one-to-one to many-to-one in
  the ORM mapping.

  Why?

  The previous one-to-one relationship prevented the same Snippet from being assigned to multiple
  SnippetAreas.