### PR TITLE
Fix SmartContent property mapping for Taxonomy data

### DIFF
--- a/packages/content/src/Application/ContentResolver/Resolver/ExcerptTaxonomyResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ExcerptTaxonomyResolver.php
@@ -27,6 +27,8 @@ use Sulu\Content\Domain\Model\TaxonomyInterface;
 
 readonly class ExcerptTaxonomyResolver implements ResolverInterface
 {
+    private const TAXONOMY_FIELDS = ['categories', 'tags', 'segment', 'audienceTargetGroups'];
+
     public function __construct(
         private MetadataProviderInterface $formMetadataProvider,
         private MetadataResolver $metadataResolver,
@@ -85,7 +87,12 @@ readonly class ExcerptTaxonomyResolver implements ResolverInterface
         $filteredProperties = [];
         foreach ($properties as $key => $value) {
             if (\str_starts_with((string) $value, self::getPrefix())) {
-                $normalizedValue = 'excerpt/' . \substr((string) $value, \strlen(self::getPrefix()));
+                $suffix = \substr((string) $value, \strlen(self::getPrefix()));
+
+                $normalizedValue = match (true) {
+                    \in_array($suffix, self::TAXONOMY_FIELDS, true) => 'excerpt' . \ucfirst($suffix),
+                    default => 'excerpt/' . $suffix,
+                };
                 $filteredProperties[$key] = $normalizedValue;
             }
         }

--- a/packages/content/tests/Application/config/templates/examples/default-example-smart-content.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-example-smart-content.xml
@@ -73,6 +73,8 @@
                     <param name="description" value="description"/>
                     <param name="excerptTitle" value="excerpt.title"/>
                     <param name="excerptDescription" value="excerpt.description"/>
+                    <param name="excerptCategories" value="excerpt.categories"/>
+                    <param name="excerptTags" value="excerpt.tags"/>
                     <param name="seoTitle" value="seo.title"/>
                     <param name="seoDescription" value="seo.description"/>
                 </param>

--- a/packages/content/tests/Functional/Application/ContentResolver/SmartContentContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/SmartContentContentResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Functional\Application\ContentResolver;
 
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzer as SuluRequestAnalyzer;
@@ -126,6 +127,10 @@ class SmartContentContentResolverTest extends SuluTestCase
 
     public function testResolveExampleSmartContentWithProperties(): void
     {
+        $category = self::createCategory(['key' => 'test-cat']);
+        $tag = self::createTag(['name' => 'test-tag']);
+        static::getEntityManager()->flush();
+
         $example0 = static::createExample(
             [
                 'en' => [
@@ -138,6 +143,8 @@ class SmartContentContentResolverTest extends SuluTestCase
                             'title' => 'excerpt-example-title-0',
                             'description' => 'excerpt-example-description-0',
                         ],
+                        'excerptCategories' => [$category->getId()],
+                        'excerptTags' => [$tag->getName()],
                         'seo' => [
                             'title' => 'seo-example-title-0',
                             'description' => 'seo-example-description-0',
@@ -183,7 +190,7 @@ class SmartContentContentResolverTest extends SuluTestCase
         $examplesWithProps = $content['examples_with_properties'];
         self::assertCount(1, $examplesWithProps);
 
-        /** @var array{id: int, title: string, description: string, excerptTitle: string, excerptDescription: string, seoTitle: string, seoDescription: string} $example */
+        /** @var array{id: int, title: string, description: string, excerptTitle: string, excerptDescription: string, excerptCategories: array<int, CategoryInterface>, excerptTags: array<int, string>, seoTitle: string, seoDescription: string} $example */
         $example = $examplesWithProps[0];
         self::assertSame($example0->getId(), $example['id']);
         self::assertSame('Example 0', $example['title']);
@@ -192,8 +199,11 @@ class SmartContentContentResolverTest extends SuluTestCase
         self::assertSame('excerpt-example-description-0', $example['excerptDescription']);
         self::assertSame('seo-example-title-0', $example['seoTitle']);
         self::assertSame('seo-example-description-0', $example['seoDescription']);
+        self::assertCount(1, $example['excerptCategories']);
+        self::assertCount(1, $example['excerptTags']);
+        self::assertSame($category->getId(), $example['excerptCategories'][0]->getId());
+        self::assertSame($tag->getName(), $example['excerptTags'][0]);
 
-        // Check view information for smart content with properties
         /** @var array<string, mixed> $view */
         $view = $result['view'];
         self::assertArrayHasKey('examples_with_properties', $view);


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes https://github.com/sulu/sulu/issues/8519
  | License | MIT

  #### What's in this PR?

  Fixes SmartContent property mapping for taxonomy data (categories, tags, segment, audienceTargetGroups) in the `ExcerptTaxonomyResolver`.

  #### Why?

  When using SmartContent with property mappings like `excerpt.categories` or `excerpt.tags`, the resolver incorrectly normalized these to `excerpt/categories` format instead of the expected `excerptCategories` format. This caused taxonomy data to not be properly resolved and returned in SmartContent results.

  The fix adds special handling for taxonomy fields to use the correct camelCase property format (e.g., `excerptCategories`, `excerptTags`) instead of the path-based format used for other excerpt properties.
