### PR TITLE
Fix sulu:build issue unknown method getSchemaManager in DatabaseBuilder

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17887,43 +17887,13 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Util/IndexComparatorInterface.php
 
 		-
-			message: '#^Cannot call method close\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
-
-		-
-			message: '#^Cannot call method connect\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
-
-		-
 			message: '#^Cannot call method get\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
 
 		-
-			message: '#^Cannot call method getConnection\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
-
-		-
 			message: '#^Cannot call method getOption\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
-
-		-
-			message: '#^Cannot call method getSchemaManager\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
-
-		-
-			message: '#^Cannot call method listDatabases\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php

--- a/src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\CoreBundle\Build;
 
 use Doctrine\DBAL\Exception\ConnectionException;
+use Webmozart\Assert\Assert;
 
 /**
  * Builder for initializing the (relational) database.
@@ -31,10 +32,12 @@ class DatabaseBuilder extends SuluBuilder
     public function build()
     {
         $doctrine = $this->container->get('doctrine');
-        $connection = $databaseExists = $doctrine->getConnection();
+        Assert::isInstanceOf($doctrine, \Doctrine\Bundle\DoctrineBundle\Registry::class);
+        $connection = $doctrine->getConnection();
+        Assert::isInstanceOf($connection, \Doctrine\DBAL\Connection::class);
 
         try {
-            $schemaManager = $connection->getSchemaManager();
+            $schemaManager = $connection->createSchemaManager();
             $databaseExists = true;
             $schemaManager->listDatabases();
         } catch (ConnectionException $e) {
@@ -48,10 +51,6 @@ class DatabaseBuilder extends SuluBuilder
                 ]);
             }
             $this->execCommand('Creating the database', 'doctrine:database:create');
-
-            // avoid "Invalid catalog name: 1046 No database selected" by reconnecting
-            $doctrine->getConnection()->close();
-            $doctrine->getConnection()->connect();
 
             $this->execCommand('Creating the schema', 'doctrine:schema:create');
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix sulu:build issue unknown method getSchemaManager in DatabaseBuilder.

#### Why?

The `sulu:build` is failing when ORM 3 is used.