### PR TITLE
Add stringable interface to models with __toString method

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactTitle.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactTitle.php
@@ -16,7 +16,7 @@ use JMS\Serializer\Annotation\Groups;
 /**
  * ContactTitle.
  */
-class ContactTitle implements \JsonSerializable
+class ContactTitle implements \Stringable, \JsonSerializable
 {
     public const RESOURCE_KEY = 'contact_titles';
 

--- a/src/Sulu/Bundle/SecurityBundle/Entity/Permission.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/Permission.php
@@ -19,7 +19,7 @@ use Sulu\Component\Security\Authentication\RoleInterface;
  * Permission.
  */
 #[ExclusionPolicy('all')] // ;
-class Permission
+class Permission implements \Stringable
 {
     /**
      * @var string

--- a/src/Sulu/Bundle/TagBundle/Entity/Tag.php
+++ b/src/Sulu/Bundle/TagBundle/Entity/Tag.php
@@ -19,7 +19,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
 /**
  * Represents single tag in the system.
  */
-class Tag implements TagInterface
+class Tag implements \Stringable, TagInterface
 {
     /**
      * @var string

--- a/src/Sulu/Component/Content/Compat/PropertyParameter.php
+++ b/src/Sulu/Component/Content/Compat/PropertyParameter.php
@@ -17,7 +17,7 @@ use JMS\Serializer\Annotation\Type;
 /**
  * Represents a parameter of a property.
  */
-class PropertyParameter implements \JsonSerializable
+class PropertyParameter implements \Stringable, \JsonSerializable
 {
     /**
      * @var string

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -18,7 +18,7 @@ use Sulu\Component\Util\ArrayableInterface;
 /**
  * Represents a localization of a webspace definition.
  */
-class Localization implements \JsonSerializable, ArrayableInterface
+class Localization implements \Stringable, \JsonSerializable, ArrayableInterface
 {
     public const UNDERSCORE = 'de_at';
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add stringable interface to models with __toString method.

#### Why?

This is what php cs fixer and the symfony ruleset recommend. Should we add it also or disable the rule @sulu/core-developer ?