### PR TITLE
Support Monolog 4 Bundle in 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
         "symfony/browser-kit": "^5.4 || ^6.0 || ^7.0",
         "symfony/debug-bundle": "^5.4 || ^6.0 || ^7.0",
         "symfony/dotenv": "^5.4 || ^6.0 || ^7.0",
-        "symfony/monolog-bundle": "^3.5",
+        "symfony/monolog-bundle": "^3.5 || ^4.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
         "symfony/runtime": "^5.4 || ^6.0 || ^7.0",
         "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/319
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Support Monolog 4 Bundle in 2.6

#### Why?

As a skeleton can already use the 4 Version we should also test against it in 2.6.