### PR TITLE
Add upgrade instructions for page block settings renamed to content block settings in 3.0

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1611,7 +1611,7 @@ Affected classes / interfaces:
 - `Sulu\Bundle\SecurityBundle\EventListener\SystemListener::__construct` (removed `RequestAnalyserInterface $requestAnalyser`)
 
 ### Extending Block Settings
-The `config/forms/page_block_settings.xml` file has been renamed to `config/forms/content_block_settings.xml`.
+The `config/forms/page_block_settings.xml` file should be renamed to `config/forms/content_block_settings.xml`.
 Additionally, ensure that the `<key>` value is changed as well:
 
 ```diff

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1609,3 +1609,18 @@ Affected classes / interfaces:
 - `Sulu\Bundle\WebsiteBundle\Cache\CacheClearer::clear` (added `?array $tags`)
 - `Sulu\Bundle\WebsiteBundle\Cache\CacheClearerInterface::clear` (added `?array $tags`)
 - `Sulu\Bundle\SecurityBundle\EventListener\SystemListener::__construct` (removed `RequestAnalyserInterface $requestAnalyser`)
+
+### Extending Block Settings
+The `config/forms/page_block_settings.xml` file has been renamed to `config/forms/content_block_settings.xml`.
+Additionally, ensure that the `<key>` value is changed as well:
+
+```diff
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
+-   <key>page_block_settings</key>
++   <key>content_block_settings</key>
+    <properties></properties>
+</form>
+```

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1611,6 +1611,7 @@ Affected classes / interfaces:
 - `Sulu\Bundle\SecurityBundle\EventListener\SystemListener::__construct` (removed `RequestAnalyserInterface $requestAnalyser`)
 
 ### Extending Block Settings
+
 The `config/forms/page_block_settings.xml` file should be renamed to `config/forms/content_block_settings.xml`.
 Additionally, ensure that the `<key>` value is changed as well:
 
@@ -1621,6 +1622,7 @@ Additionally, ensure that the `<key>` value is changed as well:
       xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
 -   <key>page_block_settings</key>
 +   <key>content_block_settings</key>
-    <properties></properties>
+    <properties>
+       <!-- ... -->
+    </properties>
 </form>
-```


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | no
| Related issues/PRs | no
| License | MIT

#### What's in this PR?

Adds a missing upgrade step in [UPGRADE-3.x.md](https://github.com/sulu/sulu/blob/3.0/UPGRADE-3.x.md) for `page_block_settings` from 2.x to 3.x.