### PR TITLE
Fix category resource loader to return category api object

### DIFF
--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Functional\Application\ContentResolver;
 
+use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
 use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Api\Media;
@@ -413,14 +414,14 @@ class ContentResolverTest extends SuluTestCase
         self::assertCount(2, $categorySelection);
 
         $contentCategory1 = $categorySelection[0];
-        self::assertInstanceOf(Category::class, $contentCategory1);
+        self::assertInstanceOf(CategoryWrapper::class, $contentCategory1);
         self::assertSame($category1->getId(), $contentCategory1->getId());
         $contentCategory2 = $categorySelection[1];
-        self::assertInstanceOf(Category::class, $contentCategory2);
+        self::assertInstanceOf(CategoryWrapper::class, $contentCategory2);
         self::assertSame($category2->getId(), $contentCategory2->getId());
 
         $singleCategorySelection = $content['single_category_selection'];
-        self::assertInstanceOf(Category::class, $singleCategorySelection);
+        self::assertInstanceOf(CategoryWrapper::class, $singleCategorySelection);
         self::assertSame($category1->getId(), $singleCategorySelection->getId());
 
         /** @var mixed[] $excerpt */
@@ -429,10 +430,10 @@ class ContentResolverTest extends SuluTestCase
         self::assertIsArray($excerptCategories);
         self::assertCount(2, $excerptCategories);
         $excerptCategory1 = $excerptCategories[0];
-        self::assertInstanceOf(Category::class, $excerptCategory1);
+        self::assertInstanceOf(CategoryWrapper::class, $excerptCategory1);
         self::assertSame($category1->getId(), $excerptCategory1->getId());
         $excerptCategory2 = $excerptCategories[1];
-        self::assertInstanceOf(Category::class, $excerptCategory2);
+        self::assertInstanceOf(CategoryWrapper::class, $excerptCategory2);
         self::assertSame($category2->getId(), $excerptCategory2->getId());
     }
 

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sulu\Content\Tests\Functional\Application\ContentResolver;
 
 use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
-use Sulu\Bundle\CategoryBundle\Entity\Category;
 use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoader.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoader.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader;
 
+use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 
@@ -26,7 +27,7 @@ class CategoryResourceLoader implements ResourceLoaderInterface
     public const RESOURCE_LOADER_KEY = 'category';
 
     public function __construct(
-        private CategoryManagerInterface $categoryManager
+        private CategoryManagerInterface $categoryManager,
     ) {
     }
 
@@ -36,7 +37,7 @@ class CategoryResourceLoader implements ResourceLoaderInterface
 
         $mappedResult = [];
         foreach ($result as $category) {
-            $mappedResult[$category->getId()] = $category;
+            $mappedResult[$category->getId()] = new CategoryWrapper($category, $locale);
         }
 
         return $mappedResult;

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoaderTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/CategoryResourceLoaderTest.php
@@ -14,8 +14,10 @@ namespace Sulu\Bundle\CategoryBundle\Tests\Unit\Infrastructure\Sulu\Content\Reso
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
 use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Bundle\CategoryBundle\Entity\Category;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslation;
 use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 
@@ -58,7 +60,12 @@ class CategoryResourceLoaderTest extends TestCase
         $this->assertSame([
             1 => $category1,
             3 => $category2,
-        ], $result);
+        ], \array_map(function($object) {
+            $this->assertInstanceOf(CategoryWrapper::class, $object);
+            $this->assertSame('en', $object->getLocale());
+
+            return $object->getEntity();
+        }, $result));
     }
 
     private static function createCategory(int $id): Category
@@ -66,6 +73,11 @@ class CategoryResourceLoaderTest extends TestCase
         $category = new Category();
         static::setPrivateProperty($category, 'id', $id);
         $category->setKey('category-' . $id);
+
+        $categoryTranslation = new CategoryTranslation();
+        $categoryTranslation->setCategory($category);
+        $categoryTranslation->setLocale('en');
+        $category->addTranslation($categoryTranslation);
 
         return $category;
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/8524
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix category resource loader to return category api object.

#### Why?

See https://github.com/sulu/sulu/issues/8524