### PR TITLE
Fix handling of maybe none exist TargetGroup Collection in Media FileVersion

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersion.php
@@ -677,7 +677,7 @@ class FileVersion implements AuditableInterface
      */
     public function addTargetGroup(TargetGroupInterface $targetGroup)
     {
-        $this->targetGroups[] = $targetGroup;
+        $this->getTargetGroups()[] = $targetGroup;
     }
 
     /**
@@ -685,8 +685,8 @@ class FileVersion implements AuditableInterface
      */
     public function removeTargetGroups()
     {
-        foreach ($this->targetGroups as $targetGroup) {
-            $this->targetGroups->removeElement($targetGroup);
+        foreach ($this->getTargetGroups() as $targetGroup) {
+            $this->getTargetGroups()->removeElement($targetGroup);
         }
     }
 
@@ -695,6 +695,13 @@ class FileVersion implements AuditableInterface
      */
     public function getTargetGroups()
     {
+        // Lazy initialization needed because targetGroups is not mapped in Doctrine
+        // (AudienceTargetingBundle is optional). Doctrine won't initialize this
+        // collection when loading entities from the database.
+        if (!isset($this->targetGroups)) { // @phpstan-ignore-line isset.initializedProperty
+            $this->targetGroups = new ArrayCollection();
+        }
+
         return $this->targetGroups;
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/8372, https://github.com/sulu/sulu/pull/8417
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix issue that target group is not initialized.

#### Why?

Bug introduced in https://github.com/sulu/sulu/pull/8372. Fixed in https://github.com/sulu/sulu/pull/8417 but forgot to backport to 2.6.