### PR TITLE
Allow installation of Symfony Monolog Bundle 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -148,7 +148,7 @@
         "symfony/dotenv": "^6.4 || ^7.1",
         "symfony/emoji": "^7.1",
         "symfony/lock": "^6.4 || ^7.1",
-        "symfony/monolog-bundle": "^3.7",
+        "symfony/monolog-bundle": "^3.7 || ^4.0",
         "symfony/phpunit-bridge": "^6.4 || ^7.1",
         "symfony/runtime": "^6.4 || ^7.1",
         "symfony/stopwatch": "^6.4 || ^7.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/317
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow installation of Symfony Monolog Bundle 4.

#### Why?

Prepare for Symfony 8 support.