### PR TITLE
fix: Resolve snippets with STAGE_LIVE to fix preview ContentNotFoundException

### DIFF
--- a/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader;
 
+use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
@@ -28,6 +30,8 @@ class SnippetResourceLoader implements ResourceLoaderInterface
 
     public function __construct(
         private SnippetRepositoryInterface $snippetRepository,
+        private ContentAggregatorInterface $contentAggregator,
+        private ContentResolverInterface $contentResolver,
     ) {
     }
 
@@ -52,7 +56,17 @@ class SnippetResourceLoader implements ResourceLoaderInterface
 
         $mappedResult = [];
         foreach ($result as $snippet) {
-            $mappedResult[$snippet->getId()] = $snippet;
+            // Aggregate the snippet with STAGE_LIVE to get the DimensionContent
+            $dimensionContent = $this->contentAggregator->aggregate($snippet, [
+                'locale' => $locale,
+                'stage' => DimensionContentInterface::STAGE_LIVE,
+            ]);
+
+            // Fully resolve the snippet content and return the resolved data structure.
+            // This ensures snippets are always resolved with STAGE_LIVE, regardless of
+            // the parent's stage (e.g., draft in preview mode), preventing
+            // ContentNotFoundException when previewing pages with snippet_selection.
+            $mappedResult[$snippet->getId()] = $this->contentResolver->resolve($dimensionContent);
         }
 
         return $mappedResult;

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -337,6 +337,8 @@ final class SuluSnippetBundle extends AbstractBundle
             ->class(SnippetResourceLoader::class)
             ->args([
                 new Reference('sulu_snippet.snippet_repository'),
+                new Reference('sulu_content.content_aggregator'),
+                new Reference('sulu_content.content_resolver'),
             ])
             ->tag('sulu_content.resource_loader', ['type' => SnippetResourceLoader::RESOURCE_LOADER_KEY]);
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where pages using `snippet_selection` fail to render in the admin preview with a `ContentNotFoundException`.

**Root cause:** When previewing a page, `ContentResolver` re-aggregates any `ContentRichEntityInterface` objects (including snippets) using the parent's stage parameter. In preview mode, this stage is `STAGE_DRAFT`, but snippets typically only have `STAGE_LIVE` content, causing the aggregation to fail.

**Solution:** `SnippetResourceLoader` now fully resolves snippets with `STAGE_LIVE` and returns the resolved data structure (with `content`, `view`, `resource`, `extension` keys) instead of the raw `Snippet` entity. This bypasses the problematic re-aggregation in `ContentResolver`.

## Changes

- `SnippetResourceLoader`: Now uses `ContentAggregator` and `ContentResolver` to fully resolve snippets before returning them
- `SuluSnippetBundle`: Added `ContentAggregator` and `ContentResolver` as dependencies for the resource loader service

## Related Issue

Fixes #8476

## Test Plan

1. Create a snippet (e.g., a "Beer" snippet)
2. Publish the snippet
3. Create a page with a `snippet_selection` field referencing the snippet
4. Open the page in admin preview mode
5. ✅ The page should render correctly with snippet data displayed
6. ✅ No `ContentNotFoundException` should occur