### PR TITLE
Backmerge 3.0 DoctrineListBuilderTest file to 2.6 for easier upmerges

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -118,7 +118,7 @@ class AccessControlQueryEnhancer implements AccessControlQueryEnhancerInterface
         $ids = \array_column($result, 'id');
 
         if (\count($ids) > 0) {
-            $queryBuilder->andWhere(\sprintf('%s.id NOT IN (:accessControlIds)', $entityAlias));
+            $queryBuilder->andWhere(\sprintf('(%s.id NOT IN (:accessControlIds) OR %s.id IS NULL)', $entityAlias, $entityAlias));
             $queryBuilder->setParameter('accessControlIds', $ids);
         }
     }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -28,6 +28,8 @@ use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\AbstractDoctrineExpressi
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineAndExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineBetweenExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineInExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNotNullExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNullExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineNotExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineOrExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineWhereExpression;
@@ -912,5 +914,23 @@ class DoctrineListBuilder extends AbstractListBuilder
     {
         return $field instanceof DoctrineCountFieldDescriptor
             || $field instanceof DoctrineGroupConcatFieldDescriptor;
+    }
+
+    public function createIsNullExpression(FieldDescriptorInterface $fieldDescriptor)
+    {
+        if (!$fieldDescriptor instanceof DoctrineFieldDescriptorInterface) {
+            throw new InvalidExpressionArgumentException('is_null', 'fieldDescriptor');
+        }
+
+        return new DoctrineIsNullExpression($fieldDescriptor);
+    }
+
+    public function createIsNotNullExpression(FieldDescriptorInterface $fieldDescriptor)
+    {
+        if (!$fieldDescriptor instanceof DoctrineFieldDescriptorInterface) {
+            throw new InvalidExpressionArgumentException('is_not_null', 'fieldDescriptor');
+        }
+
+        return new DoctrineIsNotNullExpression($fieldDescriptor);
     }
 }

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -35,6 +35,8 @@ use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineOrExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineWhereExpression;
 use Sulu\Component\Rest\ListBuilder\Expression\Exception\InvalidExpressionArgumentException;
 use Sulu\Component\Rest\ListBuilder\Expression\ExpressionInterface;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNotNullExpressionInterface;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNullExpressionInterface;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry;
 use Sulu\Component\Security\Authentication\UserInterface;
@@ -916,6 +918,9 @@ class DoctrineListBuilder extends AbstractListBuilder
             || $field instanceof DoctrineGroupConcatFieldDescriptor;
     }
 
+    /**
+     * @return IsNullExpressionInterface
+     */
     public function createIsNullExpression(FieldDescriptorInterface $fieldDescriptor)
     {
         if (!$fieldDescriptor instanceof DoctrineFieldDescriptorInterface) {
@@ -925,6 +930,9 @@ class DoctrineListBuilder extends AbstractListBuilder
         return new DoctrineIsNullExpression($fieldDescriptor);
     }
 
+    /**
+     * @return IsNotNullExpressionInterface
+     */
     public function createIsNotNullExpression(FieldDescriptorInterface $fieldDescriptor)
     {
         if (!$fieldDescriptor instanceof DoctrineFieldDescriptorInterface) {

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineIsNotNullExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineIsNotNullExpression.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNotNullExpressionInterface;
+
+class DoctrineIsNotNullExpression extends AbstractDoctrineExpression implements IsNotNullExpressionInterface
+{
+    public function __construct(protected DoctrineFieldDescriptorInterface $field)
+    {
+    }
+
+    public function getStatement(QueryBuilder $queryBuilder)
+    {
+        return $this->field->getSelect() . ' IS NOT NULL';
+    }
+
+    public function getFieldName()
+    {
+        return $this->field->getName();
+    }
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineIsNullExpression.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/Doctrine/DoctrineIsNullExpression.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNullExpressionInterface;
+
+class DoctrineIsNullExpression extends AbstractDoctrineExpression implements IsNullExpressionInterface
+{
+    public function __construct(protected DoctrineFieldDescriptorInterface $field)
+    {
+    }
+
+    public function getStatement(QueryBuilder $queryBuilder)
+    {
+        return $this->field->getSelect() . ' IS NULL';
+    }
+
+    public function getFieldName()
+    {
+        return $this->field->getName();
+    }
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/IsNotNullExpressionInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/IsNotNullExpressionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression;
+
+/**
+ * Interfaces which provides the needed information to build an in-expression.
+ */
+interface IsNotNullExpressionInterface extends BasicExpressionInterface
+{
+}

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/IsNullExpressionInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/IsNullExpressionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\ListBuilder\Expression;
+
+/**
+ * Interfaces which provides the needed information to build an in-expression.
+ */
+interface IsNullExpressionInterface extends BasicExpressionInterface
+{
+}

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -11,9 +11,9 @@
 
 namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Doctrine;
 
+use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
@@ -81,7 +81,7 @@ class DoctrineListBuilderTest extends TestCase
     private $queryBuilder;
 
     /**
-     * @var ObjectProphecy<Query<int, object>>
+     * @var ObjectProphecy<AbstractQuery>
      */
     private $query;
 
@@ -127,7 +127,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->entityManager = $this->prophesize(EntityManager::class);
         $this->filterTypeRegistry = $this->prophesize(FilterTypeRegistry::class);
         $this->queryBuilder = $this->prophesize(QueryBuilder::class);
-        $this->query = $this->prophesize(Query::class); // @phpstan-ignore-line assign.propertyType
+        $this->query = $this->prophesize(AbstractQuery::class); // @phpstan-ignore-line assign.propertyType
         $this->classMetadata = $this->prophesize(ClassMetadata::class); // @phpstan-ignore-line assign.propertyType
 
         $this->entityManager->createQueryBuilder()->willReturn($this->queryBuilder->reveal());
@@ -1300,11 +1300,11 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
 
         $queryBuilder1 = $this->prophesize(QueryBuilder::class);
-        $query1 = $this->prophesize(Query::class);
+        $query1 = $this->prophesize(AbstractQuery::class);
         $queryBuilder2 = $this->prophesize(QueryBuilder::class);
-        $query2 = $this->prophesize(Query::class);
+        $query2 = $this->prophesize(AbstractQuery::class);
         $queryBuilder3 = $this->prophesize(QueryBuilder::class);
-        $query3 = $this->prophesize(Query::class);
+        $query3 = $this->prophesize(AbstractQuery::class);
         $this->entityManager->createQueryBuilder()->willReturn(
             $queryBuilder1->reveal(),
             $queryBuilder2->reveal(),
@@ -1575,7 +1575,7 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->setParameter('permission', 64)
             ->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(Query::class);
+        $accessQuery = $this->prophesize(AbstractQuery::class);
         $accessQueryBuilder->getQuery()
             ->willReturn($accessQueryBuilder->reveal())
             ->willReturn($accessQuery->reveal());
@@ -1661,7 +1661,7 @@ class DoctrineListBuilderTest extends TestCase
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(Query::class);
+        $accessQuery = $this->prophesize(AbstractQuery::class);
         $accessQueryBuilder->getQuery()
             ->willReturn($accessQueryBuilder->reveal())
             ->willReturn($accessQuery->reveal());
@@ -1744,7 +1744,7 @@ class DoctrineListBuilderTest extends TestCase
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(Query::class);
+        $accessQuery = $this->prophesize(AbstractQuery::class);
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
@@ -1834,7 +1834,7 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->setParameter('roleIds', [1])->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
         $accessQueryBuilder->setParameter('permission', 64)->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(Query::class);
+        $accessQuery = $this->prophesize(AbstractQuery::class);
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -11,12 +11,11 @@
 
 namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Doctrine;
 
-use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\Persistence\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -36,6 +35,8 @@ use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescri
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescriptor;
 use Sulu\Component\Rest\ListBuilder\Event\ListBuilderCreateEvent;
 use Sulu\Component\Rest\ListBuilder\Event\ListBuilderEvents;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNotNullExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNullExpression;
 use Sulu\Component\Rest\ListBuilder\FieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeInterface;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry;
@@ -70,7 +71,7 @@ class DoctrineListBuilderTest extends TestCase
     private $entityManager;
 
     /**
-     * @var ObjectProphecy<ClassMetadata>
+     * @var ObjectProphecy<ClassMetadata<object>>
      */
     private $classMetadata;
 
@@ -80,7 +81,7 @@ class DoctrineListBuilderTest extends TestCase
     private $queryBuilder;
 
     /**
-     * @var ObjectProphecy<AbstractQuery>
+     * @var ObjectProphecy<Query<int, object>>
      */
     private $query;
 
@@ -126,8 +127,8 @@ class DoctrineListBuilderTest extends TestCase
         $this->entityManager = $this->prophesize(EntityManager::class);
         $this->filterTypeRegistry = $this->prophesize(FilterTypeRegistry::class);
         $this->queryBuilder = $this->prophesize(QueryBuilder::class);
-        $this->query = $this->prophesize(AbstractQuery::class);
-        $this->classMetadata = $this->prophesize(ClassMetadata::class);
+        $this->query = $this->prophesize(Query::class); // @phpstan-ignore-line assign.propertyType
+        $this->classMetadata = $this->prophesize(ClassMetadata::class); // @phpstan-ignore-line assign.propertyType
 
         $this->entityManager->createQueryBuilder()->willReturn($this->queryBuilder->reveal());
         $this->entityManager->getClassMetadata(Argument::any())
@@ -155,7 +156,7 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->doctrineListBuilder = new DoctrineListBuilder(
             $this->entityManager->reveal(),
-            self::$entityName,
+            self::$entityName, // @phpstan-ignore-line
             $this->filterTypeRegistry->reveal(),
             $this->eventDispatcher->reveal(),
             [PermissionTypes::VIEW => 64],
@@ -182,9 +183,13 @@ class DoctrineListBuilderTest extends TestCase
             ]
         );
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name_alias')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.desc AS desc_alias')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.desc AS desc_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -199,19 +204,27 @@ class DoctrineListBuilderTest extends TestCase
             ]
         );
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name_alias')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.desc AS desc_alias')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.test AS test_alias')->shouldNotBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.desc AS desc_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.test AS test_alias')->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
 
     public function testIdSelect(): void
     {
-        $this->queryBuilder->select(self::$entityNameAlias . '.id AS id')->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->select(self::$entityNameAlias . '.id AS id')->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -239,9 +252,11 @@ class DoctrineListBuilderTest extends TestCase
             )
         );
 
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
         // no joins should be made
-        $this->queryBuilder->leftJoin(Argument::cetera())->shouldNotBeCalled();
-        $this->queryBuilder->innerJoin(Argument::cetera())->shouldNotBeCalled();
+        $this->queryBuilder->leftJoin(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
+        $this->queryBuilder->innerJoin(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         $this->findIdsByGivenCriteria->invoke($this->doctrineListBuilder);
     }
@@ -271,19 +286,21 @@ class DoctrineListBuilderTest extends TestCase
             )
         );
 
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
         $this->queryBuilder->innerJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             DoctrineJoinDescriptor::JOIN_CONDITION_METHOD_WITH,
             ''
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->innerJoin(
             'anotherEntityName.translations',
             'anotherEntityName',
             DoctrineJoinDescriptor::JOIN_CONDITION_METHOD_WITH,
             ''
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->findIdsByGivenCriteria->invoke($this->doctrineListBuilder);
     }
@@ -309,22 +326,24 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->addSelectField($fieldDescriptor);
         $this->doctrineListBuilder->where($fieldDescriptor, 'test');
 
-        $this->queryBuilder->andWhere(Argument::containingString('anotherEntityName.name = :name_alias'))->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 'test')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->andWhere(Argument::containingString('anotherEntityName.name = :name_alias'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 'test')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->leftJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             DoctrineJoinDescriptor::JOIN_CONDITION_METHOD_WITH,
             ''
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->leftJoin(
             'anotherEntityName.translations',
             'anotherEntityName',
             DoctrineJoinDescriptor::JOIN_CONDITION_METHOD_WITH,
             ''
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->findIdsByGivenCriteria->invoke($this->doctrineListBuilder);
     }
@@ -334,9 +353,14 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->addSelectField(new DoctrineFieldDescriptor('name', 'name_alias', self::$entityName));
         $this->doctrineListBuilder->addSelectField(new DoctrineFieldDescriptor('desc', 'desc_alias', self::$entityName));
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name_alias')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.desc AS desc_alias')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.desc AS desc_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -347,10 +371,15 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->addSelectField(new DoctrineFieldDescriptor('desc', 'desc_alias', self::$entityName));
         $this->doctrineListBuilder->addSelectField(new FieldDescriptor('test', 'test_alias', self::$entityName));
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name_alias')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.desc AS desc_alias')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.test AS test_alias')->shouldNotBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.desc AS desc_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.test AS test_alias')->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -367,14 +396,19 @@ class DoctrineListBuilderTest extends TestCase
             )
         );
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$translationEntityNameAlias . '.desc AS desc_alias')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$translationEntityNameAlias . '.desc AS desc_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->leftJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             'WITH',
             ''
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -383,14 +417,19 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->queryBuilder->getDQL()->willReturn('SELECT * FROM table WHERE locale = :locale AND parent = :parent');
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->setParameter('locale', 'de');
         $this->doctrineListBuilder->setParameter('parent', '7');
         $this->doctrineListBuilder->setParameter('webspace', 'sulu');
 
-        $this->queryBuilder->setParameter('locale', 'de')->shouldBeCalled();
-        $this->queryBuilder->setParameter('parent', '7')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('locale', 'de')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('parent', '7')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('webspace', Argument::any())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
@@ -407,9 +446,9 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->setParameter('parent', '7');
         $this->doctrineListBuilder->setParameter('webspace', 'sulu');
 
-        $this->queryBuilder->setParameter('locale', 'de')->shouldBeCalled();
-        $this->queryBuilder->setParameter('parent', '7')->shouldBeCalled();
-        $this->queryBuilder->setParameter('webspace', Argument::any())->shouldNotBeCalled();
+        $this->queryBuilder->setParameter('locale', 'de')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('parent', '7')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('webspace', Argument::any())->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->count();
     }
@@ -426,7 +465,12 @@ class DoctrineListBuilderTest extends TestCase
             )
         );
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         // join is only needed in the preselect query, not in the main query. therefore it should be added a one time
         $this->queryBuilder->leftJoin(
@@ -434,7 +478,7 @@ class DoctrineListBuilderTest extends TestCase
             self::$translationEntityNameAlias,
             'WITH',
             ''
-        )->shouldBeCalledTimes(1);
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
 
         $this->doctrineListBuilder->execute();
     }
@@ -452,18 +496,23 @@ class DoctrineListBuilderTest extends TestCase
             'test-name'
         );
 
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
         // join is only needed in the preselect query, not in the main query. therefore it should be added a one time
         $this->queryBuilder->leftJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             'WITH',
             ''
-        )->shouldBeCalledTimes(1);
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-name')->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-name')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -480,16 +529,21 @@ class DoctrineListBuilderTest extends TestCase
             )
         );
 
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
         // join is only needed in the main query, not in the preselect query. therefore it should be added a one time
         $this->queryBuilder->leftJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             'WITH',
             ''
-        )->shouldBeCalledTimes(1);
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.name AS name')->shouldBeCalledTimes(1);
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.name AS name')->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
 
         $this->doctrineListBuilder->execute();
     }
@@ -506,22 +560,26 @@ class DoctrineListBuilderTest extends TestCase
             )
         );
 
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
         // join should be added two times: one time in the preselect query and one time in the main query
         $this->queryBuilder->leftJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             'WITH',
             ''
-        )->shouldBeCalledTimes(2);
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(2);
 
         $this->queryBuilder->getDQLPart('select')->willReturn([]);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         // will be called for preselect query
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.desc AS desc_alias')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.desc AS desc_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         // will be called for result (should not be displayed)
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.desc AS HIDDEN desc_alias')->shouldBeCalled();
-        $this->queryBuilder->addOrderBy('desc_alias', 'ASC')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_ExampleTranslation.desc AS HIDDEN desc_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy('desc_alias', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -536,12 +594,17 @@ class DoctrineListBuilderTest extends TestCase
         );
         $this->doctrineListBuilder->search('value');
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->andWhere(
             '(' . self::$translationEntityNameAlias . '.desc LIKE :search OR ' . self::$entityNameAlias . '.name LIKE :search)'
-        )->shouldBeCalled();
-        $this->queryBuilder->setParameter('search', '%value%')->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('search', '%value%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -555,14 +618,19 @@ class DoctrineListBuilderTest extends TestCase
             new DoctrineFieldDescriptor('name', 'name', self::$entityName)
         );
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->search('val*e');
 
         $this->queryBuilder->andWhere(
             '(' . self::$translationEntityNameAlias . '.desc LIKE :search OR ' . self::$entityNameAlias . '.name LIKE :search)'
-        )->shouldBeCalled();
-        $this->queryBuilder->setParameter('search', '%val%e%')->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('search', '%val%e%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -582,7 +650,12 @@ class DoctrineListBuilderTest extends TestCase
         ]);
         $this->doctrineListBuilder->filter(['name' => 'value']);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $filterType->filter($this->doctrineListBuilder, $nameFieldDescriptor, 'value')->shouldBeCalled();
 
@@ -605,12 +678,16 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->queryBuilder->getDQLPart('select')->willReturn([]);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         // will be called for result (should not be displayed)
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS HIDDEN desc')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS HIDDEN desc')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         // will be called for id query
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->shouldBeCalled();
-        $this->queryBuilder->addOrderBy('desc', 'ASC')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy('desc', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -621,12 +698,16 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->queryBuilder->getDQLPart('select')->willReturn([new Select('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')]);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         // will NOT be called for result (should not be displayed)
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS HIDDEN desc')->shouldNotBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS HIDDEN desc')->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
         // will be called for id query
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->shouldBeCalled();
-        $this->queryBuilder->addOrderBy('desc', 'ASC')->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy('desc', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -641,9 +722,13 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName));
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->shouldBeCalledTimes(1);
-        $this->queryBuilder->addOrderBy('desc', 'ASC')->shouldBeCalledTimes(2);
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
+        $this->queryBuilder->addOrderBy('desc', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(2);
 
         $this->doctrineListBuilder->execute();
     }
@@ -658,9 +743,13 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName), 'ASC');
         $this->doctrineListBuilder->sort(new DoctrineFieldDescriptor('desc', 'desc', self::$entityName), 'DESC');
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->shouldBeCalledTimes(1);
-        $this->queryBuilder->addOrderBy('desc', 'DESC')->shouldBeCalledTimes(2);
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.desc AS desc')->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
+        $this->queryBuilder->addOrderBy('desc', 'DESC')->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(2);
 
         $this->doctrineListBuilder->execute();
     }
@@ -668,9 +757,14 @@ class DoctrineListBuilderTest extends TestCase
     public function testSortWithoutDefault(): void
     {
         // when no sort is applied, results should be orderd by id by default
-        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -687,25 +781,36 @@ class DoctrineListBuilderTest extends TestCase
             'name_desc'
         ));
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect($select)->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect($select)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $selectExpression = $this->prophesize(Select::class);
         $selectExpression->getParts()->willReturn([$select]);
-        $this->queryBuilder->getDQLPart('select')->willReturn([$selectExpression->reveal()]);
+        $this->queryBuilder->getDQLPart('select')->willReturn($this->queryBuilder->reveal())->willReturn([$selectExpression->reveal()]);
+
+        $this->queryBuilder->addOrderBy('name_desc', 'ASC')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalledTimes(2);
 
         $this->doctrineListBuilder->execute();
-
-        $this->queryBuilder->addOrderBy('name_desc', 'ASC')->shouldHaveBeenCalledTimes(2);
     }
 
     public function testLimit(): void
     {
         $this->doctrineListBuilder->limit(5);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setMaxResults(5)->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
-        $this->queryBuilder->setFirstResult(0)->shouldBeCalled();
+        $this->queryBuilder->setFirstResult(0)->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
 
         $this->doctrineListBuilder->execute();
     }
@@ -714,11 +819,16 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setIds([11, 22]);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('id'), [11, 22])->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('id'), [11, 22])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -727,10 +837,15 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setIds([]);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString(' IS NULL')
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -739,10 +854,15 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setIds(null);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
-        )->shouldNotBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -751,11 +871,16 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setExcludedIds([55, 99]);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('id'), [55, 99])->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('id'), [55, 99])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('NOT(Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -764,10 +889,15 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setExcludedIds([]);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('NOT(Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
-        )->shouldNotBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -776,10 +906,15 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->setExcludedIds(null);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('NOT(Sulu_Bundle_CoreBundle_Entity_Example.id IN (:id')
-        )->shouldNotBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -806,12 +941,12 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->doctrineListBuilder->limit(5);
 
-        $this->queryBuilder->andWhere(Argument::cetera())->shouldBeCalled();
-        $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
-        $this->queryBuilder->leftJoin(Argument::cetera())->shouldBeCalledTimes(1);
-        $this->queryBuilder->setParameter(Argument::cetera())->shouldBeCalledTimes(1);
-        $this->queryBuilder->setMaxResults(Argument::cetera())->shouldNotBeCalled();
-        $this->queryBuilder->setFirstResult(Argument::cetera())->shouldNotBeCalled();
+        $this->queryBuilder->andWhere(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
+        $this->queryBuilder->leftJoin(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
+        $this->queryBuilder->setParameter(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
+        $this->queryBuilder->setMaxResults(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
+        $this->queryBuilder->setFirstResult(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->count();
     }
@@ -828,17 +963,22 @@ class DoctrineListBuilderTest extends TestCase
             'desc_id' => 1,
         ];
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS desc_id')->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('title'), 3)->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('desc'), 1)->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS desc_id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('title'), 3)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('desc'), 1)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id = :title_id')
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id = :desc_id')
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         foreach ($filter as $key => $value) {
             $this->doctrineListBuilder->addSelectField($fieldDescriptors[$key]);
@@ -866,16 +1006,21 @@ class DoctrineListBuilderTest extends TestCase
             'title_id' => null,
         ];
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('title_id'), Argument::any())->shouldNotBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('title_id'), Argument::any())->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
 
         foreach ($filter as $key => $value) {
             $this->doctrineListBuilder->addSelectField($fieldDescriptors[$key]);
             $this->doctrineListBuilder->where($fieldDescriptors[$key], $value);
         }
 
-        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')->shouldBeCalled();
+        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -890,8 +1035,13 @@ class DoctrineListBuilderTest extends TestCase
             'title_id' => null,
         ];
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('title_id'), Argument::any())->shouldNotBeCalled();
 
         foreach ($filter as $key => $value) {
@@ -899,7 +1049,7 @@ class DoctrineListBuilderTest extends TestCase
             $this->doctrineListBuilder->where($fieldDescriptors[$key], $value, ListBuilderInterface::WHERE_COMPARATOR_UNEQUAL);
         }
 
-        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id IS NOT NULL)')->shouldBeCalled();
+        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id IS NOT NULL)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -916,17 +1066,22 @@ class DoctrineListBuilderTest extends TestCase
             'desc_id' => 1,
         ];
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS desc_id')->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('title_id'), 3)->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('desc_id'), 1)->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS desc_id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('title_id'), 3)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('desc_id'), 1)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id != :title_id')
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id != :desc_id')
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         foreach ($filter as $key => $value) {
             $this->doctrineListBuilder->addSelectField($fieldDescriptors[$key]);
@@ -948,12 +1103,17 @@ class DoctrineListBuilderTest extends TestCase
     {
         $fieldDescriptor = new DoctrineFieldDescriptor('id', 'title_id', self::$entityName);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('title_id'), [1, 2])->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS title_id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('title_id'), [1, 2])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.id IN (:title_id')
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->addSelectField($fieldDescriptor);
         $this->doctrineListBuilder->in($fieldDescriptor, [1, 2]);
@@ -986,13 +1146,18 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->doctrineListBuilder->setSelectFields($fieldDescriptors);
 
-        $this->queryBuilder->addSelect('. AS ')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addSelect('. AS ')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         // not necessary for id join
-        $this->queryBuilder->leftJoin('a.test', 'a', 'WITH', '')->shouldBeCalled();
+        $this->queryBuilder->leftJoin('a.test', 'a', 'WITH', '')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         // called when select ids and for selecting data
-        $this->queryBuilder->innerJoin('b.test', 'b', 'WITH', '')->shouldBeCalled();
+        $this->queryBuilder->innerJoin('b.test', 'b', 'WITH', '')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1017,15 +1182,20 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->doctrineListBuilder->setSelectFields($fieldDescriptors);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->leftJoin(
             self::$translationEntityName,
             self::$translationEntityNameAlias,
             'WITH',
             'alias.id = translation.id'
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1050,15 +1220,20 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->doctrineListBuilder->setSelectFields($fieldDescriptors);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.name AS name')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->leftJoin(
             self::$translationEntityName,
             self::$translationEntityNameAlias,
             'WITH',
             'alias.id = translation.id'
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1097,20 +1272,26 @@ class DoctrineListBuilderTest extends TestCase
             ),
         ];
         $this->doctrineListBuilder->setSelectFields($fieldDescriptors);
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('. AS ')->shouldBeCalled();
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('. AS ')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->leftJoin(
             self::$entityName . '1',
             self::$entityNameAlias . '1',
             DoctrineJoinDescriptor::JOIN_CONDITION_METHOD_WITH,
             'field1 = value1'
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->innerJoin(
             self::$entityName . '2',
             self::$entityNameAlias . '2',
             DoctrineJoinDescriptor::JOIN_CONDITION_METHOD_ON,
             'field2 = value2'
-        )->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->doctrineListBuilder->execute();
     }
 
@@ -1119,11 +1300,11 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
 
         $queryBuilder1 = $this->prophesize(QueryBuilder::class);
-        $query1 = $this->prophesize(AbstractQuery::class);
+        $query1 = $this->prophesize(Query::class);
         $queryBuilder2 = $this->prophesize(QueryBuilder::class);
-        $query2 = $this->prophesize(AbstractQuery::class);
+        $query2 = $this->prophesize(Query::class);
         $queryBuilder3 = $this->prophesize(QueryBuilder::class);
-        $query3 = $this->prophesize(AbstractQuery::class);
+        $query3 = $this->prophesize(Query::class);
         $this->entityManager->createQueryBuilder()->willReturn(
             $queryBuilder1->reveal(),
             $queryBuilder2->reveal(),
@@ -1217,13 +1398,18 @@ class DoctrineListBuilderTest extends TestCase
     {
         $nameFieldDescriptor = new DoctrineFieldDescriptor('name', 'name_alias', self::$entityName);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.name AS name_alias')->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.name AS name_alias')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(
             Argument::containingString('Sulu_Bundle_CoreBundle_Entity_Example.name BETWEEN :name_alias')
-        )->shouldBeCalledTimes(1);
-        $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 0)->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 1)->shouldBeCalled();
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
+        $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 0)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 1)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->setSelectFields(
             [
@@ -1240,18 +1426,26 @@ class DoctrineListBuilderTest extends TestCase
     {
         $this->doctrineListBuilder->distinct(true);
 
-        $this->queryBuilder->distinct(true)->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->distinct(true)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
 
     public function testNoDistinct(): void
     {
-        $this->queryBuilder->distinct(false)->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1264,9 +1458,13 @@ class DoctrineListBuilderTest extends TestCase
 
         $this->doctrineListBuilder->setIdField($idField->reveal());
 
-        $this->queryBuilder->select('example.id AS id')->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
-        $this->queryBuilder->addSelect('example.id AS id')->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
-        $this->queryBuilder->where('example.id IN (:ids)')->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->addOrderBy('example.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->select('example.id AS id')->shouldBeCalled()->willReturn($this->queryBuilder->reveal())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->addSelect('example.id AS id')->shouldBeCalled()->willReturn($this->queryBuilder->reveal())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where('example.id IN (:ids)')->shouldBeCalled()->willReturn($this->queryBuilder->reveal())->willReturn($this->queryBuilder->reveal());
 
         $this->doctrineListBuilder->execute();
     }
@@ -1290,6 +1488,10 @@ class DoctrineListBuilderTest extends TestCase
             ],
         ]);
 
+        $this->queryBuilder->addOrderBy('example.uuid', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
         $this->queryBuilder->addSelect('example.uuid AS other')->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
         $this->queryBuilder->where('example.uuid IN (:ids)')->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
 
@@ -1298,6 +1500,10 @@ class DoctrineListBuilderTest extends TestCase
 
     public function testNoIdField(): void
     {
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
         $this->queryBuilder
             ->addSelect('Sulu_Bundle_CoreBundle_Entity_Example.id AS id')
             ->shouldBeCalled()
@@ -1336,34 +1542,57 @@ class DoctrineListBuilderTest extends TestCase
             ->willReturn($accessQueryBuilder->reveal());
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('entityClass', self::$entityName)->shouldBeCalled();
+        $accessQueryBuilder->setParameter('entityClass', self::$entityName)
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
         $accessQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
-        )->shouldBeCalled();
+        )
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin('accessControl.role', 'role')->shouldBeCalled();
+        $accessQueryBuilder->innerJoin('accessControl.role', 'role')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        )->shouldBeCalled();
-
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
-
-        $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
-        $accessQueryBuilder->setParameter('permission', 64)->shouldBeCalled();
-
-        $accessQuery = $this->prophesize(AbstractQuery::class);
-        $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
-        $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
-
-        $this->queryBuilder->andWhere('Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds)')
+        )
+            ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
+        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->setParameter('roleIds', [1])
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+        $accessQueryBuilder->setParameter('permission', 64)
+            ->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
+
+        $accessQuery = $this->prophesize(Query::class);
+        $accessQueryBuilder->getQuery()
+            ->willReturn($accessQueryBuilder->reveal())
+            ->willReturn($accessQuery->reveal());
+        $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds) OR Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('accessControlIds', [42])
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1396,36 +1625,60 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->select('entity.id')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('entityClass', self::$entityName)->shouldBeCalled();
+        $accessQueryBuilder->setParameter('entityClass', self::$entityName)
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
         $accessQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityIdInteger = entity.id'
-        )->shouldBeCalled();
+        )
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin('accessControl.role', 'role')->shouldBeCalled();
+        $accessQueryBuilder->innerJoin('accessControl.role', 'role')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        )->shouldBeCalled();
-
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
-
-        $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
-        $accessQueryBuilder->setParameter('permission', 64)->shouldBeCalled();
-
-        $accessQuery = $this->prophesize(AbstractQuery::class);
-        $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
-        $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
-
-        $this->queryBuilder->andWhere('Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds)')
+        )
+            ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
+        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->setParameter('roleIds', [1])
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+        $accessQueryBuilder->setParameter('permission', 64)
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQuery = $this->prophesize(Query::class);
+        $accessQueryBuilder->getQuery()
+            ->willReturn($accessQueryBuilder->reveal())
+            ->willReturn($accessQuery->reveal());
+        $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds) OR Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('accessControlIds', [42])
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1454,36 +1707,59 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->select('entity.id')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('entityClass', \stdClass::class)->shouldBeCalled();
+        $accessQueryBuilder->setParameter('entityClass', \stdClass::class)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $accessQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
-        )->shouldBeCalled();
+        )
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin('accessControl.role', 'role')->shouldBeCalled();
+        $accessQueryBuilder->innerJoin('accessControl.role', 'role')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        )->shouldBeCalled();
+        )
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
+        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')
+            ->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
-        $accessQueryBuilder->setParameter('permission', 64)->shouldBeCalled();
+        $accessQueryBuilder->setParameter('roleIds', [1])
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+        $accessQueryBuilder->setParameter('permission', 64)
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(AbstractQuery::class);
+        $accessQuery = $this->prophesize(Query::class);
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
-        $this->queryBuilder->andWhere(\stdClass::class . '.id NOT IN (:accessControlIds)')
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(stdClass.id NOT IN (:accessControlIds) OR stdClass.id IS NULL)')
+            ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
-        $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
+        $this->queryBuilder->setParameter('accessControlIds', [42])
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1524,33 +1800,51 @@ class DoctrineListBuilderTest extends TestCase
         $accessQueryBuilder->select('entity.id')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('entityClass', \stdClass::class)->shouldBeCalled();
+        $accessQueryBuilder->setParameter('entityClass', \stdClass::class)
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
         $accessQueryBuilder->innerJoin(
             AccessControl::class,
             'accessControl',
             'WITH',
             'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
-        )->shouldBeCalled();
+        )
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin('accessControl.role', 'role')->shouldBeCalled();
+        $accessQueryBuilder->innerJoin('accessControl.role', 'role')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
         $accessQueryBuilder->andWhere(
             'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        )->shouldBeCalled();
+        )
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')->shouldBeCalled();
+        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('roleIds', [1])->shouldBeCalled();
-        $accessQueryBuilder->setParameter('permission', 64)->shouldBeCalled();
+        $accessQueryBuilder->setParameter('roleIds', [1])->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
+        $accessQueryBuilder->setParameter('permission', 64)->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(AbstractQuery::class);
+        $accessQuery = $this->prophesize(Query::class);
         $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
         $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
 
-        $this->queryBuilder->andWhere(\stdClass::class . '.id NOT IN (:accessControlIds)')
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(stdClass.id NOT IN (:accessControlIds) OR stdClass.id IS NULL)')
+            ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
         $this->queryBuilder->leftJoin(
@@ -1558,11 +1852,41 @@ class DoctrineListBuilderTest extends TestCase
             'MyTest',
             'ON',
             'stdClass.id = MyTest.id'
-        )->shouldBeCalled();
+        )
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
-        $this->queryBuilder->setParameter('accessControlIds', [42])->shouldBeCalled();
+        $this->queryBuilder->setParameter('accessControlIds', [42])
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
+    }
+
+    public function testCreateIsNullExpression(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('test', 'test', self::$entityName);
+        $this->queryBuilder->addOrderBy(Argument::cetera())
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldNotBeCalled();
+
+        $expression = $this->doctrineListBuilder->createIsNullExpression($fieldDescriptor);
+
+        $this->assertInstanceOf(DoctrineIsNullExpression::class, $expression);
+        $this->assertEquals('test', $expression->getFieldName());
+    }
+
+    public function testCreateIsNotNullExpression(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('test', 'test', self::$entityName);
+        $this->queryBuilder->addOrderBy(Argument::cetera())
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldNotBeCalled();
+
+        $expression = $this->doctrineListBuilder->createIsNotNullExpression($fieldDescriptor);
+
+        $this->assertInstanceOf(DoctrineIsNotNullExpression::class, $expression);
+        $this->assertEquals('test', $expression->getFieldName());
     }
 
     public function testPaginationWithJoinsAppliesDistinct(): void
@@ -1584,19 +1908,22 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->where($fieldDescriptor, 'test-value');
 
         // The ID subquery should call distinct(true) because JOINs are present
-        $this->queryBuilder->distinct(true)->shouldBeCalledTimes(1);
+        $this->queryBuilder->distinct(true)->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
         // The final query should call distinct(false) (default behavior)
-        $this->queryBuilder->distinct(false)->shouldBeCalledTimes(1);
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-value')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-value')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->leftJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             'WITH',
             ''
-        )->shouldBeCalledTimes(1);
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1608,13 +1935,16 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->where($fieldDescriptor, 'test-value');
 
         // distinct(true) should NOT be called for ID subquery
-        $this->queryBuilder->distinct(true)->shouldNotBeCalled();
+        $this->queryBuilder->distinct(true)->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
         // Only distinct(false) should be called for the final query
-        $this->queryBuilder->distinct(false)->shouldBeCalledTimes(1);
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(1);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
-        $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->shouldBeCalled();
-        $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-value')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-value')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1625,9 +1955,12 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->distinct(true);
 
         // distinct(true) should be called twice: once for ID subquery, once for final query
-        $this->queryBuilder->distinct(true)->shouldBeCalledTimes(2);
+        $this->queryBuilder->distinct(true)->willReturn($this->queryBuilder->reveal())->shouldBeCalledTimes(2);
 
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1653,9 +1986,9 @@ class DoctrineListBuilderTest extends TestCase
 
         // Verify COUNT(DISTINCT ...) is used in the select
         $this->queryBuilder->select(Argument::containingString('COUNT(DISTINCT'))->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
-        $this->queryBuilder->leftJoin(Argument::cetera())->shouldBeCalled();
-        $this->queryBuilder->andWhere(Argument::cetera())->shouldBeCalled();
-        $this->queryBuilder->setParameter('search', '%value%')->shouldBeCalled();
+        $this->queryBuilder->leftJoin(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('search', '%value%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineIsNotNullExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineIsNotNullExpressionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNotNullExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNotNullExpressionInterface;
+
+class DoctrineIsNotNullExpressionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<QueryBuilder>
+     */
+    private ObjectProphecy $queryBuilder;
+
+    /**
+     * @var string
+     */
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
+
+    protected function setUp(): void
+    {
+        $this->queryBuilder = $this->prophesize(QueryBuilder::class);
+    }
+
+    public function testImplementsInterface(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNotNullExpression($fieldDescriptor);
+
+        $interfaces = \class_implements($expression);
+        $this->assertContains(IsNotNullExpressionInterface::class, $interfaces);
+    }
+
+    public function testGetStatement(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNotNullExpression($fieldDescriptor);
+
+        $statement = $expression->getStatement($this->queryBuilder->reveal());
+
+        $this->assertSame('Sulu_Bundle_CoreBundle_Entity_Example.name IS NOT NULL', $statement);
+    }
+
+    public function testGetFieldName(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNotNullExpression($fieldDescriptor);
+
+        $fieldName = $expression->getFieldName();
+
+        $this->assertSame('name', $fieldName);
+    }
+
+    public function testQueryBuilderNotModified(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNotNullExpression($fieldDescriptor);
+
+        // The QueryBuilder should not have any methods called on it
+        $statement = $expression->getStatement($this->queryBuilder->reveal());
+
+        // Just verify that we got a statement back and it contains expected content
+        $this->assertNotEmpty($statement);
+        $this->assertStringContainsString('IS NOT NULL', $statement);
+    }
+}

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineIsNullExpressionTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Expression/Doctrine/DoctrineIsNullExpressionTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Expression\Doctrine;
+
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Expression\Doctrine\DoctrineIsNullExpression;
+use Sulu\Component\Rest\ListBuilder\Expression\IsNullExpressionInterface;
+
+class DoctrineIsNullExpressionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<QueryBuilder>
+     */
+    private ObjectProphecy $queryBuilder;
+
+    /**
+     * @var string
+     */
+    private static $entityName = 'Sulu\Bundle\CoreBundle\Entity\Example';
+
+    protected function setUp(): void
+    {
+        $this->queryBuilder = $this->prophesize(QueryBuilder::class);
+    }
+
+    public function testImplementsInterface(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNullExpression($fieldDescriptor);
+
+        $interfaces = \class_implements($expression);
+        $this->assertContains(IsNullExpressionInterface::class, $interfaces);
+    }
+
+    public function testGetStatement(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNullExpression($fieldDescriptor);
+
+        $statement = $expression->getStatement($this->queryBuilder->reveal());
+
+        $this->assertSame('Sulu_Bundle_CoreBundle_Entity_Example.name IS NULL', $statement);
+    }
+
+    public function testGetFieldName(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNullExpression($fieldDescriptor);
+
+        $fieldName = $expression->getFieldName();
+
+        $this->assertSame('name', $fieldName);
+    }
+
+    public function testQueryBuilderNotModified(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor('name', 'name', self::$entityName);
+        $expression = new DoctrineIsNullExpression($fieldDescriptor);
+
+        // The QueryBuilder should not have any methods called on it
+        $statement = $expression->getStatement($this->queryBuilder->reveal());
+
+        // Just verify that we got a statement back
+        $this->assertNotEmpty($statement);
+        $this->assertStringContainsString('IS NULL', $statement);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Backmerge 3.0 `DoctrineListBuilderTest` file to 2.6 for easier upmerges.

This also includes:

 - `DoctrineIsNullExpression`
 - `DoctrineIsNotNullExpression`
 - changes in `AccessControlQueryEnhancer` from https://github.com/sulu/sulu/pull/8319/changes#r2514457121

#### Why?

During Doctrine ORM 3 upgrades for Sulu 3.0 the tests had to add a lot of willReturn because of the new `: static` return types of ORM 3.

Merging fixes of the list builder from 2.6 to 3.0 makes a lot of troubles because lot of merge conflicts happening now. There should speak nothing against copy the whole 3.0 Test file to 2.6 to avoid this conflicts.