### PR TITLE
Add a default collection builder for creating test collections in dev

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19747,12 +19747,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManager\:\:getByKey\(\) should return Sulu\\Bundle\\MediaBundle\\Api\\Collection but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManager\:\:getPreview\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -33171,24 +33165,6 @@ parameters:
 		-
 			message: '#^Property Sulu\\Component\\Media\\SystemCollections\\SystemCollectionManager\:\:\$systemCollections type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between null and Sulu\\Bundle\\MediaBundle\\Api\\Collection will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between null and Sulu\\Bundle\\MediaBundle\\Api\\Collection will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
 			count: 1
 			path: src/Sulu/Component/Media/SystemCollections/SystemCollectionManager.php
 

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -195,6 +195,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                             'fixtures' => [],
                             'user' => [],
                             'system_collections' => [],
+                            'default_collection' => [],
                             'security' => [],
                         ],
                     ],

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -139,7 +139,7 @@ class CollectionManager implements CollectionManagerInterface
         $collection = $this->collectionRepository->findCollectionByKey($key);
 
         if (!$collection) {
-            return;
+            return null;
         }
 
         return $this->getApiEntity($collection, $locale);

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
@@ -64,7 +64,7 @@ interface CollectionManagerInterface
      * @param string $key
      * @param string $locale
      *
-     * @return Collection
+     * @return Collection|null
      */
     public function getByKey($key, $locale);
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -364,6 +364,13 @@
             <tag name="massive_build.builder" />
         </service>
 
+        <service id="sulu_media.default_collection.builder" class="Sulu\Component\Media\SystemCollections\DefaultCollectionBuilder">
+            <argument type="service" id="sulu_media.collection_manager"/>
+            <argument type="service" id="sulu_core.webspace.webspace_manager" />
+
+            <tag name="massive_build.builder" />
+        </service>
+
         <service id="sulu_media.disposition_type.resolver" class="Sulu\Bundle\MediaBundle\Media\DispositionType\DispositionTypeResolver" public="true">
             <argument>%sulu_media.disposition_type.default%</argument>
             <argument>%sulu_media.disposition_type.mime_types_inline%</argument>

--- a/src/Sulu/Component/Media/SystemCollections/DefaultCollectionBuilder.php
+++ b/src/Sulu/Component/Media/SystemCollections/DefaultCollectionBuilder.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Media\SystemCollections;
+
+use Massive\Bundle\BuildBundle\Build\BuilderContext;
+use Massive\Bundle\BuildBundle\Build\BuilderInterface;
+use Sulu\Bundle\MediaBundle\Api\Collection;
+use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+readonly class DefaultCollectionBuilder implements BuilderInterface
+{
+    private ?InputInterface $input;
+    private ?OutputInterface $output;
+
+    public function __construct(
+        private CollectionManagerInterface $collectionManager,
+        private WebspaceManagerInterface $webspaceManager,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'default_collection';
+    }
+
+    public function getDependencies(): array
+    {
+        return ['database', 'fixtures'];
+    }
+
+    public function build(): void
+    {
+        foreach ($this->webspaceManager->getAllLocalizations() as $localization) {
+            $locale = $localization->getLocale();
+
+            $this->output->writeln('Updating test collection for ' . $localization);
+
+            $existingId = $this->collectionManager->getByKey('test_collection', $locale)?->getId();
+            if (null !== $existingId && $this->input->getOption('destroy')) {
+                $this->collectionManager->delete($existingId);
+                $existingId = null;
+            }
+
+            $this->collectionManager->save([
+                'title' => 'Test Collection',
+                'key' => 'test_collection',
+                'type' => ['id' => 1], // Non System collection
+                'locale' => $locale,
+                'parent' => null,
+                'id' => $existingId,
+            ]);
+        }
+    }
+
+    public function setContext(BuilderContext $context): void
+    {
+        $this->input = $context->getInput();
+        $this->output = $context->getOutput();
+    }
+}

--- a/src/Sulu/Component/Media/SystemCollections/DefaultCollectionBuilder.php
+++ b/src/Sulu/Component/Media/SystemCollections/DefaultCollectionBuilder.php
@@ -43,6 +43,11 @@ class DefaultCollectionBuilder implements BuilderInterface
 
     public function build(): void
     {
+        $title = [
+            'default' => 'Images',
+            'en_US' => 'Images',
+            'de_DE' => 'Bilder',
+        ];
         foreach ($this->webspaceManager->getAllLocalizations() as $localization) {
             $locale = $localization->getLocale();
 
@@ -55,7 +60,7 @@ class DefaultCollectionBuilder implements BuilderInterface
             }
 
             $this->collectionManager->save([
-                'title' => 'Test Collection',
+                'title' => $title[$locale] ?? $title['en_US'],
                 'key' => 'test_collection',
                 'type' => ['id' => 1], // Non System collection
                 'locale' => $locale,

--- a/src/Sulu/Component/Media/SystemCollections/DefaultCollectionBuilder.php
+++ b/src/Sulu/Component/Media/SystemCollections/DefaultCollectionBuilder.php
@@ -15,16 +15,15 @@ namespace Sulu\Component\Media\SystemCollections;
 
 use Massive\Bundle\BuildBundle\Build\BuilderContext;
 use Massive\Bundle\BuildBundle\Build\BuilderInterface;
-use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Collection\Manager\CollectionManagerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-readonly class DefaultCollectionBuilder implements BuilderInterface
+class DefaultCollectionBuilder implements BuilderInterface
 {
-    private ?InputInterface $input;
-    private ?OutputInterface $output;
+    private ?InputInterface $input = null;
+    private ?OutputInterface $output = null;
 
     public function __construct(
         private CollectionManagerInterface $collectionManager,
@@ -47,10 +46,10 @@ readonly class DefaultCollectionBuilder implements BuilderInterface
         foreach ($this->webspaceManager->getAllLocalizations() as $localization) {
             $locale = $localization->getLocale();
 
-            $this->output->writeln('Updating test collection for ' . $localization);
+            $this->output?->writeln('Updating test collection for ' . $localization);
 
             $existingId = $this->collectionManager->getByKey('test_collection', $locale)?->getId();
-            if (null !== $existingId && $this->input->getOption('destroy')) {
+            if (null !== $existingId && $this->input?->getOption('destroy')) {
                 $this->collectionManager->delete($existingId);
                 $existingId = null;
             }
@@ -68,7 +67,12 @@ readonly class DefaultCollectionBuilder implements BuilderInterface
 
     public function setContext(BuilderContext $context): void
     {
-        $this->input = $context->getInput();
-        $this->output = $context->getOutput();
+        /** @var InputInterface $input */
+        $input = $context->getInput();
+        $this->input = $input;
+
+        /** @var OutputInterface $output */
+        $output = $context->getOutput();
+        $this->output = $output;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding a builder to create one default media collection.

#### Why?
When setting up sulu for testing it would be nice to also have a default collection since you can't upload anything without one.

#### Example Usage
`bin/console sulu:build default_collection`