### PR TITLE
Prevent Media from being moved multiple times

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/MediaOverview.js
@@ -189,6 +189,7 @@ class MediaOverview extends React.Component<ViewProps> {
             this.collectionListStore.reload();
             this.showMediaMoveOverlay = false;
             this.mediaMoving = false;
+            this.mediaListStore.clearSelection();
         }));
     };
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js
@@ -666,6 +666,7 @@ test('Media should be moved when overlay is confirmed', () => {
             .toEqual(false);
         expect(mediaOverview.find(SingleListOverlay).find('[title="sulu_media.move_media"]').prop('confirmLoading'))
             .toEqual(false);
+        expect(mediaOverview.instance().mediaListStore.clearSelection).toBeCalled();
     });
 });
 


### PR DESCRIPTION
#8052

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8052
| Related issues/PRs | 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fixes #8052 .

#### Why?

Fixes a problem in media management, when moving multiple images on subsequent calls. Image selection was not cleared after moving them to a new collection. So moving another image to another collection resulted in image1  being moved to the same collection as the last moved image.
