### PR TITLE
Remove null as array accessor

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Reference/ArticleReferenceRefresher.php
+++ b/packages/article/src/Infrastructure/Sulu/Reference/ArticleReferenceRefresher.php
@@ -178,12 +178,13 @@ class ArticleReferenceRefresher implements ReferenceRefresherInterface
         $groupedArticleDimensionContents = [];
         /** @var ArticleDimensionContentInterface $articleDimensionContent */
         foreach ($articleDimensionContents as $articleDimensionContent) {
-            $groupedArticleDimensionContents[$articleDimensionContent->getResource()->getId()][$articleDimensionContent->getStage()][$articleDimensionContent->getLocale()] = $articleDimensionContent;
+            $locale = $articleDimensionContent->getLocale() ?? '';
+            $groupedArticleDimensionContents[$articleDimensionContent->getResource()->getId()][$articleDimensionContent->getStage()][$locale] = $articleDimensionContent;
         }
 
         foreach ($groupedArticleDimensionContents as $articleDimensionContentByStage) {
             foreach ($articleDimensionContentByStage as $stage => $articleDimensionContentByLocale) {
-                $unlocalizedDimensionContent = $articleDimensionContentByLocale[null] ?? null;
+                $unlocalizedDimensionContent = $articleDimensionContentByLocale[''] ?? null;
                 /** @var ArticleDimensionContentInterface $articleDimensionContent */
                 foreach ($articleDimensionContentByLocale as $locale => $articleDimensionContent) {
                     if ('' === $locale) {

--- a/packages/content/tests/Application/ExampleTestBundle/Reference/ExampleReferenceRefresher.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Reference/ExampleReferenceRefresher.php
@@ -172,12 +172,13 @@ class ExampleReferenceRefresher implements ReferenceRefresherInterface
         $groupedExampleDimensionContents = [];
         /** @var ExampleDimensionContent $exampleDimensionContent */
         foreach ($exampleDimensionContents as $exampleDimensionContent) {
-            $groupedExampleDimensionContents[$exampleDimensionContent->getResourceId()][$exampleDimensionContent->getStage()][$exampleDimensionContent->getLocale()] = $exampleDimensionContent;
+            $locale = $exampleDimensionContent->getLocale() ?? '';
+            $groupedExampleDimensionContents[$exampleDimensionContent->getResourceId()][$exampleDimensionContent->getStage()][$locale] = $exampleDimensionContent;
         }
 
         foreach ($groupedExampleDimensionContents as $exampleDimensionContentByStage) {
             foreach ($exampleDimensionContentByStage as $stage => $exampleDimensionContentByLocale) {
-                $unlocalizedDimensionContent = $exampleDimensionContentByLocale[null] ?? null;
+                $unlocalizedDimensionContent = $exampleDimensionContentByLocale[''] ?? null;
                 /** @var ExampleDimensionContent $exampleDimensionContent */
                 foreach ($exampleDimensionContentByLocale as $locale => $exampleDimensionContent) {
                     if ('' === $locale) {

--- a/packages/page/src/Infrastructure/Sulu/Reference/PageReferenceRefresher.php
+++ b/packages/page/src/Infrastructure/Sulu/Reference/PageReferenceRefresher.php
@@ -179,12 +179,13 @@ class PageReferenceRefresher implements ReferenceRefresherInterface
         $groupedPageDimensionContents = [];
         /** @var PageDimensionContentInterface $pageDimensionContent */
         foreach ($pageDimensionContents as $pageDimensionContent) {
-            $groupedPageDimensionContents[$pageDimensionContent->getResourceId()][$pageDimensionContent->getStage()][$pageDimensionContent->getLocale()] = $pageDimensionContent;
+            $locale = $pageDimensionContent->getLocale() ?? '';
+            $groupedPageDimensionContents[$pageDimensionContent->getResourceId()][$pageDimensionContent->getStage()][$locale] = $pageDimensionContent;
         }
 
         foreach ($groupedPageDimensionContents as $pageDimensionContentByStage) {
             foreach ($pageDimensionContentByStage as $stage => $pageDimensionContentByLocale) {
-                $unlocalizedDimensionContent = $pageDimensionContentByLocale[null] ?? null;
+                $unlocalizedDimensionContent = $pageDimensionContentByLocale[''] ?? null;
                 /** @var PageDimensionContentInterface $pageDimensionContent */
                 foreach ($pageDimensionContentByLocale as $locale => $pageDimensionContent) {
                     if ('' === $locale) {

--- a/packages/snippet/src/Infrastructure/Sulu/Reference/SnippetReferenceRefresher.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Reference/SnippetReferenceRefresher.php
@@ -178,12 +178,13 @@ class SnippetReferenceRefresher implements ReferenceRefresherInterface
         $groupedSnippetDimensionContents = [];
         /** @var SnippetDimensionContentInterface $snippetDimensionContent */
         foreach ($snippetDimensionContents as $snippetDimensionContent) {
-            $groupedSnippetDimensionContents[$snippetDimensionContent->getResource()->getId()][$snippetDimensionContent->getStage()][$snippetDimensionContent->getLocale()] = $snippetDimensionContent;
+            $locale = $snippetDimensionContent->getLocale() ?? '';
+            $groupedSnippetDimensionContents[$snippetDimensionContent->getResource()->getId()][$snippetDimensionContent->getStage()][$locale] = $snippetDimensionContent;
         }
 
         foreach ($groupedSnippetDimensionContents as $snippetDimensionContentByStage) {
             foreach ($snippetDimensionContentByStage as $stage => $snippetDimensionContentByLocale) {
-                $unlocalizedDimensionContent = $snippetDimensionContentByLocale[null] ?? null;
+                $unlocalizedDimensionContent = $snippetDimensionContentByLocale[''] ?? null;
                 /** @var SnippetDimensionContentInterface $snippetDimensionContent */
                 foreach ($snippetDimensionContentByLocale as $locale => $snippetDimensionContent) {
                     if ('' === $locale) {


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | License | MIT
  | Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

  #### What's in this PR?

  - Removed `null` as array accessor in reference refreshers across article, page, snippet, and example bundles

  #### Why?

  PHP 8.5 deprecates using `null` as an array offset, causing deprecation warnings. The code was using `null` as array keys for unlocalized dimension content (e.g., `$array[null]`) and as the return value from
  `getLocale()` when accessing arrays.