### PR TITLE
Use constructor property promotion on the content bundle

### DIFF
--- a/packages/content/src/Application/ContentCopier/ContentCopier.php
+++ b/packages/content/src/Application/ContentCopier/ContentCopier.php
@@ -23,36 +23,12 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 class ContentCopier implements ContentCopierInterface
 {
-    /**
-     * @var ContentAggregatorInterface
-     */
-    private $contentAggregator;
-
-    /**
-     * @var ContentMergerInterface
-     */
-    private $contentMerger;
-
-    /**
-     * @var ContentPersisterInterface
-     */
-    private $contentPersister;
-
-    /**
-     * @var ContentNormalizerInterface
-     */
-    private $contentNormalizer;
-
     public function __construct(
-        ContentAggregatorInterface $contentAggregator,
-        ContentMergerInterface $contentMerger,
-        ContentPersisterInterface $contentPersister,
-        ContentNormalizerInterface $contentNormalizer
+        private ContentAggregatorInterface $contentAggregator,
+        private ContentMergerInterface $contentMerger,
+        private ContentPersisterInterface $contentPersister,
+        private ContentNormalizerInterface $contentNormalizer
     ) {
-        $this->contentAggregator = $contentAggregator;
-        $this->contentMerger = $contentMerger;
-        $this->contentPersister = $contentPersister;
-        $this->contentNormalizer = $contentNormalizer;
     }
 
     public function copy(

--- a/packages/content/src/Application/ContentDataMapper/ContentDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/ContentDataMapper.php
@@ -19,16 +19,10 @@ use Sulu\Content\Domain\Model\DimensionContentCollectionInterface;
 class ContentDataMapper implements ContentDataMapperInterface
 {
     /**
-     * @var iterable<DataMapperInterface>
-     */
-    private $dataMappers;
-
-    /**
      * @param iterable<DataMapperInterface> $dataMappers
      */
-    public function __construct(iterable $dataMappers)
+    public function __construct(private iterable $dataMappers)
     {
-        $this->dataMappers = $dataMappers;
     }
 
     public function map(

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/AuthorDataMapper.php
@@ -20,14 +20,8 @@ use Webmozart\Assert\Assert;
 
 class AuthorDataMapper implements DataMapperInterface
 {
-    /**
-     * @var ContactFactoryInterface
-     */
-    private $contactFactory;
-
-    public function __construct(ContactFactoryInterface $contactFactory)
+    public function __construct(private ContactFactoryInterface $contactFactory)
     {
-        $this->contactFactory = $contactFactory;
     }
 
     public function map(

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
@@ -21,14 +21,8 @@ use Sulu\Content\Domain\Model\TemplateInterface;
 
 class TemplateDataMapper implements DataMapperInterface
 {
-    /**
-     * @var MetadataProviderRegistry
-     */
-    private $metadataProviderRegistry;
-
-    public function __construct(MetadataProviderRegistry $metadataProviderRegistry)
+    public function __construct(private MetadataProviderRegistry $metadataProviderRegistry)
     {
-        $this->metadataProviderRegistry = $metadataProviderRegistry;
     }
 
     public function map(

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
@@ -21,18 +21,12 @@ use Webmozart\Assert\Assert;
 class WebspaceDataMapper implements DataMapperInterface
 {
     /**
-     * @var WebspaceManagerInterface
-     */
-    private $webspaceManager;
-
-    /**
      * @var string|null
      */
     private $defaultWebspaceKey;
 
-    public function __construct(WebspaceManagerInterface $webspaceManager)
+    public function __construct(private WebspaceManagerInterface $webspaceManager)
     {
-        $this->webspaceManager = $webspaceManager;
     }
 
     public function map(

--- a/packages/content/src/Application/ContentManager/ContentManager.php
+++ b/packages/content/src/Application/ContentManager/ContentManager.php
@@ -23,43 +23,13 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 class ContentManager implements ContentManagerInterface
 {
-    /**
-     * @var ContentAggregatorInterface
-     */
-    private $contentAggregator;
-
-    /**
-     * @var ContentPersisterInterface
-     */
-    private $contentPersister;
-
-    /**
-     * @var ContentNormalizerInterface
-     */
-    private $contentNormalizer;
-
-    /**
-     * @var ContentCopierInterface
-     */
-    private $contentCopier;
-
-    /**
-     * @var ContentWorkflowInterface
-     */
-    private $contentWorkflow;
-
     public function __construct(
-        ContentAggregatorInterface $contentAggregator,
-        ContentPersisterInterface $contentPersister,
-        ContentNormalizerInterface $contentNormalizer,
-        ContentCopierInterface $contentCopier,
-        ContentWorkflowInterface $contentWorkflow,
+        private ContentAggregatorInterface $contentAggregator,
+        private ContentPersisterInterface $contentPersister,
+        private ContentNormalizerInterface $contentNormalizer,
+        private ContentCopierInterface $contentCopier,
+        private ContentWorkflowInterface $contentWorkflow
     ) {
-        $this->contentAggregator = $contentAggregator;
-        $this->contentPersister = $contentPersister;
-        $this->contentNormalizer = $contentNormalizer;
-        $this->contentCopier = $contentCopier;
-        $this->contentWorkflow = $contentWorkflow;
     }
 
     public function resolve(ContentRichEntityInterface $contentRichEntity, array $dimensionAttributes): DimensionContentInterface

--- a/packages/content/src/Application/ContentMerger/ContentMerger.php
+++ b/packages/content/src/Application/ContentMerger/ContentMerger.php
@@ -24,24 +24,12 @@ use Webmozart\Assert\Assert;
 class ContentMerger implements ContentMergerInterface
 {
     /**
-     * @var iterable<MergerInterface>
-     */
-    private $mergers;
-
-    /**
-     * @var PropertyAccessor
-     */
-    private $propertyAccessor;
-
-    /**
      * @param iterable<MergerInterface> $mergers
      */
     public function __construct(
-        iterable $mergers,
-        PropertyAccessor $propertyAccessor
+        private iterable $mergers,
+        private PropertyAccessor $propertyAccessor
     ) {
-        $this->mergers = $mergers;
-        $this->propertyAccessor = $propertyAccessor;
     }
 
     /**

--- a/packages/content/src/Application/ContentMetadataInspector/ContentMetadataInspector.php
+++ b/packages/content/src/Application/ContentMetadataInspector/ContentMetadataInspector.php
@@ -19,14 +19,8 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 class ContentMetadataInspector implements ContentMetadataInspectorInterface
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(private EntityManagerInterface $entityManager)
     {
-        $this->entityManager = $entityManager;
     }
 
     /**

--- a/packages/content/src/Application/ContentNormalizer/ContentNormalizer.php
+++ b/packages/content/src/Application/ContentNormalizer/ContentNormalizer.php
@@ -22,11 +22,6 @@ use Symfony\Component\Serializer\Serializer;
 class ContentNormalizer implements ContentNormalizerInterface
 {
     /**
-     * @var iterable<NormalizerInterface>
-     */
-    private $normalizers;
-
-    /**
      * @var SymfonyNormalizerInterface
      */
     private $serializer;
@@ -35,10 +30,9 @@ class ContentNormalizer implements ContentNormalizerInterface
      * @param iterable<NormalizerInterface> $normalizers
      */
     public function __construct(
-        iterable $normalizers,
+        private iterable $normalizers,
         ?SymfonyNormalizerInterface $serializer = null
     ) {
-        $this->normalizers = $normalizers;
         $this->serializer = $serializer ?: $this->createSerializer();
     }
 

--- a/packages/content/src/Application/ContentPersister/ContentPersister.php
+++ b/packages/content/src/Application/ContentPersister/ContentPersister.php
@@ -20,22 +20,10 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 class ContentPersister implements ContentPersisterInterface
 {
-    /**
-     * @var DimensionContentCollectionFactoryInterface
-     */
-    private $dimensionContentCollectionFactory;
-
-    /**
-     * @var ContentMergerInterface
-     */
-    private $contentMerger;
-
     public function __construct(
-        DimensionContentCollectionFactoryInterface $dimensionContentCollectionFactory,
-        ContentMergerInterface $contentMerger
+        private DimensionContentCollectionFactoryInterface $dimensionContentCollectionFactory,
+        private ContentMergerInterface $contentMerger
     ) {
-        $this->dimensionContentCollectionFactory = $dimensionContentCollectionFactory;
-        $this->contentMerger = $contentMerger;
     }
 
     public function persist(ContentRichEntityInterface $contentRichEntity, array $data, array $dimensionAttributes): DimensionContentInterface

--- a/packages/content/src/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
+++ b/packages/content/src/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
@@ -31,14 +31,8 @@ use Symfony\Component\Workflow\Event\TransitionEvent;
  */
 class PublishTransitionSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var ContentCopierInterface
-     */
-    private $contentCopier;
-
-    public function __construct(ContentCopierInterface $contentCopier)
+    public function __construct(private ContentCopierInterface $contentCopier)
     {
-        $this->contentCopier = $contentCopier;
     }
 
     public function onPublish(TransitionEvent $transitionEvent): void

--- a/packages/content/src/Application/ContentWorkflow/Subscriber/RemoveDraftTransitionSubscriber.php
+++ b/packages/content/src/Application/ContentWorkflow/Subscriber/RemoveDraftTransitionSubscriber.php
@@ -28,14 +28,8 @@ use Symfony\Component\Workflow\Event\TransitionEvent;
  */
 class RemoveDraftTransitionSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var ContentCopierInterface
-     */
-    private $contentCopier;
-
-    public function __construct(ContentCopierInterface $contentCopier)
+    public function __construct(private ContentCopierInterface $contentCopier)
     {
-        $this->contentCopier = $contentCopier;
     }
 
     public function onRemoveDraft(TransitionEvent $transitionEvent): void

--- a/packages/content/src/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
+++ b/packages/content/src/Application/ContentWorkflow/Subscriber/UnpublishTransitionSubscriber.php
@@ -32,16 +32,10 @@ use Symfony\Component\Workflow\Event\TransitionEvent;
  */
 class UnpublishTransitionSubscriber implements EventSubscriberInterface
 {
-    private ContentMetadataInspectorInterface $contentMetadataInspector;
-
-    protected EntityManagerInterface $entityManager;
-
     public function __construct(
-        ContentMetadataInspectorInterface $contentMetadataInspector,
-        EntityManagerInterface $entityManager
+        private ContentMetadataInspectorInterface $contentMetadataInspector,
+        protected EntityManagerInterface $entityManager
     ) {
-        $this->contentMetadataInspector = $contentMetadataInspector;
-        $this->entityManager = $entityManager;
     }
 
     public function onUnpublish(TransitionEvent $transitionEvent): void

--- a/packages/content/src/Domain/Model/DimensionContentCollection.php
+++ b/packages/content/src/Domain/Model/DimensionContentCollection.php
@@ -24,19 +24,9 @@ use Doctrine\Common\Collections\Criteria;
 class DimensionContentCollection implements DimensionContentCollectionInterface
 {
     /**
-     * @var Collection<int, T>
-     */
-    private Collection $dimensionContents;
-
-    /**
      * @var mixed[]
      */
     private array $dimensionAttributes;
-
-    /**
-     * @var class-string<T>
-     */
-    private string $dimensionContentClass;
 
     /**
      * @var mixed[]
@@ -51,15 +41,12 @@ class DimensionContentCollection implements DimensionContentCollectionInterface
      * @param class-string<T> $dimensionContentClass
      */
     public function __construct(
-        Collection $dimensionContents,
+        private Collection $dimensionContents,
         array $dimensionAttributes,
-        string $dimensionContentClass
+        private string $dimensionContentClass
     ) {
-        $this->dimensionContentClass = $dimensionContentClass;
-        $this->defaultDimensionAttributes = $dimensionContentClass::getDefaultDimensionAttributes();
-        $this->dimensionAttributes = $dimensionContentClass::getEffectiveDimensionAttributes($dimensionAttributes);
-
-        $this->dimensionContents = $dimensionContents;
+        $this->defaultDimensionAttributes = $this->dimensionContentClass::getDefaultDimensionAttributes();
+        $this->dimensionAttributes = $this->dimensionContentClass::getEffectiveDimensionAttributes($dimensionAttributes);
     }
 
     public function getDimensionContentClass(): string

--- a/packages/content/src/Infrastructure/Doctrine/CategoryFactory.php
+++ b/packages/content/src/Infrastructure/Doctrine/CategoryFactory.php
@@ -19,14 +19,8 @@ use Sulu\Content\Domain\Factory\CategoryFactoryInterface;
 
 class CategoryFactory implements CategoryFactoryInterface
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(private EntityManagerInterface $entityManager)
     {
-        $this->entityManager = $entityManager;
     }
 
     public function create(array $categoryIds): array

--- a/packages/content/src/Infrastructure/Doctrine/ContactFactory.php
+++ b/packages/content/src/Infrastructure/Doctrine/ContactFactory.php
@@ -19,14 +19,8 @@ use Sulu\Content\Domain\Factory\ContactFactoryInterface;
 
 class ContactFactory implements ContactFactoryInterface
 {
-    /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(private EntityManagerInterface $entityManager)
     {
-        $this->entityManager = $entityManager;
     }
 
     public function create(?int $contactId): ?ContactInterface

--- a/packages/content/src/Infrastructure/Doctrine/TagFactory.php
+++ b/packages/content/src/Infrastructure/Doctrine/TagFactory.php
@@ -24,8 +24,8 @@ class TagFactory implements TagFactoryInterface
      * @param EntityRepository<TagInterface> $tagRepository
      */
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-        private readonly EntityRepository $tagRepository
+        private EntityManagerInterface $entityManager,
+        private EntityRepository $tagRepository
     ) {
     }
 

--- a/packages/content/src/Infrastructure/Doctrine/TagFactory.php
+++ b/packages/content/src/Infrastructure/Doctrine/TagFactory.php
@@ -21,22 +21,12 @@ use Sulu\Content\Domain\Factory\TagFactoryInterface;
 class TagFactory implements TagFactoryInterface
 {
     /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
-    /**
-     * @var EntityRepository<TagInterface>
-     */
-    private $tagRepository;
-
-    /**
      * @param EntityRepository<TagInterface> $tagRepository
      */
-    public function __construct(EntityManagerInterface $entityManager, EntityRepository $tagRepository)
-    {
-        $this->entityManager = $entityManager;
-        $this->tagRepository = $tagRepository;
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly EntityRepository $tagRepository
+    ) {
     }
 
     public function create(array $tagNames): array

--- a/packages/content/src/Infrastructure/Sulu/Form/ExcerptFormMetadataVisitor.php
+++ b/packages/content/src/Infrastructure/Sulu/Form/ExcerptFormMetadataVisitor.php
@@ -22,14 +22,8 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\XmlFormMetadataLoader;
  */
 class ExcerptFormMetadataVisitor implements FormMetadataVisitorInterface
 {
-    /**
-     * @var XmlFormMetadataLoader
-     */
-    private $xmlFormMetadataLoader;
-
-    public function __construct(XmlFormMetadataLoader $xmlFormMetadataLoader)
+    public function __construct(private XmlFormMetadataLoader $xmlFormMetadataLoader)
     {
-        $this->xmlFormMetadataLoader = $xmlFormMetadataLoader;
     }
 
     public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void

--- a/packages/content/src/Infrastructure/Sulu/Form/SeoFormMetadataVisitor.php
+++ b/packages/content/src/Infrastructure/Sulu/Form/SeoFormMetadataVisitor.php
@@ -22,14 +22,8 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\XmlFormMetadataLoader;
  */
 class SeoFormMetadataVisitor implements FormMetadataVisitorInterface
 {
-    /**
-     * @var XmlFormMetadataLoader
-     */
-    private $xmlFormMetadataLoader;
-
-    public function __construct(XmlFormMetadataLoader $xmlFormMetadataLoader)
+    public function __construct(private XmlFormMetadataLoader $xmlFormMetadataLoader)
     {
-        $this->xmlFormMetadataLoader = $xmlFormMetadataLoader;
     }
 
     public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void

--- a/packages/content/src/Infrastructure/Sulu/Form/SettingsFormMetadataVisitor.php
+++ b/packages/content/src/Infrastructure/Sulu/Form/SettingsFormMetadataVisitor.php
@@ -22,14 +22,8 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\XmlFormMetadataLoader;
  */
 class SettingsFormMetadataVisitor implements FormMetadataVisitorInterface
 {
-    /**
-     * @var XmlFormMetadataLoader
-     */
-    private $xmlFormMetadataLoader;
-
-    public function __construct(XmlFormMetadataLoader $xmlFormMetadataLoader)
+    public function __construct(private XmlFormMetadataLoader $xmlFormMetadataLoader)
     {
-        $this->xmlFormMetadataLoader = $xmlFormMetadataLoader;
     }
 
     public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void

--- a/packages/content/src/Infrastructure/Sulu/Page/Select/WebspaceSelect.php
+++ b/packages/content/src/Infrastructure/Sulu/Page/Select/WebspaceSelect.php
@@ -17,14 +17,8 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 
 class WebspaceSelect
 {
-    /**
-     * @var WebspaceManagerInterface
-     */
-    private $webspaceManager;
-
-    public function __construct(WebspaceManagerInterface $webspaceManager)
+    public function __construct(private WebspaceManagerInterface $webspaceManager)
     {
-        $this->webspaceManager = $webspaceManager;
     }
 
     /**

--- a/packages/content/src/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/packages/content/src/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -37,52 +37,16 @@ use Sulu\Content\Domain\Model\TemplateInterface;
 class ContentObjectProvider implements PreviewDefaultsProviderInterface
 {
     /**
-     * @var MetadataProviderRegistry
-     */
-    private $metadataProviderRegistry;
-
-    /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
-    /**
-     * @var ContentAggregatorInterface
-     */
-    private $contentAggregator;
-
-    /**
-     * @var ContentDataMapperInterface
-     */
-    private $contentDataMapper;
-
-    /**
-     * @var class-string<T>
-     */
-    private $contentRichEntityClass;
-
-    /**
-     * @var string|null
-     */
-    private $securityContext;
-
-    /**
      * @param class-string<T> $contentRichEntityClass
      */
     public function __construct(
-        MetadataProviderRegistry $metadataProviderRegistry,
-        EntityManagerInterface $entityManager,
-        ContentAggregatorInterface $contentAggregator,
-        ContentDataMapperInterface $contentDataMapper,
-        string $contentRichEntityClass,
-        ?string $securityContext = null
+        private MetadataProviderRegistry $metadataProviderRegistry,
+        private EntityManagerInterface $entityManager,
+        private ContentAggregatorInterface $contentAggregator,
+        private ContentDataMapperInterface $contentDataMapper,
+        private string $contentRichEntityClass,
+        private ?string $securityContext = null
     ) {
-        $this->metadataProviderRegistry = $metadataProviderRegistry;
-        $this->entityManager = $entityManager;
-        $this->contentAggregator = $contentAggregator;
-        $this->contentDataMapper = $contentDataMapper;
-        $this->contentRichEntityClass = $contentRichEntityClass;
-        $this->securityContext = $securityContext;
     }
 
     public function getDefaults(PreviewContext $previewContext): array

--- a/packages/content/src/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
+++ b/packages/content/src/Infrastructure/Sulu/Preview/PreviewDimensionContentCollection.php
@@ -28,24 +28,12 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 class PreviewDimensionContentCollection implements \IteratorAggregate, DimensionContentCollectionInterface
 {
     /**
-     * @var T
-     */
-    private $previewDimensionContent;
-
-    /**
-     * @var string
-     */
-    private $previewLocale;
-
-    /**
      * @param T $previewDimensionContent
      */
     public function __construct(
-        DimensionContentInterface $previewDimensionContent,
-        string $previewLocale
+        private DimensionContentInterface $previewDimensionContent,
+        private string $previewLocale
     ) {
-        $this->previewDimensionContent = $previewDimensionContent;
-        $this->previewLocale = $previewLocale;
     }
 
     public function getDimensionContentClass(): string

--- a/packages/content/tests/Application/ExampleTestBundle/Admin/ExampleAdmin.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Admin/ExampleAdmin.php
@@ -38,36 +38,12 @@ class ExampleAdmin extends Admin
 
     public const EDIT_TABS_VIEW = 'example_test.example.edit_tabs';
 
-    /**
-     * @var ViewBuilderFactoryInterface
-     */
-    private $viewBuilderFactory;
-
-    /**
-     * @var ContentViewBuilderFactoryInterface
-     */
-    private $contentViewBuilderFactory;
-
-    /**
-     * @var SecurityCheckerInterface
-     */
-    private $securityChecker;
-
-    /**
-     * @var LocalizationManagerInterface
-     */
-    private $localizationManager;
-
     public function __construct(
-        ViewBuilderFactoryInterface $viewBuilderFactory,
-        ContentViewBuilderFactoryInterface $contentViewBuilderFactory,
-        SecurityCheckerInterface $securityChecker,
-        LocalizationManagerInterface $localizationManager
+        private ViewBuilderFactoryInterface $viewBuilderFactory,
+        private ContentViewBuilderFactoryInterface $contentViewBuilderFactory,
+        private SecurityCheckerInterface $securityChecker,
+        private LocalizationManagerInterface $localizationManager
     ) {
-        $this->viewBuilderFactory = $viewBuilderFactory;
-        $this->contentViewBuilderFactory = $contentViewBuilderFactory;
-        $this->securityChecker = $securityChecker;
-        $this->localizationManager = $localizationManager;
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void

--- a/packages/content/tests/Application/ExampleTestBundle/Controller/ExampleController.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Controller/ExampleController.php
@@ -37,53 +37,16 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 class ExampleController extends AbstractRestController
 {
-    /**
-     * @var FieldDescriptorFactoryInterface
-     */
-    private $fieldDescriptorFactory;
-
-    /**
-     * @var DoctrineListBuilderFactoryInterface
-     */
-    private $listBuilderFactory;
-
-    /**
-     * @var RestHelperInterface
-     */
-    private $restHelper;
-
-    /**
-     * @var ContentManagerInterface
-     */
-    private $contentManager;
-
-    /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
-    /**
-     * @var ExampleRepository
-     */
-    private $exampleRepository;
-
     public function __construct(
         ViewHandlerInterface $viewHandler,
         TokenStorageInterface $tokenStorage,
-        FieldDescriptorFactoryInterface $fieldDescriptorFactory,
-        DoctrineListBuilderFactoryInterface $listBuilderFactory,
-        RestHelperInterface $restHelper,
-        ContentManagerInterface $contentManager,
-        EntityManagerInterface $entityManager,
-        ExampleRepository $exampleRepository
+        private FieldDescriptorFactoryInterface $fieldDescriptorFactory,
+        private DoctrineListBuilderFactoryInterface $listBuilderFactory,
+        private RestHelperInterface $restHelper,
+        private ContentManagerInterface $contentManager,
+        private EntityManagerInterface $entityManager,
+        private ExampleRepository $exampleRepository,
     ) {
-        $this->fieldDescriptorFactory = $fieldDescriptorFactory;
-        $this->listBuilderFactory = $listBuilderFactory;
-        $this->restHelper = $restHelper;
-        $this->contentManager = $contentManager;
-        $this->entityManager = $entityManager;
-        $this->exampleRepository = $exampleRepository;
-
         parent::__construct($viewHandler, $tokenStorage);
     }
 

--- a/packages/content/tests/Application/ExampleTestBundle/Repository/ExampleRepository.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Repository/ExampleRepository.php
@@ -76,18 +76,12 @@ class ExampleRepository
      */
     private $entityRepository;
 
-    /**
-     * @var DimensionContentQueryEnhancer
-     */
-    private $dimensionContentQueryEnhancer;
-
     public function __construct(
         EntityManagerInterface $entityManager,
-        DimensionContentQueryEnhancer $dimensionContentQueryEnhancer
+        private DimensionContentQueryEnhancer $dimensionContentQueryEnhancer
     ) {
         $this->entityRepository = $entityManager->getRepository(Example::class);
         $this->entityManager = $entityManager;
-        $this->dimensionContentQueryEnhancer = $dimensionContentQueryEnhancer;
     }
 
     /**

--- a/packages/content/tests/Application/ExampleTestBundle/Repository/ExampleRepository.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Repository/ExampleRepository.php
@@ -67,21 +67,15 @@ class ExampleRepository
     ];
 
     /**
-     * @var EntityManagerInterface
-     */
-    private $entityManager;
-
-    /**
      * @var EntityRepository<Example>
      */
     private $entityRepository;
 
     public function __construct(
-        EntityManagerInterface $entityManager,
+        private EntityManagerInterface $entityManager,
         private DimensionContentQueryEnhancer $dimensionContentQueryEnhancer
     ) {
         $this->entityRepository = $entityManager->getRepository(Example::class);
-        $this->entityManager = $entityManager;
     }
 
     /**

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -268,12 +268,10 @@ class TestExampleDimensionContent implements DimensionContentInterface
     use DimensionContentTrait;
 
     protected int $id;
-    protected TestExample $example;
     protected ?string $title = null;
 
-    public function __construct(TestExample $example)
+    public function __construct(protected TestExample $example)
     {
-        $this->example = $example;
     }
 
     public function getId(): int

--- a/packages/content/tests/Unit/Content/Domain/Model/RoutableTraitTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Model/RoutableTraitTest.php
@@ -33,16 +33,10 @@ class RoutableTraitTest extends TestCase
             use RoutableTrait;
 
             /**
-             * @var Tc
-             */
-            private ContentRichEntityInterface $resource;
-
-            /**
              * @param Tc $resource
              */
-            public function __construct(ContentRichEntityInterface $resource)
+            public function __construct(private ContentRichEntityInterface $resource)
             {
-                $this->resource = $resource;
             }
 
             public static function getResourceKey(): string


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Using php8 constructor property promotion in the content bundle.

Basically only running the rector rule.

#### Why?
Now that the constructors have stabilized we can refactor them to use constructor property promotion. It's less code for the same features.