### PR TITLE
Respect requested ids over flat parameter

### DIFF
--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -87,7 +87,12 @@ class CategoryController extends AbstractRestController implements ClassResource
             $parentId = null;
         }
 
-        if ('true' == $request->get('flat')) {
+        if ($request->query->has('ids')) {
+            $ids = \array_filter(\explode(',', $request->query->get('ids')));
+            $entities = $this->categoryManager->findByIds($ids);
+            $categories = $this->categoryManager->getApiObjects($entities, $locale);
+            $list = new CollectionRepresentation($categories, CategoryInterface::RESOURCE_KEY);
+        } elseif ('true' == $request->get('flat')) {
             $rootId = ($rootKey) ? $this->categoryManager->findByKey($rootKey)->getId() : null;
             $expandedIds = \array_filter(\explode(',', $request->get('expandedIds', $request->get('selectedIds', ''))));
             $defaultSort = !$request->query->has('sortBy');
@@ -100,11 +105,6 @@ class CategoryController extends AbstractRestController implements ClassResource
                 $includeRoot,
                 $defaultSort
             );
-        } elseif ($request->query->has('ids')) {
-            $ids = \array_filter(\explode(',', $request->query->get('ids')));
-            $entities = $this->categoryManager->findByIds($ids);
-            $categories = $this->categoryManager->getApiObjects($entities, $locale);
-            $list = new CollectionRepresentation($categories, CategoryInterface::RESOURCE_KEY);
         } else {
             $entities = $this->categoryManager->findChildrenByParentKey($rootKey);
             $categories = $this->categoryManager->getApiObjects($entities, $locale);

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
@@ -223,6 +223,16 @@ class CategoryControllerTest extends SuluTestCase
 
     public function testCGetByIds(): void
     {
+        $this->testCGetByIdsWithTargetUrl('/api/categories?locale=en&ids=%s');
+    }
+
+    public function testCGetByIdsIgnoresFlat(): void
+    {
+        $this->testCGetByIdsWithTargetUrl('/api/categories?locale=en&ids=%s&flat=true');
+    }
+
+    private function testCGetByIdsWithTargetUrl(string $url): void
+    {
         $category1 = $this->createCategory('first-category-key', 'en');
         $this->createCategoryTranslation($category1, 'en', 'First Category');
         $category2 = $this->createCategory('second-category-key', 'en');
@@ -237,7 +247,7 @@ class CategoryControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'GET',
-            '/api/categories?locale=en&ids=' . $category3->getId() . ',' . $category4->getId()
+            \sprintf($url, $category3->getId() . ',' . $category4->getId())
         );
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -1703,7 +1713,7 @@ class CategoryControllerTest extends SuluTestCase
         ?string $key = null,
         ?string $defaultLocale = null,
         ?CategoryInterface $parentCategory = null
-    ) {
+    ): CategoryInterface {
         $category = $this->getContainer()->get('sulu.repository.category')->createNew();
         $category->setKey($key);
         $category->setDefaultLocale($defaultLocale);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | not really
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs |
| License | MIT

#### What's in this PR?

Allows to display attached categories in `list_overlay`-view.

#### Why?

When requesting categories via list_overlay configuration, the requested looks like this:
`admin/api/categories?locale=de&ids=16846,16884&page=1&flat=true`.
Because the order of the request checks, the flat parameter took precedence over the requested ids and so the "flat"-tree was handled. But since, when requesting ids the result should be always flat anyway, I reordered the the if branches.

#### Steps to reproduce

- Configure categories in settings tab to be used as list_overlay
- Open the category list and attach some categories to the contentpage
- Save and Refresh the page.
- The categories are not shown anymore
