### PR TITLE
Use ClockInterface in TimestampableProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "symfony-cmf/routing-bundle": "^3.0",
         "symfony/asset": "^6.4 || ^7.1",
         "symfony/cache": "^6.4 || ^7.1",
+        "symfony/clock": "^6.4 || ^7.1",
         "symfony/config": "^6.4 || ^7.1",
         "symfony/console": "^6.4 || ^7.1",
         "symfony/css-selector": "^6.4 || ^7.1",

--- a/src/Sulu/Bundle/PersistenceBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/PersistenceBundle/Resources/config/services.xml
@@ -4,6 +4,8 @@
         xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu.persistence.event_subscriber.orm.timestampable" class="Sulu\Component\Persistence\EventSubscriber\ORM\TimestampableSubscriber">
+            <argument type="service" id="clock" />
+
             <tag name="doctrine.event_listener" event="loadClassMetadata"/>
             <tag name="doctrine.event_listener" event="preUpdate"/>
             <tag name="doctrine.event_listener" event="prePersist"/>

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -26,7 +26,9 @@ class TimestampableSubscriber
 
     public const CHANGED_FIELD = 'changed';
 
-    public function __construct(private ClockInterface $clock) {}
+    public function __construct(private ClockInterface $clock)
+    {
+    }
 
     /**
      * Load the class data, mapping the created and changed fields
@@ -76,6 +78,8 @@ class TimestampableSubscriber
     /**
      * Set the timestamps. If created is NULL then set it. Always
      * set the changed field.
+     *
+     * @return void
      */
     private function handleTimestamp(LifecycleEventArgs $event)
     {
@@ -88,10 +92,12 @@ class TimestampableSubscriber
         $meta = $event->getObjectManager()->getClassMetadata(\get_class($entity));
 
         $created = $meta->getFieldValue($entity, self::CREATED_FIELD);
+
+        $now = new \DateTimeImmutable($this->clock->now()->format('Y-m-d H:i:s'), $this->clock->now()->getTimezone());
         if (null === $created) {
-            $meta->setFieldValue($entity, self::CREATED_FIELD, $this->clock->now());
+            $meta->setFieldValue($entity, self::CREATED_FIELD, $now);
         }
 
-        $meta->setFieldValue($entity, self::CHANGED_FIELD, $this->clock->now());
+        $meta->setFieldValue($entity, self::CHANGED_FIELD, $now);
     }
 }

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\Persistence\EventSubscriber\ORM;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Sulu\Component\Persistence\Model\TimestampableInterface;
+use Symfony\Component\Clock\ClockInterface;
 
 /**
  * Manage the timestamp fields on models implementing the
@@ -24,6 +25,8 @@ class TimestampableSubscriber
     public const CREATED_FIELD = 'created';
 
     public const CHANGED_FIELD = 'changed';
+
+    public function __construct(private ClockInterface $clock) {}
 
     /**
      * Load the class data, mapping the created and changed fields
@@ -86,9 +89,9 @@ class TimestampableSubscriber
 
         $created = $meta->getFieldValue($entity, self::CREATED_FIELD);
         if (null === $created) {
-            $meta->setFieldValue($entity, self::CREATED_FIELD, new \DateTimeImmutable());
+            $meta->setFieldValue($entity, self::CREATED_FIELD, $this->clock->now());
         }
 
-        $meta->setFieldValue($entity, self::CHANGED_FIELD, new \DateTimeImmutable());
+        $meta->setFieldValue($entity, self::CHANGED_FIELD, $this->clock->now());
     }
 }

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -113,7 +113,7 @@ class TimestampableSubscriberTest extends TestCase
         $this->classMetadata->getFieldValue($entity, 'created')->willReturn($created);
 
         if (null === $created) {
-            $this->classMetadata->setFieldValue( $entity, 'created', $timestamp)->shouldBeCalled();
+            $this->classMetadata->setFieldValue($entity, 'created', $timestamp)->shouldBeCalled();
         } else {
             $this->classMetadata->setFieldValue(Argument::any())->shouldNotBeCalled();
         }

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -57,10 +57,7 @@ class TimestampableSubscriberTest extends TestCase
      */
     private $entityManager;
 
-    /**
-     * @var TimestampableSubscriber
-     */
-    private $subscriber;
+    private TimestampableSubscriber $subscriber;
 
     /** @var ObjectProphecy<ClockInterface> */
     private ObjectProphecy $clock;
@@ -104,21 +101,32 @@ class TimestampableSubscriberTest extends TestCase
     public function testOnPreUpdate($created): void
     {
         $entity = $this->timestampableObject->reveal();
-        $timestamp = new \DateTimeImmutable();
+
+        $dateCreated = '2015-01-01 00:10:12';
+        $timeStamp = new \DateTimeImmutable($dateCreated);
+        $this->clock->now()->willReturn($timeStamp);
+
         $this->lifecycleEvent->getObject()->willReturn($this->timestampableObject->reveal());
         $this->lifecycleEvent->getObjectManager()->willReturn($this->entityManager->reveal());
         $this->entityManager->getClassMetadata(\get_class($entity))->willReturn($this->classMetadata);
-        $this->clock->now()->shouldBeCalled()->willReturn($timestamp);
 
         $this->classMetadata->getFieldValue($entity, 'created')->willReturn($created);
 
         if (null === $created) {
-            $this->classMetadata->setFieldValue($entity, 'created', $timestamp)->shouldBeCalled();
+            $this->classMetadata->setFieldValue(
+                $entity,
+                'created',
+                Argument::that(fn (\DateTimeInterface $dateTime) => $dateTime->format('Y-m-d H:i:s') === $dateCreated),
+            )->shouldBeCalled();
         } else {
             $this->classMetadata->setFieldValue(Argument::any())->shouldNotBeCalled();
         }
 
-        $this->classMetadata->setFieldValue($entity, 'changed', $timestamp)->shouldBeCalled();
+        $this->classMetadata->setFieldValue(
+            $entity,
+            'changed',
+            Argument::that(fn (\DateTimeInterface $dateTime) => $dateTime->format('Y-m-d H:i:s') === $dateCreated),
+        )->shouldBeCalled();
 
         $this->subscriber->preUpdate($this->lifecycleEvent->reveal());
     }

--- a/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
+++ b/src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/TimestampableSubscriberTest.php
@@ -21,6 +21,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Persistence\EventSubscriber\ORM\TimestampableSubscriber;
 use Sulu\Component\Persistence\Model\TimestampableInterface;
+use Symfony\Component\Clock\ClockInterface;
 
 class TimestampableSubscriberTest extends TestCase
 {
@@ -61,6 +62,9 @@ class TimestampableSubscriberTest extends TestCase
      */
     private $subscriber;
 
+    /** @var ObjectProphecy<ClockInterface> */
+    private ObjectProphecy $clock;
+
     public function setUp(): void
     {
         $this->loadClassMetadataEvent = $this->prophesize(LoadClassMetadataEventArgs::class);
@@ -69,8 +73,9 @@ class TimestampableSubscriberTest extends TestCase
         $this->classMetadata = $this->prophesize(ClassMetadata::class);
         $this->refl = $this->prophesize(\ReflectionClass::class);
         $this->entityManager = $this->prophesize(EntityManager::class);
+        $this->clock = $this->prophesize(ClockInterface::class);
 
-        $this->subscriber = new TimestampableSubscriber();
+        $this->subscriber = new TimestampableSubscriber($this->clock->reveal());
     }
 
     public function testLoadClassMetadata(): void
@@ -78,6 +83,7 @@ class TimestampableSubscriberTest extends TestCase
         $this->loadClassMetadataEvent->getClassMetadata()->willReturn($this->classMetadata->reveal());
         $this->classMetadata->getReflectionClass()->willReturn($this->refl->reveal());
         $this->refl->implementsInterface(TimestampableInterface::class)->willReturn(true);
+        $this->clock->now()->shouldNotBeCalled();
 
         $this->classMetadata->mapField(Argument::any())->shouldBeCalled();
         $this->classMetadata->hasField('created')->willReturn(false);
@@ -98,27 +104,21 @@ class TimestampableSubscriberTest extends TestCase
     public function testOnPreUpdate($created): void
     {
         $entity = $this->timestampableObject->reveal();
+        $timestamp = new \DateTimeImmutable();
         $this->lifecycleEvent->getObject()->willReturn($this->timestampableObject->reveal());
         $this->lifecycleEvent->getObjectManager()->willReturn($this->entityManager->reveal());
         $this->entityManager->getClassMetadata(\get_class($entity))->willReturn($this->classMetadata);
+        $this->clock->now()->shouldBeCalled()->willReturn($timestamp);
 
         $this->classMetadata->getFieldValue($entity, 'created')->willReturn($created);
 
         if (null === $created) {
-            $this->classMetadata->setFieldValue(
-                $entity,
-                'created',
-                Argument::type('\DateTimeImmutable')
-            )->shouldBeCalled();
+            $this->classMetadata->setFieldValue( $entity, 'created', $timestamp)->shouldBeCalled();
         } else {
             $this->classMetadata->setFieldValue(Argument::any())->shouldNotBeCalled();
         }
 
-        $this->classMetadata->setFieldValue(
-            $entity,
-            'changed',
-            Argument::type('\DateTimeImmutable')
-        )->shouldBeCalled();
+        $this->classMetadata->setFieldValue($entity, 'changed', $timestamp)->shouldBeCalled();
 
         $this->subscriber->preUpdate($this->lifecycleEvent->reveal());
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #8115 
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Using the ClockInterface for the timestampable subscriber.

#### Why?
Making the tests better.