### PR TITLE
Add priority ordering support for templates

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1803,7 +1803,7 @@ parameters:
 		-
 			message: '#^Parameter \#3 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\MetaXmlParser\:\:getValueFromXPath\(\) expects DOMNode\|null, DOMNameSpaceNode\|DOMNode given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/MetaXmlParser.php
 
 		-
@@ -1963,7 +1963,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParam\(\) should return array\{name\: string\|null, type\: string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, collection\?\: array\<mixed\>\} but returns array\{name\: bool\|int\|string\|null, type\: bool\|int\|string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, value\: array\<array\{name\: string\|null, type\: string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>\}, collection\?\: array\<mixed\>\}\>\|bool\|int\|string\|null\}\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\PropertiesXmlParser\:\:loadParam\(\) should return array\{name\: string\|null, type\: string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>, priority\?\: int\}, collection\?\: array\<mixed\>\} but returns array\{name\: bool\|int\|string\|null, type\: bool\|int\|string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>, priority\?\: int\}, value\: array\<array\{name\: string\|null, type\: string\|null, meta\: array\{title\?\: array\<string, string\>, info_text\?\: array\<string, string\>, placeholder\?\: array\<string, string\>, priority\?\: int\}, collection\?\: array\<mixed\>\}\>\|bool\|int\|string\|null\}\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -3843,7 +3843,7 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$context of method Sulu\\Bundle\\AdminBundle\\Metadata\\FormMetadata\\Parser\\MetaXmlParser\:\:load\(\) expects DOMNode, DOMNameSpaceNode\|DOMNode given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/MetaXmlParserTest.php
 
 		-

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadata.php
@@ -61,6 +61,12 @@ class FormMetadata extends AbstractMetadata
     #[Exclude()]
     protected $resources = [];
 
+    /**
+     * Order of the form in the list.
+     */
+    #[Exclude(if: "'admin_form_metadata_keys_only' in context.getAttribute('groups')")]
+    private int $priority = 0;
+
     public function __construct()
     {
         $this->schema = new SchemaMetadata();
@@ -249,10 +255,24 @@ class FormMetadata extends AbstractMetadata
         return $this->resources;
     }
 
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    public function setPriority(int $priority): void
+    {
+        if ($priority < 0) {
+            throw new \InvalidArgumentException('Priority must be non-negative');
+        }
+        $this->priority = $priority;
+    }
+
     public function merge(self $otherForm): FormMetadata
     {
         $mergedForm = new self();
         $mergedForm->setKey($this->getKey());
+        $mergedForm->setPriority($this->getPriority());
         if ($this->titles) {
             $mergedForm->setTitles($this->titles);
         }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Loader/TemplateXmlLoader.php
@@ -83,6 +83,10 @@ class TemplateXmlLoader extends AbstractLoader
             $form->setTitles($meta['title']);
         }
 
+        if (\array_key_exists('priority', $meta)) {
+            $form->setPriority($meta['priority']);
+        }
+
         $form->setTemplate($this->templateXmlParser->load($xpath, $templateNode));
 
         $propertiesNode = ($xpath->query('/x:template/x:properties') ?: null)?->item(0);

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/MetaXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/MetaXmlParser.php
@@ -41,6 +41,7 @@ class MetaXmlParser
      *     title?: array<string, string>,
      *     info_text?: array<string, string>,
      *     placeholder?: array<string, string>,
+     *     priority?: int,
      * }
      */
     public function load(\DOMXPath $xpath, \DOMNode $context): array
@@ -55,6 +56,11 @@ class MetaXmlParser
         $result['title'] = $this->loadMetaTag('x:title', $xpath, $metaNode);
         $result['info_text'] = $this->loadMetaTag('x:info_text', $xpath, $metaNode);
         $result['placeholder'] = $this->loadMetaTag('x:placeholder', $xpath, $metaNode);
+
+        $priority = $this->getValueFromXPath('x:priority', $xpath, $metaNode);
+        if (null !== $priority) {
+            $result['priority'] = (int) $priority;
+        }
 
         return $result;
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Parser/PropertiesXmlParser.php
@@ -351,6 +351,7 @@ class PropertiesXmlParser
      *          title?: array<string, string>,
      *          info_text?: array<string, string>,
      *          placeholder?: array<string, string>,
+     *          priority?: int,
      *      },
      *      collection?: array<mixed>,
      *  }>
@@ -375,6 +376,7 @@ class PropertiesXmlParser
      *         title?: array<string, string>,
      *         info_text?: array<string, string>,
      *         placeholder?: array<string, string>,
+     *         priority?: int,
      *     },
      *     collection?: array<mixed>,
      * }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/schema/template-1.0.xsd
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/schema/template-1.0.xsd
@@ -40,6 +40,7 @@
                 <xs:complexType>
                     <xs:choice maxOccurs="unbounded">
                         <xs:element type="langType" name="title"/>
+                        <xs:element type="xs:integer" name="priority" minOccurs="0"/>
                     </xs:choice>
                     <xs:attributeGroup ref="defaultAttributes"/>
                 </xs:complexType>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/metadataStore.js
@@ -21,6 +21,7 @@ class MetadataStore {
                         transformedTypes[key] = {
                             key,
                             title: types[key].title || key,
+                            priority: types[key].priority || 0,
                         };
 
                         return transformedTypes;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/__snapshots__/metadataStore.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/__snapshots__/metadataStore.test.js.snap
@@ -6,10 +6,12 @@ Object {
   "types": Object {
     "footer": Object {
       "key": "footer",
+      "priority": 0,
       "title": "footer",
     },
     "sidebar": Object {
       "key": "sidebar",
+      "priority": 0,
       "title": "Sidebar Snippet",
     },
   },

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/metadataStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/metadataStore.test.js
@@ -331,3 +331,27 @@ test('Return empty object as available types for given resourceKey if types are 
         expect(snippetTypes).toEqual(null);
     });
 });
+
+test('Return available types with priority for given resourceKey', () => {
+    const snippetMetadata = {
+        types: {
+            sidebar: {
+                title: 'Sidebar Snippet',
+                priority: 100,
+            },
+            footer: {
+                title: 'Footer Snippet',
+            },
+        },
+        defaultType: 'sidebar',
+    };
+    const snippetPromise = Promise.resolve(snippetMetadata);
+    generalMetadataStore.loadMetadata.mockReturnValue(snippetPromise);
+
+    const snippetTypesPromise = metadataStore.getSchemaTypes('snippets');
+
+    return snippetTypesPromise.then((snippetTypes) => {
+        expect(snippetTypes.types.sidebar.priority).toEqual(100);
+        expect(snippetTypes.types.footer.priority).toEqual(0);
+    });
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -6,6 +6,7 @@ import type {ColSpan} from '../../components/Grid';
 
 export type SchemaType = {
     key: string,
+    priority: number,
     title: string,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js
@@ -301,3 +301,52 @@ test('Return disabled true when passed disabled condition is met', () => {
 
     expect(typeToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({disabled: true}));
 });
+
+test('Return item config with options sorted by priority first, then by title', () => {
+    const typeToolbarAction = createTypeToolbarAction({sort_by: 'title'});
+    typeToolbarAction.resourceFormStore.typesLoading = false;
+    typeToolbarAction.resourceFormStore.data.template = 'default';
+    typeToolbarAction.resourceFormStore.types = {
+        article: {
+            key: 'article',
+            title: 'Article',
+            priority: 50,
+        },
+        homepage: {
+            key: 'homepage',
+            title: 'Homepage',
+            priority: 100,
+        },
+        default: {
+            key: 'default',
+            title: 'Default',
+            priority: 0,
+        },
+        contact: {
+            key: 'contact',
+            title: 'Contact',
+            priority: 0,
+        },
+    };
+
+    expect(typeToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        options: [
+            {
+                label: 'Homepage',
+                value: 'homepage',
+            },
+            {
+                label: 'Article',
+                value: 'article',
+            },
+            {
+                label: 'Contact',
+                value: 'contact',
+            },
+            {
+                label: 'Default',
+                value: 'default',
+            },
+        ],
+    }));
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -29,7 +29,13 @@ export default class TypeToolbarAction extends AbstractFormToolbarAction {
         const isDisabled = disabledCondition ? jexl.evalSync(disabledCondition, this.conditionData) : false;
 
         const sortedTypes = sortBy
-            ? formTypes.sort((t1, t2) => String(t1[sortBy]).localeCompare(String(t2[sortBy])))
+            ? formTypes.sort((t1, t2) => {
+                const priorityDiff = (t2.priority || 0) - (t1.priority || 0);
+                if (priorityDiff !== 0) {
+                    return priorityDiff;
+                }
+                return String(t1[sortBy]).localeCompare(String(t2[sortBy]));
+            })
             : formTypes;
 
         return {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/templates/pages/default.xml
@@ -14,6 +14,7 @@
     <meta>
         <title lang="de">Tiers</title>
         <title lang="en">Animals</title>
+        <priority>10</priority>
     </meta>
 
     <tag name="test" value="test-value"/>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/TemplateXmlLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Loader/TemplateXmlLoaderTest.php
@@ -455,6 +455,20 @@ class TemplateXmlLoaderTest extends TestCase
         $this->assertSame('content', $formMetadata->getGroup());
     }
 
+    public function testLoadTemplateWithPriority(): void
+    {
+        $formMetadata = $this->loader->load($this->getTemplatesDirectory() . 'default.xml');
+
+        $this->assertSame(10, $formMetadata->getPriority());
+    }
+
+    public function testLoadTemplateWithoutPriority(): void
+    {
+        $formMetadata = $this->loader->load($this->getTemplatesDirectory() . 'grouped.xml');
+
+        $this->assertSame(0, $formMetadata->getPriority());
+    }
+
     public function testLoadTemplateWithoutGroup(): void
     {
         // Test that templates without a group element return null for the group

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/MetaXmlParserTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Parser/MetaXmlParserTest.php
@@ -48,7 +48,20 @@ class MetaXmlParserTest extends TestCase
             ],
             'info_text' => [],
             'placeholder' => [],
+            'priority' => 10,
         ], $meta);
+    }
+
+    public function testParseWithoutPriority(): void
+    {
+        $resource = $this->getTemplatesDirectory() . 'grouped.xml';
+        $xpath = $this->loadXmlFile($resource);
+        $templateNode = ($xpath->query('/x:template') ?: null)?->item(0);
+        \assert(null !== $templateNode, 'Expected <template> be defined for "' . $resource . '".');
+
+        $meta = $this->metaXmlParser->load($xpath, $templateNode);
+
+        $this->assertArrayNotHasKey('priority', $meta);
     }
 
     private function loadXmlFile(string $resource): \DOMXPath


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs | #8569
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

This PR adds a `<priority>` element to the template's `<meta>` section, allowing developers to customize the display order of templates in the admin template selector.

**Changes include:**
- XSD schema update to allow `<priority>` in template meta
- `FormMetadata` class: added `priority` property with getter/setter
- `MetaXmlParser`: parsing of `<priority>` element
- `TemplateXmlLoader`: transfer priority value to FormMetadata
- Frontend: `metadataStore.js` includes priority in type transformation
- Frontend: `TypeToolbarAction.js` sorts by priority first, then by title
- Unit tests for PHP and JS

#### Why?

Templates are currently displayed in alphabetical order in the admin template selector. There is no way to customize this order.

When building a site with multiple templates (homepage, portal, collection, article, default...), it is helpful to display the most commonly used templates at the top of the selector.

The only workaround was to prefix template filenames with numbers (01_homepage.xml, 02_portal.xml), but this also affects the template key which is not ideal.

#### Example Usage

```xml
<template xmlns="http://schemas.sulu.io/template/template"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">

    <key>homepage</key>

    <meta>
        <title lang="en">Homepage</title>
        <title lang="de">Startseite</title>
        <priority>100</priority>
    </meta>

    <!-- ... -->
</template>
```

- Higher priority values appear first in the admin template selector
- Templates without `<priority>` default to 0
- Templates with the same priority are sorted alphabetically by title

#### To Do

- [ ] Create a documentation PR
