### PR TITLE
Fix to take loadExcerpt and shadowLocale into account for caching on snippet resolving

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
+++ b/src/Sulu/Bundle/SnippetBundle/Snippet/SnippetResolver.php
@@ -53,7 +53,7 @@ class SnippetResolver implements SnippetResolverInterface, ResetInterface
     {
         $snippets = [];
         foreach ($uuids as $uuid) {
-            $cacheKey = \sprintf('%s|%s', $locale, $uuid);
+            $cacheKey = \sprintf('%s|%s|%s|%s', $locale, $uuid, $shadowLocale ?? 'null', $loadExcerpt ? 'true' : 'false');
             if (!\array_key_exists($cacheKey, $this->snippetCache)) {
                 try {
                     $snippet = $this->contentMapper->load($uuid, $webspaceKey, $locale);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -255,4 +255,42 @@ class SnippetResolverTest extends TestCase
             $resolver->resolve(['123-123-123'], 'sulu_io', 'de', null, true)
         );
     }
+
+    public function testResolveCaching(): void
+    {
+        $contentMapper = $this->prophesize(ContentMapperInterface::class);
+        $structureResolver = $this->prophesize(StructureResolverInterface::class);
+
+        $uuid = '123-123-123';
+        $webspaceKey = 'sulu_io';
+        $locale = 'de';
+
+        $structure = $this->prophesize(SnippetBridge::class);
+        $structure->getUuid()->willReturn($uuid);
+        $structure->getKey()->willReturn('test');
+        $structure->getHasTranslation()->willReturn(true);
+        $structure->setIsShadow(Argument::any())->shouldBeCalled();
+        $structure->setShadowBaseLanguage(Argument::any())->shouldBeCalled();
+
+        $resolver = new SnippetResolver($contentMapper->reveal(), $structureResolver->reveal());
+
+        $contentMapper->load($uuid, $webspaceKey, $locale)
+            ->shouldBeCalledTimes(3)
+            ->willReturn($structure->reveal());
+
+        $structureResolver->resolve($structure->reveal(), false)
+            ->shouldBeCalledTimes(2)
+            ->willReturn(['content' => ['title' => 'test'], 'view' => ['title' => []]]);
+
+        $structureResolver->resolve($structure->reveal(), true)
+            ->shouldBeCalledTimes(1)
+            ->willReturn(['content' => ['title' => 'test'], 'extension' => ['excerpt' => ['categories' => [], 'tags' => []]], 'view' => ['title' => []]]);
+
+        $resolver->resolve([$uuid], $webspaceKey, $locale);
+        $resolver->resolve([$uuid], $webspaceKey, $locale); //cached
+
+        $resolver->resolve([$uuid], $webspaceKey, $locale, null, true); //not cached
+
+        $resolver->resolve([$uuid], $webspaceKey, $locale, 'en', false); //not cached
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs |
| License | MIT
| Documentation PR |

#### What's in this PR?

Allows to resolve Snippets with extension and without extensions on subsequent calls to ->resolve

#### Why?

When loading a Snippet via the Twig-function sulu_snippet_load_by_area, the snippet does not contain the extensions. 
If you load the same Snippet via a custom twig function on a later call, and you want to resolve the same Snippet, the resovler always returns the cached version, which does not contain the extension, even if the $loadExcerpt parameter is set.

#### Example Usage

$snippet1 = $snippetresolver->resolve('123-123-123-123', 'demo', 'de');
$snippet2 = $snippetresolver->resolve('123-123-123-123', 'demo', 'de', null, true);

$snippet2 does not contain the extensions.

This also is true for the other way round.
