### PR TITLE
Fix Route generation in TeaserProvider for Articles

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
@@ -41,7 +41,7 @@ class ArticleTeaserProvider extends ContentTeaserProvider
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
-        ?RouteGeneratorInterface $routeGenerator = null,
+        RouteGeneratorInterface $routeGenerator,
     ) {
         parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, ArticleInterface::class, $routeGenerator);
 

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
@@ -22,6 +22,7 @@ use Sulu\Content\Application\ContentManager\ContentManagerInterface;
 use Sulu\Content\Application\ContentMetadataInspector\ContentMetadataInspectorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Sulu\Teaser\ContentTeaserProvider;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -40,8 +41,9 @@ class ArticleTeaserProvider extends ContentTeaserProvider
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
+        ?RouteGeneratorInterface $routeGenerator = null,
     ) {
-        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, ArticleInterface::class);
+        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, ArticleInterface::class, $routeGenerator);
 
         $this->translator = $translator;
     }

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -325,6 +325,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_content.content_metadata_inspector'),
                 new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('translator'),
+                new Reference('sulu_route.route_generator'),
             ])
             ->tag('sulu.teaser.provider', ['alias' => ArticleInterface::RESOURCE_KEY]);
 

--- a/packages/content/src/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
+++ b/packages/content/src/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
@@ -25,6 +25,7 @@ use Sulu\Content\Domain\Model\ExcerptInterface;
 use Sulu\Content\Infrastructure\Sulu\Traits\FindContentRichEntitiesTrait;
 use Sulu\Content\Infrastructure\Sulu\Traits\ResolveContentDimensionUrlTrait;
 use Sulu\Content\Infrastructure\Sulu\Traits\ResolveContentTrait;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 
 /**
  * @template B of DimensionContentInterface
@@ -60,6 +61,11 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
     protected $metadataProviderRegistry;
 
     /**
+     * @var RouteGeneratorInterface|null
+     */
+    protected $routeGenerator;
+
+    /**
      * @var class-string<T>
      */
     protected $contentRichEntityClass;
@@ -73,12 +79,23 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         string $contentRichEntityClass,
+        ?RouteGeneratorInterface $routeGenerator = null,
     ) {
+        if (null === $routeGenerator) {
+            trigger_deprecation(
+                'sulu/sulu',
+                '3.0',
+                'Not passing a RouteGeneratorInterface to "%s" is deprecated and will be required in 4.0.',
+                static::class
+            );
+        }
+
         $this->contentManager = $contentManager;
         $this->entityManager = $entityManager;
         $this->contentMetadataInspector = $contentMetadataInspector;
         $this->metadataProviderRegistry = $metadataProviderRegistry;
         $this->contentRichEntityClass = $contentRichEntityClass;
+        $this->routeGenerator = $routeGenerator;
     }
 
     /**
@@ -254,6 +271,11 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
     protected function getMetadataProviderRegistry(): MetadataProviderRegistry
     {
         return $this->metadataProviderRegistry;
+    }
+
+    protected function getRouteGenerator(): ?RouteGeneratorInterface
+    {
+        return $this->routeGenerator;
     }
 
     protected function getContentManager(): ContentManagerInterface

--- a/packages/content/src/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
+++ b/packages/content/src/Infrastructure/Sulu/Teaser/ContentTeaserProvider.php
@@ -41,61 +41,16 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
     use ResolveContentTrait;
 
     /**
-     * @var ContentManagerInterface
-     */
-    protected $contentManager;
-
-    /**
-     * @var EntityManagerInterface
-     */
-    protected $entityManager;
-
-    /**
-     * @var ContentMetadataInspectorInterface
-     */
-    private $contentMetadataInspector;
-
-    /**
-     * @var MetadataProviderRegistry
-     */
-    protected $metadataProviderRegistry;
-
-    /**
-     * @var RouteGeneratorInterface|null
-     */
-    protected $routeGenerator;
-
-    /**
-     * @var class-string<T>
-     */
-    protected $contentRichEntityClass;
-
-    /**
      * @param class-string<T> $contentRichEntityClass
      */
     public function __construct(
-        ContentManagerInterface $contentManager,
-        EntityManagerInterface $entityManager,
-        ContentMetadataInspectorInterface $contentMetadataInspector,
-        MetadataProviderRegistry $metadataProviderRegistry,
-        string $contentRichEntityClass,
-        ?RouteGeneratorInterface $routeGenerator = null,
+        private ContentManagerInterface $contentManager,
+        private EntityManagerInterface $entityManager,
+        private ContentMetadataInspectorInterface $contentMetadataInspector,
+        private MetadataProviderRegistry $metadataProviderRegistry,
+        private string $contentRichEntityClass,
+        private RouteGeneratorInterface $routeGenerator,
     ) {
-        if (null === $routeGenerator) {
-            trigger_deprecation(
-                'sulu/sulu',
-                '3.0',
-                'Not passing a RouteGeneratorInterface to "%s" is deprecated and will be required in 4.0.',
-                static::class
-            );
-        }
-
-        $this->contentManager = $contentManager;
-        $this->entityManager = $entityManager;
-        $this->contentMetadataInspector = $contentMetadataInspector;
-        $this->metadataProviderRegistry = $metadataProviderRegistry;
-        $this->contentRichEntityClass = $contentRichEntityClass;
-        $this->routeGenerator = $routeGenerator;
     }
 
     /**
@@ -273,7 +228,7 @@ abstract class ContentTeaserProvider implements TeaserProviderInterface
         return $this->metadataProviderRegistry;
     }
 
-    protected function getRouteGenerator(): ?RouteGeneratorInterface
+    protected function getRouteGenerator(): RouteGeneratorInterface
     {
         return $this->routeGenerator;
     }

--- a/packages/content/src/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTrait.php
+++ b/packages/content/src/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTrait.php
@@ -17,7 +17,10 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\RoutableInterface;
 use Sulu\Content\Domain\Model\TemplateInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
+use Sulu\Route\Domain\Model\Route;
 
 /**
  * @internal
@@ -32,6 +35,18 @@ trait ResolveContentDimensionUrlTrait
      */
     protected function getUrl(DimensionContentInterface $dimensionContent, array $data): ?string
     {
+        if ($dimensionContent instanceof RoutableInterface) {
+            $route = $dimensionContent->getRoute();
+            $routeGenerator = $this->getRouteGenerator();
+            if (null !== $route && null !== $routeGenerator) {
+                return $routeGenerator->generate(
+                    $this->buildFullSlug($route),
+                    $route->getLocale(),
+                    $route->getWebspace()
+                );
+            }
+        }
+
         if (!$dimensionContent instanceof TemplateInterface) {
             // TODO FIXME add testcase for it
             return null; // @codeCoverageIgnore
@@ -60,10 +75,33 @@ trait ResolveContentDimensionUrlTrait
                 /** @var string|null */
                 return $dimensionContent->getTemplateData()[$property->getName()] ?? null;
             }
+
+            if ('page_tree_route' === $property->getType()) {
+                /** @var array{page?: array{path?: string}, suffix?: string}|null $pageTreeRoute */
+                $pageTreeRoute = $dimensionContent->getTemplateData()[$property->getName()] ?? null;
+                if (\is_array($pageTreeRoute) && isset($pageTreeRoute['page']['path'], $pageTreeRoute['suffix'])) {
+                    return \rtrim($pageTreeRoute['page']['path'], '/') . '/' . \ltrim($pageTreeRoute['suffix'], '/');
+                }
+            }
         }
 
         return null;
     }
 
+    private function buildFullSlug(Route $route): string
+    {
+        $slugParts = [];
+        $currentRoute = $route;
+
+        while (null !== $currentRoute) {
+            $slugParts[] = $currentRoute->getSlug();
+            $currentRoute = $currentRoute->getParentRoute();
+        }
+
+        return \implode('', \array_reverse($slugParts));
+    }
+
     abstract protected function getMetadataProviderRegistry(): MetadataProviderRegistry;
+
+    abstract protected function getRouteGenerator(): ?RouteGeneratorInterface;
 }

--- a/packages/content/src/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTrait.php
+++ b/packages/content/src/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTrait.php
@@ -20,7 +20,6 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\RoutableInterface;
 use Sulu\Content\Domain\Model\TemplateInterface;
 use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
-use Sulu\Route\Domain\Model\Route;
 
 /**
  * @internal
@@ -38,9 +37,9 @@ trait ResolveContentDimensionUrlTrait
         if ($dimensionContent instanceof RoutableInterface) {
             $route = $dimensionContent->getRoute();
             $routeGenerator = $this->getRouteGenerator();
-            if (null !== $route && null !== $routeGenerator) {
+            if (null !== $route) {
                 return $routeGenerator->generate(
-                    $this->buildFullSlug($route),
+                    $route->getSlug(),
                     $route->getLocale(),
                     $route->getWebspace()
                 );
@@ -88,20 +87,7 @@ trait ResolveContentDimensionUrlTrait
         return null;
     }
 
-    private function buildFullSlug(Route $route): string
-    {
-        $slugParts = [];
-        $currentRoute = $route;
-
-        while (null !== $currentRoute) {
-            $slugParts[] = $currentRoute->getSlug();
-            $currentRoute = $currentRoute->getParentRoute();
-        }
-
-        return \implode('', \array_reverse($slugParts));
-    }
-
     abstract protected function getMetadataProviderRegistry(): MetadataProviderRegistry;
 
-    abstract protected function getRouteGenerator(): ?RouteGeneratorInterface;
+    abstract protected function getRouteGenerator(): RouteGeneratorInterface;
 }

--- a/packages/content/tests/Application/ExampleTestBundle/Resources/config/services.yaml
+++ b/packages/content/tests/Application/ExampleTestBundle/Resources/config/services.yaml
@@ -41,6 +41,7 @@ services:
             - '@sulu_content.content_metadata_inspector'
             - '@sulu_admin.metadata_provider_registry'
             - '@translator'
+            - '@sulu_route.route_generator'
         tags:
             - { name: sulu.teaser.provider, alias: examples }
 

--- a/packages/content/tests/Application/ExampleTestBundle/Teaser/ExampleTeaserProvider.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Teaser/ExampleTeaserProvider.php
@@ -41,7 +41,7 @@ class ExampleTeaserProvider extends ContentTeaserProvider
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
-        ?RouteGeneratorInterface $routeGenerator = null,
+        RouteGeneratorInterface $routeGenerator,
     ) {
         parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, Example::class, $routeGenerator);
 

--- a/packages/content/tests/Application/ExampleTestBundle/Teaser/ExampleTeaserProvider.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Teaser/ExampleTeaserProvider.php
@@ -22,6 +22,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Sulu\Teaser\ContentTeaserProvider;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -40,8 +41,9 @@ class ExampleTeaserProvider extends ContentTeaserProvider
         ContentMetadataInspectorInterface $contentMetadataInspector,
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
+        ?RouteGeneratorInterface $routeGenerator = null,
     ) {
-        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, Example::class);
+        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, Example::class, $routeGenerator);
 
         $this->translator = $translator;
     }

--- a/packages/content/tests/Unit/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTraitTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTraitTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Infrastructure\Sulu\Traits;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
+use Sulu\Bundle\AdminBundle\Teaser\Configuration\TeaserConfiguration;
+use Sulu\Content\Application\ContentManager\ContentManagerInterface;
+use Sulu\Content\Application\ContentMetadataInspector\ContentMetadataInspectorInterface;
+use Sulu\Content\Infrastructure\Sulu\Teaser\ContentTeaserProvider;
+use Sulu\Content\Infrastructure\Sulu\Traits\ResolveContentDimensionUrlTrait;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
+use Sulu\Route\Domain\Model\Route;
+
+/**
+ * Test implementation of ResolveContentDimensionUrlTrait.
+ */
+class ResolveContentDimensionUrlTraitTestImpl
+{
+    use ResolveContentDimensionUrlTrait {
+        getUrl as public;
+    }
+
+    private MetadataProviderRegistry $metadataProviderRegistry;
+    private ?RouteGeneratorInterface $routeGenerator;
+
+    public function __construct(MetadataProviderRegistry $metadataProviderRegistry, ?RouteGeneratorInterface $routeGenerator)
+    {
+        $this->metadataProviderRegistry = $metadataProviderRegistry;
+        $this->routeGenerator = $routeGenerator;
+    }
+
+    protected function getMetadataProviderRegistry(): MetadataProviderRegistry
+    {
+        return $this->metadataProviderRegistry;
+    }
+
+    protected function getRouteGenerator(): ?RouteGeneratorInterface
+    {
+        return $this->routeGenerator;
+    }
+}
+
+class ResolveContentDimensionUrlTraitTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<RouteGeneratorInterface>
+     */
+    private ObjectProphecy $routeGenerator;
+
+    /**
+     * @var ObjectProphecy<ContainerInterface>
+     */
+    private ObjectProphecy $metadataContainer;
+
+    protected function setUp(): void
+    {
+        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
+        $this->metadataContainer = $this->prophesize(ContainerInterface::class);
+    }
+
+    private function createTraitInstance(?RouteGeneratorInterface $routeGenerator = null, bool $useNullRouteGenerator = false): ResolveContentDimensionUrlTraitTestImpl
+    {
+        $metadataProviderRegistry = new MetadataProviderRegistry($this->metadataContainer->reveal());
+
+        if (!$useNullRouteGenerator && null === $routeGenerator) {
+            $routeGenerator = $this->routeGenerator->reveal();
+        }
+
+        return new ResolveContentDimensionUrlTraitTestImpl($metadataProviderRegistry, $routeGenerator);
+    }
+
+    public function testGetUrlWithRoutableInterface(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+
+        $route = new Route('examples', '1', 'en', '/my-example', 'sulu-io');
+        $dimensionContent->setRoute($route);
+
+        $this->routeGenerator->generate('/my-example', 'en', 'sulu-io')
+            ->willReturn('/en/my-example')
+            ->shouldBeCalledOnce();
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertSame('/en/my-example', $url);
+    }
+
+    public function testGetUrlWithRoutableInterfaceAndParentRoute(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+
+        $parentRoute = new Route('pages', 'parent-1', 'en', '/products', 'sulu-io');
+        $childRoute = new Route('examples', '1', 'en', '/laptop', 'sulu-io', $parentRoute);
+        $dimensionContent->setRoute($childRoute);
+
+        $this->routeGenerator->generate('/products/laptop', 'en', 'sulu-io')
+            ->willReturn('/en/products/laptop')
+            ->shouldBeCalledOnce();
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertSame('/en/products/laptop', $url);
+    }
+
+    public function testGetUrlWithRoutableInterfaceAndDeepParentChain(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+
+        $grandparentRoute = new Route('pages', 'gp-1', 'en', '/shop', 'sulu-io');
+        $parentRoute = new Route('pages', 'p-1', 'en', '/electronics', 'sulu-io', $grandparentRoute);
+        $childRoute = new Route('examples', '1', 'en', '/laptop', 'sulu-io', $parentRoute);
+        $dimensionContent->setRoute($childRoute);
+
+        $this->routeGenerator->generate('/shop/electronics/laptop', 'en', 'sulu-io')
+            ->willReturn('/en/shop/electronics/laptop')
+            ->shouldBeCalledOnce();
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertSame('/en/shop/electronics/laptop', $url);
+    }
+
+    public function testGetUrlWithRoutableInterfaceNoRoute(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default');
+
+        $this->setupMetadataForRouteField('url', 'route');
+
+        $dimensionContent->setTemplateData(['url' => '/fallback-url']);
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertSame('/fallback-url', $url);
+    }
+
+    public function testGetUrlWithRoutableInterfaceNoRouteGenerator(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default');
+
+        $route = new Route('examples', '1', 'en', '/my-example', 'sulu-io');
+        $dimensionContent->setRoute($route);
+
+        $this->setupMetadataForRouteField('url', 'route');
+        $dimensionContent->setTemplateData(['url' => '/fallback-url']);
+
+        $traitInstance = $this->createTraitInstance(useNullRouteGenerator: true);
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertSame('/fallback-url', $url);
+    }
+
+    public function testGetUrlWithPageTreeRoute(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default');
+
+        $this->setupMetadataForRouteField('routePath', 'page_tree_route');
+
+        $dimensionContent->setTemplateData([
+            'routePath' => [
+                'page' => ['path' => '/parent-page'],
+                'suffix' => 'child-suffix',
+            ],
+        ]);
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertSame('/parent-page/child-suffix', $url);
+    }
+
+    public function testGetUrlWithPageTreeRouteTrimsSlashes(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default');
+
+        $this->setupMetadataForRouteField('routePath', 'page_tree_route');
+
+        $dimensionContent->setTemplateData([
+            'routePath' => [
+                'page' => ['path' => '/parent-page/'],
+                'suffix' => '/child-suffix',
+            ],
+        ]);
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertSame('/parent-page/child-suffix', $url);
+    }
+
+    public function testGetUrlWithPageTreeRouteMissingPage(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default');
+
+        $this->setupMetadataForRouteField('routePath', 'page_tree_route');
+
+        $dimensionContent->setTemplateData([
+            'routePath' => [
+                'suffix' => 'child-suffix',
+            ],
+        ]);
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertNull($url);
+    }
+
+    public function testGetUrlWithPageTreeRouteMissingSuffix(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default');
+
+        $this->setupMetadataForRouteField('routePath', 'page_tree_route');
+
+        $dimensionContent->setTemplateData([
+            'routePath' => [
+                'page' => ['path' => '/parent-page'],
+            ],
+        ]);
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertNull($url);
+    }
+
+    public function testGetUrlWithPageTreeRouteNull(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default');
+
+        $this->setupMetadataForRouteField('routePath', 'page_tree_route');
+
+        $dimensionContent->setTemplateData([]);
+
+        $traitInstance = $this->createTraitInstance();
+        $url = $traitInstance->getUrl($dimensionContent, []);
+
+        $this->assertNull($url);
+    }
+
+    public function testDeprecationWhenRouteGeneratorNull(): void
+    {
+        $this->expectUserDeprecationMessageMatches(
+            '/Not passing a RouteGeneratorInterface to .+ is deprecated/'
+        );
+
+        $contentManager = $this->prophesize(ContentManagerInterface::class);
+        $entityManager = $this->prophesize(EntityManagerInterface::class);
+        $contentMetadataInspector = $this->prophesize(ContentMetadataInspectorInterface::class);
+        $metadataProviderRegistry = new MetadataProviderRegistry($this->metadataContainer->reveal());
+
+        new class(
+            $contentManager->reveal(),
+            $entityManager->reveal(),
+            $contentMetadataInspector->reveal(),
+            $metadataProviderRegistry,
+            Example::class, /* @phpstan-ignore-line */
+            null
+        ) extends ContentTeaserProvider {
+            public function getConfiguration(): TeaserConfiguration
+            {
+                throw new \RuntimeException('Not implemented');
+            }
+        };
+    }
+
+    private function setupMetadataForRouteField(string $fieldName, string $fieldType): void
+    {
+        $fieldMetadata = $this->prophesize(FieldMetadata::class);
+        $fieldMetadata->getName()->willReturn($fieldName);
+        $fieldMetadata->getType()->willReturn($fieldType);
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()->willReturn([$fieldMetadata->reveal()]);
+
+        $typedFormMetadata = $this->prophesize(TypedFormMetadata::class);
+        $typedFormMetadata->getForms()->willReturn(['default' => $formMetadata->reveal()]);
+
+        $metadataProvider = $this->prophesize(MetadataProviderInterface::class);
+        $metadataProvider->getMetadata(Example::TEMPLATE_TYPE, 'en', [])->willReturn($typedFormMetadata->reveal());
+
+        $this->metadataContainer->has('form')->willReturn(true);
+        $this->metadataContainer->get('form')->willReturn($metadataProvider->reveal());
+    }
+}

--- a/packages/content/tests/Unit/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTraitTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Sulu/Traits/ResolveContentDimensionUrlTraitTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Unit\Infrastructure\Sulu\Traits;
 
-use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -23,10 +22,6 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
-use Sulu\Bundle\AdminBundle\Teaser\Configuration\TeaserConfiguration;
-use Sulu\Content\Application\ContentManager\ContentManagerInterface;
-use Sulu\Content\Application\ContentMetadataInspector\ContentMetadataInspectorInterface;
-use Sulu\Content\Infrastructure\Sulu\Teaser\ContentTeaserProvider;
 use Sulu\Content\Infrastructure\Sulu\Traits\ResolveContentDimensionUrlTrait;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
@@ -43,9 +38,9 @@ class ResolveContentDimensionUrlTraitTestImpl
     }
 
     private MetadataProviderRegistry $metadataProviderRegistry;
-    private ?RouteGeneratorInterface $routeGenerator;
+    private RouteGeneratorInterface $routeGenerator;
 
-    public function __construct(MetadataProviderRegistry $metadataProviderRegistry, ?RouteGeneratorInterface $routeGenerator)
+    public function __construct(MetadataProviderRegistry $metadataProviderRegistry, RouteGeneratorInterface $routeGenerator)
     {
         $this->metadataProviderRegistry = $metadataProviderRegistry;
         $this->routeGenerator = $routeGenerator;
@@ -56,7 +51,7 @@ class ResolveContentDimensionUrlTraitTestImpl
         return $this->metadataProviderRegistry;
     }
 
-    protected function getRouteGenerator(): ?RouteGeneratorInterface
+    protected function getRouteGenerator(): RouteGeneratorInterface
     {
         return $this->routeGenerator;
     }
@@ -82,11 +77,11 @@ class ResolveContentDimensionUrlTraitTest extends TestCase
         $this->metadataContainer = $this->prophesize(ContainerInterface::class);
     }
 
-    private function createTraitInstance(?RouteGeneratorInterface $routeGenerator = null, bool $useNullRouteGenerator = false): ResolveContentDimensionUrlTraitTestImpl
+    private function createTraitInstance(?RouteGeneratorInterface $routeGenerator = null): ResolveContentDimensionUrlTraitTestImpl
     {
         $metadataProviderRegistry = new MetadataProviderRegistry($this->metadataContainer->reveal());
 
-        if (!$useNullRouteGenerator && null === $routeGenerator) {
+        if (null === $routeGenerator) {
             $routeGenerator = $this->routeGenerator->reveal();
         }
 
@@ -112,47 +107,6 @@ class ResolveContentDimensionUrlTraitTest extends TestCase
         $this->assertSame('/en/my-example', $url);
     }
 
-    public function testGetUrlWithRoutableInterfaceAndParentRoute(): void
-    {
-        $example = new Example();
-        $dimensionContent = new ExampleDimensionContent($example);
-        $dimensionContent->setLocale('en');
-
-        $parentRoute = new Route('pages', 'parent-1', 'en', '/products', 'sulu-io');
-        $childRoute = new Route('examples', '1', 'en', '/laptop', 'sulu-io', $parentRoute);
-        $dimensionContent->setRoute($childRoute);
-
-        $this->routeGenerator->generate('/products/laptop', 'en', 'sulu-io')
-            ->willReturn('/en/products/laptop')
-            ->shouldBeCalledOnce();
-
-        $traitInstance = $this->createTraitInstance();
-        $url = $traitInstance->getUrl($dimensionContent, []);
-
-        $this->assertSame('/en/products/laptop', $url);
-    }
-
-    public function testGetUrlWithRoutableInterfaceAndDeepParentChain(): void
-    {
-        $example = new Example();
-        $dimensionContent = new ExampleDimensionContent($example);
-        $dimensionContent->setLocale('en');
-
-        $grandparentRoute = new Route('pages', 'gp-1', 'en', '/shop', 'sulu-io');
-        $parentRoute = new Route('pages', 'p-1', 'en', '/electronics', 'sulu-io', $grandparentRoute);
-        $childRoute = new Route('examples', '1', 'en', '/laptop', 'sulu-io', $parentRoute);
-        $dimensionContent->setRoute($childRoute);
-
-        $this->routeGenerator->generate('/shop/electronics/laptop', 'en', 'sulu-io')
-            ->willReturn('/en/shop/electronics/laptop')
-            ->shouldBeCalledOnce();
-
-        $traitInstance = $this->createTraitInstance();
-        $url = $traitInstance->getUrl($dimensionContent, []);
-
-        $this->assertSame('/en/shop/electronics/laptop', $url);
-    }
-
     public function testGetUrlWithRoutableInterfaceNoRoute(): void
     {
         $example = new Example();
@@ -165,25 +119,6 @@ class ResolveContentDimensionUrlTraitTest extends TestCase
         $dimensionContent->setTemplateData(['url' => '/fallback-url']);
 
         $traitInstance = $this->createTraitInstance();
-        $url = $traitInstance->getUrl($dimensionContent, []);
-
-        $this->assertSame('/fallback-url', $url);
-    }
-
-    public function testGetUrlWithRoutableInterfaceNoRouteGenerator(): void
-    {
-        $example = new Example();
-        $dimensionContent = new ExampleDimensionContent($example);
-        $dimensionContent->setLocale('en');
-        $dimensionContent->setTemplateKey('default');
-
-        $route = new Route('examples', '1', 'en', '/my-example', 'sulu-io');
-        $dimensionContent->setRoute($route);
-
-        $this->setupMetadataForRouteField('url', 'route');
-        $dimensionContent->setTemplateData(['url' => '/fallback-url']);
-
-        $traitInstance = $this->createTraitInstance(useNullRouteGenerator: true);
         $url = $traitInstance->getUrl($dimensionContent, []);
 
         $this->assertSame('/fallback-url', $url);
@@ -290,32 +225,6 @@ class ResolveContentDimensionUrlTraitTest extends TestCase
         $url = $traitInstance->getUrl($dimensionContent, []);
 
         $this->assertNull($url);
-    }
-
-    public function testDeprecationWhenRouteGeneratorNull(): void
-    {
-        $this->expectUserDeprecationMessageMatches(
-            '/Not passing a RouteGeneratorInterface to .+ is deprecated/'
-        );
-
-        $contentManager = $this->prophesize(ContentManagerInterface::class);
-        $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $contentMetadataInspector = $this->prophesize(ContentMetadataInspectorInterface::class);
-        $metadataProviderRegistry = new MetadataProviderRegistry($this->metadataContainer->reveal());
-
-        new class(
-            $contentManager->reveal(),
-            $entityManager->reveal(),
-            $contentMetadataInspector->reveal(),
-            $metadataProviderRegistry,
-            Example::class, /* @phpstan-ignore-line */
-            null
-        ) extends ContentTeaserProvider {
-            public function getConfiguration(): TeaserConfiguration
-            {
-                throw new \RuntimeException('Not implemented');
-            }
-        };
     }
 
     private function setupMetadataForRouteField(string $fieldName, string $fieldType): void

--- a/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
@@ -51,7 +51,7 @@ class PageTeaserProvider extends ContentTeaserProvider
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
         ContentEnhancerInterface $contentEnhancer,
-        ?RouteGeneratorInterface $routeGenerator = null,
+        RouteGeneratorInterface $routeGenerator,
     ) {
         parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, PageInterface::class, $routeGenerator);
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
@@ -24,6 +24,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Sulu\Teaser\ContentTeaserProvider;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -50,8 +51,9 @@ class PageTeaserProvider extends ContentTeaserProvider
         MetadataProviderRegistry $metadataProviderRegistry,
         TranslatorInterface $translator,
         ContentEnhancerInterface $contentEnhancer,
+        ?RouteGeneratorInterface $routeGenerator = null,
     ) {
-        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, PageInterface::class);
+        parent::__construct($contentManager, $entityManager, $contentMetadataInspector, $metadataProviderRegistry, PageInterface::class, $routeGenerator);
 
         $this->translator = $translator;
         $this->contentEnhancer = $contentEnhancer;
@@ -62,7 +64,7 @@ class PageTeaserProvider extends ContentTeaserProvider
         return new TeaserConfiguration(
             $this->translator->trans('sulu_page.page', [], 'admin'),
             $this->getResourceKey(),
-            'table',
+            'column_list',
             ['title'],
             $this->translator->trans('sulu_page.single_selection_overlay_title', [], 'admin'),
         );

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -424,6 +424,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('translator'),
                 new Reference('sulu_content.content_enhancer'),
+                new Reference('sulu_route.route_generator'),
             ])
             ->tag('sulu.teaser.provider', ['alias' => PageInterface::RESOURCE_KEY]);
 

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Admin/snapshots/sulu_page_admin_config.json
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Admin/snapshots/sulu_page_admin_config.json
@@ -15,7 +15,7 @@
             "displayProperties": [
                 "title"
             ],
-            "listAdapter": "table",
+            "listAdapter": "column_list",
             "overlayTitle": "Choose page",
             "resourceKey": "pages",
             "resultToView": null,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #8505 
| License | MIT

#### What's in this PR?

Fixes the route generation for articles with `page_tree_route`.

#### Why?

The url was not correctly resolved, which ended in skipping the teaser.