### PR TITLE
Add proper return types for the RequestAnalyzerInterface

### DIFF
--- a/packages/content/src/Application/PropertyResolver/BlockVisitor/ScheduleBlockVisitor.php
+++ b/packages/content/src/Application/PropertyResolver/BlockVisitor/ScheduleBlockVisitor.php
@@ -35,7 +35,7 @@ class ScheduleBlockVisitor implements BlockVisitorInterface
             return $block;
         }
 
-        $now = $this->requestAnalyzer->getDateTime();
+        $now = $this->requestAnalyzer->getDateTime() ?? new \DateTime();
         $nowTimestamp = $now->getTimestamp();
 
         $returnBlock = false;

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -52,8 +52,15 @@ class NavigationTwigExtension extends AbstractExtension
      */
     public function flatRootNavigationFunction(string $navigationContext, int $depth = 1, ?array $properties = null): array
     {
-        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+        $webspace = $this->requestAnalyzer->getWebspace();
+        $localization = $this->requestAnalyzer->getCurrentLocalization();
+
+        if (null === $webspace || null === $localization) {
+            return [];
+        }
+
+        $webspaceKey = $webspace->getKey();
+        $locale = $localization->getLocale();
         /** @var Segment|null $segment */
         $segment = $this->requestAnalyzer->getSegment();
 
@@ -74,8 +81,15 @@ class NavigationTwigExtension extends AbstractExtension
      */
     public function treeRootNavigationFunction(string $navigationContext, int $depth = 1, ?array $properties = null): array
     {
-        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+        $webspace = $this->requestAnalyzer->getWebspace();
+        $localization = $this->requestAnalyzer->getCurrentLocalization();
+
+        if (null === $webspace || null === $localization) {
+            return [];
+        }
+
+        $webspaceKey = $webspace->getKey();
+        $locale = $localization->getLocale();
         /** @var Segment|null $segment */
         $segment = $this->requestAnalyzer->getSegment();
 
@@ -101,8 +115,15 @@ class NavigationTwigExtension extends AbstractExtension
         ?int $level = null,
         ?array $properties = null
     ): array {
-        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+        $webspace = $this->requestAnalyzer->getWebspace();
+        $localization = $this->requestAnalyzer->getCurrentLocalization();
+
+        if (null === $webspace || null === $localization) {
+            return [];
+        }
+
+        $webspaceKey = $webspace->getKey();
+        $locale = $localization->getLocale();
 
         // Handle level parameter: get breadcrumb and use UUID at specified level
         if (null !== $level) {
@@ -147,8 +168,15 @@ class NavigationTwigExtension extends AbstractExtension
         ?int $level = null,
         ?array $properties = null
     ): array {
-        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+        $webspace = $this->requestAnalyzer->getWebspace();
+        $localization = $this->requestAnalyzer->getCurrentLocalization();
+
+        if (null === $webspace || null === $localization) {
+            return [];
+        }
+
+        $webspaceKey = $webspace->getKey();
+        $locale = $localization->getLocale();
 
         // Handle level parameter: get breadcrumb and use UUID at specified level
         if (null !== $level) {
@@ -188,8 +216,15 @@ class NavigationTwigExtension extends AbstractExtension
      */
     public function breadcrumbFunction(string $uuid, ?array $properties = null): array
     {
-        $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+        $webspace = $this->requestAnalyzer->getWebspace();
+        $localization = $this->requestAnalyzer->getCurrentLocalization();
+
+        if (null === $webspace || null === $localization) {
+            return [];
+        }
+
+        $webspaceKey = $webspace->getKey();
+        $locale = $localization->getLocale();
 
         return $this->navigationRepository->getBreadcrumb(
             $uuid,

--- a/packages/search/src/UserInterface/Controller/Website/SearchController.php
+++ b/packages/search/src/UserInterface/Controller/Website/SearchController.php
@@ -36,9 +36,14 @@ class SearchController
     {
         $query = $request->query->get('q', '');
 
-        $locale = $this->requestAnalyzer->getCurrentLocalization()->getLocale();
+        $localization = $this->requestAnalyzer->getCurrentLocalization();
         $webspace = $this->requestAnalyzer->getWebspace();
 
+        if (null === $localization || null === $webspace) {
+            throw new NotFoundHttpException();
+        }
+
+        $locale = $localization->getLocale();
         $hits = [];
 
         if ($query) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -223,18 +223,6 @@ parameters:
 			path: packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/BlockVisitor/SegmentBlockVisitor.php
 
 		-
-			message: '#^Right side of && is always true\.$#'
-			identifier: booleanAnd.rightAlwaysTrue
-			count: 1
-			path: packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/BlockVisitor/SegmentBlockVisitor.php
-
-		-
-			message: '#^Ternary operator condition is always true\.$#'
-			identifier: ternary.alwaysTrue
-			count: 1
-			path: packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/BlockVisitor/SegmentBlockVisitor.php
-
-		-
 			message: '#^Parameter \#1 \$entityName of method Sulu\\Component\\Rest\\ListBuilder\\Doctrine\\DoctrineListBuilderFactoryInterface\:\:create\(\) expects class\-string, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -3895,18 +3883,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/LocalesOptionFormMetadataVisitorTest.php
 
 		-
-			message: '#^Parameter \#1 \$cacheDir of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\XmlFormMetadataLoader\:\:warmUp\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
-			message: '#^Parameter \#4 \$cacheDir of class Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\XmlFormMetadataLoader constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlFormMetadataLoaderTest.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Tests\\Unit\\Metadata\\SchemaMetadata\\ArrayMetadataTest\:\:provideToJsonSchema\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -4948,12 +4924,6 @@ parameters:
 			message: '#^Method Sulu\\Bundle\\AudienceTargetingBundle\\TargetGroup\\TargetGroupEvaluator\:\:evaluate\(\) should return Sulu\\Bundle\\AudienceTargetingBundle\\Entity\\TargetGroupInterface but returns Sulu\\Bundle\\AudienceTargetingBundle\\Entity\\TargetGroupInterface\|null\.$#'
 			identifier: return.type
 			count: 2
-			path: src/Sulu/Bundle/AudienceTargetingBundle/TargetGroup/TargetGroupEvaluator.php
-
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/TargetGroup/TargetGroupEvaluator.php
 
 		-
@@ -31417,12 +31387,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
 
 		-
-			message: '#^Strict comparison using \=\=\= between null and Sulu\\Component\\Webspace\\PortalInformation will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/EventListener/AppendAnalyticsListener.php
-
-		-
 			message: '#^Binary operation "\." between ''\#'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
@@ -31579,12 +31543,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentCacheListener.php
 
 		-
-			message: '#^Left side of && is always true\.$#'
-			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentSubscriber.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\EventListener\\SegmentSubscriber\:\:addCookieHeader\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -31594,12 +31552,6 @@ parameters:
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\EventListener\\SegmentSubscriber\:\:addVaryHeader\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentSubscriber.php
-
-		-
-			message: '#^Ternary operator condition is always true\.$#'
-			identifier: ternary.alwaysTrue
-			count: 3
 			path: src/Sulu/Bundle/WebsiteBundle/EventListener/SegmentSubscriber.php
 
 		-
@@ -31663,12 +31615,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/EventSubscriber/GeneratorEventSubscriber.php
 
 		-
-			message: '#^Cannot call method getPreferredLanguage\(\) on Symfony\\Component\\HttpFoundation\\Request\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Locale/RequestDefaultLocaleProvider.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Resolver\\RequestAnalyzerResolver\:\:__construct\(\) has parameter \$environment with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -31696,12 +31642,6 @@ parameters:
 			message: '#^Property Sulu\\Bundle\\WebsiteBundle\\Resolver\\RequestAnalyzerResolver\:\:\$webspaceManager is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
-
-		-
-			message: '#^Ternary operator condition is always true\.$#'
-			identifier: ternary.alwaysTrue
-			count: 2
 			path: src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
 
 		-
@@ -31811,12 +31751,6 @@ parameters:
 			identifier: offsetAccess.invalidOffset
 			count: 2
 			path: src/Sulu/Bundle/WebsiteBundle/Routing/PortalLoader.php
-
-		-
-			message: '#^If condition is always true\.$#'
-			identifier: if.alwaysTrue
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Routing/RequestListener.php
 
 		-
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Sitemap\\SitemapUrl\:\:__construct\(\) has parameter \$attributes with no value type specified in iterable type array\.$#'
@@ -38407,13 +38341,13 @@ parameters:
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getCurrentLocalization\(\) should return Sulu\\Component\\Localization\\Localization but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getCurrentLocalization\(\) should return Sulu\\Component\\Localization\\Localization\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getDateTime\(\) should return DateTime but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getDateTime\(\) should return DateTime\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -38425,31 +38359,31 @@ parameters:
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getPortal\(\) should return Sulu\\Component\\Webspace\\Portal but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getPortal\(\) should return Sulu\\Component\\Webspace\\Portal\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getPortalInformation\(\) should return Sulu\\Component\\Webspace\\PortalInformation but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getPortalInformation\(\) should return Sulu\\Component\\Webspace\\PortalInformation\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getPortalUrl\(\) should return string but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getPortalUrl\(\) should return string\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getRedirect\(\) should return string but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getRedirect\(\) should return string\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getResourceLocator\(\) should return string but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getResourceLocator\(\) should return string\|false but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -38461,13 +38395,13 @@ parameters:
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getSegment\(\) should return Sulu\\Component\\Webspace\\Segment but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getSegment\(\) should return Sulu\\Component\\Webspace\\Segment\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getWebspace\(\) should return Sulu\\Component\\Webspace\\Webspace but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Webspace\\Analyzer\\RequestAnalyzer\:\:getWebspace\(\) should return Sulu\\Component\\Webspace\\Webspace\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/SegmentController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/SegmentController.php
@@ -50,6 +50,11 @@ class SegmentController
         }
 
         $webspace = $this->requestAnalyzer->getWebspace();
+
+        if (null === $webspace) {
+            throw new BadRequestHttpException('No webspace found for the current request.');
+        }
+
         $defaultSegment = $webspace->getDefaultSegment();
         $segmentKey = $request->query->get('segment');
 

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
@@ -128,6 +128,10 @@ class RedirectExceptionSubscriber implements EventSubscriberInterface
 
         $localization = $this->defaultLocaleProvider->getDefaultLocale();
 
+        if (null === $localization) {
+            return;
+        }
+
         $redirect = $attributes->getAttribute('redirect');
         $redirect = $this->urlReplacer->replaceCountry($redirect, $localization->getCountry());
         $redirect = $this->urlReplacer->replaceLanguage($redirect, $localization->getLanguage());

--- a/src/Sulu/Bundle/WebsiteBundle/Locale/DefaultLocaleProviderInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Locale/DefaultLocaleProviderInterface.php
@@ -21,7 +21,7 @@ interface DefaultLocaleProviderInterface
     /**
      * Return default locale.
      *
-     * @return Localization
+     * @return Localization|null
      */
     public function getDefaultLocale();
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Locale/PortalDefaultLocaleProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Locale/PortalDefaultLocaleProvider.php
@@ -30,12 +30,6 @@ class PortalDefaultLocaleProvider implements DefaultLocaleProviderInterface
 
     public function getDefaultLocale()
     {
-        $portal = $this->requestAnalyzer->getPortal();
-
-        if (null === $portal) {
-            return null;
-        }
-
-        return $portal->getDefaultLocalization();
+        return $this->requestAnalyzer->getPortal()?->getDefaultLocalization();
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Locale/PortalDefaultLocaleProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Locale/PortalDefaultLocaleProvider.php
@@ -30,6 +30,12 @@ class PortalDefaultLocaleProvider implements DefaultLocaleProviderInterface
 
     public function getDefaultLocale()
     {
-        return $this->requestAnalyzer->getPortal()->getDefaultLocalization();
+        $portal = $this->requestAnalyzer->getPortal();
+
+        if (null === $portal) {
+            return null;
+        }
+
+        return $portal->getDefaultLocalization();
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Locale/RequestDefaultLocaleProvider.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Locale/RequestDefaultLocaleProvider.php
@@ -38,29 +38,35 @@ class RequestDefaultLocaleProvider implements DefaultLocaleProviderInterface
 
     public function getDefaultLocale()
     {
+        $portal = $this->requestAnalyzer->getPortal();
+
+        if (null === $portal) {
+            return null;
+        }
+
         $request = $this->requestStack->getCurrentRequest();
 
         if (null === $request) {
-            return $this->requestAnalyzer->getPortal()->getDefaultLocalization();
+            return $portal->getDefaultLocalization();
         }
 
-        $defaultLocalization = $this->requestAnalyzer->getPortal()->getDefaultLocalization()->getLocale(Localization::LCID);
+        $defaultLocalization = $portal->getDefaultLocalization()->getLocale(Localization::LCID);
         $localizations = [$defaultLocalization];
 
-        foreach ($this->requestAnalyzer->getPortal()->getLocalizations() as $localization) {
+        foreach ($portal->getLocalizations() as $localization) {
             if ($localization->getLocale(Localization::LCID) !== $defaultLocalization) {
                 $localizations[] = $localization->getLocale(Localization::LCID);
             }
         }
 
-        $preferredLocale = $this->requestStack->getCurrentRequest()->getPreferredLanguage($localizations);
+        $preferredLocale = $request->getPreferredLanguage($localizations);
 
-        foreach ($this->requestAnalyzer->getPortal()->getLocalizations() as $localization) {
+        foreach ($portal->getLocalizations() as $localization) {
             if ($localization->getLocale(Localization::LCID) === $preferredLocale) {
                 return $localization;
             }
         }
 
-        return $this->requestAnalyzer->getPortal()->getDefaultLocalization();
+        return $portal->getDefaultLocalization();
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/RequestAnalyzerResolver.php
@@ -37,8 +37,11 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
 
     public function resolve(RequestAnalyzerInterface $requestAnalyzer)
     {
+        $portal = $requestAnalyzer->getPortal();
+        $webspace = $requestAnalyzer->getWebspace();
+
         // determine default locale (if one exists)
-        $defaultLocalization = $requestAnalyzer->getPortal()->getDefaultLocalization();
+        $defaultLocalization = $portal?->getDefaultLocalization();
         $defaultLocale = $defaultLocalization ? $defaultLocalization->getLocale() : null;
 
         $segment = $requestAnalyzer->getSegment();
@@ -46,11 +49,11 @@ class RequestAnalyzerResolver implements RequestAnalyzerResolverInterface
 
         return [
             'request' => [
-                'webspaceKey' => $requestAnalyzer->getWebspace()->getKey(),
-                'webspaceName' => $requestAnalyzer->getWebspace()->getName(),
+                'webspaceKey' => $webspace?->getKey(),
+                'webspaceName' => $webspace?->getName(),
                 'segmentKey' => $segmentKey,
-                'portalKey' => $requestAnalyzer->getPortal()->getKey(),
-                'portalName' => $requestAnalyzer->getPortal()->getName(),
+                'portalKey' => $portal?->getKey(),
+                'portalName' => $portal?->getName(),
                 'defaultLocale' => $defaultLocale,
                 'portalUrl' => $requestAnalyzer->getPortalUrl(),
                 'resourceLocatorPrefix' => $requestAnalyzer->getResourceLocatorPrefix(),

--- a/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resolver/TemplateAttributeResolver.php
@@ -127,14 +127,16 @@ class TemplateAttributeResolver implements TemplateAttributeResolverInterface
         $request = $this->requestStack->getCurrentRequest();
         $urls = [];
 
-        if ($request && $request->attributes->get('_route')) {
+        $portal = $this->requestAnalyzer->getPortal();
+
+        if ($request && $request->attributes->get('_route') && null !== $portal) {
             $portalInformations = $this->webspaceManager->getPortalInformations($this->environment);
             $routeParams = $request->attributes->get('_route_params');
             $routeName = $request->attributes->get('_route');
 
             foreach ($portalInformations as $portalInformation) {
                 if (
-                    $portalInformation->getPortalKey() === $this->requestAnalyzer->getPortal()->getKey()
+                    $portalInformation->getPortalKey() === $portal->getKey()
                     && RequestAnalyzerInterface::MATCH_TYPE_FULL === $portalInformation->getType()
                 ) {
                     if (isset($routeParams['prefix'])) {

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Locale/PortalDefaultLocaleProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Locale/PortalDefaultLocaleProviderTest.php
@@ -32,6 +32,7 @@ class PortalDefaultLocaleProviderTest extends TestCase
 
         $portalDefaultLocaleProvider = new PortalDefaultLocaleProvider($requestAnalyzer->reveal());
 
+        /** @var Localization $defaultLocale */
         $defaultLocale = $portalDefaultLocaleProvider->getDefaultLocale();
 
         $this->assertEquals('de-AT', $defaultLocale->getLocale(Localization::ISO6391));

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Locale/RequestDefaultLocaleProviderTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Locale/RequestDefaultLocaleProviderTest.php
@@ -75,6 +75,7 @@ class RequestDefaultLocaleProviderTest extends TestCase
         $request->getPreferredLanguage(['de_AT', 'de_DE', 'en'])->shouldBeCalled()->willReturn('en');
         $this->requestStack->getCurrentRequest()->willReturn($request->reveal());
 
+        /** @var Localization $defaultLocale */
         $defaultLocale = $this->defaultLocaleProvider->getDefaultLocale();
         $this->assertEquals('en', $defaultLocale->getLocale(Localization::ISO6391));
     }
@@ -83,6 +84,7 @@ class RequestDefaultLocaleProviderTest extends TestCase
     {
         $this->requestStack->getCurrentRequest()->willReturn(null);
 
+        /** @var Localization $defaultLocale */
         $defaultLocale = $this->defaultLocaleProvider->getDefaultLocale();
         $this->assertEquals('de-AT', $defaultLocale->getLocale(Localization::ISO6391));
     }

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzer.php
@@ -115,7 +115,13 @@ class RequestAnalyzer implements RequestAnalyzerInterface
 
     public function changeSegment(string $segmentKey)
     {
-        $segment = $this->getWebspace()->getSegment($segmentKey);
+        $webspace = $this->getWebspace();
+
+        if (null === $webspace) {
+            return;
+        }
+
+        $segment = $webspace->getSegment($segmentKey);
 
         $requestAttributes = (new RequestAttributes(['segment' => $segment]))->merge($this->getAttributes());
 

--- a/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
+++ b/src/Sulu/Component/Webspace/Analyzer/RequestAnalyzerInterface.php
@@ -74,28 +74,28 @@ interface RequestAnalyzerInterface
     /**
      * Returns the current or simulate DateTime object for this request.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getDateTime();
 
     /**
      * Returns the current webspace for this request.
      *
-     * @return Webspace
+     * @return Webspace|null
      */
     public function getWebspace();
 
     /**
      * Returns the current portal for this request.
      *
-     * @return Portal
+     * @return Portal|null
      */
     public function getPortal();
 
     /**
      * Returns the current segment for this request.
      *
-     * @return Segment
+     * @return Segment|null
      */
     public function getSegment();
 
@@ -109,28 +109,28 @@ interface RequestAnalyzerInterface
     /**
      * Returns the current localization for this Request.
      *
-     * @return Localization
+     * @return Localization|null
      */
     public function getCurrentLocalization();
 
     /**
      * Returns the redirect url.
      *
-     * @return string
+     * @return string|null
      */
     public function getRedirect();
 
     /**
      * Returns the url of the current portal.
      *
-     * @return string
+     * @return string|null
      */
     public function getPortalUrl();
 
     /**
      * Returns the path of the current request, which is the url without host, language and so on.
      *
-     * @return string
+     * @return string|false
      */
     public function getResourceLocator();
 
@@ -144,7 +144,7 @@ interface RequestAnalyzerInterface
     /**
      * Returns portal-information of request.
      *
-     * @return PortalInformation
+     * @return PortalInformation|null
      */
     public function getPortalInformation();
 

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -201,9 +201,9 @@ class RequestAnalyzerTest extends TestCase
         $this->requestAnalyzer->analyze($request);
 
         $this->assertEquals('de_at', $request->getLocale());
-        $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocale());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()->getKey());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getPortal()->getKey());
+        $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()?->getLocale());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()?->getKey());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getPortal()?->getKey());
         $this->assertEquals(null, $this->requestAnalyzer->getSegment());
         $this->assertEquals($expected['portal_url'], $this->requestAnalyzer->getPortalUrl());
         $this->assertEquals($expected['redirect'], $this->requestAnalyzer->getRedirect());
@@ -224,9 +224,9 @@ class RequestAnalyzerTest extends TestCase
 
         $this->assertEquals($expected['format'], $request->getRequestFormat());
         $this->assertEquals('de_at', $request->getLocale());
-        $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocale());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()->getKey());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getPortal()->getKey());
+        $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()?->getLocale());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()?->getKey());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getPortal()?->getKey());
         $this->assertEquals(null, $this->requestAnalyzer->getSegment());
         $this->assertEquals($expected['portal_url'], $this->requestAnalyzer->getPortalUrl());
         $this->assertEquals($expected['redirect'], $this->requestAnalyzer->getRedirect());
@@ -268,9 +268,9 @@ class RequestAnalyzerTest extends TestCase
         $this->requestAnalyzer->validate($request);
 
         $this->assertEquals('de_at', $request->getLocale());
-        $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()->getLocale());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()->getKey());
-        $this->assertEquals('sulu', $this->requestAnalyzer->getPortal()->getKey());
+        $this->assertEquals('de_at', $this->requestAnalyzer->getCurrentLocalization()?->getLocale());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getWebspace()?->getKey());
+        $this->assertEquals('sulu', $this->requestAnalyzer->getPortal()?->getKey());
         $this->assertEquals(null, $this->requestAnalyzer->getSegment());
         $this->assertEquals($expected['portal_url'], $this->requestAnalyzer->getPortalUrl());
         $this->assertEquals($expected['redirect'], $this->requestAnalyzer->getRedirect());


### PR DESCRIPTION
  | Q                  | A               |
  |--------------------|-----------------|
  | Bug fix?           | no              |
  | New feature?       | no              |
  | BC breaks?         | yes             |
  | Deprecations?      | no              |
  | Fixed tickets      | fixes #         |
  | Related issues/PRs | #               |
  | License            | MIT             |
  | Documentation PR   | sulu/sulu-docs# |

  What's in this PR?

  Updates RequestAnalyzerInterface methods to return nullable types, as the request analyzer is not guaranteed to have a request context available (e.g., in console commands).

  Why?

  The RequestAnalyzer retrieves values from the current HTTP request. When code is executed outside of a request context (CLI commands, etc.), there is no request available and these methods return null. Previously, the interface declared non-nullable return types which could lead to runtime errors when code assumed these values would always be present.

  This change makes the nullability explicit in the interface, forcing consumers to handle the case where no request context exists.