### PR TITLE
Load all properties for SnippetAreaTwigExtension by default

### DIFF
--- a/packages/snippet/src/Infrastructure/Symfony/Twig/SnippetAreaTwigExtension.php
+++ b/packages/snippet/src/Infrastructure/Symfony/Twig/SnippetAreaTwigExtension.php
@@ -46,13 +46,13 @@ class SnippetAreaTwigExtension extends AbstractExtension
     }
 
     /**
-     * @param array<string, string> $properties
+     * @param array<string, string>|null $properties
      *
      * @return array<string, mixed>|null
      */
     public function loadSnippetByArea(
         string $areaKey,
-        array $properties,
+        ?array $properties = null,
         ?string $webspaceKey = null,
         ?string $locale = null,
     ): ?array {

--- a/packages/snippet/tests/Unit/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
@@ -330,4 +330,53 @@ class SnippetAreaTwigExtensionTest extends TestCase
 
         $this->assertSame($resolvedContent, $result);
     }
+
+    public function testLoadSnippetByAreaWithoutProperties(): void
+    {
+        $areaKey = 'header';
+        $webspaceKey = 'example';
+        $locale = 'en';
+
+        $snippet = new Snippet('test-snippet-uuid');
+        $snippetDimensionContent = new SnippetDimensionContent($snippet);
+        $snippetDimensionContent->setTemplateData(['title' => 'Test Snippet', 'description' => 'Test Description']);
+
+        $snippetArea = new SnippetArea($areaKey, $webspaceKey);
+        $snippetArea->setSnippet($snippet);
+
+        $resolvedContent = [
+            'title' => 'Test Snippet',
+            'description' => 'Test Description',
+        ];
+
+        $this->snippetAreaRepository->findOneBy([
+            'webspaceKey' => $webspaceKey,
+            'areaKey' => $areaKey,
+        ])->willReturn($snippetArea);
+
+        $this->snippetRepository->findOneBy(
+            [
+                'uuid' => 'test-snippet-uuid',
+                'locale' => $locale,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
+                'version' => DimensionContentInterface::CURRENT_VERSION,
+            ],
+            Argument::any()
+        )->willReturn($snippet);
+
+        $this->contentAggregator->aggregate(
+            $snippet,
+            [
+                'locale' => $locale,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
+                'version' => DimensionContentInterface::CURRENT_VERSION,
+            ]
+        )->willReturn($snippetDimensionContent);
+
+        $this->contentResolver->resolve($snippetDimensionContent, null)->willReturn($resolvedContent);
+
+        $result = $this->extension->loadSnippetByArea($areaKey, webspaceKey: $webspaceKey, locale: $locale);
+
+        $this->assertSame($resolvedContent, $result);
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/8450
| License | MIT

#### What's in this PR?

Make the `properties` by default null, to load all properties.

#### Why?

https://github.com/sulu/sulu/issues/8450