### PR TITLE
Fix list pagination with joined fields

### DIFF
--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -196,7 +196,6 @@ class DoctrineListBuilder extends AbstractListBuilder
     {
         $applyDistinct = $this->distinct || $this->hasJoins();
 
-        // Use COUNT(DISTINCT ...) when distinct is needed to avoid counting duplicates from JOINs
         $countExpression = $applyDistinct
             ? 'COUNT(DISTINCT ' . $this->idField->getSelect() . ')'
             : 'COUNT(' . $this->idField->getSelect() . ')';
@@ -363,8 +362,6 @@ class DoctrineListBuilder extends AbstractListBuilder
      */
     protected function findIdsByGivenCriteria()
     {
-        // Apply DISTINCT if user explicitly called distinct(true) OR JOINs are present
-        // to prevent duplicate IDs when filtering by joined fields
         $applyDistinct = $this->distinct || $this->hasJoins();
 
         $subQueryBuilder = $this->createSubQueryBuilder(

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -194,7 +194,14 @@ class DoctrineListBuilder extends AbstractListBuilder
 
     public function count()
     {
-        $subQueryBuilder = $this->createSubQueryBuilder('COUNT( ' . $this->idField->getSelect() . ')', false);
+        $applyDistinct = $this->distinct || $this->hasJoins();
+
+        // Use COUNT(DISTINCT ...) when distinct is needed to avoid counting duplicates from JOINs
+        $countExpression = $applyDistinct
+            ? 'COUNT(DISTINCT ' . $this->idField->getSelect() . ')'
+            : 'COUNT(' . $this->idField->getSelect() . ')';
+
+        $subQueryBuilder = $this->createSubQueryBuilder($countExpression, false);
 
         $this->assignParameters($subQueryBuilder);
 
@@ -356,7 +363,15 @@ class DoctrineListBuilder extends AbstractListBuilder
      */
     protected function findIdsByGivenCriteria()
     {
-        $subQueryBuilder = $this->createSubQueryBuilder($this->getSelectAs($this->idField));
+        // Apply DISTINCT if user explicitly called distinct(true) OR JOINs are present
+        // to prevent duplicate IDs when filtering by joined fields
+        $applyDistinct = $this->distinct || $this->hasJoins();
+
+        $subQueryBuilder = $this->createSubQueryBuilder(
+            $this->getSelectAs($this->idField),
+            true,
+            $applyDistinct
+        );
         if (null != $this->limit) {
             $subQueryBuilder->setMaxResults((int) $this->limit)->setFirstResult((int) ($this->limit * ($this->page - 1)));
         }
@@ -542,7 +557,7 @@ class DoctrineListBuilder extends AbstractListBuilder
      *
      * @return QueryBuilder
      */
-    protected function createSubQueryBuilder(string $select, bool $includeSortFields = true)
+    protected function createSubQueryBuilder(string $select, bool $includeSortFields = true, bool $applyDistinct = false)
     {
         // get all filter-fields
         $filterFields = $this->getAllFields(true, $includeSortFields);
@@ -555,6 +570,10 @@ class DoctrineListBuilder extends AbstractListBuilder
 
         // create querybuilder and add select
         $queryBuilder = $this->createQueryBuilder($addJoins)->select($select);
+
+        if ($applyDistinct) {
+            $queryBuilder->distinct(true);
+        }
 
         if ($this->user && $this->permission && \array_key_exists($this->permission, $this->permissions)) {
             if ($this->accessControlQueryEnhancer && $this->permissionCheckWithDynamicEntityClass) {
@@ -785,6 +804,22 @@ class DoctrineListBuilder extends AbstractListBuilder
     public function distinct($flag = true)
     {
         $this->distinct = $flag;
+    }
+
+    /**
+     * This is used to determine if DISTINCT should be applied to ID subqueries
+     * to prevent duplicate IDs when filtering by joined fields.
+     */
+    protected function hasJoins(): bool
+    {
+        $filterFields = $this->getAllFields(true, true);
+        foreach ($filterFields as $field) {
+            if (!empty($field->getJoins())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -141,7 +141,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->getQuery()->willReturn($this->query->reveal());
         $this->queryBuilder->getDQL()->willReturn('');
 
-        $this->queryBuilder->distinct(false)->should(function() {});
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
         $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->should(function() {});
         $this->queryBuilder->addOrderBy(Argument::cetera())->shouldBeCalled();
 
@@ -1563,5 +1563,119 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
+    }
+
+    public function testPaginationWithJoinsAppliesDistinct(): void
+    {
+        // Test the fix for #8467: DISTINCT should be applied when filtering by joined fields
+        $fieldDescriptor = new DoctrineFieldDescriptor(
+            'name',
+            'name',
+            self::$translationEntityName,
+            'translation',
+            [
+                self::$translationEntityName => new DoctrineJoinDescriptor(
+                    self::$translationEntityName,
+                    self::$entityNameAlias . '.translations'
+                ),
+            ]
+        );
+
+        $this->doctrineListBuilder->where($fieldDescriptor, 'test-value');
+
+        // The ID subquery should call distinct(true) because JOINs are present
+        $this->queryBuilder->distinct(true)->shouldBeCalledTimes(1);
+        // The final query should call distinct(false) (default behavior)
+        $this->queryBuilder->distinct(false)->shouldBeCalledTimes(1);
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-value')->shouldBeCalled();
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->shouldBeCalledTimes(1);
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testPaginationWithoutJoinsNoDistinct(): void
+    {
+        // Test that DISTINCT is NOT applied when no JOINs are present (no performance overhead)
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $this->doctrineListBuilder->where($fieldDescriptor, 'test-value');
+
+        // distinct(true) should NOT be called for ID subquery
+        $this->queryBuilder->distinct(true)->shouldNotBeCalled();
+        // Only distinct(false) should be called for the final query
+        $this->queryBuilder->distinct(false)->shouldBeCalledTimes(1);
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-value')->shouldBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testExplicitDistinctAppliedToIdSubquery(): void
+    {
+        // Test that explicit distinct(true) is applied to both ID subquery and final query
+        $this->doctrineListBuilder->distinct(true);
+
+        // distinct(true) should be called twice: once for ID subquery, once for final query
+        $this->queryBuilder->distinct(true)->shouldBeCalledTimes(2);
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testCountWithJoinsUsesDistinct(): void
+    {
+        // Test the fix for #8467: COUNT(DISTINCT id) should be used when JOINs are present
+        $this->doctrineListBuilder->addSearchField(
+            new DoctrineFieldDescriptor(
+                'desc',
+                'desc',
+                self::$translationEntityName,
+                'translation',
+                [
+                    self::$translationEntityName => new DoctrineJoinDescriptor(
+                        self::$translationEntityName,
+                        self::$entityName . '.translations'
+                    ),
+                ]
+            )
+        );
+        $this->doctrineListBuilder->search('value');
+
+        // Verify COUNT(DISTINCT ...) is used in the select
+        $this->queryBuilder->select(Argument::containingString('COUNT(DISTINCT'))->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->leftJoin(Argument::cetera())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::cetera())->shouldBeCalled();
+        $this->queryBuilder->setParameter('search', '%value%')->shouldBeCalled();
+
+        $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->count();
+    }
+
+    public function testCountWithoutJoinsNoDistinct(): void
+    {
+        // Test that regular COUNT(id) is used when no JOINs are present
+        $this->doctrineListBuilder->addSelectField(
+            new DoctrineFieldDescriptor('name', 'name', self::$entityName)
+        );
+
+        // Verify COUNT(...) without DISTINCT is used
+        $this->queryBuilder->select(Argument::that(function($arg) {
+            return \is_string($arg) && \str_contains($arg, 'COUNT(') && !\str_contains($arg, 'DISTINCT');
+        }))->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+
+        $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->count();
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8467
| Related issues/PRs |
| License | MIT
| Documentation PR | N/A (internal bug fix)

#### What's in this PR?

This PR fixes a pagination bug in `DoctrineListBuilder` where filtering by joined fields (e.g., tags) returns incorrect result counts per page.

**Changes:**
- Added `hasJoins()` method to detect when JOINs are present in filter fields
- Extended `createSubQueryBuilder()` to accept an `applyDistinct` parameter
- Modified `findIdsByGivenCriteria()` to automatically apply DISTINCT when JOINs are detected
- Modified `count()` to use `COUNT(DISTINCT id)` when JOINs are present

The fix automatically applies DISTINCT to ID subqueries when:
1. User explicitly called `distinct(true)`, OR
2. JOINs are detected in the query

#### Why?

When filtering admin list views by joined fields (especially one-to-many relationships like tags), the ID subquery used for pagination returns duplicate IDs because each entity appears once per joined row.

**Problem scenario:**
- Request: 10 items per page (limit 10)
- Entity has 3 matching tags → appears 3 times in JOIN result
- Subquery returns: `[1, 1, 1, 2, 2, 3, 3, 3, 4, 5]` (10 rows with duplicates)
- LIMIT 10 is applied to this duplicated result
- After de-duplication: `[1, 2, 3, 4, 5]` (only 5 unique IDs)
- Result: Page shows 5 items instead of 10

The fix ensures DISTINCT is applied **before** LIMIT, returning the correct number of unique entities.
