### PR TITLE
Fix TeaserProviderConfiguration

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
+++ b/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\SaveWithFormDialogToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Teaser\Configuration\TeaserConfiguration;
 use Sulu\Bundle\AdminBundle\Teaser\Provider\TeaserProviderPoolInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -420,7 +421,7 @@ class PageAdmin extends Admin
 
     /**
      * @return array{
-     *     teaser: array<string, mixed>,
+     *     teaser: array<int|string, TeaserConfiguration>,
      *     versioning: bool,
      *     webspaces: array<string, Webspace>
      * }

--- a/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
+++ b/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
@@ -21,6 +21,7 @@ use Sulu\Bundle\AdminBundle\Admin\View\SaveWithFormDialogToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Teaser\Provider\TeaserProviderPoolInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
@@ -58,6 +59,7 @@ class PageAdmin extends Admin
         private SecurityCheckerInterface $securityChecker,
         private ContentViewBuilderFactoryInterface $contentViewBuilderFactory,
         private ActivityViewBuilderFactoryInterface $activityViewBuilderFactory,
+        private TeaserProviderPoolInterface $teaserProviderPool,
     ) {
     }
 
@@ -431,8 +433,8 @@ class PageAdmin extends Admin
         });
 
         return [
-            'teaser' => [], // $this->teaserProviderPool->getConfiguration(),
-            'versioning' => true, //$this->versioningEnabled,
+            'teaser' => $this->teaserProviderPool->getConfiguration(),
+            'versioning' => true,
             'webspaces' => $webspaces,
         ];
     }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -331,6 +331,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_security.security_checker'),
                 new Reference('sulu_content.content_view_builder_factory'),
                 new Reference('sulu_activity.activity_list_view_builder_factory'),
+                new Reference('sulu_admin.teaser_provider_pool')
             ])
             ->tag('sulu.context', ['context' => 'admin'])
             ->tag('sulu.admin');

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -331,7 +331,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_security.security_checker'),
                 new Reference('sulu_content.content_view_builder_factory'),
                 new Reference('sulu_activity.activity_list_view_builder_factory'),
-                new Reference('sulu_admin.teaser_provider_pool')
+                new Reference('sulu_admin.teaser_provider_pool'),
             ])
             ->tag('sulu.context', ['context' => 'admin'])
             ->tag('sulu.admin');

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Admin/snapshots/sulu_page_admin_config.json
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Admin/snapshots/sulu_page_admin_config.json
@@ -1,5 +1,28 @@
 {
-    "teaser": [],
+    "teaser": {
+        "examples": {
+            "displayProperties": [
+                "title"
+            ],
+            "listAdapter": "table",
+            "overlayTitle": "Select examples",
+            "resourceKey": "examples",
+            "resultToView": null,
+            "title": "Example",
+            "view": null
+        },
+        "pages": {
+            "displayProperties": [
+                "title"
+            ],
+            "listAdapter": "table",
+            "overlayTitle": "Choose page",
+            "resourceKey": "pages",
+            "resultToView": null,
+            "title": "Page",
+            "view": null
+        }
+    },
     "versioning": true,
     "webspaces": {
         "blog": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds the missing configuration to the PageAdmin.

#### Why?

Teaser Selection was not working in the Admin, as there were no providers registered.