### PR TITLE
Improve list handling and fix page_selection issue

### DIFF
--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -267,6 +267,7 @@ class PageRepository implements PageRepositoryInterface
      *     loadGhost?: bool,
      *     parentId?: string|null,
      *     descendantOfId?: string,
+     *     ancestorsOfIds?: string[],
      *     webspaceKey?: string,
      *     page?: int,
      *     limit?: int,
@@ -345,6 +346,22 @@ class PageRepository implements PageRepositoryInterface
                 )
                 ->andWhere('ancestorPage.uuid = :descendantOfId')
                 ->setParameter('descendantOfId', $descendantOfId);
+        }
+
+        $ancestorsOfIds = $filters['ancestorsOfIds'] ?? null;
+        if (null !== $ancestorsOfIds) {
+            Assert::isArray($ancestorsOfIds); // @phpstan-ignore staticMethod.alreadyNarrowedType
+            Assert::allString($ancestorsOfIds); // @phpstan-ignore staticMethod.alreadyNarrowedType
+
+            $queryBuilder
+                ->innerJoin(
+                    PageInterface::class,
+                    'descendantPage',
+                    Join::WITH,
+                    'page.lft < descendantPage.lft AND page.rgt > descendantPage.rgt'
+                )
+                ->andWhere('descendantPage.uuid IN (:ancestorsOfIds)')
+                ->setParameter('ancestorsOfIds', $ancestorsOfIds);
         }
 
         $depth = $filters['depth'] ?? null;

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -394,7 +394,6 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_core.list_builder.field_descriptor_factory'),
                 new Reference('sulu_core.doctrine_list_builder_factory'),
                 new Reference('sulu_core.doctrine_rest_helper'),
-                new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_security.access_control_manager'),
                 new Reference('security.token_storage'),
             ])

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Page\UserInterface\Controller\Admin;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
@@ -70,7 +69,6 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         private FieldDescriptorFactoryInterface $fieldDescriptorFactory,
         private DoctrineListBuilderFactoryInterface $listBuilderFactory,
         private RestHelperInterface $restHelper,
-        private EntityManagerInterface $entityManager,
         private AccessControlManagerInterface $accessControlManager,
         private TokenStorageInterface $tokenStorage,
     ) {
@@ -85,6 +83,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         $excludeGhosts = $request->query->getBoolean('exclude-ghosts', false);
         $excludeShadows = $request->query->getBoolean('exclude-shadows', false);
         $expandedIds = \array_filter(\explode(',', (string) $request->query->get('expandedIds')));
+        $ids = $request->query->get('ids');
 
         $filters = [];
 
@@ -113,6 +112,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
             expandedIds: $expandedIds,
             includedFields: $includedFields,
             listKey: 'pages',
+            filterByParentId: empty($ids),
         );
 
         return new JsonResponse($this->normalizer->normalize(
@@ -295,7 +295,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
             /** @see \Sulu\Page\Application\MessageHandler\MovePageMessageHandler */
             /** @var PageInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
-        } elseif ('copy' == $action) {
+        } elseif ('copy' === $action) {
             $destinationUuid = $request->query->getString('destination');
             $message = new CopyPageMessage(['uuid' => $uuid], ['uuid' => $destinationUuid], $this->getLocale($request));
 
@@ -354,6 +354,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         array $includedFields = [],
         array $groupByFields = [],
         ?string $listKey = null,
+        bool $filterByParentId = true,
     ): CollectionRepresentation {
         $listKey = $listKey ?? $resourceKey;
 
@@ -389,10 +390,43 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         $listBuilder->addSelectField($fieldDescriptors['version']);
         $listBuilder->sort($fieldDescriptors['lft'], 'asc');
 
+        // If no expandedIds provided, return flat list
+        if (empty($expandedIds)) {
+            if ($filterByParentId) {
+                $listBuilder->where($fieldDescriptors['parentId'], $parentId);
+            }
+
+            /** @var mixed[][] $rows */
+            $rows = $listBuilder->execute();
+            $enhancedRows = $this->enhanceRows($rows);
+
+            // Remove tree properties for flat list
+            foreach ($enhancedRows as &$row) {
+                unset($row['rgt']);
+                unset($row['lft']);
+                unset($row['parentId']);
+            }
+
+            return new CollectionRepresentation(
+                $enhancedRows,
+                $resourceKey,
+            );
+        }
+
+        // Generate nested structure when expandedIds are provided
         // collect entities of which the children should be included in the response
+        $pathIds = $parentId
+            ? \iterator_to_array($this->pageRepository->findIdentifiersBy([
+                'ancestorsOfIds' => $expandedIds,
+                'descendantOfId' => $parentId,
+            ]))
+            : \iterator_to_array($this->pageRepository->findIdentifiersBy([
+                'ancestorsOfIds' => $expandedIds,
+            ]));
+
         $idsToExpand = \array_merge(
             [$parentId],
-            $this->findIdsOnPathsBetween($fieldDescriptors['id']->getEntityName(), $parentId, $expandedIds),
+            $pathIds,
             $expandedIds,
         );
 
@@ -415,96 +449,46 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
 
         /** @var mixed[][] $rows */
         $rows = $listBuilder->execute();
+        $enhancedRows = $this->enhanceRows($rows);
 
         return new CollectionRepresentation(
-            $this->generateNestedRows($parentId, $resourceKey, $rows),
+            $this->generateNestedRows($parentId, $resourceKey, $enhancedRows),
             $resourceKey,
         );
     }
 
     /**
-     * @param string[] $endIds
+     * @param mixed[][] $rows
      *
-     * @return mixed[]
+     * @return mixed[][]
      */
-    private function findIdsOnPathsBetween(string $entityClass, int|string|null $startId, array $endIds): array
+    private function enhanceRows(array $rows): array
     {
-        // there are no paths and therefore no ids if we dont have any end-ids
-        if (0 === \count($endIds)) {
-            return [];
-        }
-
-        $queryBuilder = $this->entityManager->createQueryBuilder()
-            ->from($entityClass, 'entity')
-            ->select('entity.uuid');
-
-        // if this start-id is not set we want to include all paths from the root to our end-ids
-        if ($startId) {
-            $queryBuilder->from($entityClass, 'startEntity')
-                ->andWhere('startEntity.uuid = :startIds')
-                ->andWhere('entity.lft > startEntity.lft')
-                ->andWhere('entity.rgt < startEntity.rgt')
-                ->setParameter('startIds', $startId);
-        }
-
-        $queryBuilder->from($entityClass, 'endEntity')
-            ->andWhere('endEntity.uuid IN (:endIds)')
-            ->andWhere('entity.lft < endEntity.lft')
-            ->andWhere('entity.rgt > endEntity.rgt')
-            ->setParameter('endIds', $endIds);
-
-        return \array_map('current', $queryBuilder->getQuery()->getScalarResult()); // @phpstan-ignore argument.type
-    }
-
-    /**
-     * @param mixed[][] $flatRows
-     *
-     * @return mixed[]
-     */
-    private function generateNestedRows(?string $parentId, string $resourceKey, array $flatRows): array
-    {
-        // add hasChildren property that is expected by the sulu frontend
-        foreach ($flatRows as &$row) {
+        foreach ($rows as &$row) {
             /** @var int $lft */
             $lft = $row['lft'];
             $row['hasChildren'] = ($lft + 1) !== $row['rgt'];
         }
 
-        // group rows by the id of their parent
-        $rowsByParentId = [];
-        foreach ($flatRows as &$row) {
-            /** @var string $rowParentId */
-            $rowParentId = $row['parentId'];
-            if (!\array_key_exists($rowParentId, $rowsByParentId)) {
-                $rowsByParentId[$rowParentId] = [];
-            }
-            $rowsByParentId[$rowParentId][] = &$row;
-        }
-
-        // embed children rows int their parent rows
-        foreach ($flatRows as &$row) {
+        foreach ($rows as &$row) {
             // TODO this should be handled by the listbuilder
             $row['publishedState'] = WorkflowInterface::WORKFLOW_PLACE_PUBLISHED === $row['publishedState'];
 
-            // Add permissions data for each row
             /** @var string $rowId */
             $rowId = $row['id'];
             /** @var string $webspaceKey */
             $webspaceKey = $row['webspaceKey'];
 
-            // Get all permissions for the page
             $allPermissions = $this->accessControlManager->getPermissions(
                 Page::class,
                 $rowId
             );
             $row['_hasPermissions'] = !empty($allPermissions);
 
-            // Get user-specific permissions
             if (!empty($allPermissions)) {
                 $token = $this->tokenStorage->getToken();
                 $user = $token?->getUser();
 
-                // Ensure user is compatible with Sulu's UserInterface
                 if ($user instanceof UserInterface) {
                     $permissions = $this->accessControlManager->getUserPermissionByArray(
                         null,
@@ -517,6 +501,31 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
                     $row['_permissions'] = [];
                 }
             }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param mixed[][] $flatRows
+     *
+     * @return mixed[]
+     */
+    private function generateNestedRows(?string $parentId, string $resourceKey, array $flatRows): array
+    {
+        $rowsByParentId = [];
+        foreach ($flatRows as &$row) {
+            /** @var string $rowParentId */
+            $rowParentId = $row['parentId'];
+            if (!\array_key_exists($rowParentId, $rowsByParentId)) {
+                $rowsByParentId[$rowParentId] = [];
+            }
+            $rowsByParentId[$rowParentId][] = &$row;
+        }
+
+        foreach ($flatRows as &$row) {
+            /** @var string $rowId */
+            $rowId = $row['id'];
 
             if (\array_key_exists($rowId, $rowsByParentId)) {
                 $row['_embedded'] = [
@@ -525,7 +534,6 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
             }
         }
 
-        // remove tree related properties from the response
         foreach ($flatRows as &$row) {
             unset($row['rgt']);
             unset($row['lft']);

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -1099,4 +1099,177 @@ class PageControllerTest extends SuluTestCase
         $this->assertEquals('Page 4', $pagesAfter[2]['title'], 'After moving Page 2 to position 4: Page 4 should be at index 2');
         $this->assertEquals('Page 2', $pagesAfter[3]['title'], 'After moving Page 2 to position 4: Page 2 should be at index 3 (position 4)');
     }
+
+    public function testGetListByIdsIncludesNestedPages(): void
+    {
+        self::purgeDatabase();
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
+
+        $rootPage = $this->createPage($homepage->getUuid(), [
+            'template' => 'default',
+            'title' => 'Root Page',
+            'url' => '/root',
+            'locale' => 'en',
+        ]);
+
+        $childPage1 = $this->createPage($rootPage->getUuid(), [
+            'template' => 'default',
+            'title' => 'Child Page 1',
+            'url' => '/root/child1',
+            'locale' => 'en',
+        ]);
+
+        $grandchildPage = $this->createPage($childPage1->getUuid(), [
+            'template' => 'default',
+            'title' => 'Grandchild Page',
+            'url' => '/root/child1/grandchild',
+            'locale' => 'en',
+        ]);
+
+        $childPage2 = $this->createPage($rootPage->getUuid(), [
+            'template' => 'default',
+            'title' => 'Child Page 2',
+            'url' => '/root/child2',
+            'locale' => 'en',
+        ]);
+
+        self::getEntityManager()->clear();
+
+        // Request pages by IDs - this simulates what the page_selection does
+        $ids = \sprintf('%s,%s', $grandchildPage->getUuid(), $childPage2->getUuid());
+        $this->client->request(
+            'GET',
+            \sprintf('/admin/api/pages?locale=en&ids=%s&page=1&flat=true', $ids)
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{_embedded: array{pages?: array<int, array{title: string, id: string}>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pages = $content['_embedded']['pages'] ?? [];
+
+        $this->assertCount(2, $pages, 'Should load both nested pages');
+
+        $pageIds = \array_column($pages, 'id');
+        $this->assertContains($grandchildPage->getUuid(), $pageIds, 'Should include grandchild page');
+        $this->assertContains($childPage2->getUuid(), $pageIds, 'Should include child page 2');
+
+        $titles = \array_column($pages, 'title');
+        $this->assertContains('Grandchild Page', $titles);
+        $this->assertContains('Child Page 2', $titles);
+    }
+
+    public function testFlatListIncludesPermissions(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createHomepage('test-flat-permissions', 'sulu-io');
+        $this->createPage($homepage->getId(), [
+            'title' => 'Test Page 1',
+            'template' => 'default',
+            'url' => '/test1',
+        ]);
+        $this->createPage($homepage->getId(), [
+            'title' => 'Test Page 2',
+            'template' => 'default',
+            'url' => '/test2',
+        ]);
+
+        self::ensureKernelShutdown();
+
+        $this->client->request(
+            'GET',
+            \sprintf('/admin/api/pages?locale=en&webspace=sulu-io&parentId=%s', $homepage->getId())
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{_embedded?: array{pages?: list<array<string, mixed>>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pages = $content['_embedded']['pages'] ?? [];
+
+        $this->assertNotEmpty($pages, 'Should have pages in result');
+        foreach ($pages as $page) {
+            $this->assertArrayHasKey('_hasPermissions', $page, 'Each page should have _hasPermissions field');
+            $this->assertIsBool($page['_hasPermissions'], '_hasPermissions should be boolean');
+
+            if ($page['_hasPermissions']) {
+                $this->assertArrayHasKey('_permissions', $page, 'Pages with permissions should have _permissions array');
+                $this->assertIsArray($page['_permissions'], '_permissions should be array');
+            }
+        }
+    }
+
+    public function testNestedListIncludesPermissions(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createHomepage('test-nested-permissions', 'sulu-io');
+        $parentPage = $this->createPage($homepage->getId(), [
+            'title' => 'Parent Page',
+            'template' => 'default',
+            'url' => '/parent',
+        ]);
+        $this->createPage($parentPage->getId(), [
+            'title' => 'Child Page',
+            'template' => 'default',
+            'url' => '/parent/child',
+        ]);
+
+        self::ensureKernelShutdown();
+
+        $this->client->request(
+            'GET',
+            \sprintf('/admin/api/pages?locale=en&webspace=sulu-io&expandedIds=%s', $homepage->getId())
+        );
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{_embedded?: array{pages?: list<array{_hasPermissions?: bool, _embedded?: array{pages?: list<array<string, mixed>>}}>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pages = $content['_embedded']['pages'] ?? [];
+
+        $this->assertNotEmpty($pages, 'Should have pages in result');
+        $this->assertArrayHasKey('_hasPermissions', $pages[0], 'Root page should have _hasPermissions field');
+
+        $nestedPages = $pages[0]['_embedded']['pages'] ?? [];
+        foreach ($nestedPages as $child) {
+            $this->assertArrayHasKey('_hasPermissions', $child, 'Child pages should have _hasPermissions field');
+        }
+    }
+
+    public function testEnhanceRowsAddsHasChildrenProperty(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createHomepage('test-has-children', 'sulu-io');
+        $parentPage = $this->createPage($homepage->getId(), [
+            'title' => 'Parent Page',
+            'template' => 'default',
+            'url' => '/parent',
+        ]);
+        $this->createPage($parentPage->getId(), [
+            'title' => 'Child Page',
+            'template' => 'default',
+            'url' => '/parent/child',
+        ]);
+
+        self::ensureKernelShutdown();
+
+        $this->client->request(
+            'GET',
+            \sprintf('/admin/api/pages?locale=en&webspace=sulu-io&parentId=%s', $homepage->getId())
+        );
+
+        $response = $this->client->getResponse();
+        /** @var array{_embedded: array{pages: array<int, array{hasChildren: bool}>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pages = $content['_embedded']['pages'];
+
+        $this->assertCount(1, $pages);
+        $this->assertTrue($pages[0]['hasChildren'], 'Parent page should have hasChildren=true');
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/8515
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

  - Refactored PageController to extract permission handling into enhanceRows() method
  - Applied permission enrichment consistently to both flat and nested page lists
  - Added ancestorsOfIds filter to PageRepository for batch ancestor lookups
  - Added test coverage for permission fields (_hasPermissions, _permissions) and hasChildren property

#### Why?

  Permission handling was previously only applied to nested lists inside generateNestedRows(). This refactoring ensures both flat and nested page lists receive consistent permission data (_hasPermissions, _permissions) and other enhancements (hasChildren, publishedState).

The `page_selection` property did not correctly return the selected pages.