### PR TITLE
Add default properties for smart content resolving

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -129,7 +129,11 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
                     ];
                 },
                 $this->groupProvider->getGroups(),
-            )));
+            )))
+            ->enableProperties([
+                'title' => 'title',
+                'url' => 'url',
+            ]);
 
         // TODO
         //        if ($this->hasAudienceTargeting) {

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -130,7 +130,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
                 },
                 $this->groupProvider->getGroups(),
             )))
-            ->enableProperties([
+            ->enableDefaultProperties([
                 'title' => 'title',
                 'url' => 'url',
             ]);

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -130,7 +130,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
                 },
                 $this->groupProvider->getGroups(),
             )))
-            ->enableDefaultProperties([
+            ->enableProperties([
                 'title' => 'title',
                 'url' => 'url',
             ]);

--- a/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
+++ b/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
@@ -144,11 +144,11 @@ class SmartContentSmartResolver implements SmartResolverInterface
         ];
 
         $configuration = $smartContentProvider->getConfiguration();
-        $configProperties = $configuration->getProperties();
+        $defaultProperties = $configuration->getDefaultProperties();
         /** @var array<string, string> $passedProperties */
         $passedProperties = $params['properties'] ?? [];
-        $properties = null !== $configProperties
-            ? \array_replace($configProperties, $passedProperties)
+        $properties = null !== $defaultProperties
+            ? \array_replace($defaultProperties, $passedProperties)
             : ($passedProperties ?: null);
 
         return ContentView::createResolvables(

--- a/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
+++ b/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
@@ -143,12 +143,25 @@ class SmartContentSmartResolver implements SmartResolverInterface
             'excluded' => [],
         ];
 
+        $configuration = $smartContentProvider->getConfiguration();
+        $configProperties = $configuration->getProperties();
+        /** @var array<string, string>|null $passedProperties */
+        $passedProperties = $params['properties'] ?? null;
+        $passedProperties = \is_array($passedProperties) ? $passedProperties : null;
+
+        $properties = match (true) {
+            null === $configProperties && null === $passedProperties => null,
+            null === $configProperties => $passedProperties,
+            null === $passedProperties => $configProperties,
+            default => \array_merge($configProperties, $passedProperties),
+        };
+
         return ContentView::createResolvables(
             ids: \array_map(static fn (array $item) => $item['id'], $result),
             resourceLoaderKey: $smartContentProvider->getResourceLoaderKey(),
             view: $view,
             metadata: [
-                'properties' => $params['properties'] ?? null,
+                'properties' => $properties,
             ]
         );
     }

--- a/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
+++ b/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
@@ -145,16 +145,11 @@ class SmartContentSmartResolver implements SmartResolverInterface
 
         $configuration = $smartContentProvider->getConfiguration();
         $configProperties = $configuration->getProperties();
-        /** @var array<string, string>|null $passedProperties */
-        $passedProperties = $params['properties'] ?? null;
-        $passedProperties = \is_array($passedProperties) ? $passedProperties : null;
-
-        $properties = match (true) {
-            null === $configProperties && null === $passedProperties => null,
-            null === $configProperties => $passedProperties,
-            null === $passedProperties => $configProperties,
-            default => \array_merge($configProperties, $passedProperties),
-        };
+        /** @var array<string, string> $passedProperties */
+        $passedProperties = $params['properties'] ?? [];
+        $properties = null !== $configProperties
+            ? \array_replace($configProperties, $passedProperties)
+            : ($passedProperties ?: null);
 
         return ContentView::createResolvables(
             ids: \array_map(static fn (array $item) => $item['id'], $result),

--- a/packages/content/tests/Unit/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
+++ b/packages/content/tests/Unit/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Content\Tests\Unit\Application\SmartResolver\Resolver;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfiguration;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
@@ -93,6 +94,7 @@ class SmartContentSmartResolverTest extends TestCase
         $smartContentProvider->countBy($countByFilters, ['value' => $data['value'], ...$data['parameters']])
             ->willReturn(10);
         $smartContentProvider->getResourceLoaderKey()->willReturn('pages');
+        $smartContentProvider->getConfiguration()->willReturn(new ProviderConfiguration());
 
         $result = $this->smartResolver->resolve($smartResolvable->reveal(), 'en');
 
@@ -198,6 +200,7 @@ class SmartContentSmartResolverTest extends TestCase
         $smartContentProvider->countBy($countByFilters, ['value' => $data['value'], ...$data['parameters']])
             ->willReturn(3);
         $smartContentProvider->getResourceLoaderKey()->willReturn('pages');
+        $smartContentProvider->getConfiguration()->willReturn(new ProviderConfiguration());
 
         $result = $this->smartResolver->resolve($smartResolvable->reveal(), 'en');
 

--- a/packages/content/tests/Unit/Content/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfiguration;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
 use Sulu\Content\Application\SmartResolver\Resolver\SmartContentSmartResolver;
@@ -42,6 +43,7 @@ class SmartContentSmartResolverTest extends TestCase
     {
         $this->smartContentProvider = $this->prophesize(SmartContentProviderInterface::class);
         $this->smartContentProvider->getResourceLoaderKey()->willReturn('test_resource_loader');
+        $this->smartContentProvider->getConfiguration()->willReturn(new ProviderConfiguration());
 
         $this->serviceLocator = $this->prophesize(ServiceLocator::class); // @phpstan-ignore assign.propertyType
         $this->serviceLocator->getProvidedServices()->willReturn(['test_provider' => 'service']);

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -146,7 +146,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
             )
             ->enableTypes($this->getTypes())
             ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace'])
-            ->enableDefaultProperties([
+            ->enableProperties([
                 'title' => 'title',
                 'url' => 'url',
             ]);

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -145,7 +145,11 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
                 ],
             )
             ->enableTypes($this->getTypes())
-            ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace']);
+            ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace'])
+            ->enableProperties([
+                'title' => 'title',
+                'url' => 'url',
+            ]);
 
         if ($this->bundles['SuluAudienceTargetingBundle'] ?? false) {
             $builder->enableAudienceTargeting();

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -146,7 +146,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
             )
             ->enableTypes($this->getTypes())
             ->enableView(PageAdmin::EDIT_FORM_VIEW, ['id' => 'id', 'webspace' => 'webspace'])
-            ->enableProperties([
+            ->enableDefaultProperties([
                 'title' => 'title',
                 'url' => 'url',
             ]);

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
@@ -117,9 +117,9 @@ class Builder implements BuilderInterface
         return $this;
     }
 
-    public function enableProperties(array $properties): self
+    public function enableDefaultProperties(array $defaultProperties): self
     {
-        $this->configuration->setProperties($properties);
+        $this->configuration->setDefaultProperties($defaultProperties);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
@@ -117,7 +117,7 @@ class Builder implements BuilderInterface
         return $this;
     }
 
-    public function enableDefaultProperties(array $defaultProperties): self
+    public function enableProperties(array $defaultProperties): self
     {
         $this->configuration->setDefaultProperties($defaultProperties);
 

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
@@ -117,6 +117,13 @@ class Builder implements BuilderInterface
         return $this;
     }
 
+    public function enableProperties(array $properties): self
+    {
+        $this->configuration->setProperties($properties);
+
+        return $this;
+    }
+
     public function getConfiguration(): ProviderConfigurationInterface
     {
         return $this->configuration;

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/BuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/BuilderInterface.php
@@ -112,10 +112,8 @@ interface BuilderInterface
      * Sets default properties to be included when resolving smart content items.
      *
      * @param array<string, string> $defaultProperties
-     *
-     * @return BuilderInterface
      */
-    public function enableDefaultProperties(array $defaultProperties);
+    public function enableProperties(array $defaultProperties): BuilderInterface;
 
     /**
      * Returns build configuration.

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/BuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/BuilderInterface.php
@@ -109,6 +109,15 @@ interface BuilderInterface
     public function enableView(string $view, array $resultToView);
 
     /**
+     * Sets properties to be included when resolving smart content items.
+     *
+     * @param array<string, string> $properties
+     *
+     * @return BuilderInterface
+     */
+    public function enableProperties(array $properties);
+
+    /**
      * Returns build configuration.
      */
     public function getConfiguration(): ProviderConfigurationInterface;

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/BuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/BuilderInterface.php
@@ -109,13 +109,13 @@ interface BuilderInterface
     public function enableView(string $view, array $resultToView);
 
     /**
-     * Sets properties to be included when resolving smart content items.
+     * Sets default properties to be included when resolving smart content items.
      *
-     * @param array<string, string> $properties
+     * @param array<string, string> $defaultProperties
      *
      * @return BuilderInterface
      */
-    public function enableProperties(array $properties);
+    public function enableDefaultProperties(array $defaultProperties);
 
     /**
      * Returns build configuration.

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
@@ -245,11 +245,6 @@ class ProviderConfiguration implements ProviderConfigurationInterface
         $this->resultToView = $resultToView;
     }
 
-    public function hasProperties(): bool
-    {
-        return null !== $this->properties && [] !== $this->properties;
-    }
-
     /**
      * @return array<string, string>|null
      */
@@ -259,9 +254,9 @@ class ProviderConfiguration implements ProviderConfigurationInterface
     }
 
     /**
-     * @param array<string, string> $properties
+     * @param array<string, string>|null $properties
      */
-    public function setProperties(array $properties): void
+    public function setProperties(?array $properties): void
     {
         $this->properties = $properties;
     }

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
@@ -86,7 +86,7 @@ class ProviderConfiguration implements ProviderConfigurationInterface
     /**
      * @var array<string, string>|null
      */
-    private ?array $properties = null;
+    private ?array $defaultProperties = null;
 
     public function hasDatasource(): bool
     {
@@ -248,16 +248,16 @@ class ProviderConfiguration implements ProviderConfigurationInterface
     /**
      * @return array<string, string>|null
      */
-    public function getProperties(): ?array
+    public function getDefaultProperties(): ?array
     {
-        return $this->properties;
+        return $this->defaultProperties;
     }
 
     /**
-     * @param array<string, string>|null $properties
+     * @param array<string, string>|null $defaultProperties
      */
-    public function setProperties(?array $properties): void
+    public function setDefaultProperties(?array $defaultProperties): void
     {
-        $this->properties = $properties;
+        $this->defaultProperties = $defaultProperties;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
@@ -83,6 +83,11 @@ class ProviderConfiguration implements ProviderConfigurationInterface
      */
     private $resultToView;
 
+    /**
+     * @var array<string, string>|null
+     */
+    private ?array $properties = null;
+
     public function hasDatasource(): bool
     {
         return null !== $this->datasourceResourceKey && '' !== $this->datasourceResourceKey;
@@ -238,5 +243,26 @@ class ProviderConfiguration implements ProviderConfigurationInterface
     public function setResultToView(?array $resultToView): void
     {
         $this->resultToView = $resultToView;
+    }
+
+    public function hasProperties(): bool
+    {
+        return null !== $this->properties && [] !== $this->properties;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    public function getProperties(): ?array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param array<string, string> $properties
+     */
+    public function setProperties(array $properties): void
+    {
+        $this->properties = $properties;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfigurationInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfigurationInterface.php
@@ -109,9 +109,9 @@ interface ProviderConfigurationInterface
     public function getResultToView(): ?array;
 
     /**
-     * Returns properties to include when resolving items.
+     * Returns default properties to include when resolving items.
      *
      * @return array<string, string>|null
      */
-    public function getProperties(): ?array;
+    public function getDefaultProperties(): ?array;
 }

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfigurationInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfigurationInterface.php
@@ -107,4 +107,16 @@ interface ProviderConfigurationInterface
      * @return array<string, string>|null
      */
     public function getResultToView(): ?array;
+
+    /**
+     * Returns TRUE if properties are configured.
+     */
+    public function hasProperties(): bool;
+
+    /**
+     * Returns properties to include when resolving items.
+     *
+     * @return array<string, string>|null
+     */
+    public function getProperties(): ?array;
 }

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfigurationInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfigurationInterface.php
@@ -109,11 +109,6 @@ interface ProviderConfigurationInterface
     public function getResultToView(): ?array;
 
     /**
-     * Returns TRUE if properties are configured.
-     */
-    public function hasProperties(): bool;
-
-    /**
      * Returns properties to include when resolving items.
      *
      * @return array<string, string>|null

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
@@ -219,26 +219,26 @@ class BuilderTest extends TestCase
         $this->assertSame('News Group', $types[2]->getName());
     }
 
-    public function testProperties(): void
+    public function testDefaultProperties(): void
     {
         $builder = Builder::create();
 
-        $this->assertSame($builder, $builder->enableProperties([
+        $this->assertSame($builder, $builder->enableDefaultProperties([
             'title' => 'title',
             'url' => 'url',
         ]));
 
         $configuration = $builder->getConfiguration();
 
-        $this->assertSame(['title' => 'title', 'url' => 'url'], $configuration->getProperties());
+        $this->assertSame(['title' => 'title', 'url' => 'url'], $configuration->getDefaultProperties());
     }
 
-    public function testPropertiesDefault(): void
+    public function testDefaultPropertiesDefault(): void
     {
         $builder = Builder::create();
 
         $configuration = $builder->getConfiguration();
 
-        $this->assertNull($configuration->getProperties());
+        $this->assertNull($configuration->getDefaultProperties());
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
@@ -230,7 +230,6 @@ class BuilderTest extends TestCase
 
         $configuration = $builder->getConfiguration();
 
-        $this->assertTrue($configuration->hasProperties());
         $this->assertSame(['title' => 'title', 'url' => 'url'], $configuration->getProperties());
     }
 
@@ -240,7 +239,6 @@ class BuilderTest extends TestCase
 
         $configuration = $builder->getConfiguration();
 
-        $this->assertFalse($configuration->hasProperties());
         $this->assertNull($configuration->getProperties());
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
@@ -223,7 +223,7 @@ class BuilderTest extends TestCase
     {
         $builder = Builder::create();
 
-        $this->assertSame($builder, $builder->enableDefaultProperties([
+        $this->assertSame($builder, $builder->enableProperties([
             'title' => 'title',
             'url' => 'url',
         ]));

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
@@ -218,4 +218,29 @@ class BuilderTest extends TestCase
         $this->assertSame('news', $types[2]->getValue());
         $this->assertSame('News Group', $types[2]->getName());
     }
+
+    public function testProperties(): void
+    {
+        $builder = Builder::create();
+
+        $this->assertSame($builder, $builder->enableProperties([
+            'title' => 'title',
+            'url' => 'url',
+        ]));
+
+        $configuration = $builder->getConfiguration();
+
+        $this->assertTrue($configuration->hasProperties());
+        $this->assertSame(['title' => 'title', 'url' => 'url'], $configuration->getProperties());
+    }
+
+    public function testPropertiesDefault(): void
+    {
+        $builder = Builder::create();
+
+        $configuration = $builder->getConfiguration();
+
+        $this->assertFalse($configuration->hasProperties());
+        $this->assertNull($configuration->getProperties());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/8492
| License | MIT

#### What's in this PR?

Adds default properties for content resolving for the page / article smart content.

#### Why?

In Sulu 2.6 this was already the case and this prevents from unknowingly loading a lot of unnecessary data like nested entities that will otherwise be resolved.