### PR TITLE
Make max resolver depth configurable

### DIFF
--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -40,8 +40,7 @@
             <argument type="service" id="sulu_content.resolvable_resource_replacer" />
             <argument type="service" id="sulu_content.content_view_data_normalizer" />
             <argument type="service" id="sulu_content.content_aggregator" />
-            <!--  TODO          <argument>%sulu_content.resource_resolver.max_depth%</argument>-->
-            <argument>5</argument>
+            <argument>%sulu_content.resource_resolver.max_depth%</argument>
             <argument type="service" id="sulu_content.content_enhancer"/>
         </service>
         <service id="Sulu\Content\Application\ContentResolver\ContentResolverInterface" alias="sulu_content.content_resolver"/>

--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -40,7 +40,7 @@
             <argument type="service" id="sulu_content.resolvable_resource_replacer" />
             <argument type="service" id="sulu_content.content_view_data_normalizer" />
             <argument type="service" id="sulu_content.content_aggregator" />
-            <argument>0</argument> <!-- See config for: sulu_content.content_resolver.max_depth -->
+            <argument /> <!-- See via SuluContentBundle config for: sulu_content.content_resolver.max_depth -->
             <argument type="service" id="sulu_content.content_enhancer"/>
         </service>
         <service id="Sulu\Content\Application\ContentResolver\ContentResolverInterface" alias="sulu_content.content_resolver"/>

--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -40,7 +40,7 @@
             <argument type="service" id="sulu_content.resolvable_resource_replacer" />
             <argument type="service" id="sulu_content.content_view_data_normalizer" />
             <argument type="service" id="sulu_content.content_aggregator" />
-            <argument>%sulu_content.resource_resolver.max_depth%</argument>
+            <argument>0</argument> <!-- See config for: sulu_content.content_resolver.max_depth -->
             <argument type="service" id="sulu_content.content_enhancer"/>
         </service>
         <service id="Sulu\Content\Application\ContentResolver\ContentResolverInterface" alias="sulu_content.content_resolver"/>

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
@@ -38,7 +38,16 @@ final class SuluContentBundle extends AbstractBundle
      */
     public function configure(DefinitionConfigurator $definition): void
     {
-        $definition->rootNode();
+        $definition->rootNode() // @phpstan-ignore-line
+            ->children()
+                ->arrayNode('resource_resolver')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('max_depth')->defaultValue(5)->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
     }
 
     /**
@@ -48,6 +57,10 @@ final class SuluContentBundle extends AbstractBundle
      */
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
+        $container->parameters()
+            ->set('sulu_content.resource_resolver.max_depth', $config['resource_resolver']['max_depth'] ?? 5)
+        ;
+
         // TODO refactor to PHP based service definitions
         $loader = new XmlFileLoader($builder, new FileLocator(\dirname(__DIR__, 4) . '/config'));
         $loader->load('data-mapper.xml');

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
@@ -57,9 +57,9 @@ final class SuluContentBundle extends AbstractBundle
      */
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $container->parameters()
-            ->set('sulu_content.resource_resolver.max_depth', $config['resource_resolver']['max_depth'] ?? 5)
-        ;
+        /** @var array{max_depth: int} $resourceResolverConfig */
+        $resourceResolverConfig = $config['resource_resolver'];
+        $builder->setParameter('sulu_content.resource_resolver.max_depth', $resourceResolverConfig['max_depth']);
 
         // TODO refactor to PHP based service definitions
         $loader = new XmlFileLoader($builder, new FileLocator(\dirname(__DIR__, 4) . '/config'));

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
@@ -40,7 +40,7 @@ final class SuluContentBundle extends AbstractBundle
     {
         $definition->rootNode() // @phpstan-ignore-line
             ->children()
-                ->arrayNode('resource_resolver')
+                ->arrayNode('content_resolver')
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('max_depth')->defaultValue(5)->end()
@@ -57,10 +57,6 @@ final class SuluContentBundle extends AbstractBundle
      */
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        /** @var array{max_depth: int} $resourceResolverConfig */
-        $resourceResolverConfig = $config['resource_resolver'];
-        $builder->setParameter('sulu_content.resource_resolver.max_depth', $resourceResolverConfig['max_depth']);
-
         // TODO refactor to PHP based service definitions
         $loader = new XmlFileLoader($builder, new FileLocator(\dirname(__DIR__, 4) . '/config'));
         $loader->load('data-mapper.xml');
@@ -74,6 +70,12 @@ final class SuluContentBundle extends AbstractBundle
         $loader->load('reference.xml');
 
         $services = $container->services();
+
+        /** @var array{max_depth: int} $contentResolverConfig */
+        $contentResolverConfig = $config['content_resolver'];
+
+        $builder->getDefinition('sulu_content.content_resolver')
+            ->setArgument('$maxDepth', $contentResolverConfig['max_depth']);
 
         $services->set('sulu_content.doctrine_route_cleanup_listener')
             ->class(RouteCleanupListener::class)

--- a/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
@@ -68,7 +68,7 @@ class SuluContentBundleTest extends AbstractExtensionTestCase
         );
     }
 
-    public function testIsConfigurationEmpty(): void
+    public function testEmptyConfiguration(): void
     {
         $contentBundle = $this->getContentBundle();
         $treeBuilder = new TreeBuilder('sulu_content');
@@ -90,7 +90,11 @@ class SuluContentBundleTest extends AbstractExtensionTestCase
         $tree = $treeBuilder->buildTree();
 
         $this->assertSame([
-            'sulu_content' => [],
+            'sulu_content' => [
+                'resource_resolver' => [
+                    'max_depth' => 5,
+                ],
+            ],
         ], [
             $tree->getName() => $tree->finalize([]),
         ]);

--- a/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
@@ -91,7 +91,7 @@ class SuluContentBundleTest extends AbstractExtensionTestCase
 
         $this->assertSame([
             'sulu_content' => [
-                'resource_resolver' => [
+                'content_resolver' => [
                     'max_depth' => 5,
                 ],
             ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #8455 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding a configuration parameter for the content resolver max depth.

#### Why?
It should not be hardcoded. And there was already a todo there.

#### Example Usage
```yaml
# config/packages/sulu_content.yaml
sulu_content:
    content_resolver:
        max_depth: 10
```