### PR TITLE
fix: Move media download_admin route to admin context

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing.yaml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing.yaml
@@ -1,3 +1,11 @@
 sulu_media.redirect:
     path: /redirect/media/{id}
     controller: sulu_media.media_redirect_controller::redirectAction
+
+sulu_media.media.download_admin:
+    path: "%sulu_media.media_manager.media_download_path_admin%"
+    controller: sulu_media.media_stream_controller::downloadAction
+    defaults:
+        _requestAnalyzer: false
+    requirements:
+        id: "\\d+"

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yaml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/routing_website.yaml
@@ -13,11 +13,3 @@ sulu_media.website.media.download:
         _requestAnalyzer: false
     requirements:
         id: "\\d+"
-
-sulu_media.website.media.download_admin:
-    path: "%sulu_media.media_manager.media_download_path_admin%"
-    controller: sulu_media.media_stream_controller::downloadAction
-    defaults:
-        _requestAnalyzer: false
-    requirements:
-        id: "\\d+"


### PR DESCRIPTION
## Summary

This PR fixes a 404 error when clicking "Download master file" in the Media Manager admin interface.

## Problem

The `sulu_media.website.media.download_admin` route has path `/admin/media/{id}/download/{slug}` but was defined in `routing_website.yaml`, which is only loaded in `CONTEXT_WEBSITE`.

Since URLs starting with `/admin` use `CONTEXT_ADMIN` (determined in `index.php`), and `CONTEXT_ADMIN` loads `routing.yaml` but not `routing_website.yaml`, the download route was never accessible in the admin interface.

## Solution

Move the `download_admin` route from `routing_website.yaml` to `routing.yaml` so it's available in the admin context.

## Changes

- **routing_website.yaml**: Removed `sulu_media.website.media.download_admin` route
- **routing.yaml**: Added `sulu_media.media.download_admin` route (renamed to match context)

## Testing

1. Go to Media Manager in admin
2. Click on any media's download button
3. Click "Download master file"
4. File should download successfully (previously returned 404)

Fixes #8479