### PR TITLE
Fix depth calculation during resolving

### DIFF
--- a/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolver.php
@@ -117,7 +117,7 @@ class ContentViewResolver implements ContentViewResolverInterface
             if (\count(\array_filter($content, fn ($entry) => $entry instanceof ContentView)) === \count($content)) {
                 /** @var ContentView[] $content */
                 // resolve array of content views
-                $resolvedContentViews = $this->resolveContentViews($content, $depth + 1, $priorityQueue);
+                $resolvedContentViews = $this->resolveContentViews($content, $depth, $priorityQueue);
                 $result['content'][$name] = $resolvedContentViews['content'];
                 $result['view'][$name] = $resolvedContentViews['view'];
                 $result['resolvableResources'] = $this->resolvableResourceQueueProcessor->mergeResolvableResources(
@@ -132,7 +132,7 @@ class ContentViewResolver implements ContentViewResolverInterface
             foreach ($content as $key => $entry) {
                 // resolve array of mixed content
                 if ($entry instanceof ContentView) {
-                    $resolvedContentView = $this->resolveContentView($entry, $key, $depth + 1, $priorityQueue);
+                    $resolvedContentView = $this->resolveContentView($entry, $key, $depth, $priorityQueue);
                     $result['content'][$name] = \array_merge($result['content'][$name] ?? [], $resolvedContentView['content']);
                     $result['view'][$name] = \array_merge($result['view'][$name] ?? [], $resolvedContentView['view']);
                     $resolvableResources = $this->resolvableResourceQueueProcessor->mergeResolvableResources(

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentViewResolver/ContentViewResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentViewResolver/ContentViewResolverTest.php
@@ -215,4 +215,66 @@ class ContentViewResolverTest extends TestCase
         self::assertArrayHasKey('page', $result['resolvableResources'][1]);
         self::assertSame($resolvableResource1, $result['resolvableResources'][1]['page'][0]['123'][$resolvableResource1->getMetadataIdentifier()]);
     }
+
+    public function testDeeplyNestedContentViewsPreserveDepth(): void
+    {
+        $resolvableResource = new ResolvableResource('snippet-123', 'snippet', 1);
+
+        $level3ContentView = ContentView::create(
+            ['snippet' => $resolvableResource],
+            ['snippet' => 'Snippet Field']
+        );
+        $level2ContentView = ContentView::create([$level3ContentView], []);
+        $level1ContentView = ContentView::create([$level2ContentView], []);
+        $rootContentView = ContentView::create([$level1ContentView], []);
+
+        $priorityQueue = [];
+        $initialDepth = 0;
+        $result = $this->contentViewResolver->resolveContentView($rootContentView, 'blocks', $initialDepth, $priorityQueue);
+
+        $expectedPriority = $resolvableResource->getPriority();
+        $expectedLoaderKey = $resolvableResource->getResourceLoaderKey();
+        $expectedId = $resolvableResource->getId();
+        $expectedMetadataId = $resolvableResource->getMetadataIdentifier();
+
+        self::assertArrayHasKey($expectedPriority, $result['resolvableResources']);
+        self::assertArrayHasKey($expectedLoaderKey, $result['resolvableResources'][$expectedPriority]);
+        self::assertArrayHasKey($initialDepth, $result['resolvableResources'][$expectedPriority][$expectedLoaderKey]);
+        self::assertArrayHasKey($expectedId, $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][$initialDepth]);
+        self::assertSame(
+            $resolvableResource,
+            $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][$initialDepth][$expectedId][$expectedMetadataId]
+        );
+    }
+
+    public function testMixedNestedContentViewsPreserveDepth(): void
+    {
+        $resolvableResource1 = new ResolvableResource('snippet-1', 'snippet', 1);
+        $resolvableResource2 = new ResolvableResource('snippet-2', 'snippet', 1);
+
+        $level2ContentView = ContentView::create(
+            ['snippet' => $resolvableResource2],
+            ['snippet' => 'Snippet Field 2']
+        );
+        $level1ContentView = ContentView::create(
+            [
+                'snippet' => $resolvableResource1,
+                'nested' => $level2ContentView,
+            ],
+            []
+        );
+
+        $priorityQueue = [];
+        $initialDepth = 1;
+        $result = $this->contentViewResolver->resolveContentView($level1ContentView, 'blocks', $initialDepth, $priorityQueue);
+
+        $expectedPriority = $resolvableResource1->getPriority();
+        $expectedLoaderKey = $resolvableResource1->getResourceLoaderKey();
+
+        self::assertArrayHasKey($expectedPriority, $result['resolvableResources']);
+        self::assertArrayHasKey($expectedLoaderKey, $result['resolvableResources'][$expectedPriority]);
+        self::assertArrayHasKey($initialDepth, $result['resolvableResources'][$expectedPriority][$expectedLoaderKey]);
+        self::assertArrayHasKey('snippet-1', $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][$initialDepth]);
+        self::assertArrayHasKey('snippet-2', $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][$initialDepth]);
+    }
 }


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #8455
  | Related issues/PRs |
  | License | MIT
  | Documentation PR |

  #### What's in this PR?

  Fixed depth calculation in `ContentViewResolver` to not increment depth when iterating through nested ContentViews (blocks).

  #### Why?

  ResolvableResources in deeply nested blocks (~3+ levels) were not resolving and returned `null`.

  The root cause: depth was incorrectly incremented for each nested ContentView (block), causing resources to be stored at artificially high depths (e.g., depth 3 instead of 0). When `extractHighestPriorityResources()` filtered resources by `maxDepth` these resources were filtered out and never loaded.

  Depth should only increase when crossing ContentRichEntity boundaries (Page → Snippet), not when traversing nested blocks within the same entity.