### PR TITLE
Fix preview after query optimization

### DIFF
--- a/packages/content/src/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/packages/content/src/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -107,13 +107,14 @@ class ContentObjectProvider implements PreviewDefaultsProviderInterface
                     'entity.dimensionContents',
                     'dimensionContent',
                     Join::WITH,
-                    'dimensionContent.stage = :stage AND (dimensionContent.locale IS NULL OR dimensionContent.locale = :locale)'
+                    'dimensionContent.stage = :stage AND dimensionContent.version = :version AND (dimensionContent.locale IS NULL OR dimensionContent.locale = :locale)'
                 )
                 ->addSelect('dimensionContent')
                 ->where('entity = :id')
                 ->setParameter('id', $id)
                 ->setParameter('locale', $locale)
                 ->setParameter('stage', DimensionContentInterface::STAGE_DRAFT)
+                ->setParameter('version', DimensionContentInterface::CURRENT_VERSION)
                 ->getQuery()
                 ->getSingleResult();
         } catch (NoResultException $exception) {

--- a/packages/content/src/Infrastructure/Sulu/Preview/ContentObjectProvider.php
+++ b/packages/content/src/Infrastructure/Sulu/Preview/ContentObjectProvider.php
@@ -15,6 +15,7 @@ namespace Sulu\Content\Infrastructure\Sulu\Preview;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\Query\Expr\Join;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TemplateMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
@@ -102,8 +103,17 @@ class ContentObjectProvider implements PreviewDefaultsProviderInterface
             $contentRichEntity = $this->entityManager->createQueryBuilder()
                 ->select('entity')
                 ->from($this->contentRichEntityClass, 'entity')
+                ->leftJoin(
+                    'entity.dimensionContents',
+                    'dimensionContent',
+                    Join::WITH,
+                    'dimensionContent.stage = :stage AND (dimensionContent.locale IS NULL OR dimensionContent.locale = :locale)'
+                )
+                ->addSelect('dimensionContent')
                 ->where('entity = :id')
                 ->setParameter('id', $id)
+                ->setParameter('locale', $locale)
+                ->setParameter('stage', DimensionContentInterface::STAGE_DRAFT)
                 ->getQuery()
                 ->getSingleResult();
         } catch (NoResultException $exception) {

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -121,7 +121,7 @@ class ContentObjectProviderTest extends TestCase
 
         $queryBuilder->setParameter(Argument::type('string'), Argument::any())
             ->willReturn($queryBuilder->reveal())
-            ->shouldBeCalledTimes(3);
+            ->shouldBeCalledTimes(4);
 
         $query = $this->prophesize(Query::class);
 
@@ -185,7 +185,7 @@ class ContentObjectProviderTest extends TestCase
 
         $queryBuilder->setParameter(Argument::type('string'), Argument::any())
             ->willReturn($queryBuilder->reveal())
-            ->shouldBeCalledTimes(3);
+            ->shouldBeCalledTimes(4);
 
         $query = $this->prophesize(Query::class);
 
@@ -277,7 +277,7 @@ class ContentObjectProviderTest extends TestCase
 
         $queryBuilder->setParameter(Argument::type('string'), Argument::any())
             ->willReturn($queryBuilder->reveal())
-            ->shouldBeCalledTimes(3);
+            ->shouldBeCalledTimes(4);
 
         $query = $this->prophesize(Query::class);
 

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Preview/ContentObjectProviderTest.php
@@ -107,13 +107,21 @@ class ContentObjectProviderTest extends TestCase
             ->willReturn($queryBuilder->reveal())
             ->shouldBeCalledTimes(1);
 
+        $queryBuilder->leftJoin(Argument::cetera())
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalledTimes(1);
+
+        $queryBuilder->addSelect(Argument::type('string'))
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalledTimes(1);
+
         $queryBuilder->where(Argument::type('string'))
             ->willReturn($queryBuilder->reveal())
             ->shouldBeCalledTimes(1);
 
         $queryBuilder->setParameter(Argument::type('string'), Argument::any())
             ->willReturn($queryBuilder->reveal())
-            ->shouldBeCalledTimes(1);
+            ->shouldBeCalledTimes(3);
 
         $query = $this->prophesize(Query::class);
 
@@ -163,13 +171,21 @@ class ContentObjectProviderTest extends TestCase
             ->willReturn($queryBuilder->reveal())
             ->shouldBeCalledTimes(1);
 
+        $queryBuilder->leftJoin(Argument::cetera())
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalledTimes(1);
+
+        $queryBuilder->addSelect(Argument::type('string'))
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalledTimes(1);
+
         $queryBuilder->where(Argument::type('string'))
             ->willReturn($queryBuilder->reveal())
             ->shouldBeCalledTimes(1);
 
         $queryBuilder->setParameter(Argument::type('string'), Argument::any())
             ->willReturn($queryBuilder->reveal())
-            ->shouldBeCalledTimes(1);
+            ->shouldBeCalledTimes(3);
 
         $query = $this->prophesize(Query::class);
 
@@ -247,13 +263,21 @@ class ContentObjectProviderTest extends TestCase
             ->willReturn($queryBuilder->reveal())
             ->shouldBeCalledTimes(1);
 
+        $queryBuilder->leftJoin(Argument::cetera())
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalledTimes(1);
+
+        $queryBuilder->addSelect(Argument::type('string'))
+            ->willReturn($queryBuilder->reveal())
+            ->shouldBeCalledTimes(1);
+
         $queryBuilder->where(Argument::type('string'))
             ->willReturn($queryBuilder->reveal())
             ->shouldBeCalledTimes(1);
 
         $queryBuilder->setParameter(Argument::type('string'), Argument::any())
             ->willReturn($queryBuilder->reveal())
-            ->shouldBeCalledTimes(1);
+            ->shouldBeCalledTimes(3);
 
         $query = $this->prophesize(Query::class);
 

--- a/packages/page/translations/admin.de.json
+++ b/packages/page/translations/admin.de.json
@@ -1,4 +1,5 @@
 {
+    "sulu_page.parent_page": "Elternseite",
     "sulu_page.webspaces": "Webspaces",
     "sulu_page.show_page_in": "Zeige Seite in",
     "sulu_page.no_navigation": "keiner Navigation",

--- a/packages/page/translations/admin.en.json
+++ b/packages/page/translations/admin.en.json
@@ -1,4 +1,5 @@
 {
+    "sulu_page.parent_page": "Parent Page",
     "sulu_page.webspaces": "Webspaces",
     "sulu_page.show_page_in": "Show page in",
     "sulu_page.no_navigation": "no navigation",


### PR DESCRIPTION
  | Q                  | A               |
  |--------------------|-----------------|
  | Bug fix?           | yes             |
  | New feature?       | no              |
  | BC breaks?         | no              |
  | Deprecations?      | no              |
  | Fixed tickets      | fixes #         |
  | Related issues/PRs | #8453           |
  | License            | MIT             |
  | Documentation PR   | sulu/sulu-docs# |

  What's in this PR?

  Adds eager loading of dimensionContents in ContentObjectProvider::getObject() by including a leftJoin with the dimension content filtered by stage (draft) and locale.

  Why?

  The query optimization in #8453 (Improve navigation performance) caused the preview functionality to break. The ContentObjectProvider was fetching the content entity without its dimension contents, which are needed for the preview to work correctly. This fix ensures the dimension contents are loaded in the same query using a filtered left join.