### PR TITLE
Fix previously set where conditions being overridden in MediaSmartContentProvider

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/SmartContent/MediaSmartContentProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/SmartContent/MediaSmartContentProvider.php
@@ -270,7 +270,7 @@ readonly class MediaSmartContentProvider implements SmartContentProviderInterfac
                         Join::WITH,
                         'parentCollection.id = :collectionId',
                     )
-                    ->where('collection.lft BETWEEN parentCollection.lft AND parentCollection.rgt')
+                    ->andWhere('collection.lft BETWEEN parentCollection.lft AND parentCollection.rgt')
                     ->setParameter('collectionId', $filters['dataSource']);
             }
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8433
| Related issues/PRs | #8437
| License | MIT
| Documentation PR | --

#### What's in this PR?

This PR fixes the bug described in #8433 on the 3.0 branch.

#### Why?

To allow the filtering of media smart content with the [documented query string parameters](https://docs.sulu.io/en/3.0/reference/property-types/smart_content.html#media) and prevent previously set `where` conditions from being overridden.

#### Tests

I wasn't quite sure how to handle tests for this. To trigger the bug, the `includeSubFolders` filter has to be set. The existing tests for MediaSmartContentProvider don't seem to be setup with that in mind. But I admit that my experience with Sulu 3.0's changes is quite limited.