### PR TITLE
Add Interface for AccessControlQueryEnhancer

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -84631,13 +84631,13 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
 		-
-			message: '#^Parameter \#3 \$permission of method Sulu\\Bundle\\SecurityBundle\\AccessControl\\AccessControlQueryEnhancer\:\:enhance\(\) expects int, mixed given\.$#'
+			message: '#^Parameter \#3 \$permission of method Sulu\\Bundle\\SecurityBundle\\AccessControl\\AccessControlQueryEnhancerInterface\:\:enhance\(\) expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
 
 		-
-			message: '#^Parameter \#3 \$permission of method Sulu\\Bundle\\SecurityBundle\\AccessControl\\AccessControlQueryEnhancer\:\:enhanceWithDynamicEntityClass\(\) expects int, mixed given\.$#'
+			message: '#^Parameter \#3 \$permission of method Sulu\\Bundle\\SecurityBundle\\AccessControl\\AccessControlQueryEnhancerInterface\:\:enhanceWithDynamicEntityClass\(\) expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -89383,13 +89383,13 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:119\:\:findByFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			message: '#^Method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:120\:\:findByFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:119\:\:findByFiltersIds\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			message: '#^Method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:120\:\:findByFiltersIds\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89401,7 +89401,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#1 \$datasource of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:119\:\:appendDatasource\(\) expects int\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$datasource of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:120\:\:appendDatasource\(\) expects int\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89419,7 +89419,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#1 \$sortBy of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:119\:\:appendSortBy\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$sortBy of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:120\:\:appendSortBy\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89437,7 +89437,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#1 \$value of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:119\:\:getBoolean\(\) expects bool\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$value of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:120\:\:getBoolean\(\) expects bool\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89449,7 +89449,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#2 \$sortMethod of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:119\:\:appendSortBy\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#2 \$sortMethod of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:120\:\:appendSortBy\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89467,13 +89467,13 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#3 \$values of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:119\:\:appendRelation\(\) expects array\<int\>, array\<int, mixed\> given\.$#'
+			message: '#^Parameter \#3 \$values of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:120\:\:appendRelation\(\) expects array\<int\>, array\<int, mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#3 \$values of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:119\:\:appendRelation\(\) expects array\<int\>, mixed given\.$#'
+			message: '#^Parameter \#3 \$values of method class@anonymous/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest\.php\:120\:\:appendRelation\(\) expects array\<int\>, mixed given\.$#'
 			identifier: argument.type
 			count: 5
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
 use Sulu\Bundle\MediaBundle\Entity\Collection as CollectionEntity;
-use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\DescendantProviderInterface;
@@ -37,7 +37,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
     use SecuredEntityRepositoryTrait;
 
     /**
-     * @var AccessControlQueryEnhancer
+     * @var AccessControlQueryEnhancerInterface
      */
     private $accessControlQueryEnhancer;
 
@@ -400,7 +400,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
         }
     }
 
-    public function setAccessControlQueryEnhancer(AccessControlQueryEnhancer $accessControlQueryEnhancer)
+    public function setAccessControlQueryEnhancer(AccessControlQueryEnhancerInterface $accessControlQueryEnhancer)
     {
         $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
     }

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaDataProviderRepository.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\MediaBundle\Api\Media as MediaApi;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
-use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryInterface;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryTrait;
@@ -39,7 +39,7 @@ class MediaDataProviderRepository implements DataProviderRepositoryInterface
         private MediaManagerInterface $mediaManager,
         private $mediaEntityName,
         private $collectionEntityName,
-        ?AccessControlQueryEnhancer $accessControlQueryEnhancer = null
+        ?AccessControlQueryEnhancerInterface $accessControlQueryEnhancer = null
     ) {
         $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
     }

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\Tools\Pagination\Paginator;
-use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Persistence\Repository\ORM\EntityRepository;
 use Sulu\Component\Security\Authentication\UserInterface;
@@ -29,7 +29,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
     use SecuredEntityRepositoryTrait;
 
     /**
-     * @var AccessControlQueryEnhancer|null
+     * @var AccessControlQueryEnhancerInterface|null
      */
     private $accessControlQueryEnhancer;
 
@@ -479,7 +479,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             ->getArrayResult();
     }
 
-    public function setAccessControlQueryEnhancer(AccessControlQueryEnhancer $accessControlQueryEnhancer)
+    public function setAccessControlQueryEnhancer(AccessControlQueryEnhancerInterface $accessControlQueryEnhancer)
     {
         $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
     }

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 
-class AccessControlQueryEnhancer
+class AccessControlQueryEnhancer implements AccessControlQueryEnhancerInterface
 {
     public function __construct(
         private SystemStoreInterface $systemStore,

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancerInterface.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancerInterface.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Sulu\Bundle\SecurityBundle\AccessControl;
 
 use Doctrine\ORM\QueryBuilder;

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancerInterface.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sulu\Bundle\SecurityBundle\AccessControl;
+
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Component\Security\Authentication\UserInterface;
+
+interface AccessControlQueryEnhancerInterface
+{
+    /**
+     * @param class-string $entityClass
+     */
+    public function enhance(QueryBuilder $queryBuilder, ?UserInterface $user, int $permission, string $entityClass, string $entityAlias): void;
+
+    /**
+     * @param class-string $entityClass
+     */
+    public function enhanceWithDynamicEntityClass(QueryBuilder $queryBuilder, ?UserInterface $user, int $permission, string $entityClass, string $entityAlias, string $entityClassField, string $entityIdField): void;
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -13,7 +13,7 @@ namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
-use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
 use Sulu\Component\Rest\ListBuilder\AbstractListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineCountFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
@@ -120,7 +120,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         FilterTypeRegistry $filterTypeRegistry,
         private EventDispatcherInterface $eventDispatcher,
         private array $permissions,
-        private ?AccessControlQueryEnhancer $accessControlQueryEnhancer = null
+        private ?AccessControlQueryEnhancerInterface $accessControlQueryEnhancer = null
     ) {
         parent::__construct($filterTypeRegistry);
         $this->idField = new DoctrineFieldDescriptor(

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderFactory.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderFactory.php
@@ -22,10 +22,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class DoctrineListBuilderFactory implements DoctrineListBuilderFactoryInterface
 {
     public function __construct(
-        private EntityManagerInterface              $em,
-        private FilterTypeRegistry                  $filterTypeRegistry,
-        private EventDispatcherInterface            $eventDispatcher,
-        private array                               $permissions,
+        private EntityManagerInterface $em,
+        private FilterTypeRegistry $filterTypeRegistry,
+        private EventDispatcherInterface $eventDispatcher,
+        private array $permissions,
         private AccessControlQueryEnhancerInterface $accessControlQueryEnhancer,
     ) {
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderFactory.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilderFactory.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -22,11 +22,11 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class DoctrineListBuilderFactory implements DoctrineListBuilderFactoryInterface
 {
     public function __construct(
-        private EntityManagerInterface $em,
-        private FilterTypeRegistry $filterTypeRegistry,
-        private EventDispatcherInterface $eventDispatcher,
-        private array $permissions,
-        private AccessControlQueryEnhancer $accessControlQueryEnhancer,
+        private EntityManagerInterface              $em,
+        private FilterTypeRegistry                  $filterTypeRegistry,
+        private EventDispatcherInterface            $eventDispatcher,
+        private array                               $permissions,
+        private AccessControlQueryEnhancerInterface $accessControlQueryEnhancer,
     ) {
     }
 

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\SmartContent\Orm;
 
 use Doctrine\ORM\QueryBuilder;
-use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 /**
@@ -21,7 +21,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
 trait DataProviderRepositoryTrait
 {
     /**
-     * @var AccessControlQueryEnhancer|null
+     * @var AccessControlQueryEnhancerInterface|null
      */
     private $accessControlQueryEnhancer = null;
 

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -18,6 +18,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\SmartContent\Orm\DataProviderRepositoryTrait;
 
@@ -120,8 +121,8 @@ class DataProviderRepositoryTraitTest extends TestCase
             use DataProviderRepositoryTrait;
 
             public function __construct(
-                AccessControlQueryEnhancer $accessControlQueryEnhancer,
-                private QueryBuilder $queryBuilder,
+                AccessControlQueryEnhancerInterface $accessControlQueryEnhancer,
+                private QueryBuilder                $queryBuilder,
             ) {
                 $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
             }

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -122,7 +122,7 @@ class DataProviderRepositoryTraitTest extends TestCase
 
             public function __construct(
                 AccessControlQueryEnhancerInterface $accessControlQueryEnhancer,
-                private QueryBuilder                $queryBuilder,
+                private QueryBuilder $queryBuilder,
             ) {
                 $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Replaces all occurences of AccessControlQueryEnhancer by an interface

#### Why?

We need a much more restrictive access control mechanism on custom entities and media collections. So we need to decorate or swap the existing implementation without extending the rather inflexible implementation.
