### PR TITLE
Upgrade Doctrine Bundle to Version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/collections": "^1.6 || ^2.0",
         "doctrine/data-fixtures": "^1.5 || ^2.0",
         "doctrine/dbal": "^3.9 || ^4.0",
-        "doctrine/doctrine-bundle": "^2.6",
+        "doctrine/doctrine-bundle": "^2.6 || ^3.0",
         "doctrine/doctrine-fixtures-bundle": "^3.4 || ^4.0",
         "doctrine/inflector": "^1.4.1 || ^2.0.1",
         "doctrine/orm": "^2.17.3 || ^3.3",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -6,7 +6,6 @@ doctrine:
         # either here or in the DATABASE_URL env var (see .env file)
         #server_version: '8.0.27'
     orm:
-        auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
         auto_mapping: false
 #        mappings:
@@ -26,7 +25,6 @@ when@test:
 when@prod: &prod
     doctrine:
         orm:
-            auto_generate_proxy_classes: false
             query_cache_driver:
                 type: pool
                 pool: doctrine.system_cache_pool

--- a/packages/route/tests/Application/config/config.yml
+++ b/packages/route/tests/Application/config/config.yml
@@ -17,9 +17,8 @@ twig:
 
 doctrine:
     orm:
-        auto_generate_proxy_classes: "%kernel.debug%"
         naming_strategy: doctrine.orm.naming_strategy.underscore
-        auto_mapping: true
+        auto_mapping: false
     dbal:
         url: '%env(DATABASE_URL)%'
 

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
@@ -9,6 +9,8 @@
  * with this source code in the file LICENSE.
  */
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\Filesystem\Filesystem;
@@ -21,6 +23,10 @@ return static function(PhpFileLoader $loader, ContainerBuilder $container) {
 
     if ('admin' === $context) {
         $loader->import('security-6.yml');
+    }
+
+    if (InstalledVersions::satisfies(new VersionParser(), 'doctrine/doctrine-bundle', '^2.0')) {
+        $loader->import('doctrine_2.yml');
     }
 
     $loader->import('symfony-6.yml');

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/config.php
@@ -10,7 +10,6 @@
  */
 
 use Composer\InstalledVersions;
-use Composer\Semver\VersionParser;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\Filesystem\Filesystem;
@@ -25,7 +24,7 @@ return static function(PhpFileLoader $loader, ContainerBuilder $container) {
         $loader->import('security-6.yml');
     }
 
-    if (InstalledVersions::satisfies(new VersionParser(), 'doctrine/doctrine-bundle', '^2.0')) {
+    if (\version_compare((string) InstalledVersions::getVersion('doctrine/doctrine-bundle'), '3.0.0', '<')) {
         $loader->import('doctrine_2.yml');
     }
 

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/doctrine_2.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/doctrine_2.yml
@@ -1,0 +1,4 @@
+doctrine:
+    orm:
+        auto_generate_proxy_classes: '%kernel.debug%'
+        auto_mapping: true

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -16,9 +16,8 @@ framework:
 
 doctrine:
     orm:
-        auto_generate_proxy_classes: "%kernel.debug%"
         naming_strategy: doctrine.orm.naming_strategy.underscore
-        auto_mapping: true
+        auto_mapping: false
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
         dbname_suffix: '_test%env(default::TEST_TOKEN)%'

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -17,7 +17,6 @@ framework:
 doctrine:
     orm:
         naming_strategy: doctrine.orm.naming_strategy.underscore
-        auto_mapping: false
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
         dbname_suffix: '_test%env(default::TEST_TOKEN)%'


### PR DESCRIPTION
Built on top of: https://github.com/sulu/sulu/pull/8451

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/8451, https://github.com/sulu/sulu/issues/8216
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Update Doctrine Bundle to Version 3 (only support for >=PHP 8.4 https://github.com/doctrine/DoctrineBundle/blob/3.1.0/composer.json#L32

#### Why?

ORM 3, DBAL 4 and Persistence 4 is now supported.