### PR TITLE
Fix JavaScript permission restoration and snippet area handling

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/Permissions.js
@@ -29,6 +29,8 @@ class Permissions extends React.Component<Props> {
 
     @observable securityContextGroups: SecurityContextGroups;
 
+    removedWebspacePermissions: Map<string, ContextPermission> = new Map();
+
     @action componentDidMount() {
         this.systemDisposer = autorun(
             () => this.setSecurityContextGroups(securityContextStore.getSecurityContextGroups(this.system))
@@ -115,13 +117,17 @@ class Permissions extends React.Component<Props> {
 
     @action handleWebspaceChange = (newSelectedWebspaces: Array<string>) => {
         const newContextPermissions = [];
+
         for (const contextPermission of this.props.value) {
             if (contextPermission.context.startsWith(this.webspaceContextPermissionPrefix)) {
                 const suffix = contextPermission.context.replace(this.webspaceContextPermissionPrefix, '');
                 const webspaceKey = !suffix.includes('.') ? suffix : suffix.substring(0, suffix.indexOf('.'));
 
                 if (!newSelectedWebspaces.includes(webspaceKey)) {
+                    this.removedWebspacePermissions.set(contextPermission.context, contextPermission);
                     continue;
+                } else {
+                    this.removedWebspacePermissions.delete(contextPermission.context);
                 }
             }
 
@@ -131,23 +137,32 @@ class Permissions extends React.Component<Props> {
         const webspacesToAdd = newSelectedWebspaces.filter((newSelectedWebspace) => {
             return !this.selectedWebspaces.includes(newSelectedWebspace);
         });
+
         for (const webspaceToAdd of webspacesToAdd) {
             const securityContexts = this.getWebspaceSecurityContexts(webspaceToAdd.toString());
 
             Object.keys(securityContexts).map((securityContextKey) => {
-                const permissions = {};
-                const actions = securityContexts[securityContextKey];
+                const existingContextPermission = this.removedWebspacePermissions.get(securityContextKey);
 
-                for (const action of actions) {
-                    permissions[action] = false;
+                if (existingContextPermission) {
+                    newContextPermissions.push(existingContextPermission);
+                    this.removedWebspacePermissions.delete(securityContextKey);
+                } else {
+                    // Create new permission only if it didn't exist before
+                    const permissions = {};
+                    const actions = securityContexts[securityContextKey];
+
+                    for (const action of actions) {
+                        permissions[action] = false;
+                    }
+
+                    const newContextPermission: ContextPermission = {
+                        'id': undefined,
+                        'context': securityContextKey,
+                        permissions,
+                    };
+                    newContextPermissions.push(newContextPermission);
                 }
-
-                const newContextPermission: ContextPermission = {
-                    'id': undefined,
-                    'context': securityContextKey,
-                    permissions,
-                };
-                newContextPermissions.push(newContextPermission);
             });
         }
 

--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/Permissions.test.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/Permissions.test.js
@@ -848,3 +848,429 @@ test('Dispose autorun on unmount', () => {
 
     expect(systemDisposerSpy).toBeCalledWith();
 });
+
+test('Should restore original permission when webspace is removed and re-added without saving', () => {
+    const value: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.contact.people',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+            },
+        },
+        {
+            id: 3,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+        {
+            id: 5,
+            context: 'sulu.webspaces.example.analytics',
+            permissions: {
+                'view': true,
+                'delete': false,
+                'add': true,
+                'edit': false,
+            },
+        },
+    ];
+
+    const securityContextGroups: SecurityContextGroups = {
+        'Contacts': {
+            'sulu.contact.people': ['view', 'add', 'edit', 'delete'],
+        },
+        'Webspaces': {
+            'sulu.webspaces.#webspace#': ['view', 'add', 'edit', 'delete', 'live', 'security'],
+            'sulu.webspaces.#webspace#.analytics': ['view', 'add', 'edit', 'delete'],
+        },
+    };
+    securityContextStore.getSecurityContextGroups.mockReturnValue(securityContextGroups);
+
+    webspaceStore.allWebspaces = [
+        {
+            ...defaultWebspace,
+            'key': 'example',
+            'name': 'Example',
+        },
+        {
+            ...defaultWebspace,
+            'key': 'example2',
+            'name': 'Example 2',
+        },
+    ];
+
+    const onChange = jest.fn();
+    const permissions = mount(
+        <Permissions
+            onChange={onChange}
+            system="Sulu"
+            value={value}
+        />
+    );
+
+    // First remove the webspace
+    permissions.find('MultiSelect').prop('onChange')([]);
+
+    const expectedAfterRemove: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.contact.people',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+            },
+        },
+    ];
+
+    expect(onChange).toHaveBeenLastCalledWith(expectedAfterRemove);
+
+    // Update component props to reflect the removed state
+    permissions.setProps({value: expectedAfterRemove});
+    permissions.update();
+
+    // Now re-add the same webspace - it should restore the original permissions with their IDs
+    permissions.find('MultiSelect').prop('onChange')(['example']);
+
+    const expectedAfterReAdd: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.contact.people',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+            },
+        },
+        {
+            // IMPORTANT: This should have the original id: 3, not id: undefined
+            id: 3,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+        {
+            // IMPORTANT: This should have the original id: 5, not id: undefined
+            id: 5,
+            context: 'sulu.webspaces.example.analytics',
+            permissions: {
+                'view': true,
+                'delete': false,
+                'add': true,
+                'edit': false,
+            },
+        },
+    ];
+
+    expect(onChange).toHaveBeenLastCalledWith(expectedAfterReAdd);
+});
+
+test('Should restore multiple webspaces independently when removed and re-added', () => {
+    const value: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+        {
+            id: 2,
+            context: 'sulu.webspaces.example2',
+            permissions: {
+                'view': false,
+                'delete': true,
+                'add': false,
+                'edit': true,
+                'live': false,
+                'security': true,
+            },
+        },
+    ];
+
+    const securityContextGroups: SecurityContextGroups = {
+        'Webspaces': {
+            'sulu.webspaces.#webspace#': ['view', 'add', 'edit', 'delete', 'live', 'security'],
+        },
+    };
+    securityContextStore.getSecurityContextGroups.mockReturnValue(securityContextGroups);
+
+    webspaceStore.allWebspaces = [
+        {
+            ...defaultWebspace,
+            'key': 'example',
+            'name': 'Example',
+        },
+        {
+            ...defaultWebspace,
+            'key': 'example2',
+            'name': 'Example 2',
+        },
+    ];
+
+    const onChange = jest.fn();
+    const permissions = mount(
+        <Permissions
+            onChange={onChange}
+            system="Sulu"
+            value={value}
+        />
+    );
+
+    // Remove both webspaces
+    permissions.find('MultiSelect').prop('onChange')([]);
+    expect(onChange).toHaveBeenLastCalledWith([]);
+
+    // Update component props
+    permissions.setProps({value: []});
+    permissions.update();
+
+    // Re-add only example2 - should restore its original permissions
+    permissions.find('MultiSelect').prop('onChange')(['example2']);
+
+    const expectedWithExample2: Array<ContextPermission> = [
+        {
+            id: 2,
+            context: 'sulu.webspaces.example2',
+            permissions: {
+                'view': false,
+                'delete': true,
+                'add': false,
+                'edit': true,
+                'live': false,
+                'security': true,
+            },
+        },
+    ];
+
+    expect(onChange).toHaveBeenLastCalledWith(expectedWithExample2);
+
+    // Update component props again
+    permissions.setProps({value: expectedWithExample2});
+    permissions.update();
+
+    // Now also add example - should restore its original permissions
+    permissions.find('MultiSelect').prop('onChange')(['example2', 'example']);
+
+    const expectedWithBoth: Array<ContextPermission> = [
+        {
+            id: 2,
+            context: 'sulu.webspaces.example2',
+            permissions: {
+                'view': false,
+                'delete': true,
+                'add': false,
+                'edit': true,
+                'live': false,
+                'security': true,
+            },
+        },
+        {
+            id: 1,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+    ];
+
+    expect(onChange).toHaveBeenLastCalledWith(expectedWithBoth);
+});
+
+test('Should create new permission when adding a webspace that was never selected before', () => {
+    const value: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+    ];
+
+    const securityContextGroups: SecurityContextGroups = {
+        'Webspaces': {
+            'sulu.webspaces.#webspace#': ['view', 'add', 'edit', 'delete', 'live', 'security'],
+        },
+    };
+    securityContextStore.getSecurityContextGroups.mockReturnValue(securityContextGroups);
+
+    webspaceStore.allWebspaces = [
+        {
+            ...defaultWebspace,
+            'key': 'example',
+            'name': 'Example',
+        },
+        {
+            ...defaultWebspace,
+            'key': 'example2',
+            'name': 'Example 2',
+        },
+    ];
+
+    const onChange = jest.fn();
+    const permissions = mount(
+        <Permissions
+            onChange={onChange}
+            system="Sulu"
+            value={value}
+        />
+    );
+
+    // Add example2 which was never selected before - should create new permission with id: undefined
+    permissions.find('MultiSelect').prop('onChange')(['example', 'example2']);
+
+    const expected: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+        {
+            // Should be undefined because this webspace was never selected before
+            id: undefined,
+            context: 'sulu.webspaces.example2',
+            permissions: {
+                'view': false,
+                'delete': false,
+                'add': false,
+                'edit': false,
+                'live': false,
+                'security': false,
+            },
+        },
+    ];
+
+    expect(onChange).toHaveBeenLastCalledWith(expected);
+});
+
+test('Should maintain removed permissions cache when toggling same webspace multiple times', () => {
+    const value: Array<ContextPermission> = [
+        {
+            id: 1,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+    ];
+
+    const securityContextGroups: SecurityContextGroups = {
+        'Webspaces': {
+            'sulu.webspaces.#webspace#': ['view', 'add', 'edit', 'delete', 'live', 'security'],
+        },
+    };
+    securityContextStore.getSecurityContextGroups.mockReturnValue(securityContextGroups);
+
+    webspaceStore.allWebspaces = [
+        {
+            ...defaultWebspace,
+            'key': 'example',
+            'name': 'Example',
+        },
+    ];
+
+    const onChange = jest.fn();
+    const permissions = mount(
+        <Permissions
+            onChange={onChange}
+            system="Sulu"
+            value={value}
+        />
+    );
+
+    // Remove the webspace
+    permissions.find('MultiSelect').prop('onChange')([]);
+    expect(onChange).toHaveBeenLastCalledWith([]);
+    permissions.setProps({value: []});
+    permissions.update();
+
+    // Re-add it - should restore original
+    permissions.find('MultiSelect').prop('onChange')(['example']);
+    const firstReAdd = [
+        {
+            id: 1,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+    ];
+    expect(onChange).toHaveBeenLastCalledWith(firstReAdd);
+    permissions.setProps({value: firstReAdd});
+    permissions.update();
+
+    // Remove it again
+    permissions.find('MultiSelect').prop('onChange')([]);
+    expect(onChange).toHaveBeenLastCalledWith([]);
+    permissions.setProps({value: []});
+    permissions.update();
+
+    // Re-add it again - should still restore the original permission
+    permissions.find('MultiSelect').prop('onChange')(['example']);
+    const secondReAdd = [
+        {
+            id: 1,
+            context: 'sulu.webspaces.example',
+            permissions: {
+                'view': true,
+                'delete': true,
+                'add': true,
+                'edit': true,
+                'live': false,
+                'security': false,
+            },
+        },
+    ];
+    expect(onChange).toHaveBeenLastCalledWith(secondReAdd);
+});

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/stores/SnippetAreaStore.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/stores/SnippetAreaStore.js
@@ -6,6 +6,8 @@ import type {SnippetArea} from '../types';
 export default class SnippetAreaStore {
     @observable snippetAreas: {[key: string]: SnippetArea} = {};
     @observable loading: boolean = true;
+    @observable forbidden: boolean = false;
+    @observable unexpectedError: boolean = false;
     @observable saving: boolean = false;
     @observable deleting: boolean = false;
     webspaceKey: string;
@@ -19,6 +21,18 @@ export default class SnippetAreaStore {
 
                 return snippetAreas;
             }, {});
+            this.forbidden = false;
+            this.unexpectedError = false;
+            this.loading = false;
+        })).catch(action((response: Object) => {
+            if (response.status === 403) {
+                this.forbidden = true;
+                this.loading = false;
+
+                return;
+            }
+
+            this.unexpectedError = true;
             this.loading = false;
         }));
     }

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/stores/SnippetAreaStore.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/stores/SnippetAreaStore.test.js
@@ -182,3 +182,43 @@ test('Delete snippet area when delete is calld', () => {
         });
     });
 });
+
+test('Handle 403 forbidden error when loading snippet areas', () => {
+    const listPromise = Promise.reject({status: 403});
+    ResourceRequester.getList.mockReturnValue(listPromise);
+
+    const snippetAreaStore = new SnippetAreaStore('sulu');
+
+    expect(snippetAreaStore.loading).toEqual(true);
+    expect(snippetAreaStore.forbidden).toEqual(false);
+    expect(snippetAreaStore.unexpectedError).toEqual(false);
+
+    return listPromise.catch(() => {
+        // Wait for MobX action to complete
+    }).then(() => {
+        expect(snippetAreaStore.loading).toEqual(false);
+        expect(snippetAreaStore.forbidden).toEqual(true);
+        expect(snippetAreaStore.unexpectedError).toEqual(false);
+        expect(snippetAreaStore.snippetAreas).toEqual({});
+    });
+});
+
+test('Handle unexpected error when loading snippet areas', () => {
+    const listPromise = Promise.reject({status: 500});
+    ResourceRequester.getList.mockReturnValue(listPromise);
+
+    const snippetAreaStore = new SnippetAreaStore('sulu');
+
+    expect(snippetAreaStore.loading).toEqual(true);
+    expect(snippetAreaStore.forbidden).toEqual(false);
+    expect(snippetAreaStore.unexpectedError).toEqual(false);
+
+    return listPromise.catch(() => {
+        // Wait for MobX action to complete
+    }).then(() => {
+        expect(snippetAreaStore.loading).toEqual(false);
+        expect(snippetAreaStore.forbidden).toEqual(false);
+        expect(snippetAreaStore.unexpectedError).toEqual(true);
+        expect(snippetAreaStore.snippetAreas).toEqual({});
+    });
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | N/A
| Related issues/PRs | #8495 
| License | MIT
| Documentation PR | none

#### What's in this PR?

1. Fix webspace permission restoration when toggled without saving
   - Cache removed webspace permissions in a Map at component instance level
   - Restore cached permissions when webspace is re-added to preserve ID and settings
   - Add comprehensive tests for permission restoration scenarios

2. Update SnippetArea API integration
   - Rename defaultUuid/defaultTitle to snippetUuid/snippetTitle
   - Change API parameter from 'webspace' to 'webspaceKey'
   - Update response parsing from 'areas' to 'snippet_areas'
   - Add error handling with forbidden and unexpectedError states
   - Fix MobX action timing in tests with proper async handling

