### PR TITLE
Add functional tests for displayOption and presentAs properties

### DIFF
--- a/packages/content/tests/Application/config/templates/examples/default-example-teaser.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-example-teaser.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default-example-teaser</key>
+
+    <view>@ExampleTest/examples/default</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Example with Teaser</title>
+        <title lang="de">Example with Teaser</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="route">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="teasers" type="teaser_selection">
+            <meta>
+                <title lang="en">Teasers</title>
+                <title lang="de">Anreiser</title>
+            </meta>
+
+            <params>
+                <param name="present_as" type="collection">
+                    <param name="one-column">
+                        <meta>
+                            <title lang="en">1 Column</title>
+                            <title lang="de">1 Spalte</title>
+                        </meta>
+                    </param>
+                    <param name="two-columns">
+                        <meta>
+                            <title lang="en">2 Columns</title>
+                            <title lang="de">2 Spalten</title>
+                        </meta>
+                    </param>
+                    <param name="three-columns">
+                        <meta>
+                            <title lang="en">3 Columns</title>
+                            <title lang="de">3 Spalten</title>
+                        </meta>
+                    </param>
+                </param>
+            </params>
+        </property>
+    </properties>
+</template>

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Functional\Application\ContentResolver;
 
+use Sulu\Bundle\AdminBundle\Teaser\Teaser;
 use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
 use Sulu\Bundle\MediaBundle\Api\Collection;
 use Sulu\Bundle\MediaBundle\Api\Media;
@@ -322,6 +323,86 @@ class ContentResolverTest extends SuluTestCase
         $contentMedia2 = $excerpt['image'];
         self::assertInstanceOf(Media::class, $contentMedia2);
         self::assertSame($media2->getId(), $contentMedia2->getId());
+
+        $view = $result['view'];
+        /** @var array{ids: int[], displayOption: string|null} $mediaSelectionView */
+        $mediaSelectionView = $view['media_selection'];
+        self::assertSame('left', $mediaSelectionView['displayOption']);
+        self::assertSame([$media1->getId(), $media2->getId(), $media3->getId()], $mediaSelectionView['ids']);
+
+        /** @var array{id: int|null, displayOption: string|null} $singleMediaSelectionView */
+        $singleMediaSelectionView = $view['single_media_selection'];
+        self::assertSame('left', $singleMediaSelectionView['displayOption']);
+        self::assertSame($media1->getId(), $singleMediaSelectionView['id']);
+    }
+
+    public function testResolveTeaserSelection(): void
+    {
+        $example1 = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Example 1',
+                    'url' => '/example-1',
+                    'description' => 'First example description',
+                ],
+            ],
+        ]);
+
+        $example2 = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Example 2',
+                    'url' => '/example-2',
+                    'description' => 'Second example description',
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-teaser',
+                    'title' => 'Teaser Page',
+                    'url' => '/teaser-page',
+                    'teasers' => [
+                        'presentAs' => 'two-columns',
+                        'items' => [
+                            ['id' => (string) $example1->getId(), 'type' => 'examples'],
+                            ['id' => (string) $example2->getId(), 'type' => 'examples'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        $content = $result['content'];
+        self::assertArrayHasKey('teasers', $content);
+        $teasers = $content['teasers'];
+        self::assertIsArray($teasers);
+        self::assertCount(2, $teasers);
+
+        $teaser1 = $teasers[0];
+        self::assertInstanceOf(Teaser::class, $teaser1);
+        self::assertSame('Example 1', $teaser1->getTitle());
+
+        $teaser2 = $teasers[1];
+        self::assertInstanceOf(Teaser::class, $teaser2);
+        self::assertSame('Example 2', $teaser2->getTitle());
+
+        $view = $result['view'];
+        /** @var array{presentAs: string|null, items: array<int, array<string, mixed>>} $teasersView */
+        $teasersView = $view['teasers'];
+        self::assertSame('two-columns', $teasersView['presentAs']);
+        self::assertCount(2, $teasersView['items']);
     }
 
     public function testResolveCollections(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| License | MIT

#### What's in this PR?

Adds functional tests for `presentAs` and `displayOptions`.

#### Why?

To prevent regressions