### PR TITLE
Add error handling UI to SnippetAreas component

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/SnippetAreas.js
@@ -6,6 +6,7 @@ import {Button, Dialog, Loader, Table} from 'sulu-admin-bundle/components';
 import {SingleListOverlay, withToolbar} from 'sulu-admin-bundle/containers';
 import {translate} from 'sulu-admin-bundle/utils';
 import {CacheClearToolbarAction} from 'sulu-website-bundle/containers';
+import Hint from 'sulu-admin-bundle/components/Hint';
 import SnippetAreaStore from './stores/SnippetAreaStore';
 import snippetAreasStyles from './snippetAreas.scss';
 import type {ViewProps} from 'sulu-admin-bundle/containers';
@@ -85,6 +86,20 @@ class SnippetAreas extends React.Component<ViewProps> {
             return <Loader />;
         }
 
+        if (this.snippetAreaStore.forbidden) {
+            return <Hint icon="su-lock" title={translate('sulu_admin.no_permissions')} />;
+        }
+
+        if (this.snippetAreaStore.unexpectedError) {
+            return <Hint icon="su-exclamation-triangle" title={translate('sulu_admin.unexpected_error')} />;
+        }
+
+        const {
+            attributes: {
+                locale,
+            },
+        } = this.props.router;
+
         return (
             <Fragment>
                 <Table skin="light">
@@ -139,6 +154,7 @@ class SnippetAreas extends React.Component<ViewProps> {
                     confirmLoading={this.snippetAreaStore.saving}
                     key={this.openedAreaKey}
                     listKey="snippets"
+                    locale={observable.box(locale)}
                     onClose={this.handleListOverlayClose}
                     onConfirm={this.handleListOverlayConfirm}
                     open={!!this.openedAreaKey}

--- a/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -291,3 +291,47 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
     toolbarFunction.call(snippetAreas.instance());
     expect(cacheClearToolbarAction.getToolbarItemConfig).toBeCalled();
 });
+
+test('Show forbidden hint when user has no permission', () => {
+    const SnippetAreas = require('../SnippetAreas').default;
+    const SnippetAreaStore = require('../stores/SnippetAreaStore');
+
+    const router = new Router();
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.loading = false;
+        this.forbidden = true;
+        this.unexpectedError = false;
+        this.snippetAreas = {};
+    });
+
+    const snippetAreas = shallow(<SnippetAreas route={router.route} router={router} />);
+    const hint = snippetAreas.find('Hint');
+
+    expect(hint).toHaveLength(1);
+    expect(hint.prop('icon')).toEqual('su-lock');
+    expect(hint.prop('title')).toEqual('sulu_admin.no_permissions');
+});
+
+test('Show error hint when unexpected error occurs', () => {
+    const SnippetAreas = require('../SnippetAreas').default;
+    const SnippetAreaStore = require('../stores/SnippetAreaStore');
+
+    const router = new Router();
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.loading = false;
+        this.forbidden = false;
+        this.unexpectedError = true;
+        this.snippetAreas = {};
+    });
+
+    const snippetAreas = shallow(<SnippetAreas route={router.route} router={router} />);
+    const hint = snippetAreas.find('Hint');
+
+    expect(hint).toHaveLength(1);
+    expect(hint.prop('icon')).toEqual('su-exclamation-triangle');
+    expect(hint.prop('title')).toEqual('sulu_admin.unexpected_error');
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | N/A
| Related issues/PRs | #8495 
| License | MIT
| Documentation PR | none

#### What's in this PR?

This commit adds the missing error handling UI to the SnippetAreas component:

1. Import Hint component for error/permission messages
2. Add UI for forbidden (403) errors with lock icon
3. Add UI for unexpected errors with warning icon
4. Add locale observable to SingleListOverlay for proper locale handling
5. Extract locale from router attributes for use in overlay

These changes ensure users see appropriate error messages instead of a blank or broken UI when they lack permissions or when errors occur.