### PR TITLE
Fix ordering of localization routes

### DIFF
--- a/packages/content/src/UserInterface/Controller/Website/ContentController.php
+++ b/packages/content/src/UserInterface/Controller/Website/ContentController.php
@@ -174,6 +174,25 @@ class ContentController extends AbstractController
             return [];
         }
 
+        $webspaceLocales = $this->container->get('sulu_core.webspace.webspace_manager')
+            ->getWebspaceCollection()
+            ->getWebspace($webspaceKey)
+            ?->getAllLocalizations() ?? [];
+
+        $localizations = [];
+        foreach ($webspaceLocales as $webspaceLocale) {
+            $locale = $webspaceLocale->getLocale(Localization::UNDERSCORE);
+            $localizations[$locale] = [
+                'url' => $this->container->get('sulu_route.route_generator')->generate(
+                    '/',
+                    $locale,
+                    $webspaceKey,
+                ),
+                'locale' => $locale,
+                'alternate' => false,
+            ];
+        }
+
         $routes = [];
         foreach ($this->container->get('sulu_route.route_repository')->findBy([
             'resourceKey' => $object::getResourceKey(),
@@ -183,7 +202,6 @@ class ContentController extends AbstractController
             $routes[] = $route;
         }
 
-        $localizations = [];
         foreach ($routes as $route) {
             $locale = $route->getLocale();
             $localizations[$locale] = [
@@ -194,28 +212,6 @@ class ContentController extends AbstractController
                 ),
                 'locale' => $locale,
                 'alternate' => true,
-            ];
-        }
-
-        $webspaceLocales = $this->container->get('sulu_core.webspace.webspace_manager')
-            ->getWebspaceCollection()
-            ->getWebspace($webspaceKey)
-            ?->getAllLocalizations() ?? [];
-
-        foreach ($webspaceLocales as $webspaceLocale) {
-            $locale = $webspaceLocale->getLocale(Localization::UNDERSCORE);
-            if (\array_key_exists($locale, $localizations)) {
-                continue;
-            }
-
-            $localizations[$locale] = [
-                'url' => $this->container->get('sulu_route.route_generator')->generate(
-                    '/',
-                    $locale,
-                    $webspaceKey,
-                ),
-                'locale' => $locale,
-                'alternate' => false,
             ];
         }
 

--- a/packages/content/tests/Functional/Integration/ExampleControllerTest.php
+++ b/packages/content/tests/Functional/Integration/ExampleControllerTest.php
@@ -138,8 +138,8 @@ class ExampleControllerTest extends SuluTestCase
         });
 
         $this->assertSame([
-            'en' => '/en/my-example',
             'de' => '/',
+            'en' => '/en/my-example',
         ], $urls);
 
         return $id;


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Fixed inconsistent ordering of localization routes in ContentController
  - Ensured locales always appear in the same order as defined in webspace configuration
  - Initialize all webspace locales first, then replace with actual route URLs where they exist

  #### Why?

  The previous implementation iterated over routes first and then added missing locales from the webspace configuration. This caused the locales to appear in inconsistent order depending on the order routes were returned from the repository. By initializing all webspace locales first (pointing to homepage `/` with `alternate=false`), then replacing them with actual route URLs where routes exist (setting `alternate=true`), the localization array now maintains a consistent order based on the webspace configuration.

  This ensures language switchers and hreflang tags maintain a predictable, stable order across page loads.