### PR TITLE
Add snippet area twig extension test for querying unlocalized snippets

### DIFF
--- a/packages/snippet/tests/Functional/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Symfony/Twig/SnippetAreaTwigExtensionTest.php
@@ -131,4 +131,22 @@ class SnippetAreaTwigExtensionTest extends SuluTestCase
 
         $this->assertNull($result);
     }
+
+    public function testLoadSnippetByAreaReturnsNullWhenSnippetNotTranslatedInLocale(): void
+    {
+        $snippet = static::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet',
+                    'title' => 'English Only Snippet',
+                ],
+            ],
+        ]);
+        static::createSnippetArea('hotel', 'sulu-io', $snippet);
+        self::getEntityManager()->flush();
+        self::getEntityManager()->clear();
+
+        $result = $this->snippetAreaTwigExtension->loadSnippetByArea('hotel', [], 'sulu-io', 'de');
+        $this->assertNull($result);
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/issues/8474
| License | MIT

#### What's in this PR?

Adds a test case for https://github.com/sulu/sulu/issues/8474

#### Why?

To prevent regressions in the future.