### PR TITLE
Fix the autoloader warnings and moving namespaces

### DIFF
--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Article\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolverTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Article\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/ArticleResourceLoaderTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/ArticleResourceLoaderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ArticleBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+namespace Sulu\Article\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/packages/content/tests/Functional/Integration/ExampleRepositoryTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleRepositoryTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Content\Tests\Functional\Infrastructure\Doctrine;
+namespace Sulu\Content\Tests\Functional\Integration;
 
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;

--- a/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/ResourceLoaderCacheCompilerPassTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/ResourceLoaderCacheCompilerPassTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Content\Tests\Unit\Content\Infrastructure\Symfony\HttpKernel\Compiler;
+namespace Sulu\Content\Tests\Unit\Infrastructure\Symfony\HttpKernel\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Sulu\Content\Application\ResourceLoader\Loader\CachedResourceLoader;

--- a/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/SeoFormPassTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/SeoFormPassTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Content\Tests\Unit\Content\Infrastructure\Symfony\HttpKernel\Compiler;
+namespace Sulu\Content\Tests\Unit\Infrastructure\Symfony\HttpKernel\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/SettingsFormPassTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/SettingsFormPassTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Content\Tests\Unit\Content\Infrastructure\Symfony\HttpKernel\Compiler;
+namespace Sulu\Content\Tests\Unit\Infrastructure\Symfony\HttpKernel\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Content\Tests\Unit\Content\Infrastructure\Symfony\HttpKernel;
+namespace Sulu\Content\Tests\Unit\Infrastructure\Symfony\HttpKernel;
 
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/DataMapper/NavigationContextDataMapperTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/DataMapper/NavigationContextDataMapperTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\DataMapper;
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content\DataMapper;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/Merger/NavigationContextMergerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/Merger/NavigationContextMergerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\Merger;
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content\Merger;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageTreeRoutePropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageTreeRoutePropertyResolverTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoaderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoaderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\Page\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolverTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Snippet\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
+namespace Sulu\Snippet\Tests\Unit\Infrastructure\Sulu\Content\PropertyResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoaderTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoaderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
+namespace Sulu\Snippet\Tests\Unit\Infrastructure\Sulu\Content\ResourceLoader;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/SmartResolver/SnippetAreaSmartResolverTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Infrastructure\Sulu\Content\SmartResolver;
+namespace Sulu\Snippet\Tests\Unit\Infrastructure\Sulu\Content\SmartResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding excluded namespaces for autoloading and fixed some namespaces of test directories and the autoloader when dumped does not throw any warnings:

<img width="601" height="64" alt="image" src="https://github.com/user-attachments/assets/30696cab-6605-4ee2-ac33-d74b5101d31a" />

#### Why?
When moving from the old directory structure to the new one some of the namespaces were left out which generates a lot of warnings if you try to optimize the autoloader:

<img width="1918" height="1054" alt="image" src="https://github.com/user-attachments/assets/e74762d6-c21f-40af-8ec7-880d20bada26" />

Some of the tests when moved from the old bundle structure to the new one haven't updated their namespaces.

## Additional context

We could also add a check to the pipeline to prevent this: `composer dump-autoload -o --strict-psr`