### PR TITLE
Fix Saving zero value on SimpleContentType

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SingleSelectTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SingleSelectTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Content\Types;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface as NodePropertyInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\PageBundle\Content\Types\SingleSelect;
+use Sulu\Component\Content\Compat\PropertyInterface;
+
+class SingleSelectTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var SingleSelect
+     */
+    private $singleSelect;
+
+    /**
+     * @var ObjectProphecy<NodeInterface>
+     */
+    private $node;
+
+    /**
+     * @var ObjectProphecy<PropertyInterface>
+     */
+    private $property;
+
+    /**
+     * @var ObjectProphecy<NodePropertyInterface>
+     */
+    private $nodeProperty;
+
+    public function setUp(): void
+    {
+        $this->node = $this->prophesize(NodeInterface::class);
+        $this->property = $this->prophesize(PropertyInterface::class);
+        $this->nodeProperty = $this->prophesize(NodePropertyInterface::class);
+
+        $this->singleSelect = new SingleSelect();
+    }
+
+    public function testWrite(): void
+    {
+        $this->property->getName()->willReturn('i18n:de-single-select');
+        $this->property->getValue()->willReturn('option1');
+
+        $this->node->setProperty('i18n:de-single-select', 'option1')->shouldBeCalled();
+        $this->singleSelect->write($this->node->reveal(), $this->property->reveal(), 1, 'sulu_io', 'de', null);
+    }
+
+    public function testWriteZero(): void
+    {
+        $this->property->getName()->willReturn('i18n:de-single-select');
+        $this->property->getValue()->willReturn(0);
+
+        $this->node->setProperty('i18n:de-single-select', 0)->shouldBeCalled();
+        $this->singleSelect->write($this->node->reveal(), $this->property->reveal(), 1, 'sulu_io', 'de', null);
+    }
+
+    public function testWriteStringZero(): void
+    {
+        $this->property->getName()->willReturn('i18n:de-single-select');
+        $this->property->getValue()->willReturn('0');
+
+        $this->node->setProperty('i18n:de-single-select', '0')->shouldBeCalled();
+        $this->singleSelect->write($this->node->reveal(), $this->property->reveal(), 1, 'sulu_io', 'de', null);
+    }
+
+    public function testWriteNoValue(): void
+    {
+        $this->property->getName()->willReturn('i18n:de-single-select');
+        $this->property->getValue()->willReturn(null);
+        $this->nodeProperty->remove()->shouldBeCalled();
+
+        $this->node->hasProperty('i18n:de-single-select')->willReturn(true)->shouldBeCalled();
+        $this->node->getProperty('i18n:de-single-select')->willReturn($this->nodeProperty->reveal())->shouldBeCalled();
+        $this->singleSelect->write($this->node->reveal(), $this->property->reveal(), 1, 'sulu_io', 'de', null);
+    }
+
+    public function testRead(): void
+    {
+        $this->property->getName()->willReturn('i18n:de-single-select');
+        $this->node->hasProperty('i18n:de-single-select')->willReturn(true);
+        $this->node->getPropertyValue('i18n:de-single-select')->willReturn('option1');
+
+        $this->property->setValue('option1')->shouldBeCalled();
+
+        $this->singleSelect->read($this->node->reveal(), $this->property->reveal(), 'sulu_io', 'de', null);
+    }
+
+    public function testReadZero(): void
+    {
+        $this->property->getName()->willReturn('i18n:de-single-select');
+        $this->node->hasProperty('i18n:de-single-select')->willReturn(true);
+        $this->node->getPropertyValue('i18n:de-single-select')->willReturn(0);
+
+        $this->property->setValue(0)->shouldBeCalled();
+
+        $this->singleSelect->read($this->node->reveal(), $this->property->reveal(), 'sulu_io', 'de', null);
+    }
+
+    public function testReadWithoutExistingProperty(): void
+    {
+        $this->property->getName()->willReturn('i18n:de-single-select');
+        $this->node->hasProperty('i18n:de-single-select')->willReturn(false);
+
+        $this->property->setValue(null)->shouldBeCalled();
+
+        $this->singleSelect->read($this->node->reveal(), $this->property->reveal(), 'sulu_io', 'de', null);
+    }
+}
+

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SingleSelectTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Types/SingleSelectTest.php
@@ -122,4 +122,3 @@ class SingleSelectTest extends TestCase
         $this->singleSelect->read($this->node->reveal(), $this->property->reveal(), 'sulu_io', 'de', null);
     }
 }
-

--- a/src/Sulu/Component/Content/SimpleContentType.php
+++ b/src/Sulu/Component/Content/SimpleContentType.php
@@ -66,7 +66,7 @@ abstract class SimpleContentType implements ContentTypeInterface, ContentTypeExp
         $segmentKey
     ) {
         $value = $property->getValue();
-        if (null != $value) {
+        if (null !== $value) {
             $node->setProperty($property->getName(), $this->removeIllegalCharacters($this->encodeValue($value)));
         } else {
             $this->remove($node, $property, $webspaceKey, $languageCode, $segmentKey);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add strict comparison in the SimpleContentType so one can save values like 0.

#### Why?

When saving a SingleSelect block where the parameter is 0, the value isn't persisted and thus it falls back to the default value on reload.

#### Example Usage

```xml
<properties>
    <property name="size" type="single_select">
        <meta>
            <title>Size</title>
        </meta>

        <params>
            <param name="default_value" value="25"/>

            <param name="values" type="collection">
                <param name="0"><meta><title lang="en">0%</title></meta></param>
                <param name="25"><meta><title lang="en">25%</title></meta></param>
                <param name="100"><meta><title lang="en">100%</title></meta></param>
            </param>
        </params>
    </property>
</properties>
```