### PR TITLE
Fix query string parameters when using media as smart content data provider

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
@@ -212,7 +212,7 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
                     Join::WITH,
                     'parentCollection.id = :collectionId'
                 )
-                ->where('collection.lft BETWEEN parentCollection.lft AND parentCollection.rgt');
+                ->andWhere('collection.lft BETWEEN parentCollection.lft AND parentCollection.rgt');
         }
 
         return ['collectionId' => $datasource];

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaDataProviderRepositoryTest.php
@@ -541,6 +541,66 @@ class MediaDataProviderRepositoryTest extends SuluTestCase
                 [],
                 [],
             ],
+            // datasource sub folder with options mimetype/type
+            [
+                ['dataSource' => 1, 'includeSubFolders' => true],
+                null,
+                0,
+                null,
+                \array_slice(self::$mediaData, 0, 2),
+                [],
+                ['mimetype' => 'image/jpg', 'type' => 'image'],
+            ],
+            // datasource no sub folder with options mimetype/type
+            [
+                ['dataSource' => 1, 'includeSubFolders' => false],
+                null,
+                0,
+                null,
+                \array_slice(self::$mediaData, 0, 1),
+                [],
+                ['mimetype' => 'image/jpg', 'type' => 'image'],
+            ],
+            // datasource sub folder with option mimetype
+            [
+                ['dataSource' => 1, 'includeSubFolders' => true],
+                null,
+                0,
+                null,
+                \array_slice(self::$mediaData, 0, 2),
+                [],
+                ['mimetype' => 'image/jpg'],
+            ],
+            // datasource no sub folder with option mimetype
+            [
+                ['dataSource' => 1, 'includeSubFolders' => false],
+                null,
+                0,
+                null,
+                \array_slice(self::$mediaData, 0, 1),
+                [],
+                ['mimetype' => 'image/jpg'],
+            ],
+            // datasource sub folder with option type
+            [
+                ['dataSource' => 1, 'includeSubFolders' => true],
+                null,
+                0,
+                null,
+                \array_slice(self::$mediaData, 0, 3),
+                [],
+                ['type' => 'image'],
+            ],
+            // datasource no sub folder with option type
+            [
+                ['dataSource' => 1, 'includeSubFolders' => false],
+                null,
+                0,
+                null,
+                \array_slice(self::$mediaData, 0, 1),
+                [],
+                ['type' => 'image'],
+            ],
             // datasource sub folder without includeSubFolders
             [
                 ['dataSource' => 1],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8433
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

This PR fixes a Doctrine `QueryException` when using `media` as the smart content data provider that occurs when attempting to filter the results with the `mimetype` and `type` query string parameters. See #8433 for more details.

#### Why?

To allow the filtering of smart content with the [documented query string parameters](https://docs.sulu.io/en/2.6/reference/content-types/smart_content.html#media).