### PR TITLE
Update block type on nested block switching

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -65,7 +65,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
         let newValue = toJS(value);
 
-        if (newValue && types !== oldTypes) {
+        if (newValue) {
             if (!defaultType) {
                 throw new Error(
                     'It is impossible that a block has no defaultType. This should not happen and is likely a bug.'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Loops always through blocks to update default block types.

#### Why?

When you use nested blocks and two block types, both have a `blocks` property with the same name, but different block-types as an inner block, the request crashes, because the FE does not override the block-type to the new default block-type of the new `blocks` property.