### PR TITLE
Fix PHPStan issues add default generic to NodeBuilder and NodeDefinition

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -937,12 +937,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
 
 		-
-			message: '#^Parameter \#1 \$messages of method Symfony\\Component\\Console\\Style\\SymfonyStyle\:\:write\(\) expects iterable\<string\>\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
-
-		-
 			message: '#^Parameter \#1 \$pattern of function preg_match expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -40,11 +40,17 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
+    /**
+     * @param NodeBuilder<null> $rootNode
+     */
     private function getCoreConfiguration(NodeBuilder $rootNode)
     {
         $rootNode->scalarNode('cache_dir')->defaultValue('%kernel.cache_dir%/sulu')->end();
     }
 
+    /**
+     * @param NodeBuilder<null> $rootNode
+     */
     private function getLocaleConfiguration(NodeBuilder $rootNode)
     {
         $rootNode
@@ -60,6 +66,9 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('fallback_locale')->defaultValue('en')->end();
     }
 
+    /**
+     * @param NodeBuilder<null> $rootNode
+     */
     private function getWebspaceConfiguration(NodeBuilder $rootNode)
     {
         $rootNode->arrayNode('webspace')
@@ -72,6 +81,9 @@ class Configuration implements ConfigurationInterface
         ->end();
     }
 
+    /**
+     * @param NodeBuilder<null> $rootNode
+     */
     private function getFieldsConfiguration(NodeBuilder $rootNode)
     {
         $rootNode->arrayNode('fields_defaults')
@@ -97,6 +109,9 @@ class Configuration implements ConfigurationInterface
         ->end();
     }
 
+    /**
+     * @param NodeBuilder<null> $rootNode
+     */
     private function getContentConfiguration(NodeBuilder $rootNode)
     {
         $rootNode->arrayNode('content')
@@ -175,6 +190,9 @@ class Configuration implements ConfigurationInterface
         ->end();
     }
 
+    /**
+     * @param NodeBuilder<null> $rootNode
+     */
     private function getCacheConfiguration(NodeBuilder $rootNode)
     {
         $rootNode->arrayNode('cache')

--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/DependencyInjection/Configuration.php
@@ -75,7 +75,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @param string $name
      *
-     * @return NodeDefinition
+     * @return NodeDefinition<null>
      */
     private function addBasicProviderNode($name)
     {
@@ -88,7 +88,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Build file_system node configuration definition.
      *
-     * @return NodeDefinition
+     * @return NodeDefinition<null>
      */
     private function addFileSystemNode()
     {
@@ -109,7 +109,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Build redis node configuration definition.
      *
-     * @return NodeDefinition
+     * @return NodeDefinition<null>
      */
     private function addRedisNode()
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix PHPStan issues add default generic to NodeBuilder and NodeDefinition.

#### Why?

Currently required may future Symfony versions remove required generics again.