### PR TITLE
Replace `Command::getDefaultName` with inheritance check

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/EventSubscriber/CacheCommandSubscriber.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/EventSubscriber/CacheCommandSubscriber.php
@@ -50,15 +50,7 @@ class CacheCommandSubscriber implements EventSubscriberInterface
     {
         $command = $event->getCommand();
 
-        if (null === $command
-            || !\in_array(
-                $command->getName(),
-                [
-                    CacheClearCommand::getDefaultName(),
-                    CacheWarmupCommand::getDefaultName(),
-                ]
-            )
-        ) {
+        if (!($command instanceof CacheClearCommand) && !($command instanceof CacheWarmupCommand)) {
             return;
         }
 

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Infrastructure/Symfony/EventSubscriber/CacheCommandSubscriberTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Infrastructure/Symfony/EventSubscriber/CacheCommandSubscriberTest.php
@@ -11,10 +11,12 @@
 
 namespace Sulu\Bundle\PreviewBundle\Tests\Unit\Infrastructure\Symfony\EventSubscriber;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MediaBundle\Command\InitCommand;
 use Sulu\Bundle\PreviewBundle\Infrastructure\Symfony\EventSubscriber\CacheCommandSubscriber;
 use Sulu\Bundle\PreviewBundle\Preview\Renderer\KernelFactoryInterface;
 use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand;
@@ -22,7 +24,9 @@ use Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -30,25 +34,19 @@ class CacheCommandSubscriberTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ObjectProphecy<KernelFactoryInterface>
-     */
-    private $kernelFactory;
+    /** @var ObjectProphecy<KernelFactoryInterface> */
+    private ObjectProphecy $kernelFactory;
 
-    /**
-     * @var CacheCommandSubscriber
-     */
-    private $cacheCommandSubscriber;
+    /** @var ObjectProphecy<KernelInterface> */
+    private ObjectProphecy $previewKernel;
 
-    /**
-     * @var ObjectProphecy<KernelInterface>
-     */
-    private $previewKernel;
+    /** @var ObjectProphecy<Application> */
+    private ObjectProphecy $application;
 
-    /**
-     * @var ObjectProphecy<Application>
-     */
-    private $application;
+    private CacheCommandSubscriber $cacheCommandSubscriber;
+
+    private InputInterface $input;
+    private OutputInterface $output;
 
     public function setUp(): void
     {
@@ -56,59 +54,43 @@ class CacheCommandSubscriberTest extends TestCase
         $this->previewKernel = $this->prophesize(KernelInterface::class);
         $this->kernelFactory = $this->prophesize(KernelFactoryInterface::class);
         $this->cacheCommandSubscriber = new CacheCommandSubscriber($this->kernelFactory->reveal());
+        $this->input = new ArrayInput([]);
+        $this->output = new NullOutput();
 
         $this->cacheCommandSubscriber->setApplication($this->application->reveal());
     }
 
-    public function testEventCacheClear(): void
+    #[DataProvider('dataCommandIsRunProvider')]
+    public function testCommandIsRun(string $commandClass): void
     {
-        $command = $this->prophesize(CacheClearCommand::class);
+        $command = $this->prophesize($commandClass);
 
         $this->kernelFactory->create()
             ->shouldBeCalled()
             ->willReturn($this->previewKernel->reveal());
-
         $this->application->setAutoExit(false)->shouldBeCalled();
-        $this->application->run(Argument::any(), Argument::any())
-            ->shouldBeCalled();
+        $this->application->run($this->input, $this->output)->shouldBeCalled();
 
-        $this->runCommand($command->reveal());
+        $event = new ConsoleCommandEvent($command->reveal(), $this->input, $this->output);
+
+        $this->cacheCommandSubscriber->onCommand($event);
     }
 
-    public function testEventCacheWarmup(): void
+    public static function dataCommandIsRunProvider(): array
     {
-        $command = $this->prophesize(CacheWarmupCommand::class);
-
-        $this->kernelFactory->create()
-            ->shouldBeCalled()
-            ->willReturn($this->previewKernel->reveal());
-
-        $this->application->setAutoExit(false)->shouldBeCalled();
-        $this->application->run(Argument::any(), Argument::any())
-            ->shouldBeCalled();
-
-        $this->runCommand($command->reveal());
+        return [
+            [CacheClearCommand::class],
+            [CacheWarmupCommand::class],
+        ];
     }
 
-    public function testEventOtherCommand(): void
+    public function testOtherCommandsAreNotForwarded(): void
     {
-        $command = $this->prophesize(Command::class);
+        $command = $this->prophesize(InitCommand::class);
 
-        $this->kernelFactory->create()
-            ->shouldNotBeCalled();
+        $this->application->run($this->input, $this->output)->shouldNotBeCalled();
 
-        $this->application->run(Argument::any(), Argument::any())
-            ->shouldNotBeCalled();
-
-        $this->runCommand($command->reveal());
-    }
-
-    private function runCommand(Command $command): void
-    {
-        $input = $this->prophesize(InputInterface::class);
-        $output = $this->prophesize(OutputInterface::class);
-
-        $event = new ConsoleCommandEvent($command, $input->reveal(), $output->reveal());
+        $event = new ConsoleCommandEvent($command->reveal(), $this->input, $this->output);
 
         $this->cacheCommandSubscriber->onCommand($event);
     }

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Infrastructure/Symfony/EventSubscriber/CacheCommandSubscriberTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Infrastructure/Symfony/EventSubscriber/CacheCommandSubscriberTest.php
@@ -17,6 +17,8 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\PreviewBundle\Infrastructure\Symfony\EventSubscriber\CacheCommandSubscriber;
 use Sulu\Bundle\PreviewBundle\Preview\Renderer\KernelFactoryInterface;
+use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand;
+use Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -60,8 +62,7 @@ class CacheCommandSubscriberTest extends TestCase
 
     public function testEventCacheClear(): void
     {
-        $command = $this->prophesize(Command::class);
-        $command->getName()->willReturn('cache:clear');
+        $command = $this->prophesize(CacheClearCommand::class);
 
         $this->kernelFactory->create()
             ->shouldBeCalled()
@@ -76,8 +77,7 @@ class CacheCommandSubscriberTest extends TestCase
 
     public function testEventCacheWarmup(): void
     {
-        $command = $this->prophesize(Command::class);
-        $command->getName()->willReturn('cache:warmup');
+        $command = $this->prophesize(CacheWarmupCommand::class);
 
         $this->kernelFactory->create()
             ->shouldBeCalled()
@@ -93,7 +93,6 @@ class CacheCommandSubscriberTest extends TestCase
     public function testEventOtherCommand(): void
     {
         $command = $this->prophesize(Command::class);
-        $command->getName()->willReturn('other:command');
 
         $this->kernelFactory->create()
             ->shouldNotBeCalled();

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Infrastructure/Symfony/EventSubscriber/CacheCommandSubscriberTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Unit/Infrastructure/Symfony/EventSubscriber/CacheCommandSubscriberTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\PreviewBundle\Tests\Unit\Infrastructure\Symfony\EventSubsc
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MediaBundle\Command\InitCommand;
@@ -60,9 +59,13 @@ class CacheCommandSubscriberTest extends TestCase
         $this->cacheCommandSubscriber->setApplication($this->application->reveal());
     }
 
+    /**
+     * @param class-string $commandClass
+     */
     #[DataProvider('dataCommandIsRunProvider')]
     public function testCommandIsRun(string $commandClass): void
     {
+        /** @var ObjectProphecy<Command> */
         $command = $this->prophesize($commandClass);
 
         $this->kernelFactory->create()
@@ -76,6 +79,9 @@ class CacheCommandSubscriberTest extends TestCase
         $this->cacheCommandSubscriber->onCommand($event);
     }
 
+    /**
+     * @return array<array{class-string}>
+     */
     public static function dataCommandIsRunProvider(): array
     {
         return [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Related issues/PRs | #8216 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Replacing the 'getDefaultName' function which has been deprecated with a class inheritance check.

#### Why?
The function has been deprecated and replaced by attributes.

### Alternative solutions
Check the attributes of the command class, but this is probably too complicated for this use-case.