### PR TITLE
Add form metadata to container as resources to trigger recompile

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
@@ -17,10 +17,15 @@ use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @internal no backwards compatibility promise, only for internal use.
+ */
 class FormMetadataCachePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        $kernelProjectDir = $container->getParameter('kernel.project_dir');
+
         foreach ($container->getParameter('sulu_admin.forms.directories') as $directory) {
             $this->addDirectory($directory, $container);
         }
@@ -41,9 +46,27 @@ class FormMetadataCachePass implements CompilerPassInterface
     private function addDirectory(string $directory, ContainerBuilder $container): void
     {
         // Resolving container parameters
-        $directory = \preg_replace_callback('#%([^%]+)%#', fn ($match) => $container->getParameter($match[1]), $directory);
-        if (\file_exists($directory)) {
-            $container->addResource(new DirectoryResource($directory, '/\.xml$/'));
+        $directory = $container->resolveEnvPlaceholders(
+            \preg_replace_callback(
+                '#%([^%]+)%#',
+                static function(array $match) use ($container): string {
+                    /** @var string $param */
+                    $param = $container->getParameter($match[1]);
+
+                    return $param;
+                },
+                $directory
+            )
+        );
+
+        if (!\is_string($directory)) {
+            return;
         }
+
+        if (!\file_exists($directory) || !\is_dir($directory)) {
+            return;
+        }
+
+        $container->addResource(new DirectoryResource($directory, '/\.xml$/'));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class FormMetadataCachePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getParameter('sulu_admin.forms.directories') as $directory) {
+            $container->addResource(new DirectoryResource($directory, '/\.xml$/'));
+        }
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @internal no backwards compatibility promise, only for internal use.
+ * @internal no backwards compatibility promise, only for internal use
  */
 class FormMetadataCachePass implements CompilerPassInterface
 {

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
@@ -22,11 +22,28 @@ class FormMetadataCachePass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         foreach ($container->getParameter('sulu_admin.forms.directories') as $directory) {
+            $this->addDirectory($directory, $container);
+        }
+        foreach ($container->getParameter('sulu_admin.lists.directories') as $directory) {
+            $this->addDirectory($directory, $container);
+        }
+
+        $this->addDirectory($container->getParameter('sulu_core.webspace.config_dir'), $container);
+
+        // Adding templates to the cache
+        foreach ($container->getParameter('sulu_admin.templates.configuration') as $configuration) {
+            foreach ($configuration['directories'] as $directory) {
+                $this->addDirectory($directory, $container);
+            }
+        }
+    }
+
+    private function addDirectory(string $directory, ContainerBuilder $container): void
+    {
+        // Resolving container parameters
+        $directory = \preg_replace_callback('#%([^%]+)%#', fn ($match) => $container->getParameter($match[1]), $directory);
+        if (\file_exists($directory)) {
             $container->addResource(new DirectoryResource($directory, '/\.xml$/'));
         }
-        foreach ($container->getParameter('sulu_admin.list.directories') as $directory) {
-            $container->addResource(new DirectoryResource($directory, '/\.xml$/'));
-        }
-        $container->addResource(new DirectoryResource($container->getParameter('sulu_core.webspace.config_dir'), '/\.xml$/'));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
@@ -24,5 +24,9 @@ class FormMetadataCachePass implements CompilerPassInterface
         foreach ($container->getParameter('sulu_admin.forms.directories') as $directory) {
             $container->addResource(new DirectoryResource($directory, '/\.xml$/'));
         }
+        foreach ($container->getParameter('sulu_admin.list.directories') as $directory) {
+            $container->addResource(new DirectoryResource($directory, '/\.xml$/'));
+        }
+        $container->addResource(new DirectoryResource($container->getParameter('sulu_core.webspace.config_dir'), '/\.xml$/'));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/FormMetadataCachePass.php
@@ -24,8 +24,6 @@ class FormMetadataCachePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        $kernelProjectDir = $container->getParameter('kernel.project_dir');
-
         foreach ($container->getParameter('sulu_admin.forms.directories') as $directory) {
             $this->addDirectory($directory, $container);
         }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlFormMetadataLoader.php
@@ -20,42 +20,15 @@ use Symfony\Component\VarExporter\VarExporter;
 class XmlFormMetadataLoader implements FormMetadataLoaderInterface, CacheWarmerInterface
 {
     /**
-     * @var FormXmlLoader
+     * @param array<string> $formDirectories
      */
-    private $formXmlLoader;
-
-    /**
-     * @var FieldMetadataValidatorInterface
-     */
-    private $fieldMetadataValidator;
-
-    /**
-     * @var string[]
-     */
-    private $formDirectories;
-
-    /**
-     * @var string
-     */
-    private $cacheDir;
-
-    /**
-     * @var bool
-     */
-    private $debug;
-
     public function __construct(
-        FormXmlLoader $formXmlLoader,
-        FieldMetadataValidatorInterface $fieldMetadataValidator,
-        array $formDirectories,
-        string $cacheDir,
-        bool $debug
+        private FormXmlLoader $formXmlLoader,
+        private FieldMetadataValidatorInterface $fieldMetadataValidator,
+        private array $formDirectories,
+        private string $cacheDir,
+        private bool $debug
     ) {
-        $this->formXmlLoader = $formXmlLoader;
-        $this->fieldMetadataValidator = $fieldMetadataValidator;
-        $this->formDirectories = $formDirectories;
-        $this->cacheDir = $cacheDir;
-        $this->debug = $debug;
     }
 
     public function getMetadata(string $key, string $locale, array $metadataOptions = []): ?FormMetadata

--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\AdminBundle;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ExposeResourceRoutesPass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\FormMetadataCachePass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\SuluVersionPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -32,6 +33,6 @@ final class SuluAdminBundle extends Bundle
             $container->addCompilerPass(new ExposeResourceRoutesPass());
         }
 
-        $container->addCompilerPass(new FormMetadataCachePass());
+        $container->addCompilerPass(new FormMetadataCachePass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle;
 
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ExposeResourceRoutesPass;
+use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\FormMetadataCachePass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\SuluVersionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -30,5 +31,7 @@ final class SuluAdminBundle extends Bundle
         if ($container->hasExtension('fos_js_routing')) {
             $container->addCompilerPass(new ExposeResourceRoutesPass());
         }
+
+        $container->addCompilerPass(new FormMetadataCachePass());
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -32,7 +32,8 @@ final class SuluAdminBundle extends Bundle
         if ($container->hasExtension('fos_js_routing')) {
             $container->addCompilerPass(new ExposeResourceRoutesPass());
         }
-
-        $container->addCompilerPass(new FormMetadataCachePass(), PassConfig::TYPE_BEFORE_REMOVING);
+        if ($container->getParameter('kernel.debug')) {
+            $container->addCompilerPass(new FormMetadataCachePass(), PassConfig::TYPE_BEFORE_REMOVING);
+        }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8488 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding form metadata xml files to the container so that it re-compiles on form metadata changes.

#### Why?
After various optimizations the hotreload broke.
