### PR TITLE
Include PHP 8.5 in version string to be more transparent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "docs": "https://docs.sulu.io/"
     },
     "require": {
-        "php": "^8.2 || ^8.3 || ^8.4",
+        "php": "^8.2 || ^8.3 || ^8.4 || ^8.5",
         "ext-dom": "*",
         "ext-fileinfo": "*",
         "ext-filter": "*",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu-docs/pull/859
| License | MIT
| Documentation PR | https://github.com/sulu/sulu-docs/pull/859

#### What's in this PR?

Include PHP 8.5 in version string to be more transparent.

#### Why?

We are not strict to PHP versions like other Libraries which do explicit `8.2.* || 8.3.* || ...` to limit the version to what it is tested to. But we are also not as open like Symfony just do `>=8.2`.

Still in the past we got reported if a specific php version is already supported or not. The composer.json should reflect what versions we are testing against and supporting at that state officially without being too strict. Even a `^8.4` includes `^8.5` we still make this way transparent.