### PR TITLE
Add test against MySQL 8.4

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -199,7 +199,7 @@ jobs:
                           DATABASE_COLLATE: utf8mb4_unicode_ci
 
                     - php-version: '8.5'
-                      database: mysql-80
+                      database: mysql-84
                       phpcr-transport: doctrinedbal
                       dependency-versions: 'highest'
                       php-extensions: 'ctype, iconv, mysql, imagick'
@@ -207,7 +207,7 @@ jobs:
                       composer-stability: 'dev'
                       env:
                           SYMFONY_DEPRECATIONS_HELPER: weak
-                          DATABASE_URL: mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=8.0
+                          DATABASE_URL: mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=8.4
                           DATABASE_CHARSET: utf8mb4
                           DATABASE_COLLATE: utf8mb4_unicode_ci
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: '3'
 services:
 ###> doctrine/doctrine-bundle ###
   database:
-    # arm compatible mysql docker image
-    image: mysql/mysql-server:${MYSQL_VERSION:-8.0} # arm and x86/x64 compatible mysql image
+    image: mysql:${MYSQL_VERSION:-8.4}
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE:-sulu}
       # You should definitely change the password in production

--- a/tests/docker/docker-compose.mysql-84.yml
+++ b/tests/docker/docker-compose.mysql-84.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  database:
+    image: mysql:8.4
+    command: [ "--max_connections=10000" ]
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: 'sulu_test'
+      MYSQL_ROOT_PASSWORD: 'ChangeMe'
+      MYSQL_ROOT_HOST: '%'
+    volumes:
+      - sulu-mysql84-data:/var/lib/mysql
+
+volumes:
+  sulu-mysql84-data:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/315
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add test against MySQL 8.4.

#### Why?

MySQL 8.4 is the latest LTS which we should make sure to test in Sulu.