### PR TITLE
Fix block duplication MobX invariant violation

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -363,9 +363,33 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     @action duplicateBlocks = async(indexes: Array<number>, insertAfterIndex: number) => {
         const {generateBlockIds, onChange, onDisplaySnackbar, value} = this.props;
 
-        if (!value) {
+        if (!value || indexes.length === 0) {
             return;
         }
+
+        // Validate maximum limit before any operations
+        if (value.length + indexes.length > (this.props.maxOccurs || Infinity)) {
+            throw new Error('The maximum amount of blocks has already been reached!');
+        }
+
+        const insertionIndex = insertAfterIndex + 1;
+
+        // Update tracking arrays BEFORE async operations (must be in action context)
+        this.expandedBlocks.splice(
+            insertionIndex,
+            0,
+            ...indexes.map(() => true)
+        );
+        this.selectedBlocks.splice(
+            insertionIndex,
+            0,
+            ...indexes.map(() => false)
+        );
+        this.generatedBlockIds.splice(
+            insertionIndex,
+            0,
+            ...indexes.map(() => ++BlockCollection.idCounter)
+        );
 
         // Generate all IDs upfront in a single batch request
         let generatedIds = [];
@@ -373,38 +397,24 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
             generatedIds = await generateBlockIds(indexes.length);
         }
 
-        let newValue = [...value];
-
-        for (let count = 0; count < indexes.length; count++) {
-            const index = indexes[count];
-            if (this.hasMaximumReached) {
-                // TODO throw snackbar message or maybe its not required as fillArrays already refill the array
-                throw new Error('The maximum amount of blocks has already been reached!');
-            }
-
-            const currentInsertAfterIndex = insertAfterIndex + count;
-
-            this.expandedBlocks.splice(currentInsertAfterIndex, 0, true);
-            this.selectedBlocks.splice(currentInsertAfterIndex, 0, false);
-            this.generatedBlockIds.splice(currentInsertAfterIndex, 0, ++BlockCollection.idCounter);
-
-            const elementsBefore = newValue.slice(0, currentInsertAfterIndex);
-            const elementsAfter = newValue.slice(currentInsertAfterIndex);
-
+        // Build all duplicated blocks from the ORIGINAL value array
+        const duplicatedBlocks = indexes.map((sourceIndex, count) => {
             // Remove all _id fields (including nested ones) from the duplicated block
             const duplicatedBlock = generateBlockIds
-                ? this.removeBlockIds(toJS(newValue[index]))
-                : {...toJS(newValue[index])};
+                ? this.removeBlockIds(toJS(value[sourceIndex]))
+                : {...toJS(value[sourceIndex])};
 
             // Assign new ID to top-level block
             if (generateBlockIds && generatedIds.length > count) {
                 duplicatedBlock._id = generatedIds[count];
             }
 
-            newValue = [...elementsBefore, duplicatedBlock, ...elementsAfter];
-        }
+            return duplicatedBlock;
+        });
 
-        onChange(newValue);
+        const elementsBefore = value.slice(0, insertionIndex);
+        const elementsAfter = value.slice(insertionIndex);
+        onChange([...elementsBefore, ...duplicatedBlocks, ...elementsAfter]);
 
         if (onDisplaySnackbar) {
             onDisplaySnackbar({

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -1300,6 +1300,153 @@ test('Duplicate selected blocks via the BlockToolbar', () => {
     expect(changeSpy).toBeCalledWith([...value, ...value]);
 });
 
+test('Duplicate multiple non-contiguous blocks correctly', async() => {
+    const changeSpy = jest.fn();
+    const generateBlockIdsSpy = jest.fn().mockResolvedValue(['id1', 'id2']);
+
+    const types = {
+        type1: 'Type 1',
+        type2: 'Type 2',
+        type3: 'Type 3',
+        type4: 'Type 4',
+    };
+
+    const value = [
+        {type: 'type1', content: 'Block 0'},
+        {type: 'type2', content: 'Block 1'},
+        {type: 'type3', content: 'Block 2'},
+        {type: 'type4', content: 'Block 3'},
+    ];
+
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            generateBlockIds={generateBlockIdsSpy}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            types={types}
+            value={value}
+        />
+    );
+
+    const instance = blockCollection.instance();
+
+    await instance.duplicateBlocks([0, 2], value.length);
+
+    expect(generateBlockIdsSpy).toBeCalledWith(2);
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+
+    const newValue = changeSpy.mock.calls[0][0];
+    expect(newValue).toHaveLength(6);
+    expect(newValue[0].content).toBe('Block 0');
+    expect(newValue[1].content).toBe('Block 1');
+    expect(newValue[2].content).toBe('Block 2');
+    expect(newValue[3].content).toBe('Block 3');
+    expect(newValue[4].content).toBe('Block 0');
+    expect(newValue[4]._id).toBe('id1');
+    expect(newValue[5].content).toBe('Block 2');
+    expect(newValue[5]._id).toBe('id2');
+});
+
+test('Duplicate single block maintains correct position', async() => {
+    const changeSpy = jest.fn();
+
+    const types = {
+        type1: 'Type 1',
+        type2: 'Type 2',
+        type3: 'Type 3',
+    };
+
+    const value = [
+        {type: 'type1', content: 'Block 0'},
+        {type: 'type2', content: 'Block 1'},
+        {type: 'type3', content: 'Block 2'},
+    ];
+
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            types={types}
+            value={value}
+        />
+    );
+
+    const instance = blockCollection.instance();
+
+    await instance.duplicateBlocks([1], 1);
+
+    const newValue = changeSpy.mock.calls[0][0];
+    expect(newValue).toHaveLength(4);
+    expect(newValue[0].content).toBe('Block 0');
+    expect(newValue[1].content).toBe('Block 1');
+    expect(newValue[2].content).toBe('Block 1');
+    expect(newValue[3].content).toBe('Block 2');
+});
+
+test('Tracking arrays stay synchronized after block duplication', async() => {
+    const changeSpy = jest.fn();
+
+    const types = {
+        type1: 'Type 1',
+        type2: 'Type 2',
+    };
+
+    const value = [
+        {type: 'type1', content: 'Block 0'},
+        {type: 'type2', content: 'Block 1'},
+    ];
+
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            types={types}
+            value={value}
+        />
+    );
+
+    const instance = blockCollection.instance();
+
+    await instance.duplicateBlocks([0, 1], value.length);
+
+    const newValue = changeSpy.mock.calls[0][0];
+
+    expect(instance.expandedBlocks).toHaveLength(newValue.length);
+    expect(instance.selectedBlocks).toHaveLength(newValue.length);
+    expect(instance.generatedBlockIds).toHaveLength(newValue.length);
+
+    expect(instance.expandedBlocks[2]).toBe(true);
+    expect(instance.expandedBlocks[3]).toBe(true);
+
+    expect(instance.selectedBlocks[2]).toBe(false);
+    expect(instance.selectedBlocks[3]).toBe(false);
+});
+
+test('Empty selection does not trigger duplication', async() => {
+    const changeSpy = jest.fn();
+
+    const value = [{type: 'type1', content: 'Block 0'}];
+
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            types={{type1: 'Type 1'}}
+            value={value}
+        />
+    );
+
+    const instance = blockCollection.instance();
+
+    await instance.duplicateBlocks([], 0);
+
+    expect(changeSpy).not.toHaveBeenCalled();
+});
+
 test('Cut selected blocks via the BlockToolbar', () => {
     const changeSpy = jest.fn();
     const clipboardSpy = jest.fn();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The duplicateBlocks() method had multiple critical bugs:

1. Loop-based array reconstruction used stale indexes - when duplicating blocks [0, 2], the second iteration referenced the wrong block because newValue was growing during the loop

2. MobX tracking array splices happened AFTER await, losing the action context and causing invariant violations in MobX 4

3. Mid-loop validation could leave component in inconsistent state

Fixed by following the handlePasteBlocks pattern:
- Update tracking arrays BEFORE async operations (in action context)
- Map duplicated blocks from ORIGINAL value array (not mutating newValue)
- Reconstruct value array ONCE at the end
- Renamed insertAfterIndex to insertionIndex for clarity
- handleDuplicateBlock now passes index + 1 for correct insertion position

#### Why?

See issue #8521
