### PR TITLE
Fix teaser presentAs for 3.0

### DIFF
--- a/packages/content/src/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolver.php
@@ -22,7 +22,7 @@ class TeaserSelectionPropertyResolver implements PropertyResolverInterface
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
         $returnedParams = [
-            ...(\is_array($data) && isset($data['presentsAs']) && \is_string($data['presentsAs']) ? ['presentsAs' => $data['presentsAs']] : ['presentsAs' => null]),
+            ...(\is_array($data) && isset($data['presentAs']) && \is_string($data['presentAs']) ? ['presentAs' => $data['presentAs']] : ['presentAs' => null]),
             ...$params,
         ];
         unset($returnedParams['metadata']);

--- a/packages/content/src/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolver.php
@@ -15,29 +15,33 @@ namespace Sulu\Content\Application\PropertyResolver\Resolver;
 
 use Sulu\Bundle\AdminBundle\Teaser\Teaser;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Content\Application\ResourceLoader\Loader\TeaserResourceLoader;
 
 class TeaserSelectionPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        $returnedParams = [
-            ...(\is_array($data) && isset($data['presentAs']) && \is_string($data['presentAs']) ? ['presentAs' => $data['presentAs']] : ['presentAs' => null]),
+        $view = [
+            'presentAs' => \is_array($data) && isset($data['presentAs']) && \is_string($data['presentAs']) ? $data['presentAs'] : null,
+            'items' => [],
             ...$params,
         ];
-        unset($returnedParams['metadata']);
+        unset($view['metadata'], $view['present_as']);
 
         if (
             !\is_array($data)
             || !\array_key_exists('items', $data)
             || !\is_array($data['items'])
         ) {
-            return ContentView::create([], $returnedParams);
+            return ContentView::create([], $view);
         }
 
         $resourceLoaderKey = isset($params['resourceLoader']) && \is_string($params['resourceLoader']) ? $params['resourceLoader'] : TeaserResourceLoader::getKey();
 
-        $contentViews = [];
+        /** @var list<array{id: string, type: string}> $items */
+        $items = [];
+        $resolvableResources = [];
         foreach ($data['items'] as $item) {
             if (!\is_array($item)
                 || !\array_key_exists('id', $item)
@@ -50,22 +54,27 @@ class TeaserSelectionPropertyResolver implements PropertyResolverInterface
 
             $type = $item['type'];
             $id = $item['id'];
+            /** @var array<string, mixed> $itemData */
+            $itemData = $item;
 
-            $contentViews[] = ContentView::createResolvable(
+            $items[] = [
+                'id' => $id,
+                'type' => $type,
+            ];
+
+            $resolvableResources[] = new ResolvableResource(
                 id: $type . '::' . $id,
                 resourceLoaderKey: $resourceLoaderKey,
-                view: [
-                    'id' => $id,
-                    'type' => $type,
-                ],
                 priority: -50,
-                closure: static function(Teaser $resource) use ($item) {
-                    return $resource->merge($item);
+                resourceCallback: static function(Teaser $resource) use ($itemData): Teaser {
+                    return $resource->merge($itemData);
                 }
             );
         }
 
-        return ContentView::create($contentViews, $returnedParams);
+        $view['items'] = $items;
+
+        return ContentView::create($resolvableResources, $view);
     }
 
     public static function getType(): string

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolverTest.php
@@ -33,7 +33,7 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en');
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['presentsAs' => null], $contentView->getView());
+        $this->assertSame(['presentAs' => null], $contentView->getView());
     }
 
     public function testResolveWrongData(): void
@@ -41,7 +41,7 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve(['source' => 1], 'en');
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['presentsAs' => null], $contentView->getView());
+        $this->assertSame(['presentAs' => null], $contentView->getView());
     }
 
     public function testResolveParams(): void
@@ -49,13 +49,13 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['presentsAs' => null, 'custom' => 'params'], $contentView->getView());
+        $this->assertSame(['presentAs' => null, 'custom' => 'params'], $contentView->getView());
     }
 
     public function testResolveData(): void
     {
         $data = [
-            'presentsAs' => 'two-columns',
+            'presentAs' => 'two-columns',
             'items' => [
                 ['id' => '123', 'type' => 'article'],
                 ['id' => '456', 'type' => 'page'],
@@ -84,7 +84,7 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $this->assertSame('teaser', $resolvableResource->getResourceLoaderKey());
         $this->assertSame(['id' => '456', 'type' => 'page'], $innerContentView2->getView());
 
-        $this->assertSame(['presentsAs' => 'two-columns'], $contentView->getView());
+        $this->assertSame(['presentAs' => 'two-columns'], $contentView->getView());
     }
 
     public function testResolveCustomResourceLoader(): void

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/TeaserSelectionPropertyResolverTest.php
@@ -15,7 +15,6 @@ namespace Sulu\Content\Tests\Unit\Content\Application\PropertyResolver\Resolver;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Teaser\Teaser;
-use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Content\Application\PropertyResolver\Resolver\TeaserSelectionPropertyResolver;
 
@@ -33,7 +32,7 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en');
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['presentAs' => null], $contentView->getView());
+        $this->assertSame(['presentAs' => null, 'items' => []], $contentView->getView());
     }
 
     public function testResolveWrongData(): void
@@ -41,7 +40,7 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve(['source' => 1], 'en');
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['presentAs' => null], $contentView->getView());
+        $this->assertSame(['presentAs' => null, 'items' => []], $contentView->getView());
     }
 
     public function testResolveParams(): void
@@ -49,7 +48,7 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
 
         $this->assertSame([], $contentView->getContent());
-        $this->assertSame(['presentAs' => null, 'custom' => 'params'], $contentView->getView());
+        $this->assertSame(['presentAs' => null, 'items' => [], 'custom' => 'params'], $contentView->getView());
     }
 
     public function testResolveData(): void
@@ -68,23 +67,22 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $this->assertIsArray($content);
         $this->assertCount(2, $content);
 
-        $innerContentView1 = $content[0];
-        $this->assertInstanceOf(ContentView::class, $innerContentView1);
-        $resolvableResource = $innerContentView1->getContent();
-        $this->assertInstanceOf(ResolvableResource::class, $resolvableResource);
-        $this->assertSame('article::123', $resolvableResource->getId());
-        $this->assertSame('teaser', $resolvableResource->getResourceLoaderKey());
-        $this->assertSame(['id' => '123', 'type' => 'article'], $innerContentView1->getView());
+        $resolvable1 = $content[0];
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable1);
+        $this->assertSame('article::123', $resolvable1->getId());
+        $this->assertSame('teaser', $resolvable1->getResourceLoaderKey());
 
-        $innerContentView2 = $content[1];
-        $this->assertInstanceOf(ContentView::class, $innerContentView2);
-        $resolvableResource = $innerContentView2->getContent();
-        $this->assertInstanceOf(ResolvableResource::class, $resolvableResource);
-        $this->assertSame('page::456', $resolvableResource->getId());
-        $this->assertSame('teaser', $resolvableResource->getResourceLoaderKey());
-        $this->assertSame(['id' => '456', 'type' => 'page'], $innerContentView2->getView());
+        $resolvable2 = $content[1];
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable2);
+        $this->assertSame('page::456', $resolvable2->getId());
+        $this->assertSame('teaser', $resolvable2->getResourceLoaderKey());
 
-        $this->assertSame(['presentAs' => 'two-columns'], $contentView->getView());
+        $view = $contentView->getView();
+        $this->assertSame('two-columns', $view['presentAs']);
+        $this->assertIsArray($view['items']);
+        $this->assertCount(2, $view['items']);
+        $this->assertSame(['id' => '123', 'type' => 'article'], $view['items'][0]);
+        $this->assertSame(['id' => '456', 'type' => 'page'], $view['items'][1]);
     }
 
     public function testResolveCustomResourceLoader(): void
@@ -101,9 +99,7 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $this->assertIsArray($content);
         $this->assertCount(1, $content);
 
-        $innerContent = $content[0];
-        $this->assertInstanceOf(ContentView::class, $innerContent);
-        $resolvable = $innerContent->getContent();
+        $resolvable = $content[0];
         $this->assertInstanceOf(ResolvableResource::class, $resolvable);
         $this->assertSame('article::123', $resolvable->getId());
         $this->assertSame('custom_teaser', $resolvable->getResourceLoaderKey());
@@ -129,9 +125,7 @@ class TeaserSelectionPropertyResolverTest extends TestCase
         $this->assertIsArray($content);
         $this->assertCount(1, $content);
 
-        $innerContent = $content[0];
-        $this->assertInstanceOf(ContentView::class, $innerContent);
-        $resolvable = $innerContent->getContent();
+        $resolvable = $content[0];
         $this->assertInstanceOf(ResolvableResource::class, $resolvable);
         $this->assertSame('article::123', $resolvable->getId());
         $this->assertSame('teaser', $resolvable->getResourceLoaderKey());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adjusted `presentsAs` to `presentAs`.

#### Why?

For the Sulu 3.0 update the `presentAs` was wrongfully implemented as `presentsAs`, therefore the documentation was not aligned anymore. This PR adjusts it to be consistent with Sulu 2.6