### PR TITLE
Fix BC break in PropertyXMLParser

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -34,7 +34,7 @@ class PropertiesXmlParser
     }
 
     /**
-     * @return array<FieldMetadata|SectionMetadata>
+     * @return array<string, FieldMetadata|SectionMetadata>
      */
     public function load(
         \DOMXPath $xpath,
@@ -398,7 +398,7 @@ class PropertiesXmlParser
     /**
      * @param array<string, array<string, mixed>> $data
      *
-     * @return array<FieldMetadata|SectionMetadata>
+     * @return array<string, FieldMetadata|SectionMetadata>
      */
     private function mapProperties(array $data): array
     {
@@ -407,7 +407,7 @@ class PropertiesXmlParser
             $property = $this->createProperty($propertyName, $dataProperty);
 
             if ($property) {
-                $properties[] = $property;
+                $properties[$propertyName] = $property;
             }
         }
 
@@ -426,7 +426,7 @@ class PropertiesXmlParser
         return $property;
     }
 
-    private function createSection($propertyName, $data): SectionMetadata
+    private function createSection(string $propertyName, $data): SectionMetadata
     {
         $section = new SectionMetadata($propertyName);
         if (isset($data['colspan'])) {
@@ -456,7 +456,10 @@ class PropertiesXmlParser
         return $section;
     }
 
-    private function mapProperty(FieldMetadata $property, $data): void
+    /**
+     * @param array<mixed> $data
+     */
+    private function mapProperty(FieldMetadata $property, array $data): void
     {
         $data = $this->normalizePropertyData($data);
 
@@ -528,7 +531,12 @@ class PropertiesXmlParser
         }
     }
 
-    private function normalizePropertyData($data): array
+    /**
+     * @param array<mixed> $data
+     *
+     * @return array<mixed>
+     */
+    private function normalizePropertyData(array $data): array
     {
         $data = \array_replace_recursive(
             [
@@ -556,7 +564,12 @@ class PropertiesXmlParser
         return $data;
     }
 
-    private function normalizeItem($data): array
+    /**
+     * @param array<mixed> $data
+     *
+     * @return array<mixed>
+     */
+    private function normalizeItem(array $data): array
     {
         $data = \array_merge_recursive(
             [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/sulu/SuluFormBundle/pull/415
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Returning the name with the parsed content of the XML

#### Why?
This is how it was in 2.6 and the form bundle needs this otherwise building the config produces a white page in the admin (probably because of the changed json config)
