### PR TITLE
Add default properties to page/article selections

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
@@ -60,7 +60,13 @@ class ArticleSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 100,
             metadata: [
-                'properties' => $params['properties'] ?? null,
+                'properties' => \array_merge(
+                    $params['properties'] ?? [],
+                    [
+                        'title' => 'title',
+                        'url' => 'url',
+                    ],
+                ),
             ]
         );
     }

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
@@ -48,7 +48,13 @@ class SingleArticleSelectionPropertyResolver implements PropertyResolverInterfac
             ],
             priority: 100,
             metadata: [
-                'properties' => $params['properties'] ?? null,
+                'properties' => \array_merge(
+                    $params['properties'] ?? [],
+                    [
+                        'title' => 'title',
+                        'url' => 'url',
+                    ],
+                ),
             ]
         );
     }

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
@@ -152,6 +152,8 @@ class ArticleSelectionPropertyResolverTest extends TestCase
             'properties' => [
                 'property1' => 'value1',
                 'property2' => 'value2',
+                'title' => 'title',
+                'url' => 'url',
             ],
         ], $content[0]->getMetadata());
 
@@ -170,7 +172,10 @@ class ArticleSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content[0]);
 
         $this->assertSame([
-            'properties' => null,
+            'properties' => [
+                'title' => 'title',
+                'url' => 'url',
+            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();
@@ -190,7 +195,10 @@ class ArticleSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content[0]);
 
         $this->assertSame([
-            'properties' => null,
+            'properties' => [
+                'title' => 'title',
+                'url' => 'url',
+            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolverTest.php
@@ -134,6 +134,8 @@ class SingleArticleSelectionPropertyResolverTest extends TestCase
             'properties' => [
                 'property1' => 'value1',
                 'property2' => 'value2',
+                'title' => 'title',
+                'url' => 'url',
             ],
         ], $content->getMetadata());
 
@@ -151,7 +153,10 @@ class SingleArticleSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content);
 
         $this->assertSame([
-            'properties' => null,
+            'properties' => [
+                'title' => 'title',
+                'url' => 'url',
+            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();
@@ -170,7 +175,10 @@ class SingleArticleSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content);
 
         $this->assertSame([
-            'properties' => null,
+            'properties' => [
+                'title' => 'title',
+                'url' => 'url',
+            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -54,7 +54,13 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 150,
             metadata: [
-                'properties' => $params['properties'] ?? null,
+                'properties' => \array_merge(
+                    $params['properties'] ?? [],
+                    [
+                        'title' => 'title',
+                        'url' => 'url',
+                    ],
+                ),
             ]
         );
     }

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -48,7 +48,13 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
             ],
             priority: 150,
             metadata: [
-                'properties' => $params['properties'] ?? null,
+                'properties' => \array_merge(
+                    $params['properties'] ?? [],
+                    [
+                        'title' => 'title',
+                        'url' => 'url',
+                    ],
+                ),
             ]
         );
     }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
@@ -149,6 +149,8 @@ class PageSelectionPropertyResolverTest extends TestCase
             'properties' => [
                 'property1' => 'value1',
                 'property2' => 'value2',
+                'title' => 'title',
+                'url' => 'url',
             ],
         ], $content[0]->getMetadata());
 
@@ -167,7 +169,10 @@ class PageSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content[0]);
 
         $this->assertSame([
-            'properties' => null,
+            'properties' => [
+                'title' => 'title',
+                'url' => 'url',
+            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();
@@ -187,7 +192,10 @@ class PageSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content[0]);
 
         $this->assertSame([
-            'properties' => null,
+            'properties' => [
+                'title' => 'title',
+                'url' => 'url',
+            ],
         ], $content[0]->getMetadata());
 
         $references = $contentView->getReferences();

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolverTest.php
@@ -135,6 +135,8 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
             'properties' => [
                 'property1' => 'value1',
                 'property2' => 'value2',
+                'title' => 'title',
+                'url' => 'url',
             ],
         ], $content->getMetadata());
 
@@ -152,7 +154,10 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content);
 
         $this->assertSame([
-            'properties' => null,
+            'properties' => [
+                'title' => 'title',
+                'url' => 'url',
+            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();
@@ -171,7 +176,10 @@ class SinglePageSelectionPropertyResolverTest extends TestCase
         $this->assertInstanceOf(ResolvableResource::class, $content);
 
         $this->assertSame([
-            'properties' => null,
+            'properties' => [
+                'title' => 'title',
+                'url' => 'url',
+            ],
         ], $content->getMetadata());
 
         $references = $contentView->getReferences();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/8493
| License | MIT

#### What's in this PR?

Adds default properties for content resolving for the page / article selections.

#### Why?

In Sulu 2.6 this was already the case and this prevents from unknowingly loading a lot uf unnecessary data like nested entities that will otherwise be resolved.