### PR TITLE
Fix phpstan issues after dependency update

### DIFF
--- a/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
+++ b/src/Sulu/Component/Content/Metadata/Loader/AbstractLoader.php
@@ -93,6 +93,7 @@ abstract class AbstractLoader implements LoaderInterface
     {
         $result = [];
 
+        /** @var \DOMElement $node */
         foreach ($xpath->query($path) ?: [] as $node) {
             $tag = [
                 'name' => null,
@@ -100,7 +101,7 @@ abstract class AbstractLoader implements LoaderInterface
             ];
 
             /** @var \DOMAttr $attr */
-            foreach ($node->attributes ?? [] as $key => $attr) {
+            foreach ($node->attributes as $key => $attr) {
                 if (\in_array($key, ['name'])) {
                     $tag[$key] = $attr->value;
                 } else {
@@ -133,11 +134,12 @@ abstract class AbstractLoader implements LoaderInterface
     {
         $result = [];
 
+        /** @var \DOMElement $node */
         foreach ($xpath->query($path) ?: [] as $node) {
             $area = [];
 
             /** @var \DOMAttr $attr */
-            foreach ($node->attributes ?? [] as $key => $attr) {
+            foreach ($node->attributes as $key => $attr) {
                 if (\in_array($key, ['key', 'cache-invalidation'])) {
                     $area[$key] = $attr->value;
                 } else {

--- a/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
+++ b/src/Sulu/Component/Webspace/Loader/XmlFileLoader10.php
@@ -213,6 +213,7 @@ class XmlFileLoader10 extends BaseXmlFileLoader
      */
     protected function generateLocalizationsFromNodeList(\DOMNodeList $localizationNodes, Portal $portal, $flat = false)
     {
+        /** @var \DOMElement $localizationNode */
         foreach ($localizationNodes as $localizationNode) {
             $localization = $this->generateLocalizationFromNode($localizationNode, $flat);
 


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Added PHPDoc type hints for `\DOMElement` nodes in foreach loops
  - Removed unnecessary null coalescing operator (`??`) from `$node->attributes` access
  - Fixed PHPStan type inference issues with DOMNodeList iterations