### PR TITLE
Fix duplicated package after backmerge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
         "jms/serializer-bundle": "^4.0.1 || ^5.0",
         "league/flysystem": "^3.0",
         "league/flysystem-bundle": "^3.0",
-        "massive/build-bundle": "^0.5.7",
         "massive/build-bundle": "^0.5.7 || ^0.6",
         "matomo/device-detector": "^3.9 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.3",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix duplicated package after backmerge.

#### Why?

During backmerge the conflict was resolved falsely.