### PR TITLE
Improve FormMetadataLoader Cache

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -34,6 +34,7 @@ return $config
             'ext-openssl', // fallbacks to random_bytes
             'ext-zip', // not required to run Sulu
             'ext-intl', // optional fallback to strcmp
+            'ext-zend-opcache', // optional for cache invalidation
         ],
         [ErrorType::SHADOW_DEPENDENCY],
     )
@@ -79,7 +80,6 @@ return $config
         [
             'guzzlehttp/promises', // required for faster fos http cache clearing
             'nyholm/psr7', // required for faster fos http cache clearing
-            'symfony/var-exporter', // required for doctrine lazy objects
             'symfony/css-selector', // kept for future usage
         ],
         [ErrorType::UNUSED_DEPENDENCY],

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -13,8 +13,6 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\FormXmlLoader;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\FieldMetadataValidatorInterface;
-use Symfony\Component\Config\ConfigCache;
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\VarExporter\VarExporter;
@@ -62,10 +60,10 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
 
     public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?FormMetadata
     {
-        $configCache = $this->getConfigCache($key);
+        $path = $this->getCachePath($key);
 
-        if ($configCache->isFresh()) {
-            $formMetadata = @include $configCache->getPath();
+        if (\file_exists($path)) {
+            $formMetadata = include $path;
             if ($formMetadata instanceof FormMetadata) {
                 return $formMetadata;
             }
@@ -76,21 +74,25 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
         }
 
         $this->warmUp($this->cacheDir);
-        $formMetadata = @include $configCache->getPath();
 
-        return $formMetadata instanceof FormMetadata ? $formMetadata : null;
+        if (\file_exists($path)) {
+            $formMetadata = include $path;
+            if ($formMetadata instanceof FormMetadata) {
+                return $formMetadata;
+            }
+        }
+
+        return null;
     }
 
     public function warmUp($cacheDir, ?string $buildDir = null): array
     {
         $formFinder = (new Finder())->in($this->formDirectories)->name('*.xml');
         $formsMetadataCollection = [];
-        $formsMetadataResources = [];
 
         foreach ($formFinder as $formFile) {
             $formMetadata = $this->formXmlLoader->load($formFile->getPathName());
             $formKey = $formMetadata->getKey();
-            $formsMetadataResources[$formKey][] = $formFile->getPathName();
             if (!\array_key_exists($formKey, $formsMetadataCollection)) {
                 $formsMetadataCollection[$formKey] = $formMetadata;
             } else {
@@ -101,17 +103,8 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
         foreach ($formsMetadataCollection as $key => $formMetadata) {
             $this->validateItems($formMetadata->getItems(), $key);
 
-            $configCache = $this->getConfigCache($key);
-            $configCache->write(
-                '<?php return ' . VarExporter::export($formMetadata) . ';',
-                \array_map(function(string $resource) {
-                    return new FileResource($resource);
-                }, $formsMetadataResources[$key])
-            );
-
-            if (\function_exists('opcache_invalidate')) {
-                \opcache_invalidate($configCache->getPath(), true);
-            }
+            $path = $this->getCachePath($key);
+            $this->writeCache($path, '<?php return ' . VarExporter::export($formMetadata) . ';');
         }
 
         return [];
@@ -142,8 +135,24 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
         return false;
     }
 
-    private function getConfigCache(string $key): ConfigCache
+    private function getCachePath(string $key): string
     {
-        return new ConfigCache(\sprintf('%s%s%s.php', $this->cacheDir, \DIRECTORY_SEPARATOR, $key), $this->debug);
+        return \sprintf('%s%s%s.php', $this->cacheDir, \DIRECTORY_SEPARATOR, $key);
+    }
+
+    private function writeCache(string $path, string $content): void
+    {
+        $dir = \dirname($path);
+        if (!\is_dir($dir)) {
+            \mkdir($dir, 0777, true);
+        }
+
+        $tmpFile = $path . '.' . \uniqid('', true);
+        \file_put_contents($tmpFile, $content);
+        \rename($tmpFile, $path);
+
+        if (\function_exists('opcache_invalidate')) {
+            \opcache_invalidate($path, true);
+        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\VarExporter\VarExporter;
 
 class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerInterface
 {
@@ -63,19 +64,21 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
     {
         $configCache = $this->getConfigCache($key);
 
-        if (!\file_exists($configCache->getPath())) {
+        if ($configCache->isFresh()) {
+            $formMetadata = @include $configCache->getPath();
+            if ($formMetadata instanceof FormMetadata) {
+                return $formMetadata;
+            }
+        }
+
+        if (!$this->debug) {
             return null;
         }
 
-        if (!$configCache->isFresh()) {
-            $this->warmUp($this->cacheDir);
-        }
+        $this->warmUp($this->cacheDir);
+        $formMetadata = @include $configCache->getPath();
 
-        $form = \unserialize(\file_get_contents($configCache->getPath()) ?: '');
-
-        \assert($form instanceof FormMetadata, 'Expected FormMetadata instance for key: "' . $key . '".');
-
-        return $form;
+        return $formMetadata instanceof FormMetadata ? $formMetadata : null;
     }
 
     public function warmUp($cacheDir, ?string $buildDir = null): array
@@ -100,11 +103,15 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
 
             $configCache = $this->getConfigCache($key);
             $configCache->write(
-                \serialize($formMetadata),
+                '<?php return ' . VarExporter::export($formMetadata) . ';',
                 \array_map(function(string $resource) {
                     return new FileResource($resource);
                 }, $formsMetadataResources[$key])
             );
+
+            if (\function_exists('opcache_invalidate')) {
+                \opcache_invalidate($configCache->getPath(), true);
+            }
         }
 
         return [];
@@ -137,6 +144,6 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
 
     private function getConfigCache(string $key): ConfigCache
     {
-        return new ConfigCache(\sprintf('%s%s%s', $this->cacheDir, \DIRECTORY_SEPARATOR, $key), $this->debug);
+        return new ConfigCache(\sprintf('%s%s%s.php', $this->cacheDir, \DIRECTORY_SEPARATOR, $key), $this->debug);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -62,11 +62,9 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
     {
         $path = $this->getCachePath($key);
 
-        if (\file_exists($path)) {
-            $formMetadata = include $path;
-            if ($formMetadata instanceof FormMetadata) {
-                return $formMetadata;
-            }
+        $formMetadata = @include $path;
+        if ($formMetadata instanceof FormMetadata) {
+            return $formMetadata;
         }
 
         if (!$this->debug) {
@@ -75,14 +73,9 @@ class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerI
 
         $this->warmUp($this->cacheDir);
 
-        if (\file_exists($path)) {
-            $formMetadata = include $path;
-            if ($formMetadata instanceof FormMetadata) {
-                return $formMetadata;
-            }
-        }
+        $formMetadata = @include $path;
 
-        return null;
+        return $formMetadata instanceof FormMetadata ? $formMetadata : null;
     }
 
     public function warmUp($cacheDir, ?string $buildDir = null): array

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
@@ -13,8 +13,6 @@ namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\FieldMetadataValidatorInterface;
-use Symfony\Component\Config\ConfigCache;
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\VarExporter\VarExporter;
@@ -38,10 +36,10 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
 
     public function getMetadata(string $key, ?string $locale = null, array $metadataOptions = []): ?TypedFormMetadata
     {
-        $configCache = $this->getConfigCache($key);
+        $path = $this->getCachePath($key);
 
-        if ($configCache->isFresh()) {
-            $typedFormMetadata = @include $configCache->getPath();
+        if (\file_exists($path)) {
+            $typedFormMetadata = include $path;
             if ($typedFormMetadata instanceof TypedFormMetadata) {
                 return $typedFormMetadata;
             }
@@ -52,9 +50,15 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
         }
 
         $this->warmUp($this->cacheDir);
-        $typedFormMetadata = @include $configCache->getPath();
 
-        return $typedFormMetadata instanceof TypedFormMetadata ? $typedFormMetadata : null;
+        if (\file_exists($path)) {
+            $typedFormMetadata = include $path;
+            if ($typedFormMetadata instanceof TypedFormMetadata) {
+                return $typedFormMetadata;
+            }
+        }
+
+        return null;
     }
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
@@ -67,7 +71,6 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
             );
 
             $formsMetadataCollection = [];
-            $formsMetadataResources = [];
 
             $typedFormMetadata = new TypedFormMetadata();
             if (null !== $defaultType) {
@@ -80,7 +83,6 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
                 foreach ($formFinder as $formFile) {
                     $formMetadata = $this->templateXmlLoader->load($formFile->getPathName());
                     $formKey = $formMetadata->getKey();
-                    $formsMetadataResources[] = $formFile->getPathName();
                     if (!\array_key_exists($formKey, $formsMetadataCollection)) {
                         $formsMetadataCollection[$formKey] = $formMetadata;
                     } else {
@@ -94,17 +96,8 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
                 $typedFormMetadata->addForm($formMetadata->getKey(), $formMetadata);
             }
 
-            $configCache = $this->getConfigCache($type);
-            $configCache->write(
-                '<?php return ' . VarExporter::export($typedFormMetadata) . ';',
-                \array_map(function(string $resource) {
-                    return new FileResource($resource);
-                }, $formsMetadataResources)
-            );
-
-            if (\function_exists('opcache_invalidate')) {
-                \opcache_invalidate($configCache->getPath(), true);
-            }
+            $path = $this->getCachePath($type);
+            $this->writeCache($path, '<?php return ' . VarExporter::export($typedFormMetadata) . ';');
         }
 
         return [];
@@ -135,8 +128,24 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
         return false;
     }
 
-    private function getConfigCache(string $key): ConfigCache
+    private function getCachePath(string $key): string
     {
-        return new ConfigCache(\sprintf('%s%s%s.php', $this->cacheDir, \DIRECTORY_SEPARATOR, $key), $this->debug);
+        return \sprintf('%s%s%s.php', $this->cacheDir, \DIRECTORY_SEPARATOR, $key);
+    }
+
+    private function writeCache(string $path, string $content): void
+    {
+        $dir = \dirname($path);
+        if (!\is_dir($dir)) {
+            \mkdir($dir, 0777, true);
+        }
+
+        $tmpFile = $path . '.' . \uniqid('', true);
+        \file_put_contents($tmpFile, $content);
+        \rename($tmpFile, $path);
+
+        if (\function_exists('opcache_invalidate')) {
+            \opcache_invalidate($path, true);
+        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\VarExporter\VarExporter;
 
 class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerInterface
 {
@@ -39,19 +40,21 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
     {
         $configCache = $this->getConfigCache($key);
 
-        if (!\file_exists($configCache->getPath())) {
+        if ($configCache->isFresh()) {
+            $typedFormMetadata = @include $configCache->getPath();
+            if ($typedFormMetadata instanceof TypedFormMetadata) {
+                return $typedFormMetadata;
+            }
+        }
+
+        if (!$this->debug) {
             return null;
         }
 
-        if (!$configCache->isFresh()) {
-            $this->warmUp($this->cacheDir);
-        }
+        $this->warmUp($this->cacheDir);
+        $typedFormMetadata = @include $configCache->getPath();
 
-        $typedForm = \unserialize(\file_get_contents($configCache->getPath()) ?: '');
-
-        \assert($typedForm instanceof TypedFormMetadata, 'Expected TypedFormMetadata instance for key: "' . $key . '".');
-
-        return $typedForm;
+        return $typedFormMetadata instanceof TypedFormMetadata ? $typedFormMetadata : null;
     }
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array
@@ -93,11 +96,15 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
 
             $configCache = $this->getConfigCache($type);
             $configCache->write(
-                \serialize($typedFormMetadata),
+                '<?php return ' . VarExporter::export($typedFormMetadata) . ';',
                 \array_map(function(string $resource) {
                     return new FileResource($resource);
                 }, $formsMetadataResources)
             );
+
+            if (\function_exists('opcache_invalidate')) {
+                \opcache_invalidate($configCache->getPath(), true);
+            }
         }
 
         return [];
@@ -130,6 +137,6 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
 
     private function getConfigCache(string $key): ConfigCache
     {
-        return new ConfigCache(\sprintf('%s%s%s', $this->cacheDir, \DIRECTORY_SEPARATOR, $key), $this->debug);
+        return new ConfigCache(\sprintf('%s%s%s.php', $this->cacheDir, \DIRECTORY_SEPARATOR, $key), $this->debug);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
@@ -38,11 +38,9 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
     {
         $path = $this->getCachePath($key);
 
-        if (\file_exists($path)) {
-            $typedFormMetadata = include $path;
-            if ($typedFormMetadata instanceof TypedFormMetadata) {
-                return $typedFormMetadata;
-            }
+        $typedFormMetadata = @include $path;
+        if ($typedFormMetadata instanceof TypedFormMetadata) {
+            return $typedFormMetadata;
         }
 
         if (!$this->debug) {
@@ -51,14 +49,9 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
 
         $this->warmUp($this->cacheDir);
 
-        if (\file_exists($path)) {
-            $typedFormMetadata = include $path;
-            if ($typedFormMetadata instanceof TypedFormMetadata) {
-                return $typedFormMetadata;
-            }
-        }
+        $typedFormMetadata = @include $path;
 
-        return null;
+        return $typedFormMetadata instanceof TypedFormMetadata ? $typedFormMetadata : null;
     }
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
@@ -27,7 +27,12 @@ class XmlFormMetadataLoaderTest extends TestCase
 {
     use ProphecyTrait;
 
-    public const CACHE_DIR = __DIR__ . '/../../../../../../../../tests/Resources/cache';
+    private const CACHE_DIR = __DIR__ . '/../../../../../../../../tests/Resources/cache';
+
+    private static function getCacheDir(): string
+    {
+        return self::CACHE_DIR;
+    }
 
     /**
      * @var ObjectProphecy<FormXmlLoader>
@@ -55,7 +60,7 @@ class XmlFormMetadataLoaderTest extends TestCase
             [
                 __DIR__ . '/dummy-forms',
             ],
-            static::CACHE_DIR,
+            self::getCacheDir(),
             false
         );
     }
@@ -108,6 +113,18 @@ class XmlFormMetadataLoaderTest extends TestCase
         return $sectionMetadata;
     }
 
+    protected function tearDown(): void
+    {
+        $cacheFile = self::getCacheDir() . '/some_form_key.php';
+        if (\file_exists($cacheFile)) {
+            \unlink($cacheFile);
+        }
+        $metaFile = $cacheFile . '.meta';
+        if (\file_exists($metaFile)) {
+            \unlink($metaFile);
+        }
+    }
+
     public function testWarmUp(): void
     {
         $propertyMetadata = $this->createFieldMetadata('some_property', 'text_line');
@@ -126,6 +143,74 @@ class XmlFormMetadataLoaderTest extends TestCase
         $this->fieldMetadataValidator->validate($blockPropertyMetadata, 'some_form_key')->shouldBeCalled();
         $this->fieldMetadataValidator->validate($blockMetadata, 'some_form_key')->shouldBeCalled();
 
-        $this->xmlFormMetadataLoader->warmUp(static::CACHE_DIR);
+        $this->xmlFormMetadataLoader->warmUp(self::getCacheDir());
+    }
+
+    public function testWarmUpGeneratesPhpFile(): void
+    {
+        $formMetadata = $this->createFormMetadata('some_form_key', [
+            $this->createFieldMetadata('test_field', 'text_line'),
+        ]);
+
+        $this->formXmlLoader->load(Argument::cetera())->willReturn($formMetadata);
+        $this->fieldMetadataValidator->validate(Argument::cetera(), Argument::cetera())->shouldBeCalled();
+
+        $this->xmlFormMetadataLoader->warmUp(self::getCacheDir());
+
+        $cacheFile = self::getCacheDir() . '/some_form_key.php';
+        $this->assertFileExists($cacheFile);
+
+        $content = \file_get_contents($cacheFile);
+        $this->assertIsString($content);
+        $this->assertStringStartsWith('<?php return ', $content);
+        $this->assertStringNotContainsString('unserialize', $content);
+    }
+
+    public function testGetMetadataFromCache(): void
+    {
+        $formMetadata = $this->createFormMetadata('some_form_key', [
+            $this->createFieldMetadata('test_field', 'text_line'),
+        ]);
+
+        $this->formXmlLoader->load(Argument::cetera())->willReturn($formMetadata);
+        $this->fieldMetadataValidator->validate(Argument::cetera(), Argument::cetera())->shouldBeCalled();
+
+        $this->xmlFormMetadataLoader->warmUp(self::getCacheDir());
+
+        $loadedMetadata = $this->xmlFormMetadataLoader->getMetadata('some_form_key', 'en');
+
+        $this->assertInstanceOf(FormMetadata::class, $loadedMetadata);
+        $this->assertSame('some_form_key', $loadedMetadata->getKey());
+        $this->assertCount(1, $loadedMetadata->getItems());
+    }
+
+    public function testGetMetadataReturnsNullWhenCacheMissingInProdMode(): void
+    {
+        $result = $this->xmlFormMetadataLoader->getMetadata('nonexistent_form', 'en');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetMetadataAutoRebuildsInDebugMode(): void
+    {
+        $formMetadata = $this->createFormMetadata('some_form_key', [
+            $this->createFieldMetadata('test_field', 'text_line'),
+        ]);
+
+        $this->formXmlLoader->load(Argument::cetera())->willReturn($formMetadata);
+        $this->fieldMetadataValidator->validate(Argument::cetera(), Argument::cetera())->shouldBeCalled();
+
+        $debugLoader = new XmlFormMetadataLoader(
+            $this->formXmlLoader->reveal(),
+            $this->fieldMetadataValidator->reveal(),
+            [__DIR__ . '/dummy-forms'],
+            self::getCacheDir(),
+            true
+        );
+
+        $loadedMetadata = $debugLoader->getMetadata('some_form_key', 'en');
+
+        $this->assertInstanceOf(FormMetadata::class, $loadedMetadata);
+        $this->assertSame('some_form_key', $loadedMetadata->getKey());
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlTemplateFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlTemplateFormMetadataLoaderTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Loader\TemplateXmlLoader;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Validation\FieldMetadataValidatorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\XmlTemplateFormMetadataLoader;
+
+class XmlTemplateFormMetadataLoaderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private const CACHE_DIR = __DIR__ . '/../../../../../../../../tests/Resources/cache/templates';
+
+    private static function getCacheDir(): string
+    {
+        return self::CACHE_DIR;
+    }
+
+    /**
+     * @var ObjectProphecy<TemplateXmlLoader>
+     */
+    private ObjectProphecy $templateXmlLoader;
+
+    /**
+     * @var ObjectProphecy<FieldMetadataValidatorInterface>
+     */
+    private ObjectProphecy $fieldMetadataValidator;
+
+    private XmlTemplateFormMetadataLoader $loader;
+
+    protected function setUp(): void
+    {
+        $this->templateXmlLoader = $this->prophesize(TemplateXmlLoader::class);
+        $this->fieldMetadataValidator = $this->prophesize(FieldMetadataValidatorInterface::class);
+
+        $cacheDir = self::getCacheDir();
+        if (!\is_dir($cacheDir)) {
+            \mkdir($cacheDir, 0777, true);
+        }
+
+        $this->loader = new XmlTemplateFormMetadataLoader(
+            $this->templateXmlLoader->reveal(),
+            $this->fieldMetadataValidator->reveal(),
+            [
+                'page' => [
+                    'default_type' => 'default',
+                    'directories' => [__DIR__ . '/dummy-templates'],
+                ],
+            ],
+            $cacheDir,
+            false
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $cacheFile = self::getCacheDir() . '/page.php';
+        if (\file_exists($cacheFile)) {
+            \unlink($cacheFile);
+        }
+        $metaFile = $cacheFile . '.meta';
+        if (\file_exists($metaFile)) {
+            \unlink($metaFile);
+        }
+    }
+
+    private function createFieldMetadata(string $name, string $type): FieldMetadata
+    {
+        $fieldMetadata = new FieldMetadata($name);
+        $fieldMetadata->setType($type);
+
+        return $fieldMetadata;
+    }
+
+    /**
+     * @param ItemMetadata[] $items
+     */
+    private function createFormMetadata(string $key, array $items = []): FormMetadata
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey($key);
+        $formMetadata->setItems([]);
+
+        foreach ($items as $item) {
+            $formMetadata->addItem($item);
+        }
+
+        return $formMetadata;
+    }
+
+    public function testWarmUpGeneratesPhpFile(): void
+    {
+        $formMetadata = $this->createFormMetadata('default', [
+            $this->createFieldMetadata('title', 'text_line'),
+        ]);
+
+        $this->templateXmlLoader->load(Argument::cetera())->willReturn($formMetadata);
+        $this->fieldMetadataValidator->validate(Argument::cetera(), Argument::cetera())->shouldBeCalled();
+
+        $this->loader->warmUp(self::getCacheDir());
+
+        $cacheFile = self::getCacheDir() . '/page.php';
+        $this->assertFileExists($cacheFile);
+
+        $content = \file_get_contents($cacheFile);
+        $this->assertIsString($content);
+        $this->assertStringStartsWith('<?php return ', $content);
+        $this->assertStringNotContainsString('unserialize', $content);
+    }
+
+    public function testGetMetadataFromCache(): void
+    {
+        $formMetadata = $this->createFormMetadata('default', [
+            $this->createFieldMetadata('title', 'text_line'),
+        ]);
+
+        $this->templateXmlLoader->load(Argument::cetera())->willReturn($formMetadata);
+        $this->fieldMetadataValidator->validate(Argument::cetera(), Argument::cetera())->shouldBeCalled();
+
+        $this->loader->warmUp(self::getCacheDir());
+
+        $loadedMetadata = $this->loader->getMetadata('page', 'en');
+
+        $this->assertInstanceOf(TypedFormMetadata::class, $loadedMetadata);
+        $this->assertSame('default', $loadedMetadata->getDefaultType());
+        $this->assertArrayHasKey('default', $loadedMetadata->getForms());
+    }
+
+    public function testGetMetadataReturnsNullWhenCacheMissingInProdMode(): void
+    {
+        $result = $this->loader->getMetadata('nonexistent', 'en');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetMetadataAutoRebuildsInDebugMode(): void
+    {
+        $formMetadata = $this->createFormMetadata('default', [
+            $this->createFieldMetadata('title', 'text_line'),
+        ]);
+
+        $this->templateXmlLoader->load(Argument::cetera())->willReturn($formMetadata);
+        $this->fieldMetadataValidator->validate(Argument::cetera(), Argument::cetera())->shouldBeCalled();
+
+        $debugLoader = new XmlTemplateFormMetadataLoader(
+            $this->templateXmlLoader->reveal(),
+            $this->fieldMetadataValidator->reveal(),
+            [
+                'page' => [
+                    'default_type' => 'default',
+                    'directories' => [__DIR__ . '/dummy-templates'],
+                ],
+            ],
+            self::getCacheDir(),
+            true
+        );
+
+        $loadedMetadata = $debugLoader->getMetadata('page', 'en');
+
+        $this->assertInstanceOf(TypedFormMetadata::class, $loadedMetadata);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/dummy-templates/dummy-template.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/dummy-templates/dummy-template.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd"
+>
+    <key>dummy-template</key>
+    <view>pages/dummy</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>86400</cacheLifetime>
+    <properties>
+        <property name="title" type="text_line"/>
+    </properties>
+</template>


### PR DESCRIPTION
| Q                  | A               |
  |--------------------|-----------------|
  | Bug fix?           | no              |
  | New feature?       | no              |
  | BC breaks?         | yes             |
  | Deprecations?      | no              |
  | Fixed tickets      | fixes #8448     |
  | Related issues/PRs | #               |
  | License            | MIT             |
  | Documentation PR   | sulu/sulu-docs# |

  What's in this PR?

  Replaces PHP serialization with Symfony VarExporter for FormMetadata caching in both XmlFormMetadataLoader and XmlTemplateFormMetadataLoader. This allows cached metadata to be served from OPcache instead of requiring file_get_contents() + unserialize() on every request.

  Changes:
  - Cache files now have .php extension and contain executable PHP code
  - Uses include() instead of file_get_contents() + unserialize() to load cached metadata
  - Adds opcache_invalidate() after writing cache files during warmup
  - In production mode (debug=false), returns null on cache miss instead of auto-rebuilding
  - In development mode (debug=true), auto-rebuilds cache when missing or stale

  Why?

FormMetadataProvider::getMetadata() caused significant performance degradation due to repeated file_get_contents() + unserialize() operations.

  By using VarExporter, the cached metadata is stored as executable PHP code that gets compiled and cached by OPcache. After the first request, subsequent requests serve the metadata directly from memory without any file I/O or deserialization overhead.

  Example Usage

  No changes to the public API. The optimization is transparent to consumers.

  Deployment note: In production, run cache:warmup during deployment to ensure cache files exist before the first request.

  BC Breaks

  - Cache file format changed from serialized data to PHP code
  - Cache files now have .php extension instead of no extension
  - Production mode now returns null on cache miss instead of auto-rebuilding (requires cache:warmup during deployment)