### PR TITLE
Fix linting issues after dependency updates

### DIFF
--- a/packages/content/tests/Unit/Content/Domain/Model/RoutableTraitTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Model/RoutableTraitTest.php
@@ -35,14 +35,14 @@ class RoutableTraitTest extends TestCase
             /**
              * @var T
              */
-            private $resource;
+            private ContentRichEntityInterface $resource;
 
             /**
              * @param T $resource
              */
             public function __construct(ContentRichEntityInterface $resource)
             {
-                $this->resource = $resource;
+                $this->resource = $resource; // @phpstan-ignore-line assign.propertyType
             }
 
             public static function getResourceKey(): string
@@ -60,7 +60,7 @@ class RoutableTraitTest extends TestCase
              */
             public function getResource(): ContentRichEntityInterface
             {
-                return $this->resource;
+                return $this->resource; // @phpstan-ignore-line return.type
             }
         };
     }

--- a/packages/content/tests/Unit/Content/Domain/Model/RoutableTraitTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Model/RoutableTraitTest.php
@@ -29,20 +29,20 @@ class RoutableTraitTest extends TestCase
      */
     protected function getRoutableInstance(ContentRichEntityInterface $contentRichEntity): RoutableInterface
     {
-        return new class($contentRichEntity) implements RoutableInterface {
+        return new /** @template Tc of ContentRichEntityInterface */ class($contentRichEntity) implements RoutableInterface {
             use RoutableTrait;
 
             /**
-             * @var T
+             * @var Tc
              */
             private ContentRichEntityInterface $resource;
 
             /**
-             * @param T $resource
+             * @param Tc $resource
              */
             public function __construct(ContentRichEntityInterface $resource)
             {
-                $this->resource = $resource; // @phpstan-ignore-line assign.propertyType
+                $this->resource = $resource;
             }
 
             public static function getResourceKey(): string
@@ -56,11 +56,11 @@ class RoutableTraitTest extends TestCase
             }
 
             /**
-             * @return T
+             * @return Tc
              */
             public function getResource(): ContentRichEntityInterface
             {
-                return $this->resource; // @phpstan-ignore-line return.type
+                return $this->resource;
             }
         };
     }


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Added targeted `@phpstan-ignore-line` directives for anonymous class template type limitations

  #### Why?

  PHPStan has stricter rules around generic type annotations in anonymous classes. While the test helper method uses template type `T`, PHPStan cannot properly infer these types within anonymous class contexts.