### PR TITLE
Add configurable ordering for template groups

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,5 +1,95 @@
 # Upgrade
 
+## 3.0.1
+
+### Template Group Ordering and Custom Translations
+
+Template groups can now be ordered and configured with custom translation keys via the `sulu_admin.template_groups` configuration.
+
+**Configuration Example:**
+
+You can configure the order and custom translation keys for template groups in your `config/packages/sulu_admin.yaml`:
+
+```yaml
+sulu_admin:
+    template_groups:
+        articles:  # resource key
+            blog:
+                order: 1
+                translation_key: 'app.blog_articles'
+            news:
+                order: 2
+                translation_key: 'app.news_articles'
+            archive: 'app.archive_articles'  # shorthand for translation_key only
+```
+
+**Configuration Options:**
+
+- **Full format**: Specify both `order` and `translation_key`
+  ```yaml
+  blog:
+      order: 1
+      translation_key: 'app.blog_articles'
+  ```
+
+- **Shorthand format**: Specify only the translation key (order defaults to array index)
+  ```yaml
+  archive: 'app.archive_articles'  # order will be set based on position (0, 1, 2, ...)
+  ```
+
+- **Mixed format**: Combine both approaches
+  ```yaml
+  sulu_admin:
+      template_groups:
+          articles:
+              blog: 'app.blog_articles'      # order: 0 (array index)
+              news: 'app.news_articles'      # order: 1 (array index)
+              archive:
+                  order: 99
+                  translation_key: 'app.archive'  # explicit order overrides array index
+  ```
+
+Groups without configuration will:
+- Use default order of 9999
+- Appear alphabetically at the end
+- Use `sulu_admin.template_group.<group_name>` as translation key
+
+
+### Deprecated: GroupProvider::getGroups() without arguments
+
+**What changed?**
+
+The `GroupProviderInterface::getGroups()` method now accepts optional `$resourceKey` and `$templateType` parameters.
+Calling it without arguments is deprecated and will be removed in Sulu 4.0.
+
+**Before (deprecated):**
+```php
+$groups = $groupProvider->getGroups();
+```
+
+**After (recommended):**
+```php
+use Sulu\Article\Domain\Model\ArticleInterface;
+
+$groups = $groupProvider->getGroups(
+    ArticleInterface::RESOURCE_KEY,
+    ArticleInterface::TEMPLATE_TYPE
+);
+```
+
+**Migration:**
+
+If you're calling `getGroups()` in your custom code, update the calls to pass both arguments:
+
+```diff
+- $groups = $this->groupProvider->getGroups();
++ $groups = $this->groupProvider->getGroups('articles', 'articles');
+```
+
+This change allows you to retrieve groups for different resource types, making the system more flexible and avoiding
+hardcoded dependencies on the Article entity.
+
+
 ## 3.0.0
 
 The upgrade from Sulu 2.6 to Sulu 3.0 is a major upgrade and will require some migration steps.
@@ -1586,6 +1676,11 @@ separate permission contexts, so you'll need to grant permissions for each group
 1. Log in to the Sulu admin interface
 2. Navigate to Settings → User Roles
 3. Edit each role and grant permissions for the new template groups under the Articles section
+
+**5. Configure Template Group Ordering and Translations (Optional)**
+
+Template groups can now be ordered and configured with custom translation keys. See the [3.0.1 upgrade notes](#301)
+above for details on how to configure template group ordering and custom translations.
 
 
 ### Changing deprecated signatures

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Configuration.php
@@ -247,6 +247,38 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('template_groups')
+                    ->useAttributeAsKey('resource_key')
+                    ->prototype('array')
+                        ->useAttributeAsKey('group')
+                        ->beforeNormalization()
+                            ->always(function ($v) {
+                                // Normalize string values to array format and assign order based on array index
+                                $index = 0;
+                                foreach ($v as $key => $value) {
+                                    if (\is_string($value)) {
+                                        $v[$key] = [
+                                            'translation_key' => $value,
+                                            'order' => $index,
+                                        ];
+                                    } elseif (!\array_key_exists('order', $value)) {
+                                        // If order is not set, use array index
+                                        $v[$key]['order'] = $index;
+                                    }
+                                    ++$index;
+                                }
+
+                                return $v;
+                            })
+                        ->end()
+                        ->prototype('array')
+                            ->children()
+                                ->integerNode('order')->defaultValue(9999)->end()
+                                ->scalarNode('translation_key')->defaultNull()->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ->end();
 

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -170,6 +170,7 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sulu_admin.forms.directories', $config['forms']['directories'] ?? []);
         $container->setParameter('sulu_admin.lists.directories', $config['lists']['directories'] ?? []);
         $container->setParameter('sulu_admin.templates.configuration', $config['templates']);
+        $container->setParameter('sulu_admin.template_groups', $config['template_groups'] ?? []);
 
         $container->setParameter('sulu_admin.icon_sets', $config['icon_sets'] ?? []);
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormGroup.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormGroup.php
@@ -20,6 +20,7 @@ final readonly class FormGroup
         public string $identifier,
         public string $title,
         public array $templates = [],
+        public int $order = 9999,
     ) {
     }
 
@@ -29,6 +30,17 @@ final readonly class FormGroup
             $this->identifier,
             $this->title,
             [...$this->templates, $template],
+            $this->order,
+        );
+    }
+
+    public function withOrder(int $order): self
+    {
+        return new self(
+            $this->identifier,
+            $this->title,
+            $this->templates,
+            $order,
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/GroupProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/GroupProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -18,17 +20,42 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class GroupProvider implements GroupProviderInterface
 {
+    /**
+     * @param array<string, array<string, array{order?: int, translation_key?: string}>> $templateGroupsConfig
+     */
     public function __construct(
         private MetadataProviderRegistry $metadataProviderRegistry,
         private TranslatorInterface $translator,
+        private array $templateGroupsConfig = [],
     ) {
     }
 
-    public function getGroups(): array
+    /**
+     * @return array<string, FormGroup>
+     */
+    public function getGroups(/* ?string $resourceKey = null, ?string $templateType = null */): array
     {
+        $argv = \func_get_args();
+        $resourceKey = $argv[0] ?? null;
+        $templateType = $argv[1] ?? null;
+
+        // Trigger deprecation warning when called without arguments
+        if (0 === \func_num_args()) {
+            @\trigger_error(
+                'Calling "GroupProvider::getGroups()" without arguments is deprecated since Sulu 3.x and will be removed in 4.0. Pass the resourceKey and templateType as arguments.',
+                \E_USER_DEPRECATED,
+            );
+        }
+
+        // BC: Defaults to Article
+        $templateType = $templateType ?? ArticleInterface::TEMPLATE_TYPE;
+        $resourceKey = $resourceKey ?? $templateType;
+
         /** @var TypedFormMetadata $metadata */
         $metadata = $this->metadataProviderRegistry->getMetadataProvider('form')
-            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', []);
+            ->getMetadata($templateType, '', []);
+
+        $groupsConfig = $this->templateGroupsConfig[$resourceKey] ?? [];
 
         $groups = [];
 
@@ -36,17 +63,26 @@ final readonly class GroupProvider implements GroupProviderInterface
             $group = $articleForm->getGroup() ?: 'default';
 
             if (!\array_key_exists($group, $groups)) {
-                $groups[$group] = new FormGroup($group, $this->getGroupTitle($group));
+                $groupConfig = $groupsConfig[$group] ?? [];
+                $order = $groupConfig['order'] ?? 9999;
+                $translationKey = $groupConfig['translation_key'] ?? null;
+
+                $groups[$group] = new FormGroup(
+                    $group,
+                    $this->getGroupTitle($group, $translationKey),
+                    [],
+                    $order,
+                );
             }
             $groups[$group] = $groups[$group]->withTemplate($articleForm->getKey());
         }
 
-        return $groups;
+        return $this->sortGroups($groups);
     }
 
-    private function getGroupTitle(string $groupIdentifier): string
+    private function getGroupTitle(string $groupIdentifier, ?string $customTranslationKey = null): string
     {
-        $translationKey = 'sulu_admin.template_group.' . $groupIdentifier;
+        $translationKey = $customTranslationKey ?? 'sulu_admin.template_group.' . $groupIdentifier;
         $translated = $this->translator->trans($translationKey, [], 'admin');
 
         // If translation key doesn't exist, translator returns the key itself
@@ -56,5 +92,24 @@ final readonly class GroupProvider implements GroupProviderInterface
         }
 
         return $translated;
+    }
+
+    /**
+     * @param array<string, FormGroup> $groups
+     *
+     * @return array<string, FormGroup>
+     */
+    private function sortGroups(array $groups): array
+    {
+        // Sort groups by order, then by identifier (alphabetically)
+        \uasort($groups, function (FormGroup $a, FormGroup $b): int {
+            if ($a->order === $b->order) {
+                return $a->identifier <=> $b->identifier;
+            }
+
+            return $a->order <=> $b->order;
+        });
+
+        return $groups;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/GroupProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/GroupProviderInterface.php
@@ -16,7 +16,10 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
 interface GroupProviderInterface
 {
     /**
+     * @param string|null $resourceKey (optional) The resource key to get groups for
+     * @param string|null $templateType (optional) The template type to get groups for
+     *
      * @return array<string, FormGroup>
      */
-    public function getGroups(): array;
+    public function getGroups(/* ?string $resourceKey = null, ?string $templateType = null */): array;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -49,6 +49,7 @@
         <service id="sulu_admin.metadata_group_provider" class="Sulu\Bundle\AdminBundle\Metadata\GroupProvider">
             <argument type="service" id="sulu_admin.metadata_provider_registry"/>
             <argument type="service" id="translator"/>
+            <argument>%sulu_admin.template_groups%</argument>
         </service>
 
         <service

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
@@ -54,7 +54,7 @@ class GroupProviderTest extends TestCase
         $this->translator = $this->prophesize(TranslatorInterface::class);
 
         $this->metadataProviderRegistry = new MetadataProviderRegistry($this->container->reveal());
-        $this->groupProvider = new GroupProvider($this->metadataProviderRegistry, $this->translator->reveal());
+        $this->groupProvider = new GroupProvider($this->metadataProviderRegistry, $this->translator->reveal(), []);
     }
 
     public function testGetGroupsWithSingleGroup(): void
@@ -81,7 +81,7 @@ class GroupProviderTest extends TestCase
         $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
             ->willReturnArgument(0);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(1, $groups);
         $this->assertArrayHasKey('content', $groups);
@@ -120,7 +120,7 @@ class GroupProviderTest extends TestCase
         $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
             ->willReturnArgument(0);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(3, $groups);
         $this->assertArrayHasKey('content', $groups);
@@ -159,7 +159,7 @@ class GroupProviderTest extends TestCase
         $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
             ->willReturnArgument(0);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(1, $groups);
         $this->assertArrayHasKey('default', $groups);
@@ -179,7 +179,7 @@ class GroupProviderTest extends TestCase
             ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
             ->willReturn($typedFormMetadata);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(0, $groups);
         $this->assertEmpty($groups);
@@ -214,7 +214,7 @@ class GroupProviderTest extends TestCase
         $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
             ->willReturnArgument(0);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(2, $groups);
         $this->assertArrayHasKey('content', $groups);
@@ -271,5 +271,428 @@ class GroupProviderTest extends TestCase
             'single_char' => ['a', 'A'],
             'empty_string' => ['', ''],
         ];
+    }
+
+    public function testGetGroupsWithOrdering(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('content');
+
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+        $formMetadata2->setGroup('blog');
+
+        $formMetadata3 = new FormMetadata();
+        $formMetadata3->setKey('news');
+        $formMetadata3->setGroup('news');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+        $typedFormMetadata->addForm('news', $formMetadata3);
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
+            ->willReturnArgument(0);
+
+        // Create a GroupProvider with ordering configuration
+        $groupProvider = new GroupProvider(
+            $this->metadataProviderRegistry,
+            $this->translator->reveal(),
+            [
+                ArticleInterface::TEMPLATE_TYPE => [
+                    'news' => ['order' => 10],
+                    'blog' => ['order' => 20],
+                    'content' => ['order' => 30],
+                ],
+            ]
+        );
+
+        $groups = $groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertCount(3, $groups);
+
+        // Verify groups are returned in the configured order
+        $groupKeys = \array_keys($groups);
+        $this->assertSame('news', $groupKeys[0]);
+        $this->assertSame('blog', $groupKeys[1]);
+        $this->assertSame('content', $groupKeys[2]);
+
+        // Verify order property
+        $this->assertSame(10, $groups['news']->order);
+        $this->assertSame(20, $groups['blog']->order);
+        $this->assertSame(30, $groups['content']->order);
+    }
+
+    public function testGetGroupsWithPartialOrdering(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('content');
+
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+        $formMetadata2->setGroup('blog');
+
+        $formMetadata3 = new FormMetadata();
+        $formMetadata3->setKey('news');
+        $formMetadata3->setGroup('news');
+
+        $formMetadata4 = new FormMetadata();
+        $formMetadata4->setKey('archive');
+        $formMetadata4->setGroup('archive');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+        $typedFormMetadata->addForm('news', $formMetadata3);
+        $typedFormMetadata->addForm('archive', $formMetadata4);
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
+            ->willReturnArgument(0);
+
+        // Create a GroupProvider with partial ordering configuration (only news and blog)
+        $groupProvider = new GroupProvider(
+            $this->metadataProviderRegistry,
+            $this->translator->reveal(),
+            [
+                ArticleInterface::TEMPLATE_TYPE => [
+                    'news' => ['order' => 10],
+                    'blog' => ['order' => 20],
+                ],
+            ]
+        );
+
+        $groups = $groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertCount(4, $groups);
+
+        // Verify groups are returned in correct order:
+        // - configured groups first (news, blog)
+        // - unconfigured groups last, alphabetically (archive, content)
+        $groupKeys = \array_keys($groups);
+        $this->assertSame('news', $groupKeys[0]);
+        $this->assertSame('blog', $groupKeys[1]);
+        $this->assertSame('archive', $groupKeys[2]);
+        $this->assertSame('content', $groupKeys[3]);
+
+        // Verify order property
+        $this->assertSame(10, $groups['news']->order);
+        $this->assertSame(20, $groups['blog']->order);
+        $this->assertSame(9999, $groups['archive']->order);
+        $this->assertSame(9999, $groups['content']->order);
+    }
+
+    public function testGetGroupsWithoutOrdering(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('content');
+
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('blog');
+        $formMetadata2->setGroup('blog');
+
+        $formMetadata3 = new FormMetadata();
+        $formMetadata3->setKey('news');
+        $formMetadata3->setGroup('news');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('blog', $formMetadata2);
+        $typedFormMetadata->addForm('news', $formMetadata3);
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
+            ->willReturnArgument(0);
+
+        // Create a GroupProvider without ordering configuration
+        $groupProvider = new GroupProvider(
+            $this->metadataProviderRegistry,
+            $this->translator->reveal(),
+            []
+        );
+
+        $groups = $groupProvider->getGroups();
+
+        $this->assertCount(3, $groups);
+
+        // Verify groups are returned in alphabetical order
+        $groupKeys = \array_keys($groups);
+        $this->assertSame('blog', $groupKeys[0]);
+        $this->assertSame('content', $groupKeys[1]);
+        $this->assertSame('news', $groupKeys[2]);
+
+        // Verify all have default order
+        $this->assertSame(9999, $groups['blog']->order);
+        $this->assertSame(9999, $groups['content']->order);
+        $this->assertSame(9999, $groups['news']->order);
+    }
+
+    public function testGetGroupsWithCustomTranslationKey(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('blog');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans('app.custom_blog_title', [], 'admin')
+            ->willReturn('Custom Blog Title');
+
+        // Create a GroupProvider with custom translation key
+        $groupProvider = new GroupProvider(
+            $this->metadataProviderRegistry,
+            $this->translator->reveal(),
+            [
+                ArticleInterface::TEMPLATE_TYPE => [
+                    'blog' => ['translation_key' => 'app.custom_blog_title'],
+                ],
+            ]
+        );
+
+        $groups = $groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertCount(1, $groups);
+        $this->assertSame('Custom Blog Title', $groups['blog']->title);
+    }
+
+    public function testGetGroupsWithCustomResourceKey(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('page');
+        $formMetadata1->setGroup('homepage');
+
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('default');
+        $formMetadata2->setGroup('standard');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('page', $formMetadata1);
+        $typedFormMetadata->addForm('default', $formMetadata2);
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata('pages', '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
+            ->willReturnArgument(0);
+
+        // Create a GroupProvider with configuration for custom resource key
+        $groupProvider = new GroupProvider(
+            $this->metadataProviderRegistry,
+            $this->translator->reveal(),
+            [
+                'pages' => [
+                    'homepage' => ['order' => 1],
+                    'standard' => ['order' => 2],
+                ],
+            ]
+        );
+
+        $groups = $groupProvider->getGroups('pages', 'pages');
+
+        $this->assertCount(2, $groups);
+
+        // Verify groups are returned in the configured order
+        $groupKeys = \array_keys($groups);
+        $this->assertSame('homepage', $groupKeys[0]);
+        $this->assertSame('standard', $groupKeys[1]);
+
+        // Verify order property
+        $this->assertSame(1, $groups['homepage']->order);
+        $this->assertSame(2, $groups['standard']->order);
+    }
+
+    public function testGetGroupsBackwardCompatibility(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('blog');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
+            ->willReturnArgument(0);
+
+        $groupProvider = new GroupProvider(
+            $this->metadataProviderRegistry,
+            $this->translator->reveal(),
+            []
+        );
+
+        // Capture deprecation warning
+        $deprecationTriggered = false;
+        set_error_handler(function ($errno, $errstr) use (&$deprecationTriggered) {
+            if (\E_USER_DEPRECATED === $errno && false !== \strpos($errstr, 'Calling "GroupProvider::getGroups()" without arguments is deprecated')) {
+                $deprecationTriggered = true;
+
+                return true;
+            }
+
+            return false;
+        }, \E_USER_DEPRECATED);
+
+        // Call without parameters - should use ArticleInterface::TEMPLATE_TYPE as default and trigger deprecation
+        $groups = $groupProvider->getGroups();
+
+        restore_error_handler();
+
+        $this->assertTrue($deprecationTriggered, 'Deprecation warning should have been triggered');
+        $this->assertCount(1, $groups);
+        $this->assertArrayHasKey('blog', $groups);
+    }
+
+    public function testGetGroupsWithTemplateTypeOnly(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('page');
+        $formMetadata1->setGroup('homepage');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('page', $formMetadata1);
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata('pages', '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
+            ->willReturnArgument(0);
+
+        $groupProvider = new GroupProvider(
+            $this->metadataProviderRegistry,
+            $this->translator->reveal(),
+            [
+                'pages' => [
+                    'homepage' => ['order' => 10],
+                ],
+            ]
+        );
+
+        // Call with only templateType - resourceKey should default to templateType
+        $groups = $groupProvider->getGroups(null, 'pages');
+
+        $this->assertCount(1, $groups);
+        $this->assertArrayHasKey('homepage', $groups);
+        $this->assertSame(10, $groups['homepage']->order);
+    }
+
+    public function testGetGroupsWithShorthandConfigurationUsesArrayIndex(): void
+    {
+        $formMetadata1 = new FormMetadata();
+        $formMetadata1->setKey('article');
+        $formMetadata1->setGroup('blog');
+
+        $formMetadata2 = new FormMetadata();
+        $formMetadata2->setKey('news');
+        $formMetadata2->setGroup('news');
+
+        $formMetadata3 = new FormMetadata();
+        $formMetadata3->setKey('archive');
+        $formMetadata3->setGroup('archive');
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('article', $formMetadata1);
+        $typedFormMetadata->addForm('news', $formMetadata2);
+        $typedFormMetadata->addForm('archive', $formMetadata3);
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans('app.blog_articles', [], 'admin')
+            ->willReturn('Blog Articles');
+        $this->translator->trans('app.news_articles', [], 'admin')
+            ->willReturn('News Articles');
+        $this->translator->trans('app.archive_articles', [], 'admin')
+            ->willReturn('Archive Articles');
+
+        // Config processed by Symfony would have array indices as order
+        // This simulates what the configuration normalization does
+        $groupProvider = new GroupProvider(
+            $this->metadataProviderRegistry,
+            $this->translator->reveal(),
+            [
+                ArticleInterface::TEMPLATE_TYPE => [
+                    'blog' => [
+                        'translation_key' => 'app.blog_articles',
+                        'order' => 0, // array index
+                    ],
+                    'news' => [
+                        'translation_key' => 'app.news_articles',
+                        'order' => 1, // array index
+                    ],
+                    'archive' => [
+                        'translation_key' => 'app.archive_articles',
+                        'order' => 2, // array index
+                    ],
+                ],
+            ]
+        );
+
+        $groups = $groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE, ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertCount(3, $groups);
+
+        // Verify groups are returned in array index order
+        $groupKeys = \array_keys($groups);
+        $this->assertSame('blog', $groupKeys[0]);
+        $this->assertSame('news', $groupKeys[1]);
+        $this->assertSame('archive', $groupKeys[2]);
+
+        // Verify order property matches array indices
+        $this->assertSame(0, $groups['blog']->order);
+        $this->assertSame(1, $groups['news']->order);
+        $this->assertSame(2, $groups['archive']->order);
+
+        // Verify custom translation keys were used
+        $this->assertSame('Blog Articles', $groups['blog']->title);
+        $this->assertSame('News Articles', $groups['news']->title);
+        $this->assertSame('Archive Articles', $groups['archive']->title);
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes (But with BC-Layer
| Deprecations? | yes (Additional arguments for `getGroups`)
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This change introduces the ability to configure custom ordering and translation keys for template groups via sulu_admin.yaml configuration.

#### Why?

This allows to reorder the template groups in the admin via configuration ad a

#### Example Usage

Configuration example:
```yaml
sulu_admin:
    template_groups:
        articles:
            blog:
                order: 1
                translation_key: 'app.blog_articles'
            news: 'app.news_articles'  # shorthand, order = array index
```

#### To Do

- [x] Add breaking changes to UPGRADE.md
