### PR TITLE
Update docs link from 2.x versions to 2.6

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,6 @@ Template](http://docs.sulu.io/en/latest/developer/contributing/pull-requests.htm
 
 Useful links:
 
-* [Creating a Pull Request](https://docs.sulu.io/en/latest/developer/contributing/index.html): Sulu specific Pull Request Guide.
+* [Creating a Pull Request](https://docs.sulu.io/en/2.6/developer/contributing/index.html): Sulu specific Pull Request Guide.
 * [Coding Standards](http://symfony.com/doc/current/contributing/code/index.html): General Symfony coding standards.
 * [General Developer Documentation](https://docs.sulu.io/): General Sulu Developer documentation index.

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -256,7 +256,7 @@ Sulu now uses Webpack 5 to build the administration interface application. To en
 If you have integrated custom JavaScript components into the administration interface,
 you might need to adjust your components to be compatible with the updated dependencies.
 If you have not integrated custom JavaScript code, you project is adjusted automatically by the
-[update build](https://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html) command.
+[update build](https://docs.sulu.io/en/2.6/upgrades/upgrade-2.x.html) command.
 
 Additionally, the following packages where upgraded:
 
@@ -703,7 +703,7 @@ The JavaScript dependencies of the Sulu administration interface were updated to
 If you have integrated custom JavaScript components into the administration interface,
 you might need to adjust your components to be compatible with the updated dependencies.
 If you have not integrated custom JavaScript code, you project is adjusted automatically by the
-[update build](https://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html) command.
+[update build](https://docs.sulu.io/en/2.6/upgrades/upgrade-2.x.html) command.
 
 ### Rename labelRef to inputContainerRef
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -62,7 +62,7 @@ security:
 #            # For an advanced user management with registration and opt-in emails have a look at the:
 #            # https://github.com/sulu/SuluCommunityBundle
 #            # Also have a look at the user context based caching when you output user role specific data
-#            # https://docs.sulu.io/en/2.2/cookbook/user-context-caching.html
+#            # https://docs.sulu.io/en/2.6/cookbook/user-context-caching.html
 #            form_login:
 #                login_path: login
 #                check_path: login

--- a/config/packages/sulu_document_manager.yaml
+++ b/config/packages/sulu_document_manager.yaml
@@ -3,9 +3,9 @@ parameters:
 
 sulu_document_manager:
     versioning:
-        enabled: false # See https://docs.sulu.io/en/2.0/bundles/page/versioning.html if you want to enable versioning
+        enabled: false # See https://docs.sulu.io/en/2.6/bundles/page/versioning.html if you want to enable versioning
     sessions:
-        # See https://docs.sulu.io/en/2.0/cookbook/jackrabbit.html if you want to use Jackrabbit
+        # See https://docs.sulu.io/en/2.6/cookbook/jackrabbit.html if you want to use Jackrabbit
         default:
             backend:
                 type: doctrinedbal

--- a/config/packages/sulu_http_cache.yaml
+++ b/config/packages/sulu_http_cache.yaml
@@ -6,7 +6,7 @@ when@prod: &prod
 
     # Varnish Configuration:
     #
-    # See: https://docs.sulu.io/en/2.0/cookbook/caching-with-varnish.html
+    # See: https://docs.sulu.io/en/2.6/cookbook/caching-with-varnish.html
     # Changes in the public/index.php is needed to disable the symfony http cache and use varnish instead
     #
     #        varnish:

--- a/config/packages/sulu_markup.yaml
+++ b/config/packages/sulu_markup.yaml
@@ -1,4 +1,4 @@
-# see also: https://docs.sulu.io/en/2.4/bundles/markup/index.html
+# see also: https://docs.sulu.io/en/2.6/bundles/markup/index.html
 sulu_markup:
     link_tag:
         provider_attribute: 'data-provider'

--- a/config/packages/sulu_media.yaml
+++ b/config/packages/sulu_media.yaml
@@ -2,6 +2,6 @@ sulu_media:
     format_manager:
         default_imagine_options:
             # a value between 95 and 75 is recommended
-            # see also: https://docs.sulu.io/en/2.5/book/image-formats.html
+            # see also: https://docs.sulu.io/en/2.6/book/image-formats.html
             jpeg_quality: 90
             webp_quality: 90

--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -310,7 +310,7 @@ class UpdateBuildCommand extends Command
         $this->cleanupPreviouslyInstalledDependencies();
 
         $errorHelpMessage =
-            'Visit https://docs.sulu.io/en/latest/cookbook/build-admin-frontend.html#common-errors' . \PHP_EOL
+            'Visit https://docs.sulu.io/en/2.6/cookbook/build-admin-frontend.html#common-errors' . \PHP_EOL
             . 'to get some tips on how to fix this error.';
 
         $ui->section('Install npm dependencies');

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -427,7 +427,7 @@ function startAdmin() {
             '\nJavaScript build of the Sulu administration interface does not match the version of the Sulu backend.' +
             '\nBackend version: ' + Config.suluVersion + ', JavaScript build version: ' + SULU_ADMIN_BUILD_VERSION +
             '\n\nHave you forgotten to update the build while upgrading your application?' + '' +
-            '\nhttps://docs.sulu.io/en/latest/upgrades/upgrade-2.x.html'
+            '\nhttps://docs.sulu.io/en/2.6/upgrades/upgrade-2.x.html'
         );
     }
 

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/config_with_security.yml
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Application/config/config_with_security.yml
@@ -21,7 +21,7 @@ security:
             # For an advanced user management with registration and opt-in emails have a look at the:
             # https://github.com/sulu/SuluCommunityBundle
             # Also have a look at the user context based caching when you output user role specific data
-            # https://docs.sulu.io/en/2.2/cookbook/user-context-caching.html
+            # https://docs.sulu.io/en/2.6/cookbook/user-context-caching.html
             form_login:
                 login_path: login
                 check_path: login


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/314
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Update docs link from 2.x versions to 2.6.

#### Why?

There is maybe some refactoring in the docs coming for 3.0 we should not 404 for any links on 2.6 branch.