### PR TITLE
Allow usage of webmozart/assert ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,7 @@
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
         "toflar/psr6-symfony-http-cache-store": "^3.0 || ^4.0",
         "twig/twig": "^2.13 || ^3.0",
-        "webmozart/assert": "^1.9"
+        "webmozart/assert": "^1.9 || ^2.0"
     },
     "require-dev": {
         "google/cloud-storage": "^1.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow usage of webmozart/assert ^2.0.

#### Why?

There was a new major release and more and more packages will use it to not block 2.6 on version 1 we should wider the range.