### PR TITLE
Use article mainWebspace as default preview webspace

### DIFF
--- a/packages/article/src/Application/MessageHandler/CopyLocaleArticleMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/CopyLocaleArticleMessageHandler.php
@@ -45,6 +45,9 @@ final class CopyLocaleArticleMessageHandler
             [
                 'stage' => DimensionContentInterface::STAGE_DRAFT,
                 'locale' => $message->getTargetLocale(),
+            ],
+            [
+                'ignoredAttributes' => ['mainWebspace', 'additionalWebspaces'],
             ]
         );
 

--- a/packages/article/src/Infrastructure/Sulu/Content/DataMapper/AdditionalWebspacesDataMapper.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/DataMapper/AdditionalWebspacesDataMapper.php
@@ -15,6 +15,7 @@ namespace Sulu\Article\Infrastructure\Sulu\Content\DataMapper;
 
 use Sulu\Article\Application\Webspace\WebspaceSettingsConfigurationResolver;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\DataMapperInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Webmozart\Assert\Assert;
@@ -23,6 +24,7 @@ class AdditionalWebspacesDataMapper implements DataMapperInterface
 {
     public function __construct(
         private readonly WebspaceSettingsConfigurationResolver $webspaceSettingsConfigurationResolver,
+        private readonly WebspaceManagerInterface $webspaceManager,
     ) {
     }
 
@@ -73,7 +75,34 @@ class AdditionalWebspacesDataMapper implements DataMapperInterface
                 return \is_string($webspace) && '' !== $webspace;
             });
 
+            // Validate all webspaces support the current locale
+            if (\count($additionalWebspaces) > 0) {
+                $locale = (string) $dimensionContent->getLocale();
+                foreach ($additionalWebspaces as $webspaceKey) {
+                    $this->validateWebspaceSupportsLocale($webspaceKey, $locale);
+                }
+            }
+
             $dimensionContent->setAdditionalWebspaces(\array_values($additionalWebspaces));
+        }
+    }
+
+    private function validateWebspaceSupportsLocale(string $webspaceKey, ?string $locale): void
+    {
+        if (!$locale) {
+            return;
+        }
+
+        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+
+        if (!$webspace) {
+            throw new \InvalidArgumentException(\sprintf('Webspace "%s" not found', $webspaceKey));
+        }
+
+        if (!$webspace->getLocalization($locale)) {
+            throw new \InvalidArgumentException(
+                \sprintf('Webspace "%s" does not support locale "%s"', $webspaceKey, $locale)
+            );
         }
     }
 }

--- a/packages/article/src/Infrastructure/Sulu/Content/DataMapper/AdditionalWebspacesDataMapper.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/DataMapper/AdditionalWebspacesDataMapper.php
@@ -70,12 +70,10 @@ class AdditionalWebspacesDataMapper implements DataMapperInterface
             Assert::nullOrIsArray($data['additionalWebspaces']);
             $additionalWebspaces = $data['additionalWebspaces'] ?? [];
 
-            // Ensure all values are strings
             $additionalWebspaces = \array_filter($additionalWebspaces, static function($webspace): bool {
                 return \is_string($webspace) && '' !== $webspace;
             });
 
-            // Validate all webspaces support the current locale
             if (\count($additionalWebspaces) > 0) {
                 $locale = (string) $dimensionContent->getLocale();
                 foreach ($additionalWebspaces as $webspaceKey) {

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -236,6 +236,7 @@ final class SuluArticleBundle extends AbstractBundle
             ->class(AdditionalWebspacesDataMapper::class)
             ->args([
                 new Reference('sulu_article.webspace_settings_configuration_resolver'),
+                new Reference('sulu_core.webspace.webspace_manager'),
             ])
             ->tag('sulu_content.data_mapper');
 

--- a/packages/article/tests/Unit/Application/Content/DataMapper/AdditionalWebspacesDataMapperTest.php
+++ b/packages/article/tests/Unit/Application/Content/DataMapper/AdditionalWebspacesDataMapperTest.php
@@ -178,4 +178,62 @@ class AdditionalWebspacesDataMapperTest extends TestCase
 
         $dataMapper->map($unlocalizedDimensionContent->reveal(), $dimensionContent->reveal(), $data);
     }
+
+    public function testMapWithUnsupportedLocaleThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Webspace "example-com" does not support locale "de"');
+
+        $dataMapper = $this->getAdditionalWebspacesDataMapperInstance();
+
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(ArticleDimensionContentInterface::class);
+        $dimensionContent->setCustomizeWebspaceSettings(true)->shouldBeCalled()->willReturn($dimensionContent->reveal());
+        $dimensionContent->getLocale()->willReturn('de');
+
+        // Mock webspace that only supports 'en'
+        $localizationEn = new Localization('en');
+        $webspace = new Webspace();
+        $webspace->setKey('example-com');
+        $webspace->setName('Example');
+        $webspace->addLocalization($localizationEn);
+        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($webspace);
+
+        $data = [
+            'customizeWebspaceSettings' => true,
+            'mainWebspace' => 'sulu-io',
+            'additionalWebspaces' => ['example-com'],
+        ];
+
+        $dataMapper->map($unlocalizedDimensionContent->reveal(), $dimensionContent->reveal(), $data);
+    }
+
+    public function testMapWithSupportedLocale(): void
+    {
+        $dataMapper = $this->getAdditionalWebspacesDataMapperInstance();
+
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(ArticleDimensionContentInterface::class);
+        $dimensionContent->setCustomizeWebspaceSettings(true)->shouldBeCalled()->willReturn($dimensionContent->reveal());
+        $dimensionContent->getLocale()->willReturn('en');
+        $dimensionContent->setAdditionalWebspaces(['example-com'])->shouldBeCalled()->willReturn($dimensionContent->reveal());
+
+        // Mock webspace that supports 'en'
+        $localizationEn = new Localization('en');
+        $webspace = new Webspace();
+        $webspace->setKey('example-com');
+        $webspace->setName('Example');
+        $webspace->addLocalization($localizationEn);
+        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($webspace);
+
+        $data = [
+            'customizeWebspaceSettings' => true,
+            'mainWebspace' => 'sulu-io',
+            'additionalWebspaces' => ['example-com'],
+        ];
+
+        $dataMapper->map($unlocalizedDimensionContent->reveal(), $dimensionContent->reveal(), $data);
+    }
 }

--- a/packages/article/tests/Unit/Application/Content/DataMapper/AdditionalWebspacesDataMapperTest.php
+++ b/packages/article/tests/Unit/Application/Content/DataMapper/AdditionalWebspacesDataMapperTest.php
@@ -19,6 +19,9 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Article\Application\Webspace\WebspaceSettingsConfigurationResolver;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Infrastructure\Sulu\Content\DataMapper\AdditionalWebspacesDataMapper;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 class AdditionalWebspacesDataMapperTest extends TestCase
@@ -28,14 +31,21 @@ class AdditionalWebspacesDataMapperTest extends TestCase
     /** @var ObjectProphecy<WebspaceSettingsConfigurationResolver> */
     private ObjectProphecy $configurationResolver;
 
+    /** @var ObjectProphecy<WebspaceManagerInterface> */
+    private ObjectProphecy $webspaceManager;
+
     protected function setUp(): void
     {
         $this->configurationResolver = $this->prophesize(WebspaceSettingsConfigurationResolver::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
     }
 
     protected function getAdditionalWebspacesDataMapperInstance(): AdditionalWebspacesDataMapper
     {
-        return new AdditionalWebspacesDataMapper($this->configurationResolver->reveal());
+        return new AdditionalWebspacesDataMapper(
+            $this->configurationResolver->reveal(),
+            $this->webspaceManager->reveal()
+        );
     }
 
     public function testMapNotImplementingInterface(): void
@@ -65,7 +75,16 @@ class AdditionalWebspacesDataMapperTest extends TestCase
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent->willImplement(ArticleDimensionContentInterface::class);
         $dimensionContent->setCustomizeWebspaceSettings(true)->shouldBeCalled()->willReturn($dimensionContent->reveal());
+        $dimensionContent->getLocale()->willReturn('en');
         $dimensionContent->setAdditionalWebspaces(['example-com'])->shouldBeCalled()->willReturn($dimensionContent->reveal());
+
+        // Mock webspace with locale support
+        $localization = new Localization('en');
+        $webspace = new Webspace();
+        $webspace->setKey('example-com');
+        $webspace->setName('Example');
+        $webspace->addLocalization($localization);
+        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($webspace);
 
         $data = [
             'customizeWebspaceSettings' => true,

--- a/packages/article/tests/Unit/Application/Content/DataMapper/AdditionalWebspacesDataMapperTest.php
+++ b/packages/article/tests/Unit/Application/Content/DataMapper/AdditionalWebspacesDataMapperTest.php
@@ -78,7 +78,6 @@ class AdditionalWebspacesDataMapperTest extends TestCase
         $dimensionContent->getLocale()->willReturn('en');
         $dimensionContent->setAdditionalWebspaces(['example-com'])->shouldBeCalled()->willReturn($dimensionContent->reveal());
 
-        // Mock webspace with locale support
         $localization = new Localization('en');
         $webspace = new Webspace();
         $webspace->setKey('example-com');
@@ -192,7 +191,6 @@ class AdditionalWebspacesDataMapperTest extends TestCase
         $dimensionContent->setCustomizeWebspaceSettings(true)->shouldBeCalled()->willReturn($dimensionContent->reveal());
         $dimensionContent->getLocale()->willReturn('de');
 
-        // Mock webspace that only supports 'en'
         $localizationEn = new Localization('en');
         $webspace = new Webspace();
         $webspace->setKey('example-com');
@@ -220,7 +218,6 @@ class AdditionalWebspacesDataMapperTest extends TestCase
         $dimensionContent->getLocale()->willReturn('en');
         $dimensionContent->setAdditionalWebspaces(['example-com'])->shouldBeCalled()->willReturn($dimensionContent->reveal());
 
-        // Mock webspace that supports 'en'
         $localizationEn = new Localization('en');
         $webspace = new Webspace();
         $webspace->setKey('example-com');

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
@@ -57,7 +57,6 @@ class WebspaceDataMapper implements DataMapperInterface
         if (\array_key_exists('mainWebspace', $data)) {
             Assert::nullOrString($data['mainWebspace']);
 
-            // Validate that the webspace supports the current locale
             if ($data['mainWebspace']) {
                 $this->validateWebspaceSupportsLocale($data['mainWebspace'], $dimensionContent->getLocale());
             }

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
@@ -56,12 +56,37 @@ class WebspaceDataMapper implements DataMapperInterface
         //      on the template itself which will be injected with ["type" => ["template-key" => "webspace-key"]] into this service.
         if (\array_key_exists('mainWebspace', $data)) {
             Assert::nullOrString($data['mainWebspace']);
+
+            // Validate that the webspace supports the current locale
+            if ($data['mainWebspace']) {
+                $this->validateWebspaceSupportsLocale($data['mainWebspace'], $dimensionContent->getLocale());
+            }
+
             $dimensionContent->setMainWebspace($data['mainWebspace']);
         }
 
         if (!$dimensionContent->getMainWebspace()) {
             // if no main webspace is yet set a default webspace will be set
             $dimensionContent->setMainWebspace($this->getDefaultWebspaceKey());
+        }
+    }
+
+    private function validateWebspaceSupportsLocale(string $webspaceKey, ?string $locale): void
+    {
+        if (!$locale) {
+            return;
+        }
+
+        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+
+        if (!$webspace) {
+            throw new \InvalidArgumentException(\sprintf('Webspace "%s" not found', $webspaceKey));
+        }
+
+        if (!$webspace->getLocalization($locale)) {
+            throw new \InvalidArgumentException(
+                \sprintf('Webspace "%s" does not support locale "%s"', $webspaceKey, $locale)
+            );
         }
     }
 

--- a/packages/content/tests/Functional/Integration/ExampleControllerTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerTest.php
@@ -451,7 +451,7 @@ class ExampleControllerTest extends SuluTestCase
             'excerptIcon' => null,
             'excerptMedia' => null,
             'authored' => '2020-06-09T00:00:00+00:00',
-            'mainWebspace' => 'sulu-io2',
+            'mainWebspace' => 'sulu-io',
             'lastModifiedEnabled' => true,
             'lastModified' => '2022-05-08T00:00:00+00:00',
         ]) ?: null);

--- a/packages/content/tests/Functional/Integration/responses/example_put.json
+++ b/packages/content/tests/Functional/Integration/responses/example_put.json
@@ -57,5 +57,5 @@
     "url": "/my-example-2",
     "version": 0,
     "workflowPlace": "unpublished",
-    "mainWebspace": "sulu-io2"
+    "mainWebspace": "sulu-io"
 }

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
@@ -146,7 +146,6 @@ class WebspaceDataMapperTest extends TestCase
         $localizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent->setLocale('de');
 
-        // Mock webspace that only supports 'en'
         $localizationEn = new Localization('en');
         $webspace = new Webspace();
         $webspace->setKey('example');
@@ -169,7 +168,6 @@ class WebspaceDataMapperTest extends TestCase
         $localizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent->setLocale('en');
 
-        // Mock webspace that supports 'en'
         $localizationEn = new Localization('en');
         $webspace = new Webspace();
         $webspace->setKey('example');

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Content\Tests\Unit\Content\Application\ContentDataMapper\DataMapp
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceCollection;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
@@ -129,5 +130,56 @@ class WebspaceDataMapperTest extends TestCase
         $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertNull($localizedDimensionContent->getMainWebspace());
+    }
+
+    public function testMapDataWithUnsupportedLocaleThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Webspace "example" does not support locale "de"');
+
+        $data = [
+            'mainWebspace' => 'example',
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('de');
+
+        // Mock webspace that only supports 'en'
+        $localizationEn = new Localization('en');
+        $webspace = new Webspace();
+        $webspace->setKey('example');
+        $webspace->addLocalization($localizationEn);
+
+        $this->webspaceManager->findWebspaceByKey('example')->willReturn($webspace);
+
+        $authorMapper = $this->createWebspaceDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+    }
+
+    public function testMapDataWithSupportedLocale(): void
+    {
+        $data = [
+            'mainWebspace' => 'example',
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        // Mock webspace that supports 'en'
+        $localizationEn = new Localization('en');
+        $webspace = new Webspace();
+        $webspace->setKey('example');
+        $webspace->addLocalization($localizationEn);
+
+        $this->webspaceManager->findWebspaceByKey('example')->willReturn($webspace);
+
+        $authorMapper = $this->createWebspaceDataMapperInstance();
+        $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame('example', $localizedDimensionContent->getMainWebspace());
     }
 }

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -41,7 +41,6 @@ class Preview extends React.Component<Props> {
 
     @observable previewStore: PreviewStore;
     @observable previewWindow: any;
-    @observable webspaceOptions: Array<Object> = [];
     @observable reloadCounter: number = 0;
 
     schemaDisposer: () => mixed;
@@ -50,6 +49,9 @@ class Preview extends React.Component<Props> {
 
     @computed get webspaceKey() {
         const {
+            formStore: {
+                data,
+            },
             router: {
                 attributes: {
                     webspace,
@@ -61,7 +63,38 @@ class Preview extends React.Component<Props> {
             throw new Error('The "webspace" router attribute must be a string if set!');
         }
 
-        return webspace || this.webspaceOptions[0].value;
+        // Priority: router attribute > article mainWebspace > first available webspace
+        const mainWebspace = data?.mainWebspace;
+        if (webspace) {
+            return webspace;
+        }
+
+        // Use mainWebspace if it's valid and supports the current locale
+        if (mainWebspace && this.webspaceOptions.some((option) => option.value === mainWebspace)) {
+            return mainWebspace;
+        }
+
+        return this.webspaceOptions[0]?.value;
+    }
+
+    @computed get webspaceOptions(): Array<Object> {
+        const {formStore: {locale}} = this.props;
+        const currentLocale = locale?.get();
+
+        return webspaceStore.grantedWebspaces
+            .filter((webspace) => {
+                // Filter webspaces that support the current locale
+                if (!currentLocale || !webspace.localizations) {
+                    return true;
+                }
+                return webspace.localizations.some(
+                    (localization) => localization.locale === currentLocale
+                );
+            })
+            .map((webspace): Object => ({
+                label: webspace.name,
+                value: webspace.key,
+            }));
     }
 
     @computed get segments() {
@@ -82,11 +115,6 @@ class Preview extends React.Component<Props> {
         if (Preview.audienceTargeting) {
             this.targetGroupsStore = new ResourceListStore('target_groups');
         }
-
-        this.webspaceOptions = webspaceStore.grantedWebspaces.map((webspace): Object => ({
-            label: webspace.name,
-            value: webspace.key,
-        }));
 
         this.createPreviewStore();
         if (Preview.mode === 'auto') {
@@ -166,6 +194,8 @@ class Preview extends React.Component<Props> {
         this.localeDisposer = reaction(
             () => toJS(formStore.locale),
             (locale) => {
+                // Update webspace to one that supports the new locale
+                this.previewStore.setWebspace(this.webspaceKey);
                 this.previewStore.restart(locale);
             }
         );

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -58,6 +58,7 @@ jest.mock('sulu-admin-bundle/containers/Form/stores/ResourceFormStore', () => je
         return {
             resourceKey: resourceStore.resourceKey,
             locale: resourceStore.observableOptions?.locale,
+            data: {},
         };
     }
 ));
@@ -583,7 +584,7 @@ test('Change target group in PreviewStore when selection of target group has cha
 
         preview.find('Select').at(2).prop('onChange')(4);
         expect(previewStore.setTargetGroup).toBeCalledWith(4);
-        expect(previewStore.update).toBeCalledWith(undefined);
+        expect(previewStore.update).toBeCalledWith({});
     });
 });
 
@@ -610,4 +611,34 @@ test('Change dateTime in PreviewStore when DatePicker changed', () => {
         preview.find('DatePicker').prop('onChange')(date);
         expect(previewStore.setDateTime).toBeCalledWith(date);
     });
+});
+
+test('Use mainWebspace from formStore data as default webspace', () => {
+    const resourceStore = new ResourceStore('articles', 1);
+    const formStore = new ResourceFormStore(resourceStore, 'articles');
+
+    // $FlowFixMe
+    formStore.data = {mainWebspace: 'example'};
+
+    const router = new Router({});
+
+    mount(<Preview formStore={formStore} router={router} />);
+
+    // Should use mainWebspace from formStore.data instead of first webspace
+    expect(PreviewStore).toBeCalledWith('articles', undefined, undefined, 'example', undefined);
+});
+
+test('Fall back to first webspace when mainWebspace is not in webspace options', () => {
+    const resourceStore = new ResourceStore('articles', 1);
+    const formStore = new ResourceFormStore(resourceStore, 'articles');
+
+    // $FlowFixMe
+    formStore.data = {mainWebspace: 'non_existent_webspace'};
+
+    const router = new Router({});
+
+    mount(<Preview formStore={formStore} router={router} />);
+
+    // Should fall back to first webspace when mainWebspace is not available
+    expect(PreviewStore).toBeCalledWith('articles', undefined, undefined, 'sulu_io', undefined);
 });

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -624,7 +624,6 @@ test('Use mainWebspace from formStore data as default webspace', () => {
 
     mount(<Preview formStore={formStore} router={router} />);
 
-    // Should use mainWebspace from formStore.data instead of first webspace
     expect(PreviewStore).toBeCalledWith('articles', undefined, undefined, 'example', undefined);
 });
 
@@ -639,6 +638,5 @@ test('Fall back to first webspace when mainWebspace is not in webspace options',
 
     mount(<Preview formStore={formStore} router={router} />);
 
-    // Should fall back to first webspace when mainWebspace is not available
     expect(PreviewStore).toBeCalledWith('articles', undefined, undefined, 'sulu_io', undefined);
 });


### PR DESCRIPTION
 Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes none
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

The preview now uses the article's mainWebspace setting as the default webspace for preview rendering. This fixes an issue where previewing an article in a locale not supported by the first webspace would fail with WebspaceLocalizationNotFoundException.

#### To Do
