### PR TITLE
Remove php-cr "node_order" build target in massive_build

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -198,8 +198,6 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                             'security' => [],
                         ],
                     ],
-                    'maintain' => [
-                    ],
                 ],
             ];
 

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -199,9 +199,6 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                         ],
                     ],
                     'maintain' => [
-                        'dependencies' => [
-                            'node_order' => [],
-                        ],
                     ],
                 ],
             ];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Remove the dependency of the "maintain" build job on the "node_order" job.

#### Why?
I've run `bin/console sulu:build` without any argument it lists all jobs and the "maintain" job still has a dependency on "node_order" from the phpcr implementation.

Maybe we should also consider validating this kind of errors in the massive bundle at compile time.

## Alternative solution
Remove the "maintain" build target. This might break running "sulu:build maintain"