### PR TITLE
Add `sulu:content:debug` command

### DIFF
--- a/packages/content/config/services.php
+++ b/packages/content/config/services.php
@@ -44,6 +44,7 @@ use Sulu\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactory;
 use Sulu\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface;
 use Sulu\Content\Infrastructure\Sulu\HttpCache\EventSubscriber\DimensionContentTagSubscriber;
 use Sulu\Content\Infrastructure\Sulu\Page\Select\WebspaceSelect;
+use Sulu\Content\Infrastructure\Symfony\Command\DebugContentCommand;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -194,4 +195,14 @@ return static function(ContainerConfigurator $container) {
         ]);
 
     $services->alias(ContentManagerInterface::class, 'sulu_content.content_manager');
+
+    // Commands
+    $services->set('sulu_content.command.debug_content', DebugContentCommand::class)
+        ->args([
+            tagged_iterator(tag: 'sulu_content.resource_loader', defaultIndexMethod: 'getKey', indexAttribute: 'key'),
+            tagged_iterator(tag: 'sulu_content.content_resolver', indexAttribute: 'type'),
+            tagged_iterator(tag: 'sulu_content.property_resolver', defaultIndexMethod: 'getType'),
+        ])
+        ->tag('console.command')
+    ;
 };

--- a/packages/content/src/Application/ResourceLoader/Loader/CachedResourceLoader.php
+++ b/packages/content/src/Application/ResourceLoader/Loader/CachedResourceLoader.php
@@ -57,6 +57,11 @@ class CachedResourceLoader implements ResourceLoaderContentViewEnhancementInterf
         return $result;
     }
 
+    public function getInnerClass(): string
+    {
+        return $this->decoratedResourceLoader::class;
+    }
+
     public static function getKey(): string
     {
         throw new \LogicException('Should not be called statically on CachedResourceLoader');

--- a/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
+++ b/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
@@ -23,7 +23,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand('sulu:debug:content', description: 'Debugging the content services to see if they are correctly registered')]
+/**
+ * @internal the command can be used and console command call is under bc promise but no bc promise is given for this PHP class itself
+ * as it may will have additional dependencies in future
+ */
+#[AsCommand('sulu:content:debug', description: 'Debugging the content services to see if they are correctly registered')]
 final class DebugContentCommand extends Command
 {
     /**

--- a/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
+++ b/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Content\Infrastructure\Symfony\Command;
 
 use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\CachedResourceLoader;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -21,7 +22,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 #[AsCommand('sulu:debug:content', description: 'Debugging the content services to see if they are correctly registered')]
 final class DebugContentCommand extends Command

--- a/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
+++ b/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
@@ -21,17 +21,19 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 
 #[AsCommand('sulu:debug:content', description: 'Debugging the content services to see if they are correctly registered')]
 final class DebugContentCommand extends Command
 {
     /**
-     * @param iterable<string, ResourceLoaderInterface> $loaders
-     * @param iterable<string, ResolverInterface> $resolvers
+     * @param iterable<string, ResourceLoaderInterface> $loader
+     * @param iterable<string, ResolverInterface> $resolver
+     * @param iterable<string, PropertyResolverInterface> $propertyResolver
      */
     public function __construct(
-        private readonly iterable $loaders,
-        private readonly iterable $resolvers,
+        private readonly iterable $loader,
+        private readonly iterable $resolver,
         private readonly iterable $propertyResolver,
     ) {
         parent::__construct();
@@ -42,13 +44,13 @@ final class DebugContentCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         $io->title('Loaders');
-        $this->printLoaders($io, $this->loaders);
+        $this->printLoaders($io, $this->loader);
 
         $io->title('Content resolvers');
-        $this->printContentResolvers($io, $this->resolvers);
+        $this->printContentResolvers($io, $this->resolver);
 
         $io->title('Property resolvers');
-        $this->printContentResolvers($io, $this->propertyResolver);
+        $this->printPropertyResolver($io, $this->propertyResolver);
 
         return Command::SUCCESS;
     }
@@ -59,7 +61,7 @@ final class DebugContentCommand extends Command
     private function printLoaders(SymfonyStyle $io, iterable $loaders): void
     {
         $tableData = [];
-        foreach ($this->loaders as $key => $loader) {
+        foreach ($loaders as $key => $loader) {
             $cached = false;
             if ($loader instanceof CachedResourceLoader) {
                 $loader = $loader->getInnerClass();
@@ -88,6 +90,9 @@ final class DebugContentCommand extends Command
         $io->table(['Type', 'Resolver Class'], $tableData);
     }
 
+    /**
+     * @param iterable<string, PropertyResolverInterface> $resolvers
+     */
     private function printPropertyResolver(SymfonyStyle $io, iterable $resolvers): void
     {
         $tableData = [];

--- a/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
+++ b/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Symfony\Command;
+
+use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
+use Sulu\Content\Application\ResourceLoader\Loader\CachedResourceLoader;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand('sulu:debug:content', description: 'Debugging the content services to see if they are correctly registered')]
+final class DebugContentCommand extends Command
+{
+    /**
+     * @param iterable<string, ResourceLoaderInterface> $loaders
+     * @param iterable<string, ResolverInterface> $resolvers
+     */
+    public function __construct(
+        private readonly iterable $loaders,
+        private readonly iterable $resolvers,
+        private readonly iterable $propertyResolver,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('Loaders');
+        $this->printLoaders($io, $this->loaders);
+
+        $io->title('Content resolvers');
+        $this->printContentResolvers($io, $this->resolvers);
+
+        $io->title('Property resolvers');
+        $this->printContentResolvers($io, $this->propertyResolver);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param iterable<string, ResourceLoaderInterface> $loaders
+     */
+    private function printLoaders(SymfonyStyle $io, iterable $loaders): void
+    {
+        $tableData = [];
+        foreach ($this->loaders as $key => $loader) {
+            $cached = false;
+            if ($loader instanceof CachedResourceLoader) {
+                $loader = $loader->getInnerClass();
+                $cached = true;
+            }
+
+            $tableData[] = [
+                $key,
+                $loader,
+                $cached ? 'x' : '',
+            ];
+        }
+
+        $io->table(['Content Type', 'Loader Class', 'Cached'], $tableData);
+    }
+
+    /**
+     * @param iterable<string, ResolverInterface> $resolvers
+     */
+    private function printContentResolvers(SymfonyStyle $io, iterable $resolvers): void
+    {
+        $tableData = [];
+        foreach ($resolvers as $type => $resolver) {
+            $tableData[] = [$type, $resolver::class];
+        }
+        $io->table(['Type', 'Resolver Class'], $tableData);
+    }
+
+    private function printPropertyResolver(SymfonyStyle $io, iterable $resolvers): void
+    {
+        $tableData = [];
+        foreach ($resolvers as $type => $resolver) {
+            $tableData[] = [$type, $resolver::class];
+        }
+        $io->table(['Type', 'Property resolver class'], $tableData);
+    }
+}

--- a/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
+++ b/packages/content/src/Infrastructure/Symfony/Command/DebugContentCommand.php
@@ -47,13 +47,10 @@ final class DebugContentCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $io->title('Loaders');
         $this->printLoaders($io, $this->loader);
 
-        $io->title('Content resolvers');
         $this->printContentResolvers($io, $this->resolver);
 
-        $io->title('Property resolvers');
         $this->printPropertyResolver($io, $this->propertyResolver);
 
         return Command::SUCCESS;
@@ -64,22 +61,21 @@ final class DebugContentCommand extends Command
      */
     private function printLoaders(SymfonyStyle $io, iterable $loaders): void
     {
+        $io->title('Resource loaders');
+
         $tableData = [];
         foreach ($loaders as $key => $loader) {
-            $cached = false;
             if ($loader instanceof CachedResourceLoader) {
                 $loader = $loader->getInnerClass();
-                $cached = true;
             }
 
             $tableData[] = [
                 $key,
                 $loader,
-                $cached ? 'x' : '',
             ];
         }
 
-        $io->table(['Content Type', 'Loader Class', 'Cached'], $tableData);
+        $io->table(['Type', 'Loader Class'], $tableData);
     }
 
     /**
@@ -87,6 +83,8 @@ final class DebugContentCommand extends Command
      */
     private function printContentResolvers(SymfonyStyle $io, iterable $resolvers): void
     {
+        $io->title('Dimension Content resolvers');
+
         $tableData = [];
         foreach ($resolvers as $type => $resolver) {
             $tableData[] = [$type, $resolver::class];
@@ -99,10 +97,14 @@ final class DebugContentCommand extends Command
      */
     private function printPropertyResolver(SymfonyStyle $io, iterable $resolvers): void
     {
+        $io->title('Property resolvers');
+
+        $io->info('If a type does not have an explicit property resolver (eg. "text" or "text_area") the "default" property resolver is used.');
+
         $tableData = [];
         foreach ($resolvers as $type => $resolver) {
-            $tableData[] = [$type, $resolver::class];
+            $tableData[] = ['default' === $type ? '->' : '', $type, $resolver::class];
         }
-        $io->table(['Type', 'Property resolver class'], $tableData);
+        $io->table(['#', 'Type', 'Property resolver class'], $tableData);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -532,7 +532,7 @@ class PropertiesXmlParser
         }
     }
 
-    private function normalizePropertyData($data): array
+    private function normalizePropertyData(array $data): array
     {
         $data = \array_replace_recursive(
             [

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -34,7 +34,7 @@ class PropertiesXmlParser
     }
 
     /**
-     * @return array<string, FieldMetadata|SectionMetadata>
+     * @return array<FieldMetadata|SectionMetadata>
      */
     public function load(
         \DOMXPath $xpath,
@@ -398,7 +398,7 @@ class PropertiesXmlParser
     /**
      * @param array<string, array<string, mixed>> $data
      *
-     * @return array<string, FieldMetadata|SectionMetadata>
+     * @return array<FieldMetadata|SectionMetadata>
      */
     private function mapProperties(array $data): array
     {
@@ -407,7 +407,7 @@ class PropertiesXmlParser
             $property = $this->createProperty($propertyName, $dataProperty);
 
             if ($property) {
-                $properties[$propertyName] = $property;
+                $properties[] = $property;
             }
         }
 
@@ -426,7 +426,7 @@ class PropertiesXmlParser
         return $property;
     }
 
-    private function createSection(string $propertyName, $data): SectionMetadata
+    private function createSection($propertyName, $data): SectionMetadata
     {
         $section = new SectionMetadata($propertyName);
         if (isset($data['colspan'])) {
@@ -532,7 +532,7 @@ class PropertiesXmlParser
         }
     }
 
-    private function normalizePropertyData(array $data): array
+    private function normalizePropertyData($data): array
     {
         $data = \array_replace_recursive(
             [
@@ -560,7 +560,7 @@ class PropertiesXmlParser
         return $data;
     }
 
-    private function normalizeItem(array $data): array
+    private function normalizeItem($data): array
     {
         $data = \array_merge_recursive(
             [

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -34,7 +34,7 @@ class PropertiesXmlParser
     }
 
     /**
-     * @return array<FieldMetadata|SectionMetadata>
+     * @return array<string, FieldMetadata|SectionMetadata>
      */
     public function load(
         \DOMXPath $xpath,
@@ -398,7 +398,7 @@ class PropertiesXmlParser
     /**
      * @param array<string, array<string, mixed>> $data
      *
-     * @return array<FieldMetadata|SectionMetadata>
+     * @return array<string, FieldMetadata|SectionMetadata>
      */
     private function mapProperties(array $data): array
     {
@@ -407,7 +407,7 @@ class PropertiesXmlParser
             $property = $this->createProperty($propertyName, $dataProperty);
 
             if ($property) {
-                $properties[] = $property;
+                $properties[$propertyName] = $property;
             }
         }
 
@@ -426,7 +426,7 @@ class PropertiesXmlParser
         return $property;
     }
 
-    private function createSection($propertyName, $data): SectionMetadata
+    private function createSection(string $propertyName, $data): SectionMetadata
     {
         $section = new SectionMetadata($propertyName);
         if (isset($data['colspan'])) {
@@ -560,7 +560,7 @@ class PropertiesXmlParser
         return $data;
     }
 
-    private function normalizeItem($data): array
+    private function normalizeItem(array $data): array
     {
         $data = \array_merge_recursive(
             [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #7585
| License | MIT
| Documentation PR | -

#### What's in this PR?
A command "sulu:debug:content" that lists all content resolvers, property resolvers and resource loaders that are registered in Sulu. This should help when trying to create new content and debug why it might not work.

<img width="956" height="1050" alt="image" src="https://github.com/user-attachments/assets/bb5e2837-2d0a-4e0d-b246-8a431a710423" />

#### Why?
As part of the FormBundle upgrade process this was very helpful to see what I configured incorrectly. (This command could also highlight errors (missing loaders etc. in the future)