### PR TITLE
Add support for Massive Build 0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "jackalope/jackalope": "^1.4.5 || ^2.0",
         "jms/serializer": "^3.16",
         "jms/serializer-bundle": "^4.0.1 || ^5.0",
-        "massive/build-bundle": "^0.5.7",
+        "massive/build-bundle": "^0.5.7 || ^0.6",
         "massive/search-bundle": "^2.8.2",
         "matomo/device-detector": "^3.9 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.3",

--- a/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
+++ b/src/Sulu/Bundle/CoreBundle/CommandOptional/SuluBuildCommand.php
@@ -22,7 +22,7 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'sulu:build')]
 class SuluBuildCommand extends BuildCommand
 {
-    public function configure()
+    public function configure(): void
     {
         parent::configure();
         $this->addOption('destroy', null, InputOption::VALUE_NONE, 'Destroy existing data');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add support for Massive Build 0.6.

#### Why?

There was a BC Break in massive Build Bundle during: https://github.com/massiveart/MassiveBuildBundle/pull/35 which required a new 0.x version. This PR adds the new return type, It is sure a technical bc break but think nobody overwritten that part of Sulu, to support the newer version I would do this bc break.

It makes maintainance for us easier as we only need maintain the 0.6 of massive build bundle.