### PR TITLE
Add excerpt data and field roles to website search index

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
@@ -35,6 +35,11 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
         'text_editor',
     ];
 
+    private const MEDIA_FIELD_TYPES = [
+        'media_selection',
+        'single_media_selection',
+    ];
+
     public function __construct(
         private FormMetadataProvider $formMetadataProvider,
     ) {
@@ -66,9 +71,18 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
 
         $searchableFields = [];
         $this->collectSearchableFields($metadata->getFlatFieldMetadata(), $searchableFields);
-        $content = $this->extractContent($templateData, $searchableFields);
 
-        $document['content'] = $content;
+        $document['content'] = $this->extractContent($templateData, $searchableFields);
+
+        $title = $this->extractTitle($templateData, $searchableFields);
+        if (null !== $title) {
+            $document['title'] = $title;
+        }
+
+        $mediaId = $this->extractMediaId($templateData, $searchableFields);
+        if ('' !== $mediaId) {
+            $document['mediaId'] = $mediaId;
+        }
 
         return $document;
     }
@@ -85,7 +99,7 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
 
     /**
      * @param array<ItemMetadata> $items
-     * @param array<string, string> $fields
+     * @param array<string, array{type: string, role: string|null}> $fields
      */
     private function collectSearchableFields(array $items, array &$fields, string $prefix = ''): void
     {
@@ -94,17 +108,22 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
                 continue;
             }
 
+            $role = null;
             $hasSearchTag = false;
             foreach ($item->getTags() as $tag) {
                 if (TagMetadata::SEARCH_FIELD_TAG === $tag->getName()) {
                     $hasSearchTag = true;
+                    $role = $tag->getAttribute('role');
                     break;
                 }
             }
 
             if ($hasSearchTag) {
                 $fieldPath = $prefix ? $prefix . '.' . $item->getName() : $item->getName();
-                $fields[$fieldPath] = $item->getType();
+                $fields[$fieldPath] = [
+                    'type' => $item->getType(),
+                    'role' => \is_string($role) ? $role : null,
+                ];
             }
 
             if ('block' === $item->getType()) {
@@ -122,7 +141,7 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
 
     /**
      * @param array<string, mixed> $templateData
-     * @param array<string, string> $searchableFields
+     * @param array<string, array{type: string, role: string|null}> $searchableFields
      *
      * @return array<int, string>
      */
@@ -130,8 +149,12 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
     {
         $content = [];
 
-        foreach ($searchableFields as $fieldPath => $fieldType) {
-            if (!\in_array($fieldType, self::SUPPORTED_FIELD_TYPES, true)) {
+        foreach ($searchableFields as $fieldPath => $fieldInfo) {
+            if (!\in_array($fieldInfo['type'], self::SUPPORTED_FIELD_TYPES, true)) {
+                continue;
+            }
+
+            if (\in_array($fieldInfo['role'], ['image', 'title', 'url'], true)) {
                 continue;
             }
 
@@ -143,6 +166,65 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
         }
 
         return $content;
+    }
+
+    /**
+     * @param array<string, mixed> $templateData
+     * @param array<string, array{type: string, role: string|null}> $searchableFields
+     */
+    private function extractTitle(array $templateData, array $searchableFields): ?string
+    {
+        foreach ($searchableFields as $fieldPath => $fieldInfo) {
+            if ('title' !== $fieldInfo['role']) {
+                continue;
+            }
+
+            if (!\in_array($fieldInfo['type'], self::SUPPORTED_FIELD_TYPES, true)) {
+                continue;
+            }
+
+            $value = $this->getValueByPath($templateData, $fieldPath);
+            if (\is_string($value) && '' !== \trim($value)) {
+                return $this->stripHtml($value);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $templateData
+     * @param array<string, array{type: string, role: string|null}> $searchableFields
+     */
+    private function extractMediaId(array $templateData, array $searchableFields): string
+    {
+        foreach ($searchableFields as $fieldPath => $fieldInfo) {
+            if ('image' !== $fieldInfo['role']) {
+                continue;
+            }
+
+            if (!\in_array($fieldInfo['type'], self::MEDIA_FIELD_TYPES, true)) {
+                continue;
+            }
+
+            $value = $this->getValueByPath($templateData, $fieldPath);
+            if (!\is_array($value)) {
+                continue;
+            }
+
+            if (isset($value['id']) && \is_numeric($value['id'])) {
+                return (string) $value['id'];
+            }
+
+            if (isset($value['ids']) && \is_array($value['ids']) && [] !== $value['ids']) {
+                $firstId = $value['ids'][0] ?? null;
+                if (null !== $firstId && \is_numeric($firstId)) {
+                    return (string) $firstId;
+                }
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancer.php
@@ -16,7 +16,8 @@ namespace Sulu\Article\Infrastructure\Sulu\Search\Visitor;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * @internal
+ * @internal if you need to override this service, create a new service based on the WebsitePageReindexProviderEnhancerInterface
+ * instead of extending this class
  *
  * @final
  */

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * @internal
+ *
+ * @final
+ */
+class WebsiteArticleReindexExcerptEnhancer implements WebsiteArticleReindexProviderEnhancerInterface
+{
+    public function enhanceQuery(QueryBuilder $queryBuilder): void
+    {
+        $queryBuilder->addSelect('dimensionContent.excerptData');
+    }
+
+    public function enhanceDocument(array $queryResult, array $document): array
+    {
+        $excerptData = $queryResult['excerptData'] ?? [];
+        if (!\is_array($excerptData)) {
+            return $document;
+        }
+
+        $excerpt = [];
+
+        $excerptTitle = $excerptData['title'] ?? null;
+        if (\is_string($excerptTitle) && '' !== \trim($excerptTitle)) {
+            $excerpt['title'] = \trim($excerptTitle);
+
+            if ('' === ($document['title'] ?? '')) {
+                $document['title'] = \trim($excerptTitle);
+            }
+        }
+
+        $excerptDescription = $excerptData['description'] ?? null;
+        if (\is_string($excerptDescription) && '' !== \trim($excerptDescription)) {
+            $excerpt['description'] = \trim(\strip_tags($excerptDescription));
+        }
+
+        $excerptMore = $excerptData['more'] ?? null;
+        if (\is_string($excerptMore) && '' !== \trim($excerptMore)) {
+            $excerpt['more'] = \trim($excerptMore);
+        }
+
+        $image = $excerptData['image'] ?? null;
+        if (\is_array($image) && isset($image['id']) && \is_numeric($image['id'])) {
+            $excerpt['imageId'] = (int) $image['id'];
+
+            if ('' === ($document['mediaId'] ?? '')) {
+                $document['mediaId'] = (string) $image['id'];
+            }
+        }
+
+        $icon = $excerptData['icon'] ?? null;
+        if (\is_array($icon) && isset($icon['id']) && \is_numeric($icon['id'])) {
+            $excerpt['iconId'] = (int) $icon['id'];
+        }
+
+        if ([] !== $excerpt) {
+            $properties = \is_array($document['properties'] ?? null) ? $document['properties'] : [];
+            $properties['excerpt'] = $excerpt;
+            $document['properties'] = $properties;
+        }
+
+        return $document;
+    }
+}

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancer.php
@@ -36,10 +36,13 @@ class WebsiteArticleReindexExcerptEnhancer implements WebsiteArticleReindexProvi
         }
 
         $excerpt = [];
+        /** @var list<string> */
+        $content = \is_array($document['content'] ?? null) ? $document['content'] : [];
 
         $excerptTitle = $excerptData['title'] ?? null;
         if (\is_string($excerptTitle) && '' !== \trim($excerptTitle)) {
             $excerpt['title'] = \trim($excerptTitle);
+            $content[] = \trim($excerptTitle);
 
             if ('' === ($document['title'] ?? '')) {
                 $document['title'] = \trim($excerptTitle);
@@ -48,7 +51,8 @@ class WebsiteArticleReindexExcerptEnhancer implements WebsiteArticleReindexProvi
 
         $excerptDescription = $excerptData['description'] ?? null;
         if (\is_string($excerptDescription) && '' !== \trim($excerptDescription)) {
-            $excerpt['description'] = \trim(\strip_tags($excerptDescription));
+            $excerpt['description'] = \trim($excerptDescription);
+            $content[] = \trim(\strip_tags($excerptDescription));
         }
 
         $excerptMore = $excerptData['more'] ?? null;
@@ -70,10 +74,12 @@ class WebsiteArticleReindexExcerptEnhancer implements WebsiteArticleReindexProvi
             $excerpt['iconId'] = (int) $icon['id'];
         }
 
+        $document['content'] = $content;
+
         if ([] !== $excerpt) {
-            $properties = \is_array($document['properties'] ?? null) ? $document['properties'] : [];
-            $properties['excerpt'] = $excerpt;
-            $document['properties'] = $properties;
+            $metadata = \is_array($document['metadata'] ?? null) ? $document['metadata'] : [];
+            $metadata['excerpt'] = $excerpt;
+            $document['metadata'] = $metadata;
         }
 
         return $document;

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
@@ -25,12 +25,21 @@ class WebsiteArticleReindexTaxonomyEnhancer implements WebsiteArticleReindexProv
 {
     public function enhanceQuery(QueryBuilder $queryBuilder): void
     {
+        $entityManager = $queryBuilder->getEntityManager();
+
+        $categorySubquery = $entityManager->createQueryBuilder()
+            ->select('GROUP_CONCAT(DISTINCT excerptCategory.id)')
+            ->from(\Sulu\Bundle\CategoryBundle\Entity\CategoryInterface::class, 'excerptCategory')
+            ->where('excerptCategory MEMBER OF dimensionContent.excerptCategories');
+
+        $tagSubquery = $entityManager->createQueryBuilder()
+            ->select('GROUP_CONCAT(DISTINCT excerptTag.name)')
+            ->from(\Sulu\Bundle\TagBundle\Tag\TagInterface::class, 'excerptTag')
+            ->where('excerptTag MEMBER OF dimensionContent.excerptTags');
+
         $queryBuilder
-            ->leftJoin('dimensionContent.excerptCategories', 'category')
-            ->leftJoin('dimensionContent.excerptTags', 'tag')
-            ->addSelect('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
-            ->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')
-            ->addGroupBy('dimensionContent.id');
+            ->addSelect('(' . $categorySubquery->getDQL() . ') AS categoryIds')
+            ->addSelect('(' . $tagSubquery->getDQL() . ') AS tagNames');
     }
 
     public function enhanceDocument(array $queryResult, array $document): array

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
+
+/**
+ * @internal if you need to override this service, create a new service based on the WebsitePageReindexProviderEnhancerInterface
+ * instead of extending this class
+ *
+ * @final
+ */
+class WebsiteArticleReindexTaxonomyEnhancer implements WebsiteArticleReindexProviderEnhancerInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function enhanceQuery(QueryBuilder $queryBuilder): void
+    {
+    }
+
+    public function enhanceDocument(array $queryResult, array $document): array
+    {
+        $dimensionContentId = $queryResult['dimensionContentId'] ?? null;
+        if (null === $dimensionContentId || !\is_int($dimensionContentId)) {
+            return $document;
+        }
+
+        $categoryIds = $this->loadCategoryIds($dimensionContentId);
+        $tagNames = $this->loadTagNames($dimensionContentId);
+
+        if ([] !== $categoryIds || [] !== $tagNames) {
+            $properties = \is_array($document['properties'] ?? null) ? $document['properties'] : [];
+            $excerpt = \is_array($properties['excerpt'] ?? null) ? $properties['excerpt'] : [];
+
+            if ([] !== $categoryIds) {
+                $excerpt['categoryIds'] = $categoryIds;
+            }
+
+            if ([] !== $tagNames) {
+                $excerpt['tagNames'] = $tagNames;
+            }
+
+            $properties['excerpt'] = $excerpt;
+            $document['properties'] = $properties;
+        }
+
+        return $document;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function loadCategoryIds(int $dimensionContentId): array
+    {
+        /** @var list<array{id: int|null}> $results */
+        $results = $this->entityManager->createQueryBuilder()
+            ->select('category.id')
+            ->from(ArticleDimensionContentInterface::class, 'dimensionContent')
+            ->leftJoin('dimensionContent.excerptCategories', 'category')
+            ->where('dimensionContent.id = :id')
+            ->setParameter('id', $dimensionContentId)
+            ->getQuery()
+            ->getScalarResult();
+
+        return \array_map(static fn (array $row): int => (int) $row['id'], \array_filter($results, static fn (array $row): bool => null !== $row['id']));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function loadTagNames(int $dimensionContentId): array
+    {
+        /** @var list<array{name: string|null}> $results */
+        $results = $this->entityManager->createQueryBuilder()
+            ->select('tag.name')
+            ->from(ArticleDimensionContentInterface::class, 'dimensionContent')
+            ->leftJoin('dimensionContent.excerptTags', 'tag')
+            ->where('dimensionContent.id = :id')
+            ->setParameter('id', $dimensionContentId)
+            ->getQuery()
+            ->getScalarResult();
+
+        return \array_map(static fn (array $row): string => (string) $row['name'], \array_filter($results, static fn (array $row): bool => null !== $row['name']));
+    }
+}

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
@@ -74,7 +74,7 @@ class WebsiteArticleReindexTaxonomyEnhancer implements WebsiteArticleReindexProv
         /** @var array{categoryIds: string|null, tagNames: string|null} $result */
         $result = $this->entityManager->createQueryBuilder()
             ->select('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
-            ->addSelect("GROUP_CONCAT(DISTINCT tag.name SEPARATOR '||') AS tagNames")
+            ->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')
             ->from(ArticleDimensionContentInterface::class, 'dimensionContent')
             ->leftJoin('dimensionContent.excerptCategories', 'category')
             ->leftJoin('dimensionContent.excerptTags', 'tag')
@@ -110,6 +110,6 @@ class WebsiteArticleReindexTaxonomyEnhancer implements WebsiteArticleReindexProv
             return [];
         }
 
-        return \explode('||', $tagNames);
+        return \explode(',', $tagNames);
     }
 }

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\QueryBuilder;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 
 /**
- * @internal if you need to override this service, create a new service based on the WebsitePageReindexProviderEnhancerInterface
+ * @internal if you need to override this service, create a new service based on the WebsiteArticleReindexProviderEnhancerInterface
  * instead of extending this class
  *
  * @final
@@ -37,65 +37,79 @@ class WebsiteArticleReindexTaxonomyEnhancer implements WebsiteArticleReindexProv
     public function enhanceDocument(array $queryResult, array $document): array
     {
         $dimensionContentId = $queryResult['dimensionContentId'] ?? null;
-        if (null === $dimensionContentId || !\is_int($dimensionContentId)) {
+        if (!\is_int($dimensionContentId)) {
             return $document;
         }
 
-        $categoryIds = $this->loadCategoryIds($dimensionContentId);
-        $tagNames = $this->loadTagNames($dimensionContentId);
+        $taxonomy = $this->loadTaxonomy($dimensionContentId);
+        $categoryIds = $taxonomy['categoryIds'];
+        $tagNames = $taxonomy['tagNames'];
 
-        if ([] !== $categoryIds || [] !== $tagNames) {
-            $properties = \is_array($document['properties'] ?? null) ? $document['properties'] : [];
-            $excerpt = \is_array($properties['excerpt'] ?? null) ? $properties['excerpt'] : [];
-
-            if ([] !== $categoryIds) {
-                $excerpt['categoryIds'] = $categoryIds;
-            }
-
-            if ([] !== $tagNames) {
-                $excerpt['tagNames'] = $tagNames;
-            }
-
-            $properties['excerpt'] = $excerpt;
-            $document['properties'] = $properties;
+        if ([] === $categoryIds && [] === $tagNames) {
+            return $document;
         }
+
+        $metadata = \is_array($document['metadata'] ?? null) ? $document['metadata'] : [];
+        $excerpt = \is_array($metadata['excerpt'] ?? null) ? $metadata['excerpt'] : [];
+
+        if ([] !== $categoryIds) {
+            $excerpt['categoryIds'] = $categoryIds;
+        }
+
+        if ([] !== $tagNames) {
+            $excerpt['tagNames'] = $tagNames;
+        }
+
+        $metadata['excerpt'] = $excerpt;
+        $document['metadata'] = $metadata;
 
         return $document;
     }
 
     /**
-     * @return int[]
+     * @return array{categoryIds: int[], tagNames: string[]}
      */
-    private function loadCategoryIds(int $dimensionContentId): array
+    private function loadTaxonomy(int $dimensionContentId): array
     {
-        /** @var list<array{id: int|null}> $results */
-        $results = $this->entityManager->createQueryBuilder()
-            ->select('category.id')
+        /** @var array{categoryIds: string|null, tagNames: string|null} $result */
+        $result = $this->entityManager->createQueryBuilder()
+            ->select('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
+            ->addSelect("GROUP_CONCAT(DISTINCT tag.name SEPARATOR '||') AS tagNames")
             ->from(ArticleDimensionContentInterface::class, 'dimensionContent')
             ->leftJoin('dimensionContent.excerptCategories', 'category')
+            ->leftJoin('dimensionContent.excerptTags', 'tag')
             ->where('dimensionContent.id = :id')
             ->setParameter('id', $dimensionContentId)
             ->getQuery()
-            ->getScalarResult();
+            ->getSingleResult();
 
-        return \array_map(static fn (array $row): int => (int) $row['id'], \array_filter($results, static fn (array $row): bool => null !== $row['id']));
+        return [
+            'categoryIds' => $this->parseCategoryIds($result['categoryIds']),
+            'tagNames' => $this->parseTagNames($result['tagNames']),
+        ];
+    }
+
+    /**
+     * @return int[]
+     */
+    private function parseCategoryIds(?string $categoryIds): array
+    {
+        if (null === $categoryIds || '' === $categoryIds) {
+            return [];
+        }
+
+        return \array_map(static fn (string $id): int => (int) $id, \explode(',', $categoryIds));
     }
 
     /**
      * @return string[]
      */
-    private function loadTagNames(int $dimensionContentId): array
+    private function parseTagNames(?string $tagNames): array
     {
-        /** @var list<array{name: string|null}> $results */
-        $results = $this->entityManager->createQueryBuilder()
-            ->select('tag.name')
-            ->from(ArticleDimensionContentInterface::class, 'dimensionContent')
-            ->leftJoin('dimensionContent.excerptTags', 'tag')
-            ->where('dimensionContent.id = :id')
-            ->setParameter('id', $dimensionContentId)
-            ->getQuery()
-            ->getScalarResult();
+        if (null === $tagNames || '' === $tagNames) {
+            return [];
+        }
 
-        return \array_map(static fn (array $row): string => (string) $row['name'], \array_filter($results, static fn (array $row): bool => null !== $row['name']));
+        return \explode('||', $tagNames);
     }
 }

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancer.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Search\Visitor;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
-use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 
 /**
  * @internal if you need to override this service, create a new service based on the WebsiteArticleReindexProviderEnhancerInterface
@@ -25,25 +23,23 @@ use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
  */
 class WebsiteArticleReindexTaxonomyEnhancer implements WebsiteArticleReindexProviderEnhancerInterface
 {
-    public function __construct(
-        private EntityManagerInterface $entityManager,
-    ) {
-    }
-
     public function enhanceQuery(QueryBuilder $queryBuilder): void
     {
+        $queryBuilder
+            ->leftJoin('dimensionContent.excerptCategories', 'category')
+            ->leftJoin('dimensionContent.excerptTags', 'tag')
+            ->addSelect('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
+            ->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')
+            ->addGroupBy('dimensionContent.id');
     }
 
     public function enhanceDocument(array $queryResult, array $document): array
     {
-        $dimensionContentId = $queryResult['dimensionContentId'] ?? null;
-        if (!\is_int($dimensionContentId)) {
-            return $document;
-        }
+        $rawCategoryIds = $queryResult['categoryIds'] ?? null;
+        $rawTagNames = $queryResult['tagNames'] ?? null;
 
-        $taxonomy = $this->loadTaxonomy($dimensionContentId);
-        $categoryIds = $taxonomy['categoryIds'];
-        $tagNames = $taxonomy['tagNames'];
+        $categoryIds = $this->parseCategoryIds(\is_string($rawCategoryIds) ? $rawCategoryIds : null);
+        $tagNames = $this->parseTagNames(\is_string($rawTagNames) ? $rawTagNames : null);
 
         if ([] === $categoryIds && [] === $tagNames) {
             return $document;
@@ -64,29 +60,6 @@ class WebsiteArticleReindexTaxonomyEnhancer implements WebsiteArticleReindexProv
         $document['metadata'] = $metadata;
 
         return $document;
-    }
-
-    /**
-     * @return array{categoryIds: int[], tagNames: string[]}
-     */
-    private function loadTaxonomy(int $dimensionContentId): array
-    {
-        /** @var array{categoryIds: string|null, tagNames: string|null} $result */
-        $result = $this->entityManager->createQueryBuilder()
-            ->select('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
-            ->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')
-            ->from(ArticleDimensionContentInterface::class, 'dimensionContent')
-            ->leftJoin('dimensionContent.excerptCategories', 'category')
-            ->leftJoin('dimensionContent.excerptTags', 'tag')
-            ->where('dimensionContent.id = :id')
-            ->setParameter('id', $dimensionContentId)
-            ->getQuery()
-            ->getSingleResult();
-
-        return [
-            'categoryIds' => $this->parseCategoryIds($result['categoryIds']),
-            'tagNames' => $this->parseTagNames($result['tagNames']),
-        ];
     }
 
     /**

--- a/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleReindexProvider.php
@@ -101,15 +101,20 @@ final class WebsiteArticleReindexProvider implements ReindexProviderInterface
                 'resourceId' => (string) $article['articleId'],
                 'locale' => $article['locale'],
                 'webspaces' => $webspaces,
-                'title' => $article['title'],
+                'title' => '',
                 'url' => $article['slug'],
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => $authoredAt->format('c'),
+                'properties' => [],
             ];
 
             foreach ($this->enhancers as $enhancer) {
                 $data = $enhancer->enhanceDocument($article, $data);
+            }
+
+            if ('' === $data['title']) {
+                $data['title'] = $article['title'];
             }
 
             yield $data;

--- a/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleReindexProvider.php
@@ -106,7 +106,7 @@ final class WebsiteArticleReindexProvider implements ReindexProviderInterface
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => $authoredAt->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ];
 
             foreach ($this->enhancers as $enhancer) {

--- a/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/WebsiteArticleReindexProvider.php
@@ -41,6 +41,8 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
  */
 final class WebsiteArticleReindexProvider implements ReindexProviderInterface
 {
+    private const BATCH_SIZE = 100;
+
     /**
      * @var EntityRepository<ArticleDimensionContentInterface>
      */
@@ -67,68 +69,68 @@ final class WebsiteArticleReindexProvider implements ReindexProviderInterface
 
     public function total(): ?int
     {
-        // Todo: Add correct count for multiple locales.
         return null;
     }
 
     public function provide(ReindexConfig $reindexConfig): \Generator
     {
-        $articles = $this->loadArticles($reindexConfig->getIdentifiers());
-        $dimesionContentIds = [];
-        $resolvedArticles = [];
+        $identifiers = $reindexConfig->getIdentifiers();
+        $offset = 0;
+        $batch = $this->loadBatch($identifiers, $offset);
 
-        foreach ($articles as $article) {
-            $dimesionContentIds[] = $article['dimensionContentId'];
-            $resolvedArticles[$article['dimensionContentId']] = $article;
-        }
+        while ([] !== $batch) {
+            $dimensionContentIds = \array_column($batch, 'dimensionContentId');
+            $additionalWebspacesResult = $this->loadAdditionalWebspaces($dimensionContentIds);
 
-        $additionalWebspacesResult = $this->loadAdditionalWebspaces($dimesionContentIds);
+            /** @var Article $article */
+            foreach ($batch as $article) {
+                $authoredAt = $article['authored'] ?? $article['changed'];
+                $webspaces = $article['mainWebspace'] ? [$article['mainWebspace']] : [];
 
-        /** @var Article $article */
-        foreach ($resolvedArticles as $article) {
-            $authoredAt = $article['authored'] ?? $article['changed'];
-            $webspaces = $article['mainWebspace'] ? [$article['mainWebspace']] : [];
-
-            foreach ($additionalWebspacesResult as $additionalWebspaceRow) {
-                if ($additionalWebspaceRow['articleDimensionContentId'] === $article['dimensionContentId'] && !\in_array($additionalWebspaceRow['webspace'], $webspaces, true)) {
-                    $webspaces[] = $additionalWebspaceRow['webspace'];
+                foreach ($additionalWebspacesResult as $additionalWebspaceRow) {
+                    if ($additionalWebspaceRow['articleDimensionContentId'] === $article['dimensionContentId'] && !\in_array($additionalWebspaceRow['webspace'], $webspaces, true)) {
+                        $webspaces[] = $additionalWebspaceRow['webspace'];
+                    }
                 }
+
+                $data = [
+                    'id' => ArticleInterface::RESOURCE_KEY . '__' . ((string) $article['articleId']) . '__' . $article['locale'],
+                    'resourceKey' => ArticleInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $article['articleId'],
+                    'locale' => $article['locale'],
+                    'webspaces' => $webspaces,
+                    'title' => '',
+                    'url' => $article['slug'],
+                    'content' => [],
+                    'mediaId' => '',
+                    'authoredAt' => $authoredAt->format('c'),
+                    'metadata' => [],
+                ];
+
+                foreach ($this->enhancers as $enhancer) {
+                    $data = $enhancer->enhanceDocument($article, $data);
+                }
+
+                if ('' === $data['title']) {
+                    $data['title'] = $article['title'];
+                }
+
+                yield $data;
             }
 
-            $data = [
-                'id' => ArticleInterface::RESOURCE_KEY . '__' . ((string) $article['articleId']) . '__' . $article['locale'],
-                'resourceKey' => ArticleInterface::RESOURCE_KEY,
-                'resourceId' => (string) $article['articleId'],
-                'locale' => $article['locale'],
-                'webspaces' => $webspaces,
-                'title' => '',
-                'url' => $article['slug'],
-                'content' => [],
-                'mediaId' => '',
-                'authoredAt' => $authoredAt->format('c'),
-                'metadata' => [],
-            ];
-
-            foreach ($this->enhancers as $enhancer) {
-                $data = $enhancer->enhanceDocument($article, $data);
-            }
-
-            if ('' === $data['title']) {
-                $data['title'] = $article['title'];
-            }
-
-            yield $data;
+            $offset += self::BATCH_SIZE;
+            $batch = $this->loadBatch($identifiers, $offset);
         }
     }
 
     /**
      * @param string[] $identifiers
      *
-     * @return iterable<Article>
+     * @return array<int, Article>
      */
-    private function loadArticles(array $identifiers = []): iterable
+    private function loadBatch(array $identifiers, int $offset): array
     {
-        $qb = $this->dimensionContentRepository->createQueryBuilder('dimensionContent')
+        $queryBuilder = $this->dimensionContentRepository->createQueryBuilder('dimensionContent')
             ->leftJoin('dimensionContent.route', 'route')
             ->select('IDENTITY(dimensionContent.article) AS articleId')
             ->addSelect('dimensionContent.authored')
@@ -169,39 +171,43 @@ final class WebsiteArticleReindexProvider implements ReindexProviderInterface
                 return [];
             }
 
-            $qb->andWhere(\implode(' OR ', $conditions));
+            $queryBuilder->andWhere(\implode(' OR ', $conditions));
         }
 
         foreach ($parameters as $parameterKey => $parameterValue) {
-            $qb->setParameter($parameterKey, $parameterValue);
+            $queryBuilder->setParameter($parameterKey, $parameterValue);
         }
 
         foreach ($this->enhancers as $enhancer) {
-            $enhancer->enhanceQuery($qb);
+            $enhancer->enhanceQuery($queryBuilder);
         }
 
-        /** @var iterable<Article> */
-        return $qb->getQuery()->toIterable();
+        $queryBuilder->orderBy('dimensionContent.id', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults(self::BATCH_SIZE);
+
+        /** @var array<int, Article> */
+        return $queryBuilder->getQuery()->getResult();
     }
 
     /**
-     * @param int[] $dimesionContentIds
+     * @param int[] $dimensionContentIds
      *
      * @return array<int, array{articleDimensionContentId: int, webspace: string}>
      */
-    private function loadAdditionalWebspaces(array $dimesionContentIds = []): array
+    private function loadAdditionalWebspaces(array $dimensionContentIds = []): array
     {
-        if (0 === \count($dimesionContentIds)) {
+        if (0 === \count($dimensionContentIds)) {
             return [];
         }
 
-        $qb = $this->additionalWebspacesRepository->createQueryBuilder('additionalWebspace')
+        $queryBuilder = $this->additionalWebspacesRepository->createQueryBuilder('additionalWebspace')
             ->select('IDENTITY(additionalWebspace.articleDimensionContent) AS articleDimensionContentId')
             ->addSelect('additionalWebspace.additionalWebspace AS webspace')
-            ->where('additionalWebspace.articleDimensionContent IN (:dimesionContentIds)')
-            ->setParameter('dimesionContentIds', $dimesionContentIds);
+            ->where('additionalWebspace.articleDimensionContent IN (:dimensionContentIds)')
+            ->setParameter('dimensionContentIds', $dimensionContentIds);
 
-        return $qb->getQuery()->getResult();
+        return $queryBuilder->getQuery()->getResult();
     }
 
     public static function getIndex(): string

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -54,6 +54,7 @@ use Sulu\Article\Infrastructure\Sulu\Route\ArticleRouteDefaultsProvider;
 use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleIndexListener;
 use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleReindexProvider;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexContentEnhancer;
+use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexExcerptEnhancer;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexProviderEnhancerInterface;
 use Sulu\Article\Infrastructure\Sulu\Search\WebsiteArticleIndexListener;
 use Sulu\Article\Infrastructure\Sulu\Search\WebsiteArticleReindexProvider;
@@ -482,6 +483,10 @@ final class SuluArticleBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_admin.form_metadata_provider'),
             ])
+            ->tag('sulu_article.website_article_reindex_provider_enhancer');
+
+        $services->set('sulu_article.website_article_reindex_excerpt_enhancer')
+            ->class(WebsiteArticleReindexExcerptEnhancer::class)
             ->tag('sulu_article.website_article_reindex_provider_enhancer');
 
         $services->set('sulu_article.website_article_reindex_provider')

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -492,7 +492,6 @@ final class SuluArticleBundle extends AbstractBundle
 
         $services->set('sulu_article.website_article_reindex_taxonomy_enhancer')
             ->class(WebsiteArticleReindexTaxonomyEnhancer::class)
-            ->args([new Reference('doctrine.orm.entity_manager')])
             ->tag('sulu_article.website_article_reindex_provider_enhancer');
 
         $services->set('sulu_article.website_article_reindex_provider')

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -56,6 +56,7 @@ use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleReindexProvider;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexContentEnhancer;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexExcerptEnhancer;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexProviderEnhancerInterface;
+use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexTaxonomyEnhancer;
 use Sulu\Article\Infrastructure\Sulu\Search\WebsiteArticleIndexListener;
 use Sulu\Article\Infrastructure\Sulu\Search\WebsiteArticleReindexProvider;
 use Sulu\Article\Infrastructure\Sulu\Sitemap\ArticlesSitemapProvider;
@@ -487,6 +488,13 @@ final class SuluArticleBundle extends AbstractBundle
 
         $services->set('sulu_article.website_article_reindex_excerpt_enhancer')
             ->class(WebsiteArticleReindexExcerptEnhancer::class)
+            ->tag('sulu_article.website_article_reindex_provider_enhancer');
+
+        $services->set('sulu_article.website_article_reindex_taxonomy_enhancer')
+            ->class(WebsiteArticleReindexTaxonomyEnhancer::class)
+            ->args([
+                new Reference('doctrine.orm.entity_manager'),
+            ])
             ->tag('sulu_article.website_article_reindex_provider_enhancer');
 
         $services->set('sulu_article.website_article_reindex_provider')

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -492,9 +492,7 @@ final class SuluArticleBundle extends AbstractBundle
 
         $services->set('sulu_article.website_article_reindex_taxonomy_enhancer')
             ->class(WebsiteArticleReindexTaxonomyEnhancer::class)
-            ->args([
-                new Reference('doctrine.orm.entity_manager'),
-            ])
+            ->args([new Reference('doctrine.orm.entity_manager')])
             ->tag('sulu_article.website_article_reindex_provider_enhancer');
 
         $services->set('sulu_article.website_article_reindex_provider')

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
@@ -525,7 +525,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
 
         $provider = new WebsiteArticleReindexProvider(
             $this->entityManager,
-            [new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager)],
+            [new WebsiteArticleReindexTaxonomyEnhancer()],
         );
 
         $article = static::createArticle([
@@ -564,7 +564,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
 
         $provider = new WebsiteArticleReindexProvider(
             $this->entityManager,
-            [new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager)],
+            [new WebsiteArticleReindexTaxonomyEnhancer()],
         );
 
         $article = static::createArticle([
@@ -602,7 +602,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
 
         $provider = new WebsiteArticleReindexProvider(
             $this->entityManager,
-            [new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager)],
+            [new WebsiteArticleReindexTaxonomyEnhancer()],
         );
 
         $article = static::createArticle([
@@ -635,7 +635,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
     {
         $provider = new WebsiteArticleReindexProvider(
             $this->entityManager,
-            [new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager)],
+            [new WebsiteArticleReindexTaxonomyEnhancer()],
         );
 
         $article = static::createArticle([
@@ -670,7 +670,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
             $this->entityManager,
             [
                 new WebsiteArticleReindexExcerptEnhancer(),
-                new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager),
+                new WebsiteArticleReindexTaxonomyEnhancer(),
             ],
         );
 

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Article\Tests\Functional\Infrastructure\Sulu\Search;
 use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexExcerptEnhancer;
 use Sulu\Article\Infrastructure\Sulu\Search\WebsiteArticleReindexProvider;
 use Sulu\Article\Tests\Traits\CreateArticleTrait;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
@@ -147,6 +148,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
+                'properties' => [],
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
@@ -159,6 +161,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                'properties' => [],
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__en',
@@ -171,6 +174,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                'properties' => [],
             ],
         ];
 
@@ -257,6 +261,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
+                'properties' => [],
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
@@ -269,6 +274,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                'properties' => [],
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__en',
@@ -281,6 +287,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                'properties' => [],
             ],
         ];
 
@@ -358,5 +365,147 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $this->assertNotContains('Article TWO EN', $resultTitles);
         $this->assertNotContains('Article THREE DE', $resultTitles);
         $this->assertNotContains('Article THREE EN', $resultTitles);
+    }
+
+    public function testExcerptEnhancerPopulatesExcerptProperties(): void
+    {
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [new WebsiteArticleReindexExcerptEnhancer()],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Article With Excerpt',
+                    'url' => '/article-excerpt',
+                    'excerpt' => [
+                        'title' => 'Excerpt Title',
+                        'description' => '<p>Excerpt <strong>description</strong></p>',
+                        'more' => 'Read more',
+                        'image' => ['id' => 1],
+                        'icon' => ['id' => 2],
+                    ],
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertSame('Excerpt Title', $result['title']);
+
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Excerpt description', $excerpt['description']);
+        $this->assertSame('Read more', $excerpt['more']);
+        $this->assertSame(1, $excerpt['imageId']);
+        $this->assertSame(2, $excerpt['iconId']);
+    }
+
+    public function testExcerptTitleFallbackWhenNoContentTitle(): void
+    {
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [new WebsiteArticleReindexExcerptEnhancer()],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Original Title',
+                    'url' => '/article-title-fallback',
+                    'excerpt' => [
+                        'title' => 'Excerpt Title Override',
+                    ],
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertSame('Excerpt Title Override', $result['title']);
+
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+        $this->assertSame('Excerpt Title Override', $excerpt['title']);
+    }
+
+    public function testExcerptImageFallbackToMediaId(): void
+    {
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [new WebsiteArticleReindexExcerptEnhancer()],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Article With Excerpt Image',
+                    'url' => '/article-excerpt-image',
+                    'excerpt' => [
+                        'image' => ['id' => 55],
+                    ],
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertSame('55', $result['mediaId']);
+
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+        $this->assertSame(55, $excerpt['imageId']);
+    }
+
+    public function testNoExcerptDataProducesEmptyProperties(): void
+    {
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [new WebsiteArticleReindexExcerptEnhancer()],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'No Excerpt Article',
+                    'url' => '/no-excerpt',
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertSame('No Excerpt Article', $result['title']);
+        $this->assertSame([], $result['properties']);
     }
 }

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
@@ -153,7 +153,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
@@ -166,7 +166,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__en',
@@ -179,7 +179,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ],
         ];
 
@@ -266,7 +266,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
@@ -279,7 +279,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__en',
@@ -292,7 +292,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ],
         ];
 
@@ -405,12 +405,12 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $result = $results[0];
         $this->assertSame('Excerpt Title', $result['title']);
 
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertSame('Excerpt Title', $excerpt['title']);
-        $this->assertSame('Excerpt description', $excerpt['description']);
+        $this->assertSame('<p>Excerpt <strong>description</strong></p>', $excerpt['description']);
         $this->assertSame('Read more', $excerpt['more']);
         $this->assertSame(1, $excerpt['imageId']);
         $this->assertSame(2, $excerpt['iconId']);
@@ -445,8 +445,8 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $result = $results[0];
         $this->assertSame('Excerpt Title Override', $result['title']);
 
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
         $this->assertSame('Excerpt Title Override', $excerpt['title']);
     }
@@ -480,8 +480,8 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $result = $results[0];
         $this->assertSame('55', $result['mediaId']);
 
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
         $this->assertSame(55, $excerpt['imageId']);
     }
@@ -511,7 +511,7 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
 
         $result = $results[0];
         $this->assertSame('No Excerpt Article', $result['title']);
-        $this->assertSame([], $result['properties']);
+        $this->assertSame([], $result['metadata']);
     }
 
     public function testTaxonomyEnhancerPopulatesCategoriesAndTags(): void
@@ -547,8 +547,8 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertSame([$category1->getId(), $category2->getId()], $excerpt['categoryIds']);
@@ -585,8 +585,8 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertSame([$category1->getId(), $category2->getId()], $excerpt['categoryIds']);
@@ -623,8 +623,8 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertArrayNotHasKey('categoryIds', $excerpt);
@@ -655,8 +655,8 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $this->assertArrayNotHasKey('excerpt', $result['properties']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertArrayNotHasKey('excerpt', $result['metadata']);
     }
 
     public function testTaxonomyEnhancerPreservesExistingExcerptProperties(): void
@@ -697,12 +697,12 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertSame('Excerpt Title', $excerpt['title']);
-        $this->assertSame('Excerpt description', $excerpt['description']);
+        $this->assertSame('<p>Excerpt description</p>', $excerpt['description']);
         $this->assertSame([$category->getId()], $excerpt['categoryIds']);
         $this->assertSame(['test-tag'], $excerpt['tagNames']);
     }

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/WebsiteArticleReindexProviderTest.php
@@ -17,11 +17,14 @@ use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexExcerptEnhancer;
+use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexTaxonomyEnhancer;
 use Sulu\Article\Infrastructure\Sulu\Search\WebsiteArticleReindexProvider;
 use Sulu\Article\Tests\Traits\CreateArticleTrait;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Tests\Traits\CreateCategoryTrait;
+use Sulu\Content\Tests\Traits\CreateTagTrait;
 
 /**
  * @phpstan-type ArticleData array{
@@ -39,6 +42,8 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
 {
     use SetGetPrivatePropertyTrait;
     use CreateArticleTrait;
+    use CreateCategoryTrait;
+    use CreateTagTrait;
 
     private EntityManagerInterface $entityManager;
     private WebsiteArticleReindexProvider $provider;
@@ -507,5 +512,198 @@ class WebsiteArticleReindexProviderTest extends SuluTestCase
         $result = $results[0];
         $this->assertSame('No Excerpt Article', $result['title']);
         $this->assertSame([], $result['properties']);
+    }
+
+    public function testTaxonomyEnhancerPopulatesCategoriesAndTags(): void
+    {
+        $category1 = static::createCategory(['en' => ['title' => 'Category 1']]);
+        $category2 = static::createCategory(['en' => ['title' => 'Category 2']]);
+        $tag1 = static::createTag(['name' => 'tag-one']);
+        $tag2 = static::createTag(['name' => 'tag-two']);
+
+        $this->entityManager->flush();
+
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager)],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Article With Taxonomy',
+                    'url' => '/article-taxonomy',
+                    'excerptCategories' => [$category1->getId(), $category2->getId()],
+                    'excerptTags' => [$tag1->getName(), $tag2->getName()],
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertSame([$category1->getId(), $category2->getId()], $excerpt['categoryIds']);
+        $this->assertSame(['tag-one', 'tag-two'], $excerpt['tagNames']);
+    }
+
+    public function testTaxonomyEnhancerPopulatesOnlyCategories(): void
+    {
+        $category1 = static::createCategory(['en' => ['title' => 'Category 1']]);
+        $category2 = static::createCategory(['en' => ['title' => 'Category 2']]);
+
+        $this->entityManager->flush();
+
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager)],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Article With Categories',
+                    'url' => '/article-categories',
+                    'excerptCategories' => [$category1->getId(), $category2->getId()],
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertSame([$category1->getId(), $category2->getId()], $excerpt['categoryIds']);
+        $this->assertArrayNotHasKey('tagNames', $excerpt);
+    }
+
+    public function testTaxonomyEnhancerPopulatesOnlyTags(): void
+    {
+        $tag1 = static::createTag(['name' => 'php']);
+        $tag2 = static::createTag(['name' => 'sulu']);
+
+        $this->entityManager->flush();
+
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager)],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Article With Tags',
+                    'url' => '/article-tags',
+                    'excerptTags' => [$tag1->getName(), $tag2->getName()],
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertArrayNotHasKey('categoryIds', $excerpt);
+        $this->assertSame(['php', 'sulu'], $excerpt['tagNames']);
+    }
+
+    public function testTaxonomyEnhancerWithEmptyTaxonomyDoesNotAddKeys(): void
+    {
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager)],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Article Without Taxonomy',
+                    'url' => '/article-no-taxonomy',
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $this->assertArrayNotHasKey('excerpt', $result['properties']);
+    }
+
+    public function testTaxonomyEnhancerPreservesExistingExcerptProperties(): void
+    {
+        $category = static::createCategory(['en' => ['title' => 'Category 1']]);
+        $tag = static::createTag(['name' => 'test-tag']);
+
+        $this->entityManager->flush();
+
+        $provider = new WebsiteArticleReindexProvider(
+            $this->entityManager,
+            [
+                new WebsiteArticleReindexExcerptEnhancer(),
+                new WebsiteArticleReindexTaxonomyEnhancer($this->entityManager),
+            ],
+        );
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Article With Excerpt and Taxonomy',
+                    'url' => '/article-excerpt-taxonomy',
+                    'excerpt' => [
+                        'title' => 'Excerpt Title',
+                        'description' => '<p>Excerpt description</p>',
+                    ],
+                    'excerptCategories' => [$category->getId()],
+                    'excerptTags' => [$tag->getName()],
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Excerpt description', $excerpt['description']);
+        $this->assertSame([$category->getId()], $excerpt['categoryIds']);
+        $this->assertSame(['test-tag'], $excerpt['tagNames']);
     }
 }

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
@@ -412,6 +412,229 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         ];
     }
 
+    public function testRoleImageSingleMediaSelectionSetsMediaId(): void
+    {
+        $imageField = new FieldMetadata('header_image');
+        $imageField->setType('single_media_selection');
+        $imageField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'image'));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($imageField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'header_image' => ['id' => 42],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame('42', $returnedData['mediaId']);
+    }
+
+    public function testRoleImageMediaSelectionSetsMediaIdFromFirstId(): void
+    {
+        $imageField = new FieldMetadata('images');
+        $imageField->setType('media_selection');
+        $imageField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'image'));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($imageField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'images' => ['ids' => [10, 20, 30]],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame('10', $returnedData['mediaId']);
+    }
+
+    public function testRoleImageWithEmptyDataDoesNotSetMediaId(): void
+    {
+        $imageField = new FieldMetadata('header_image');
+        $imageField->setType('single_media_selection');
+        $imageField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'image'));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($imageField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'header_image' => [],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertArrayNotHasKey('mediaId', $returnedData);
+    }
+
+    public function testRoleTitleOverridesDocumentTitle(): void
+    {
+        $titleField = new FieldMetadata('headline');
+        $titleField->setType('text_line');
+        $titleField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'title'));
+
+        $descriptionField = new FieldMetadata('description');
+        $descriptionField->setType('text_area');
+        $descriptionField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($titleField);
+        $formMetadata->addItem($descriptionField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'headline' => 'Custom Headline',
+                'description' => 'Some description',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => [], 'title' => 'Original Title']);
+
+        $this->assertSame('Custom Headline', $returnedData['title']);
+        $this->assertSame(['Some description'], $returnedData['content']);
+    }
+
+    public function testRoleTitleFieldExcludedFromContent(): void
+    {
+        $titleField = new FieldMetadata('headline');
+        $titleField->setType('text_line');
+        $titleField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'title'));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($titleField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'headline' => 'Custom Headline',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame([], $returnedData['content']);
+    }
+
+    public function testRoleUrlFieldExcludedFromContent(): void
+    {
+        $urlField = new FieldMetadata('custom_url');
+        $urlField->setType('text_line');
+        $urlField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'url'));
+
+        $descriptionField = new FieldMetadata('description');
+        $descriptionField->setType('text_area');
+        $descriptionField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($urlField);
+        $formMetadata->addItem($descriptionField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'custom_url' => '/some-url',
+                'description' => 'Some description',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['Some description'], $returnedData['content']);
+    }
+
+    public function testNoRoleFieldIncludedInContent(): void
+    {
+        $textField = new FieldMetadata('body');
+        $textField->setType('text_editor');
+        $textField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($textField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'body' => '<p>Body content</p>',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['Body content'], $returnedData['content']);
+    }
+
     private function createBlockFormMetadata(): FormMetadata
     {
         $titleField = new FieldMetadata('title');
@@ -469,10 +692,14 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         return $formMetadata;
     }
 
-    private function createTag(string $name): TagMetadata
+    private function createTag(string $name, ?string $role = null): TagMetadata
     {
         $tag = new TagMetadata();
         $tag->setName($name);
+
+        if (null !== $role) {
+            $tag->setAttributes(['role' => $role]);
+        }
 
         return $tag;
     }

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancerTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Tests\Unit\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexExcerptEnhancer;
+
+class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private WebsiteArticleReindexExcerptEnhancer $enhancer;
+
+    protected function setUp(): void
+    {
+        $this->enhancer = new WebsiteArticleReindexExcerptEnhancer();
+    }
+
+    public function testEnhanceQueryAddsExcerptData(): void
+    {
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->addSelect('dimensionContent.excerptData')->willReturn($queryBuilder)->shouldBeCalled();
+
+        $this->enhancer->enhanceQuery($queryBuilder->reveal());
+    }
+
+    public function testExcerptDataIsNullReturnsUnchanged(): void
+    {
+        $queryResult = ['excerptData' => null];
+        $document = ['content' => [], 'title' => '', 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertSame('', $returnedData['title']);
+        $this->assertSame('', $returnedData['mediaId']);
+    }
+
+    public function testExcerptDataMissingReturnsUnchanged(): void
+    {
+        $queryResult = [];
+        $document = ['content' => [], 'title' => '', 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertSame('', $returnedData['title']);
+        $this->assertSame('', $returnedData['mediaId']);
+    }
+
+    public function testExcerptTitleSetsExcerptTitleAndFallsBackToTitle(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => 'Excerpt Title'],
+        ];
+        $document = ['content' => [], 'title' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Excerpt Title', $returnedData['title']);
+    }
+
+    public function testExcerptTitleDoesNotOverrideExistingTitle(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => 'Excerpt Title'],
+        ];
+        $document = ['content' => [], 'title' => 'Tagged Title'];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Tagged Title', $returnedData['title']);
+    }
+
+    public function testExcerptTitleEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => ''],
+        ];
+        $document = ['content' => [], 'title' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertSame('', $returnedData['title']);
+    }
+
+    public function testExcerptTitleWhitespaceIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => '   '],
+        ];
+        $document = ['content' => [], 'title' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptDescriptionSetsField(): void
+    {
+        $queryResult = [
+            'excerptData' => ['description' => '<p>Some <strong>rich</strong> description</p>'],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Some rich description', $excerpt['description']);
+    }
+
+    public function testExcerptDescriptionEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['description' => ''],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptMoreSetsField(): void
+    {
+        $queryResult = [
+            'excerptData' => ['more' => 'Read more'],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Read more', $excerpt['more']);
+    }
+
+    public function testExcerptMoreEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['more' => ''],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptImageSetsExcerptImageIdAndFallsBackToMediaId(): void
+    {
+        $queryResult = [
+            'excerptData' => ['image' => ['id' => 99]],
+        ];
+        $document = ['content' => [], 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame(99, $excerpt['imageId']);
+        $this->assertSame('99', $returnedData['mediaId']);
+    }
+
+    public function testExcerptImageDoesNotOverrideExistingMediaId(): void
+    {
+        $queryResult = [
+            'excerptData' => ['image' => ['id' => 99]],
+        ];
+        $document = ['content' => [], 'mediaId' => '42'];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame(99, $excerpt['imageId']);
+        $this->assertSame('42', $returnedData['mediaId']);
+    }
+
+    public function testExcerptImageEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['image' => []],
+        ];
+        $document = ['content' => [], 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptImageNonNumericIdIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['image' => ['id' => 'invalid']],
+        ];
+        $document = ['content' => [], 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptIconSetsField(): void
+    {
+        $queryResult = [
+            'excerptData' => ['icon' => ['id' => 77]],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame(77, $excerpt['iconId']);
+    }
+
+    public function testExcerptIconEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['icon' => []],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptIconNonNumericIdIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['icon' => ['id' => 'invalid']],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testAllExcerptFieldsPopulated(): void
+    {
+        $queryResult = [
+            'excerptData' => [
+                'title' => 'Excerpt Title',
+                'description' => '<p>Description</p>',
+                'more' => 'Read more',
+                'image' => ['id' => 55],
+                'icon' => ['id' => 33],
+            ],
+        ];
+        $document = ['content' => [], 'title' => '', 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Excerpt Title', $returnedData['title']);
+        $this->assertSame('Description', $excerpt['description']);
+        $this->assertSame('Read more', $excerpt['more']);
+        $this->assertSame(55, $excerpt['imageId']);
+        $this->assertSame('55', $returnedData['mediaId']);
+        $this->assertSame(33, $excerpt['iconId']);
+    }
+
+    /**
+     * @param array<string, mixed> $returnedData
+     *
+     * @return array<string, mixed>
+     */
+    private function getExcerpt(array $returnedData): array
+    {
+        $properties = $returnedData['properties'] ?? null;
+        $this->assertIsArray($properties);
+
+        $excerpt = $properties['excerpt'] ?? null;
+        $this->assertIsArray($excerpt);
+
+        /** @var array<string, mixed> $excerpt */
+        return $excerpt;
+    }
+}

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexExcerptEnhancerTest.php
@@ -96,7 +96,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
         $this->assertSame('', $returnedData['title']);
     }
 
@@ -109,7 +109,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptDescriptionSetsField(): void
@@ -122,7 +122,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
         $excerpt = $this->getExcerpt($returnedData);
 
-        $this->assertSame('Some rich description', $excerpt['description']);
+        $this->assertSame('<p>Some <strong>rich</strong> description</p>', $excerpt['description']);
     }
 
     public function testExcerptDescriptionEmptyIsSkipped(): void
@@ -134,7 +134,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptMoreSetsField(): void
@@ -159,7 +159,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptImageSetsExcerptImageIdAndFallsBackToMediaId(): void
@@ -199,7 +199,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptImageNonNumericIdIsSkipped(): void
@@ -211,7 +211,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptIconSetsField(): void
@@ -236,7 +236,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptIconNonNumericIdIsSkipped(): void
@@ -248,7 +248,47 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
+    }
+
+    public function testExcerptTitleAddedToContent(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => 'Excerpt Title'],
+        ];
+        $document = ['content' => ['existing content'], 'title' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertIsArray($returnedData['content']);
+        $this->assertContains('Excerpt Title', $returnedData['content']);
+        $this->assertContains('existing content', $returnedData['content']);
+    }
+
+    public function testExcerptDescriptionAddedToContentStripped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['description' => '<p>Some <strong>rich</strong> description</p>'],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertIsArray($returnedData['content']);
+        $this->assertContains('Some rich description', $returnedData['content']);
+    }
+
+    public function testExcerptDescriptionInMetadataKeepsHtml(): void
+    {
+        $queryResult = [
+            'excerptData' => ['description' => '<p>Some <strong>rich</strong> description</p>'],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('<p>Some <strong>rich</strong> description</p>', $excerpt['description']);
     }
 
     public function testAllExcerptFieldsPopulated(): void
@@ -269,7 +309,7 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
 
         $this->assertSame('Excerpt Title', $excerpt['title']);
         $this->assertSame('Excerpt Title', $returnedData['title']);
-        $this->assertSame('Description', $excerpt['description']);
+        $this->assertSame('<p>Description</p>', $excerpt['description']);
         $this->assertSame('Read more', $excerpt['more']);
         $this->assertSame(55, $excerpt['imageId']);
         $this->assertSame('55', $returnedData['mediaId']);
@@ -283,10 +323,10 @@ class WebsiteArticleReindexExcerptEnhancerTest extends TestCase
      */
     private function getExcerpt(array $returnedData): array
     {
-        $properties = $returnedData['properties'] ?? null;
-        $this->assertIsArray($properties);
+        $metadata = $returnedData['metadata'] ?? null;
+        $this->assertIsArray($metadata);
 
-        $excerpt = $properties['excerpt'] ?? null;
+        $excerpt = $metadata['excerpt'] ?? null;
         $this->assertIsArray($excerpt);
 
         /** @var array<string, mixed> $excerpt */

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
@@ -50,76 +50,76 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
 
     public function testCategoriesPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => 1], ['id' => 2], ['id' => 3]],
-            tagResults: [['name' => null]],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: '1,2,3',
+            tagNames: null,
         );
 
-        $document = ['title' => 'Test', 'properties' => []];
+        $document = ['title' => 'Test', 'metadata' => []];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertIsArray($result['properties']['excerpt']);
-        $this->assertSame([1, 2, 3], $result['properties']['excerpt']['categoryIds']);
-        $this->assertArrayNotHasKey('tagNames', $result['properties']['excerpt']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertIsArray($result['metadata']['excerpt']);
+        $this->assertSame([1, 2, 3], $result['metadata']['excerpt']['categoryIds']);
+        $this->assertArrayNotHasKey('tagNames', $result['metadata']['excerpt']);
     }
 
     public function testTagsPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => null]],
-            tagResults: [['name' => 'php'], ['name' => 'sulu']],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: null,
+            tagNames: 'php||sulu',
         );
 
-        $document = ['title' => 'Test', 'properties' => []];
+        $document = ['title' => 'Test', 'metadata' => []];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertIsArray($result['properties']['excerpt']);
-        $this->assertArrayNotHasKey('categoryIds', $result['properties']['excerpt']);
-        $this->assertSame(['php', 'sulu'], $result['properties']['excerpt']['tagNames']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertIsArray($result['metadata']['excerpt']);
+        $this->assertArrayNotHasKey('categoryIds', $result['metadata']['excerpt']);
+        $this->assertSame(['php', 'sulu'], $result['metadata']['excerpt']['tagNames']);
     }
 
     public function testBothCategoriesAndTagsPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => 5], ['id' => 10]],
-            tagResults: [['name' => 'cms'], ['name' => 'web']],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: '5,10',
+            tagNames: 'cms||web',
         );
 
-        $document = ['title' => 'Test', 'properties' => []];
+        $document = ['title' => 'Test', 'metadata' => []];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertIsArray($result['properties']['excerpt']);
-        $this->assertSame([5, 10], $result['properties']['excerpt']['categoryIds']);
-        $this->assertSame(['cms', 'web'], $result['properties']['excerpt']['tagNames']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertIsArray($result['metadata']['excerpt']);
+        $this->assertSame([5, 10], $result['metadata']['excerpt']['categoryIds']);
+        $this->assertSame(['cms', 'web'], $result['metadata']['excerpt']['tagNames']);
     }
 
     public function testEmptyTaxonomyDoesNotAddKeys(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => null]],
-            tagResults: [['name' => null]],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: null,
+            tagNames: null,
         );
 
-        $document = ['title' => 'Test', 'properties' => []];
+        $document = ['title' => 'Test', 'metadata' => []];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertArrayNotHasKey('excerpt', $result['properties']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertArrayNotHasKey('excerpt', $result['metadata']);
     }
 
-    public function testPreservesExistingExcerptProperties(): void
+    public function testPreservesExistingExcerptMetadata(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => 1]],
-            tagResults: [['name' => 'tag1']],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: '1',
+            tagNames: 'tag1',
         );
 
         $document = [
             'title' => 'Test',
-            'properties' => [
+            'metadata' => [
                 'excerpt' => [
                     'title' => 'Existing Excerpt Title',
                 ],
@@ -127,38 +127,34 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
         ];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertIsArray($result['properties']['excerpt']);
-        $this->assertSame('Existing Excerpt Title', $result['properties']['excerpt']['title']);
-        $this->assertSame([1], $result['properties']['excerpt']['categoryIds']);
-        $this->assertSame(['tag1'], $result['properties']['excerpt']['tagNames']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertIsArray($result['metadata']['excerpt']);
+        $this->assertSame('Existing Excerpt Title', $result['metadata']['excerpt']['title']);
+        $this->assertSame([1], $result['metadata']['excerpt']['categoryIds']);
+        $this->assertSame(['tag1'], $result['metadata']['excerpt']['tagNames']);
     }
 
-    /**
-     * @param list<array{id: int|null}> $categoryResults
-     * @param list<array{name: string|null}> $tagResults
-     */
-    private function createEnhancerWithResults(array $categoryResults, array $tagResults): WebsiteArticleReindexTaxonomyEnhancer
+    private function createEnhancerWithTaxonomyResult(?string $categoryIds, ?string $tagNames): WebsiteArticleReindexTaxonomyEnhancer
     {
-        $categoryQb = $this->createQueryBuilderStub($categoryResults);
-        $tagQb = $this->createQueryBuilderStub($tagResults);
+        $qb = $this->createQueryBuilderStub(['categoryIds' => $categoryIds, 'tagNames' => $tagNames]);
 
         $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $entityManager->createQueryBuilder()->willReturn($categoryQb, $tagQb);
+        $entityManager->createQueryBuilder()->willReturn($qb);
 
         return new WebsiteArticleReindexTaxonomyEnhancer($entityManager->reveal());
     }
 
     /**
-     * @param list<array<string, mixed>> $scalarResult
+     * @param array<string, mixed> $singleResult
      */
-    private function createQueryBuilderStub(array $scalarResult): QueryBuilder
+    private function createQueryBuilderStub(array $singleResult): QueryBuilder
     {
         $query = $this->prophesize(Query::class);
-        $query->getScalarResult()->willReturn($scalarResult);
+        $query->getSingleResult()->willReturn($singleResult);
 
         $qb = $this->prophesize(QueryBuilder::class);
         $qb->select(Argument::any())->willReturn($qb);
+        $qb->addSelect(Argument::any())->willReturn($qb);
         $qb->from(Argument::any(), Argument::any())->willReturn($qb);
         $qb->leftJoin(Argument::any(), Argument::any())->willReturn($qb);
         $qb->where(Argument::any())->willReturn($qb);

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
@@ -29,16 +29,27 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
         $this->enhancer = new WebsiteArticleReindexTaxonomyEnhancer();
     }
 
-    public function testEnhanceQueryAddsJoinsAndGroupConcat(): void
+    public function testEnhanceQueryAddsSubqueries(): void
     {
-        $queryBuilder = $this->prophesize(QueryBuilder::class);
-        $queryBuilder->leftJoin('dimensionContent.excerptCategories', 'category')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->leftJoin('dimensionContent.excerptTags', 'tag')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->addSelect('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->addGroupBy('dimensionContent.id')->willReturn($queryBuilder)->shouldBeCalled();
+        // Create a real EntityManager and QueryBuilder for this test
+        // since mocking the nested QueryBuilder creation is too complex
+        $entityManager = $this->prophesize(\Doctrine\ORM\EntityManagerInterface::class);
 
-        $this->enhancer->enhanceQuery($queryBuilder->reveal());
+        $categorySubQueryBuilder = new QueryBuilder($entityManager->reveal());
+        $tagSubQueryBuilder = new QueryBuilder($entityManager->reveal());
+
+        $entityManager->createQueryBuilder()
+            ->willReturn($categorySubQueryBuilder, $tagSubQueryBuilder);
+
+        $queryBuilder = new QueryBuilder($entityManager->reveal());
+        $queryBuilder->from('TestEntity', 't');
+
+        $this->enhancer->enhanceQuery($queryBuilder);
+
+        // Verify that subqueries were added
+        $dql = $queryBuilder->getDQL();
+        $this->assertStringContainsString('categoryIds', $dql);
+        $this->assertStringContainsString('tagNames', $dql);
     }
 
     public function testMissingTaxonomyDataReturnsUnchanged(): void

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
@@ -13,11 +13,8 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Tests\Unit\Infrastructure\Sulu\Search\Visitor;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexTaxonomyEnhancer;
 
@@ -25,38 +22,38 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testEnhanceQueryDoesNotModifyQuery(): void
+    private WebsiteArticleReindexTaxonomyEnhancer $enhancer;
+
+    protected function setUp(): void
     {
-        $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $enhancer = new WebsiteArticleReindexTaxonomyEnhancer($entityManager->reveal());
-
-        $queryBuilder = $this->prophesize(QueryBuilder::class);
-        $queryBuilder->addSelect(Argument::any())->shouldNotBeCalled();
-
-        $enhancer->enhanceQuery($queryBuilder->reveal());
+        $this->enhancer = new WebsiteArticleReindexTaxonomyEnhancer();
     }
 
-    public function testMissingDimensionContentIdReturnsUnchanged(): void
+    public function testEnhanceQueryAddsJoinsAndGroupConcat(): void
     {
-        $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $enhancer = new WebsiteArticleReindexTaxonomyEnhancer($entityManager->reveal());
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->leftJoin('dimensionContent.excerptCategories', 'category')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->leftJoin('dimensionContent.excerptTags', 'tag')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->addSelect('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->addGroupBy('dimensionContent.id')->willReturn($queryBuilder)->shouldBeCalled();
 
-        $document = ['title' => 'Test'];
+        $this->enhancer->enhanceQuery($queryBuilder->reveal());
+    }
 
-        $result = $enhancer->enhanceDocument([], $document);
+    public function testMissingTaxonomyDataReturnsUnchanged(): void
+    {
+        $document = ['title' => 'Test', 'metadata' => []];
+
+        $result = $this->enhancer->enhanceDocument([], $document);
 
         $this->assertSame($document, $result);
     }
 
     public function testCategoriesPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: '1,2,3',
-            tagNames: null,
-        );
-
         $document = ['title' => 'Test', 'metadata' => []];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => '1,2,3', 'tagNames' => null], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertIsArray($result['metadata']['excerpt']);
@@ -66,13 +63,8 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
 
     public function testTagsPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: null,
-            tagNames: 'php,sulu',
-        );
-
         $document = ['title' => 'Test', 'metadata' => []];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => null, 'tagNames' => 'php,sulu'], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertIsArray($result['metadata']['excerpt']);
@@ -82,13 +74,8 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
 
     public function testBothCategoriesAndTagsPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: '5,10',
-            tagNames: 'cms,web',
-        );
-
         $document = ['title' => 'Test', 'metadata' => []];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => '5,10', 'tagNames' => 'cms,web'], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertIsArray($result['metadata']['excerpt']);
@@ -98,13 +85,8 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
 
     public function testEmptyTaxonomyDoesNotAddKeys(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: null,
-            tagNames: null,
-        );
-
         $document = ['title' => 'Test', 'metadata' => []];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => null, 'tagNames' => null], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertArrayNotHasKey('excerpt', $result['metadata']);
@@ -112,11 +94,6 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
 
     public function testPreservesExistingExcerptMetadata(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: '1',
-            tagNames: 'tag1',
-        );
-
         $document = [
             'title' => 'Test',
             'metadata' => [
@@ -125,42 +102,12 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
                 ],
             ],
         ];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => '1', 'tagNames' => 'tag1'], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertIsArray($result['metadata']['excerpt']);
         $this->assertSame('Existing Excerpt Title', $result['metadata']['excerpt']['title']);
         $this->assertSame([1], $result['metadata']['excerpt']['categoryIds']);
         $this->assertSame(['tag1'], $result['metadata']['excerpt']['tagNames']);
-    }
-
-    private function createEnhancerWithTaxonomyResult(?string $categoryIds, ?string $tagNames): WebsiteArticleReindexTaxonomyEnhancer
-    {
-        $qb = $this->createQueryBuilderStub(['categoryIds' => $categoryIds, 'tagNames' => $tagNames]);
-
-        $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $entityManager->createQueryBuilder()->willReturn($qb);
-
-        return new WebsiteArticleReindexTaxonomyEnhancer($entityManager->reveal());
-    }
-
-    /**
-     * @param array<string, mixed> $singleResult
-     */
-    private function createQueryBuilderStub(array $singleResult): QueryBuilder
-    {
-        $query = $this->prophesize(Query::class);
-        $query->getSingleResult()->willReturn($singleResult);
-
-        $qb = $this->prophesize(QueryBuilder::class);
-        $qb->select(Argument::any())->willReturn($qb);
-        $qb->addSelect(Argument::any())->willReturn($qb);
-        $qb->from(Argument::any(), Argument::any())->willReturn($qb);
-        $qb->leftJoin(Argument::any(), Argument::any())->willReturn($qb);
-        $qb->where(Argument::any())->willReturn($qb);
-        $qb->setParameter(Argument::any(), Argument::any())->willReturn($qb);
-        $qb->getQuery()->willReturn($query->reveal());
-
-        return $qb->reveal();
     }
 }

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Tests\Unit\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexTaxonomyEnhancer;
+
+class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testEnhanceQueryDoesNotModifyQuery(): void
+    {
+        $entityManager = $this->prophesize(EntityManagerInterface::class);
+        $enhancer = new WebsiteArticleReindexTaxonomyEnhancer($entityManager->reveal());
+
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->addSelect(Argument::any())->shouldNotBeCalled();
+
+        $enhancer->enhanceQuery($queryBuilder->reveal());
+    }
+
+    public function testMissingDimensionContentIdReturnsUnchanged(): void
+    {
+        $entityManager = $this->prophesize(EntityManagerInterface::class);
+        $enhancer = new WebsiteArticleReindexTaxonomyEnhancer($entityManager->reveal());
+
+        $document = ['title' => 'Test'];
+
+        $result = $enhancer->enhanceDocument([], $document);
+
+        $this->assertSame($document, $result);
+    }
+
+    public function testCategoriesPopulated(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => 1], ['id' => 2], ['id' => 3]],
+            tagResults: [['name' => null]],
+        );
+
+        $document = ['title' => 'Test', 'properties' => []];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertIsArray($result['properties']['excerpt']);
+        $this->assertSame([1, 2, 3], $result['properties']['excerpt']['categoryIds']);
+        $this->assertArrayNotHasKey('tagNames', $result['properties']['excerpt']);
+    }
+
+    public function testTagsPopulated(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => null]],
+            tagResults: [['name' => 'php'], ['name' => 'sulu']],
+        );
+
+        $document = ['title' => 'Test', 'properties' => []];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertIsArray($result['properties']['excerpt']);
+        $this->assertArrayNotHasKey('categoryIds', $result['properties']['excerpt']);
+        $this->assertSame(['php', 'sulu'], $result['properties']['excerpt']['tagNames']);
+    }
+
+    public function testBothCategoriesAndTagsPopulated(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => 5], ['id' => 10]],
+            tagResults: [['name' => 'cms'], ['name' => 'web']],
+        );
+
+        $document = ['title' => 'Test', 'properties' => []];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertIsArray($result['properties']['excerpt']);
+        $this->assertSame([5, 10], $result['properties']['excerpt']['categoryIds']);
+        $this->assertSame(['cms', 'web'], $result['properties']['excerpt']['tagNames']);
+    }
+
+    public function testEmptyTaxonomyDoesNotAddKeys(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => null]],
+            tagResults: [['name' => null]],
+        );
+
+        $document = ['title' => 'Test', 'properties' => []];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertArrayNotHasKey('excerpt', $result['properties']);
+    }
+
+    public function testPreservesExistingExcerptProperties(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => 1]],
+            tagResults: [['name' => 'tag1']],
+        );
+
+        $document = [
+            'title' => 'Test',
+            'properties' => [
+                'excerpt' => [
+                    'title' => 'Existing Excerpt Title',
+                ],
+            ],
+        ];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertIsArray($result['properties']['excerpt']);
+        $this->assertSame('Existing Excerpt Title', $result['properties']['excerpt']['title']);
+        $this->assertSame([1], $result['properties']['excerpt']['categoryIds']);
+        $this->assertSame(['tag1'], $result['properties']['excerpt']['tagNames']);
+    }
+
+    /**
+     * @param list<array{id: int|null}> $categoryResults
+     * @param list<array{name: string|null}> $tagResults
+     */
+    private function createEnhancerWithResults(array $categoryResults, array $tagResults): WebsiteArticleReindexTaxonomyEnhancer
+    {
+        $categoryQb = $this->createQueryBuilderStub($categoryResults);
+        $tagQb = $this->createQueryBuilderStub($tagResults);
+
+        $entityManager = $this->prophesize(EntityManagerInterface::class);
+        $entityManager->createQueryBuilder()->willReturn($categoryQb, $tagQb);
+
+        return new WebsiteArticleReindexTaxonomyEnhancer($entityManager->reveal());
+    }
+
+    /**
+     * @param list<array<string, mixed>> $scalarResult
+     */
+    private function createQueryBuilderStub(array $scalarResult): QueryBuilder
+    {
+        $query = $this->prophesize(Query::class);
+        $query->getScalarResult()->willReturn($scalarResult);
+
+        $qb = $this->prophesize(QueryBuilder::class);
+        $qb->select(Argument::any())->willReturn($qb);
+        $qb->from(Argument::any(), Argument::any())->willReturn($qb);
+        $qb->leftJoin(Argument::any(), Argument::any())->willReturn($qb);
+        $qb->where(Argument::any())->willReturn($qb);
+        $qb->setParameter(Argument::any(), Argument::any())->willReturn($qb);
+        $qb->getQuery()->willReturn($query->reveal());
+
+        return $qb->reveal();
+    }
+}

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexTaxonomyEnhancerTest.php
@@ -68,7 +68,7 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
     {
         $enhancer = $this->createEnhancerWithTaxonomyResult(
             categoryIds: null,
-            tagNames: 'php||sulu',
+            tagNames: 'php,sulu',
         );
 
         $document = ['title' => 'Test', 'metadata' => []];
@@ -84,7 +84,7 @@ class WebsiteArticleReindexTaxonomyEnhancerTest extends TestCase
     {
         $enhancer = $this->createEnhancerWithTaxonomyResult(
             categoryIds: '5,10',
-            tagNames: 'cms||web',
+            tagNames: 'cms,web',
         );
 
         $document = ['title' => 'Test', 'metadata' => []];

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
@@ -35,6 +35,11 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
         'text_editor',
     ];
 
+    private const MEDIA_FIELD_TYPES = [
+        'media_selection',
+        'single_media_selection',
+    ];
+
     public function __construct(
         private FormMetadataProvider $formMetadataProvider,
     ) {
@@ -66,9 +71,18 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
 
         $searchableFields = [];
         $this->collectSearchableFields($metadata->getFlatFieldMetadata(), $searchableFields);
-        $content = $this->extractContent($templateData, $searchableFields);
 
-        $document['content'] = $content;
+        $document['content'] = $this->extractContent($templateData, $searchableFields);
+
+        $title = $this->extractTitle($templateData, $searchableFields);
+        if (null !== $title) {
+            $document['title'] = $title;
+        }
+
+        $mediaId = $this->extractMediaId($templateData, $searchableFields);
+        if ('' !== $mediaId) {
+            $document['mediaId'] = $mediaId;
+        }
 
         return $document;
     }
@@ -85,7 +99,7 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
 
     /**
      * @param array<ItemMetadata> $items
-     * @param array<string, string> $fields
+     * @param array<string, array{type: string, role: string|null}> $fields
      */
     private function collectSearchableFields(array $items, array &$fields, string $prefix = ''): void
     {
@@ -94,17 +108,22 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
                 continue;
             }
 
+            $role = null;
             $hasSearchTag = false;
             foreach ($item->getTags() as $tag) {
                 if (TagMetadata::SEARCH_FIELD_TAG === $tag->getName()) {
                     $hasSearchTag = true;
+                    $role = $tag->getAttribute('role');
                     break;
                 }
             }
 
             if ($hasSearchTag) {
                 $fieldPath = $prefix ? $prefix . '.' . $item->getName() : $item->getName();
-                $fields[$fieldPath] = $item->getType();
+                $fields[$fieldPath] = [
+                    'type' => $item->getType(),
+                    'role' => \is_string($role) ? $role : null,
+                ];
             }
 
             if ('block' === $item->getType()) {
@@ -122,7 +141,7 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
 
     /**
      * @param array<string, mixed> $templateData
-     * @param array<string, string> $searchableFields
+     * @param array<string, array{type: string, role: string|null}> $searchableFields
      *
      * @return array<int, string>
      */
@@ -130,8 +149,12 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
     {
         $content = [];
 
-        foreach ($searchableFields as $fieldPath => $fieldType) {
-            if (!\in_array($fieldType, self::SUPPORTED_FIELD_TYPES, true)) {
+        foreach ($searchableFields as $fieldPath => $fieldInfo) {
+            if (!\in_array($fieldInfo['type'], self::SUPPORTED_FIELD_TYPES, true)) {
+                continue;
+            }
+
+            if (\in_array($fieldInfo['role'], ['image', 'title', 'url'], true)) {
                 continue;
             }
 
@@ -143,6 +166,65 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
         }
 
         return $content;
+    }
+
+    /**
+     * @param array<string, mixed> $templateData
+     * @param array<string, array{type: string, role: string|null}> $searchableFields
+     */
+    private function extractTitle(array $templateData, array $searchableFields): ?string
+    {
+        foreach ($searchableFields as $fieldPath => $fieldInfo) {
+            if ('title' !== $fieldInfo['role']) {
+                continue;
+            }
+
+            if (!\in_array($fieldInfo['type'], self::SUPPORTED_FIELD_TYPES, true)) {
+                continue;
+            }
+
+            $value = $this->getValueByPath($templateData, $fieldPath);
+            if (\is_string($value) && '' !== \trim($value)) {
+                return $this->stripHtml($value);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $templateData
+     * @param array<string, array{type: string, role: string|null}> $searchableFields
+     */
+    private function extractMediaId(array $templateData, array $searchableFields): string
+    {
+        foreach ($searchableFields as $fieldPath => $fieldInfo) {
+            if ('image' !== $fieldInfo['role']) {
+                continue;
+            }
+
+            if (!\in_array($fieldInfo['type'], self::MEDIA_FIELD_TYPES, true)) {
+                continue;
+            }
+
+            $value = $this->getValueByPath($templateData, $fieldPath);
+            if (!\is_array($value)) {
+                continue;
+            }
+
+            if (isset($value['id']) && \is_numeric($value['id'])) {
+                return (string) $value['id'];
+            }
+
+            if (isset($value['ids']) && \is_array($value['ids']) && [] !== $value['ids']) {
+                $firstId = $value['ids'][0] ?? null;
+                if (null !== $firstId && \is_numeric($firstId)) {
+                    return (string) $firstId;
+                }
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * @internal
+ *
+ * @final
+ */
+class WebsitePageReindexExcerptEnhancer implements WebsitePageReindexProviderEnhancerInterface
+{
+    public function enhanceQuery(QueryBuilder $queryBuilder): void
+    {
+        $queryBuilder->addSelect('dimensionContent.excerptData');
+    }
+
+    public function enhanceDocument(array $queryResult, array $document): array
+    {
+        $excerptData = $queryResult['excerptData'] ?? [];
+        if (!\is_array($excerptData)) {
+            return $document;
+        }
+
+        $excerpt = [];
+
+        $excerptTitle = $excerptData['title'] ?? null;
+        if (\is_string($excerptTitle) && '' !== \trim($excerptTitle)) {
+            $excerpt['title'] = \trim($excerptTitle);
+
+            if ('' === ($document['title'] ?? '')) {
+                $document['title'] = \trim($excerptTitle);
+            }
+        }
+
+        $excerptDescription = $excerptData['description'] ?? null;
+        if (\is_string($excerptDescription) && '' !== \trim($excerptDescription)) {
+            $excerpt['description'] = \trim(\strip_tags($excerptDescription));
+        }
+
+        $excerptMore = $excerptData['more'] ?? null;
+        if (\is_string($excerptMore) && '' !== \trim($excerptMore)) {
+            $excerpt['more'] = \trim($excerptMore);
+        }
+
+        $image = $excerptData['image'] ?? null;
+        if (\is_array($image) && isset($image['id']) && \is_numeric($image['id'])) {
+            $excerpt['imageId'] = (int) $image['id'];
+
+            if ('' === ($document['mediaId'] ?? '')) {
+                $document['mediaId'] = (string) $image['id'];
+            }
+        }
+
+        $icon = $excerptData['icon'] ?? null;
+        if (\is_array($icon) && isset($icon['id']) && \is_numeric($icon['id'])) {
+            $excerpt['iconId'] = (int) $icon['id'];
+        }
+
+        if ([] !== $excerpt) {
+            $properties = \is_array($document['properties'] ?? null) ? $document['properties'] : [];
+            $properties['excerpt'] = $excerpt;
+            $document['properties'] = $properties;
+        }
+
+        return $document;
+    }
+}

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancer.php
@@ -16,7 +16,8 @@ namespace Sulu\Page\Infrastructure\Sulu\Search\Visitor;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * @internal
+ * @internal if you need to override this service, create a new service based on the WebsitePageReindexProviderEnhancerInterface
+ * instead of extending this class
  *
  * @final
  */

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancer.php
@@ -36,10 +36,13 @@ class WebsitePageReindexExcerptEnhancer implements WebsitePageReindexProviderEnh
         }
 
         $excerpt = [];
+        /** @var list<string> */
+        $content = \is_array($document['content'] ?? null) ? $document['content'] : [];
 
         $excerptTitle = $excerptData['title'] ?? null;
         if (\is_string($excerptTitle) && '' !== \trim($excerptTitle)) {
             $excerpt['title'] = \trim($excerptTitle);
+            $content[] = \trim($excerptTitle);
 
             if ('' === ($document['title'] ?? '')) {
                 $document['title'] = \trim($excerptTitle);
@@ -48,7 +51,8 @@ class WebsitePageReindexExcerptEnhancer implements WebsitePageReindexProviderEnh
 
         $excerptDescription = $excerptData['description'] ?? null;
         if (\is_string($excerptDescription) && '' !== \trim($excerptDescription)) {
-            $excerpt['description'] = \trim(\strip_tags($excerptDescription));
+            $excerpt['description'] = \trim($excerptDescription);
+            $content[] = \trim(\strip_tags($excerptDescription));
         }
 
         $excerptMore = $excerptData['more'] ?? null;
@@ -70,10 +74,12 @@ class WebsitePageReindexExcerptEnhancer implements WebsitePageReindexProviderEnh
             $excerpt['iconId'] = (int) $icon['id'];
         }
 
+        $document['content'] = $content;
+
         if ([] !== $excerpt) {
-            $properties = \is_array($document['properties'] ?? null) ? $document['properties'] : [];
-            $properties['excerpt'] = $excerpt;
-            $document['properties'] = $properties;
+            $metadata = \is_array($document['metadata'] ?? null) ? $document['metadata'] : [];
+            $metadata['excerpt'] = $excerpt;
+            $document['metadata'] = $metadata;
         }
 
         return $document;

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
@@ -38,65 +38,79 @@ class WebsitePageReindexTaxonomyEnhancer implements WebsitePageReindexProviderEn
     public function enhanceDocument(array $queryResult, array $document): array
     {
         $dimensionContentId = $queryResult['dimensionContentId'] ?? null;
-        if (null === $dimensionContentId || !\is_int($dimensionContentId)) {
+        if (!\is_int($dimensionContentId)) {
             return $document;
         }
 
-        $categoryIds = $this->loadCategoryIds($dimensionContentId);
-        $tagNames = $this->loadTagNames($dimensionContentId);
+        $taxonomy = $this->loadTaxonomy($dimensionContentId);
+        $categoryIds = $taxonomy['categoryIds'];
+        $tagNames = $taxonomy['tagNames'];
 
-        if ([] !== $categoryIds || [] !== $tagNames) {
-            $properties = \is_array($document['properties'] ?? null) ? $document['properties'] : [];
-            $excerpt = \is_array($properties['excerpt'] ?? null) ? $properties['excerpt'] : [];
-
-            if ([] !== $categoryIds) {
-                $excerpt['categoryIds'] = $categoryIds;
-            }
-
-            if ([] !== $tagNames) {
-                $excerpt['tagNames'] = $tagNames;
-            }
-
-            $properties['excerpt'] = $excerpt;
-            $document['properties'] = $properties;
+        if ([] === $categoryIds && [] === $tagNames) {
+            return $document;
         }
+
+        $metadata = \is_array($document['metadata'] ?? null) ? $document['metadata'] : [];
+        $excerpt = \is_array($metadata['excerpt'] ?? null) ? $metadata['excerpt'] : [];
+
+        if ([] !== $categoryIds) {
+            $excerpt['categoryIds'] = $categoryIds;
+        }
+
+        if ([] !== $tagNames) {
+            $excerpt['tagNames'] = $tagNames;
+        }
+
+        $metadata['excerpt'] = $excerpt;
+        $document['metadata'] = $metadata;
 
         return $document;
     }
 
     /**
-     * @return int[]
+     * @return array{categoryIds: int[], tagNames: string[]}
      */
-    private function loadCategoryIds(int $dimensionContentId): array
+    private function loadTaxonomy(int $dimensionContentId): array
     {
-        /** @var list<array{id: int|null}> $results */
-        $results = $this->entityManager->createQueryBuilder()
-            ->select('category.id')
+        /** @var array{categoryIds: string|null, tagNames: string|null} $result */
+        $result = $this->entityManager->createQueryBuilder()
+            ->select('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
+            ->addSelect("GROUP_CONCAT(DISTINCT tag.name SEPARATOR '||') AS tagNames")
             ->from(PageDimensionContentInterface::class, 'dimensionContent')
             ->leftJoin('dimensionContent.excerptCategories', 'category')
+            ->leftJoin('dimensionContent.excerptTags', 'tag')
             ->where('dimensionContent.id = :id')
             ->setParameter('id', $dimensionContentId)
             ->getQuery()
-            ->getScalarResult();
+            ->getSingleResult();
 
-        return \array_map(static fn (array $row): int => (int) $row['id'], \array_filter($results, static fn (array $row): bool => null !== $row['id']));
+        return [
+            'categoryIds' => $this->parseCategoryIds($result['categoryIds']),
+            'tagNames' => $this->parseTagNames($result['tagNames']),
+        ];
+    }
+
+    /**
+     * @return int[]
+     */
+    private function parseCategoryIds(?string $categoryIds): array
+    {
+        if (null === $categoryIds || '' === $categoryIds) {
+            return [];
+        }
+
+        return \array_map(static fn (string $id): int => (int) $id, \explode(',', $categoryIds));
     }
 
     /**
      * @return string[]
      */
-    private function loadTagNames(int $dimensionContentId): array
+    private function parseTagNames(?string $tagNames): array
     {
-        /** @var list<array{name: string|null}> $results */
-        $results = $this->entityManager->createQueryBuilder()
-            ->select('tag.name')
-            ->from(PageDimensionContentInterface::class, 'dimensionContent')
-            ->leftJoin('dimensionContent.excerptTags', 'tag')
-            ->where('dimensionContent.id = :id')
-            ->setParameter('id', $dimensionContentId)
-            ->getQuery()
-            ->getScalarResult();
+        if (null === $tagNames || '' === $tagNames) {
+            return [];
+        }
 
-        return \array_map(static fn (array $row): string => (string) $row['name'], \array_filter($results, static fn (array $row): bool => null !== $row['name']));
+        return \explode('||', $tagNames);
     }
 }

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
@@ -75,7 +75,7 @@ class WebsitePageReindexTaxonomyEnhancer implements WebsitePageReindexProviderEn
         /** @var array{categoryIds: string|null, tagNames: string|null} $result */
         $result = $this->entityManager->createQueryBuilder()
             ->select('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
-            ->addSelect("GROUP_CONCAT(DISTINCT tag.name SEPARATOR '||') AS tagNames")
+            ->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')
             ->from(PageDimensionContentInterface::class, 'dimensionContent')
             ->leftJoin('dimensionContent.excerptCategories', 'category')
             ->leftJoin('dimensionContent.excerptTags', 'tag')
@@ -111,6 +111,6 @@ class WebsitePageReindexTaxonomyEnhancer implements WebsitePageReindexProviderEn
             return [];
         }
 
-        return \explode('||', $tagNames);
+        return \explode(',', $tagNames);
     }
 }

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Infrastructure\Sulu\Search\Visitor;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
-use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 
 /**
  * @internal if you need to override this service, create a new service based on the WebsitePageReindexProviderEnhancerInterface
@@ -25,26 +23,24 @@ use Sulu\Page\Domain\Model\PageDimensionContentInterface;
  */
 class WebsitePageReindexTaxonomyEnhancer implements WebsitePageReindexProviderEnhancerInterface
 {
-    public function __construct(
-        private EntityManagerInterface $entityManager,
-    ) {
-    }
-
     public function enhanceQuery(QueryBuilder $queryBuilder): void
     {
-        $queryBuilder->addSelect('dimensionContent.id AS dimensionContentId');
+        $queryBuilder
+            ->addSelect('dimensionContent.id AS dimensionContentId')
+            ->leftJoin('dimensionContent.excerptCategories', 'category')
+            ->leftJoin('dimensionContent.excerptTags', 'tag')
+            ->addSelect('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
+            ->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')
+            ->addGroupBy('dimensionContent.id');
     }
 
     public function enhanceDocument(array $queryResult, array $document): array
     {
-        $dimensionContentId = $queryResult['dimensionContentId'] ?? null;
-        if (!\is_int($dimensionContentId)) {
-            return $document;
-        }
+        $rawCategoryIds = $queryResult['categoryIds'] ?? null;
+        $rawTagNames = $queryResult['tagNames'] ?? null;
 
-        $taxonomy = $this->loadTaxonomy($dimensionContentId);
-        $categoryIds = $taxonomy['categoryIds'];
-        $tagNames = $taxonomy['tagNames'];
+        $categoryIds = $this->parseCategoryIds(\is_string($rawCategoryIds) ? $rawCategoryIds : null);
+        $tagNames = $this->parseTagNames(\is_string($rawTagNames) ? $rawTagNames : null);
 
         if ([] === $categoryIds && [] === $tagNames) {
             return $document;
@@ -65,29 +61,6 @@ class WebsitePageReindexTaxonomyEnhancer implements WebsitePageReindexProviderEn
         $document['metadata'] = $metadata;
 
         return $document;
-    }
-
-    /**
-     * @return array{categoryIds: int[], tagNames: string[]}
-     */
-    private function loadTaxonomy(int $dimensionContentId): array
-    {
-        /** @var array{categoryIds: string|null, tagNames: string|null} $result */
-        $result = $this->entityManager->createQueryBuilder()
-            ->select('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
-            ->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')
-            ->from(PageDimensionContentInterface::class, 'dimensionContent')
-            ->leftJoin('dimensionContent.excerptCategories', 'category')
-            ->leftJoin('dimensionContent.excerptTags', 'tag')
-            ->where('dimensionContent.id = :id')
-            ->setParameter('id', $dimensionContentId)
-            ->getQuery()
-            ->getSingleResult();
-
-        return [
-            'categoryIds' => $this->parseCategoryIds($result['categoryIds']),
-            'tagNames' => $this->parseTagNames($result['tagNames']),
-        ];
     }
 
     /**

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
@@ -25,13 +25,22 @@ class WebsitePageReindexTaxonomyEnhancer implements WebsitePageReindexProviderEn
 {
     public function enhanceQuery(QueryBuilder $queryBuilder): void
     {
+        $entityManager = $queryBuilder->getEntityManager();
+
+        $categorySubquery = $entityManager->createQueryBuilder()
+            ->select('GROUP_CONCAT(DISTINCT excerptCategory.id)')
+            ->from(\Sulu\Bundle\CategoryBundle\Entity\CategoryInterface::class, 'excerptCategory')
+            ->where('excerptCategory MEMBER OF dimensionContent.excerptCategories');
+
+        $tagSubquery = $entityManager->createQueryBuilder()
+            ->select('GROUP_CONCAT(DISTINCT excerptTag.name)')
+            ->from(\Sulu\Bundle\TagBundle\Tag\TagInterface::class, 'excerptTag')
+            ->where('excerptTag MEMBER OF dimensionContent.excerptTags');
+
         $queryBuilder
             ->addSelect('dimensionContent.id AS dimensionContentId')
-            ->leftJoin('dimensionContent.excerptCategories', 'category')
-            ->leftJoin('dimensionContent.excerptTags', 'tag')
-            ->addSelect('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')
-            ->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')
-            ->addGroupBy('dimensionContent.id');
+            ->addSelect('(' . $categorySubquery->getDQL() . ') AS categoryIds')
+            ->addSelect('(' . $tagSubquery->getDQL() . ') AS tagNames');
     }
 
     public function enhanceDocument(array $queryResult, array $document): array

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancer.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+
+/**
+ * @internal if you need to override this service, create a new service based on the WebsitePageReindexProviderEnhancerInterface
+ * instead of extending this class
+ *
+ * @final
+ */
+class WebsitePageReindexTaxonomyEnhancer implements WebsitePageReindexProviderEnhancerInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function enhanceQuery(QueryBuilder $queryBuilder): void
+    {
+        $queryBuilder->addSelect('dimensionContent.id AS dimensionContentId');
+    }
+
+    public function enhanceDocument(array $queryResult, array $document): array
+    {
+        $dimensionContentId = $queryResult['dimensionContentId'] ?? null;
+        if (null === $dimensionContentId || !\is_int($dimensionContentId)) {
+            return $document;
+        }
+
+        $categoryIds = $this->loadCategoryIds($dimensionContentId);
+        $tagNames = $this->loadTagNames($dimensionContentId);
+
+        if ([] !== $categoryIds || [] !== $tagNames) {
+            $properties = \is_array($document['properties'] ?? null) ? $document['properties'] : [];
+            $excerpt = \is_array($properties['excerpt'] ?? null) ? $properties['excerpt'] : [];
+
+            if ([] !== $categoryIds) {
+                $excerpt['categoryIds'] = $categoryIds;
+            }
+
+            if ([] !== $tagNames) {
+                $excerpt['tagNames'] = $tagNames;
+            }
+
+            $properties['excerpt'] = $excerpt;
+            $document['properties'] = $properties;
+        }
+
+        return $document;
+    }
+
+    /**
+     * @return int[]
+     */
+    private function loadCategoryIds(int $dimensionContentId): array
+    {
+        /** @var list<array{id: int|null}> $results */
+        $results = $this->entityManager->createQueryBuilder()
+            ->select('category.id')
+            ->from(PageDimensionContentInterface::class, 'dimensionContent')
+            ->leftJoin('dimensionContent.excerptCategories', 'category')
+            ->where('dimensionContent.id = :id')
+            ->setParameter('id', $dimensionContentId)
+            ->getQuery()
+            ->getScalarResult();
+
+        return \array_map(static fn (array $row): int => (int) $row['id'], \array_filter($results, static fn (array $row): bool => null !== $row['id']));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function loadTagNames(int $dimensionContentId): array
+    {
+        /** @var list<array{name: string|null}> $results */
+        $results = $this->entityManager->createQueryBuilder()
+            ->select('tag.name')
+            ->from(PageDimensionContentInterface::class, 'dimensionContent')
+            ->leftJoin('dimensionContent.excerptTags', 'tag')
+            ->where('dimensionContent.id = :id')
+            ->setParameter('id', $dimensionContentId)
+            ->getQuery()
+            ->getScalarResult();
+
+        return \array_map(static fn (array $row): string => (string) $row['name'], \array_filter($results, static fn (array $row): bool => null !== $row['name']));
+    }
+}

--- a/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
@@ -83,7 +83,7 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => $authoredAt->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ];
 
             foreach ($this->enhancers as $enhancer) {

--- a/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
@@ -41,6 +41,8 @@ use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexProviderEnhan
  */
 final class WebsitePageReindexProvider implements ReindexProviderInterface
 {
+    private const BATCH_SIZE = 100;
+
     /**
      * @var EntityRepository<PageDimensionContentInterface>
      */
@@ -60,52 +62,58 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
 
     public function total(): ?int
     {
-        // Todo: Add correct count for multiple locales.
         return null;
     }
 
     public function provide(ReindexConfig $reindexConfig): \Generator
     {
-        $pages = $this->loadPages($reindexConfig->getIdentifiers());
+        $identifiers = $reindexConfig->getIdentifiers();
+        $offset = 0;
+        $batch = $this->loadBatch($identifiers, $offset);
 
-        /** @var PageData $page */
-        foreach ($pages as $page) {
-            $authoredAt = $page['authored'] ?? $page['changed'];
+        while ([] !== $batch) {
+            /** @var PageData $page */
+            foreach ($batch as $page) {
+                $authoredAt = $page['authored'] ?? $page['changed'];
 
-            $data = [
-                'id' => PageInterface::RESOURCE_KEY . '__' . ((string) $page['pageId']) . '__' . $page['locale'],
-                'resourceKey' => PageInterface::RESOURCE_KEY,
-                'resourceId' => (string) $page['pageId'],
-                'locale' => $page['locale'],
-                'webspaces' => [$page['webspaceKey']],
-                'title' => '',
-                'url' => $page['slug'],
-                'content' => [],
-                'mediaId' => '',
-                'authoredAt' => $authoredAt->format('c'),
-                'metadata' => [],
-            ];
+                $data = [
+                    'id' => PageInterface::RESOURCE_KEY . '__' . ((string) $page['pageId']) . '__' . $page['locale'],
+                    'resourceKey' => PageInterface::RESOURCE_KEY,
+                    'resourceId' => (string) $page['pageId'],
+                    'locale' => $page['locale'],
+                    'webspaces' => [$page['webspaceKey']],
+                    'title' => '',
+                    'url' => $page['slug'],
+                    'content' => [],
+                    'mediaId' => '',
+                    'authoredAt' => $authoredAt->format('c'),
+                    'metadata' => [],
+                ];
 
-            foreach ($this->enhancers as $enhancer) {
-                $data = $enhancer->enhanceDocument($page, $data);
+                foreach ($this->enhancers as $enhancer) {
+                    $data = $enhancer->enhanceDocument($page, $data);
+                }
+
+                if ('' === $data['title']) {
+                    $data['title'] = $page['title'];
+                }
+
+                yield $data;
             }
 
-            if ('' === $data['title']) {
-                $data['title'] = $page['title'];
-            }
-
-            yield $data;
+            $offset += self::BATCH_SIZE;
+            $batch = $this->loadBatch($identifiers, $offset);
         }
     }
 
     /**
      * @param string[] $identifiers
      *
-     * @return iterable<PageData>
+     * @return array<int, PageData>
      */
-    private function loadPages(array $identifiers = []): iterable
+    private function loadBatch(array $identifiers, int $offset): array
     {
-        $qb = $this->dimensionContentRepository->createQueryBuilder('dimensionContent')
+        $queryBuilder = $this->dimensionContentRepository->createQueryBuilder('dimensionContent')
             ->leftJoin('dimensionContent.route', 'route')
             ->leftJoin('dimensionContent.page', 'page')
             ->leftJoin(
@@ -154,19 +162,23 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
                 return [];
             }
 
-            $qb->andWhere(\implode(' OR ', $conditions));
+            $queryBuilder->andWhere(\implode(' OR ', $conditions));
         }
 
         foreach ($parameters as $parameterKey => $parameterValue) {
-            $qb->setParameter($parameterKey, $parameterValue);
+            $queryBuilder->setParameter($parameterKey, $parameterValue);
         }
 
         foreach ($this->enhancers as $enhancer) {
-            $enhancer->enhanceQuery($qb);
+            $enhancer->enhanceQuery($queryBuilder);
         }
 
-        /** @var iterable<PageData> */
-        return $qb->getQuery()->toIterable();
+        $queryBuilder->orderBy('dimensionContent.id', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults(self::BATCH_SIZE);
+
+        /** @var array<int, PageData> */
+        return $queryBuilder->getQuery()->getResult();
     }
 
     public static function getIndex(): string

--- a/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
@@ -78,15 +78,20 @@ final class WebsitePageReindexProvider implements ReindexProviderInterface
                 'resourceId' => (string) $page['pageId'],
                 'locale' => $page['locale'],
                 'webspaces' => [$page['webspaceKey']],
-                'title' => $page['title'],
+                'title' => '',
                 'url' => $page['slug'],
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => $authoredAt->format('c'),
+                'properties' => [],
             ];
 
             foreach ($this->enhancers as $enhancer) {
                 $data = $enhancer->enhanceDocument($page, $data);
+            }
+
+            if ('' === $data['title']) {
+                $data['title'] = $page['title'];
             }
 
             yield $data;

--- a/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/WebsitePageReindexProvider.php
@@ -34,6 +34,7 @@ use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexProviderEnhan
  *     slug: string,
  *     authored: \DateTimeImmutable|null,
  *     webspaceKey: string,
+ *     dimensionContentId: int,
  * }
  *
  * @internal this class is internal no backwards compatibility promise is given for this class

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -71,6 +71,7 @@ use Sulu\Page\Infrastructure\Sulu\Route\PageWebspaceRouteGenerator;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexContentEnhancer;
+use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexExcerptEnhancer;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexProviderEnhancerInterface;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageIndexListener;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageReindexProvider;
@@ -607,6 +608,10 @@ final class SuluPageBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_admin.form_metadata_provider'),
             ])
+            ->tag('sulu_page.website_page_reindex_provider_enhancer');
+
+        $services->set('sulu_page.website_page_reindex_excerpt_enhancer')
+            ->class(WebsitePageReindexExcerptEnhancer::class)
             ->tag('sulu_page.website_page_reindex_provider_enhancer');
 
         $services->set('sulu_page.website_page_reindex_provider')

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -617,7 +617,6 @@ final class SuluPageBundle extends AbstractBundle
 
         $services->set('sulu_page.website_page_reindex_taxonomy_enhancer')
             ->class(WebsitePageReindexTaxonomyEnhancer::class)
-            ->args([new Reference('doctrine.orm.entity_manager')])
             ->tag('sulu_page.website_page_reindex_provider_enhancer');
 
         $services->set('sulu_page.website_page_reindex_provider')

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -73,6 +73,7 @@ use Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexContentEnhancer;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexExcerptEnhancer;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexProviderEnhancerInterface;
+use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexTaxonomyEnhancer;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageIndexListener;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageReindexProvider;
 use Sulu\Page\Infrastructure\Sulu\Security\PageDescendantSecurityListener;
@@ -612,6 +613,13 @@ final class SuluPageBundle extends AbstractBundle
 
         $services->set('sulu_page.website_page_reindex_excerpt_enhancer')
             ->class(WebsitePageReindexExcerptEnhancer::class)
+            ->tag('sulu_page.website_page_reindex_provider_enhancer');
+
+        $services->set('sulu_page.website_page_reindex_taxonomy_enhancer')
+            ->class(WebsitePageReindexTaxonomyEnhancer::class)
+            ->args([
+                new Reference('doctrine.orm.entity_manager'),
+            ])
             ->tag('sulu_page.website_page_reindex_provider_enhancer');
 
         $services->set('sulu_page.website_page_reindex_provider')

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -617,9 +617,7 @@ final class SuluPageBundle extends AbstractBundle
 
         $services->set('sulu_page.website_page_reindex_taxonomy_enhancer')
             ->class(WebsitePageReindexTaxonomyEnhancer::class)
-            ->args([
-                new Reference('doctrine.orm.entity_manager'),
-            ])
+            ->args([new Reference('doctrine.orm.entity_manager')])
             ->tag('sulu_page.website_page_reindex_provider_enhancer');
 
         $services->set('sulu_page.website_page_reindex_provider')

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
@@ -134,7 +134,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ],
             [
                 'id' => PageInterface::RESOURCE_KEY . '__' . $page2->getUuid() . '__en',
@@ -147,7 +147,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
-                'properties' => [],
+                'metadata' => [],
             ],
         ];
 
@@ -194,12 +194,12 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $result = $results[0];
         $this->assertSame('Excerpt Title', $result['title']);
 
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertSame('Excerpt Title', $excerpt['title']);
-        $this->assertSame('Excerpt description', $excerpt['description']);
+        $this->assertSame('<p>Excerpt <strong>description</strong></p>', $excerpt['description']);
         $this->assertSame('Read more', $excerpt['more']);
         $this->assertSame(1, $excerpt['imageId']);
         $this->assertSame(2, $excerpt['iconId']);
@@ -235,8 +235,8 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $result = $results[0];
         $this->assertSame('Excerpt Title Override', $result['title']);
 
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
         $this->assertSame('Excerpt Title Override', $excerpt['title']);
     }
@@ -271,8 +271,8 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $result = $results[0];
         $this->assertSame('55', $result['mediaId']);
 
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
         $this->assertSame(55, $excerpt['imageId']);
     }
@@ -303,7 +303,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
 
         $result = $results[0];
         $this->assertSame('No Excerpt Page', $result['title']);
-        $this->assertSame([], $result['properties']);
+        $this->assertSame([], $result['metadata']);
     }
 
     public function testTaxonomyEnhancerPopulatesCategoriesAndTags(): void
@@ -340,8 +340,8 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertSame([$category1->getId(), $category2->getId()], $excerpt['categoryIds']);
@@ -379,8 +379,8 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertSame([$category1->getId(), $category2->getId()], $excerpt['categoryIds']);
@@ -418,8 +418,8 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertArrayNotHasKey('categoryIds', $excerpt);
@@ -451,8 +451,8 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $this->assertArrayNotHasKey('excerpt', $result['properties']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertArrayNotHasKey('excerpt', $result['metadata']);
     }
 
     public function testTaxonomyEnhancerPreservesExistingExcerptProperties(): void
@@ -494,12 +494,12 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $this->assertCount(1, $results);
 
         $result = $results[0];
-        $this->assertIsArray($result['properties']);
-        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($result['metadata']);
+        $excerpt = $result['metadata']['excerpt'];
         $this->assertIsArray($excerpt);
 
         $this->assertSame('Excerpt Title', $excerpt['title']);
-        $this->assertSame('Excerpt description', $excerpt['description']);
+        $this->assertSame('<p>Excerpt description</p>', $excerpt['description']);
         $this->assertSame([$category->getId()], $excerpt['categoryIds']);
         $this->assertSame(['test-tag'], $excerpt['tagNames']);
     }

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexExcerptEnhancer;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageReindexProvider;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
 use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
@@ -128,6 +129,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable('1995-11-29 12:00:00'))->format('c'),
+                'properties' => [],
             ],
             [
                 'id' => PageInterface::RESOURCE_KEY . '__' . $page2->getUuid() . '__en',
@@ -140,6 +142,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
                 'content' => [],
                 'mediaId' => '',
                 'authoredAt' => (new \DateTimeImmutable($changedDateString2))->format('c'),
+                'properties' => [],
             ],
         ];
 
@@ -150,5 +153,151 @@ class WebsitePageReindexProviderTest extends SuluTestCase
             $expectedResult,
             $results,
         );
+    }
+
+    public function testExcerptEnhancerPopulatesExcerptProperties(): void
+    {
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [new WebsitePageReindexExcerptEnhancer()],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Page With Excerpt',
+                    'url' => '/page-excerpt',
+                    'excerpt' => [
+                        'title' => 'Excerpt Title',
+                        'description' => '<p>Excerpt <strong>description</strong></p>',
+                        'more' => 'Read more',
+                        'image' => ['id' => 1],
+                        'icon' => ['id' => 2],
+                    ],
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertSame('Excerpt Title', $result['title']);
+
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Excerpt description', $excerpt['description']);
+        $this->assertSame('Read more', $excerpt['more']);
+        $this->assertSame(1, $excerpt['imageId']);
+        $this->assertSame(2, $excerpt['iconId']);
+    }
+
+    public function testExcerptTitleFallbackWhenNoContentTitle(): void
+    {
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [new WebsitePageReindexExcerptEnhancer()],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Original Title',
+                    'url' => '/page-title-fallback',
+                    'excerpt' => [
+                        'title' => 'Excerpt Title Override',
+                    ],
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertSame('Excerpt Title Override', $result['title']);
+
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+        $this->assertSame('Excerpt Title Override', $excerpt['title']);
+    }
+
+    public function testExcerptImageFallbackToMediaId(): void
+    {
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [new WebsitePageReindexExcerptEnhancer()],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Page With Excerpt Image',
+                    'url' => '/page-excerpt-image',
+                    'excerpt' => [
+                        'image' => ['id' => 55],
+                    ],
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertSame('55', $result['mediaId']);
+
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+        $this->assertSame(55, $excerpt['imageId']);
+    }
+
+    public function testNoExcerptDataProducesEmptyProperties(): void
+    {
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [new WebsitePageReindexExcerptEnhancer()],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'No Excerpt Page',
+                    'url' => '/no-excerpt',
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertSame('No Excerpt Page', $result['title']);
+        $this->assertSame([], $result['properties']);
     }
 }

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
@@ -317,7 +317,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
 
         $provider = new WebsitePageReindexProvider(
             $this->entityManager,
-            [new WebsitePageReindexTaxonomyEnhancer($this->entityManager)],
+            [new WebsitePageReindexTaxonomyEnhancer()],
         );
 
         $page = $this->createPage([
@@ -357,7 +357,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
 
         $provider = new WebsitePageReindexProvider(
             $this->entityManager,
-            [new WebsitePageReindexTaxonomyEnhancer($this->entityManager)],
+            [new WebsitePageReindexTaxonomyEnhancer()],
         );
 
         $page = $this->createPage([
@@ -396,7 +396,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
 
         $provider = new WebsitePageReindexProvider(
             $this->entityManager,
-            [new WebsitePageReindexTaxonomyEnhancer($this->entityManager)],
+            [new WebsitePageReindexTaxonomyEnhancer()],
         );
 
         $page = $this->createPage([
@@ -430,7 +430,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
     {
         $provider = new WebsitePageReindexProvider(
             $this->entityManager,
-            [new WebsitePageReindexTaxonomyEnhancer($this->entityManager)],
+            [new WebsitePageReindexTaxonomyEnhancer()],
         );
 
         $page = $this->createPage([
@@ -466,7 +466,7 @@ class WebsitePageReindexProviderTest extends SuluTestCase
             $this->entityManager,
             [
                 new WebsitePageReindexExcerptEnhancer(),
-                new WebsitePageReindexTaxonomyEnhancer($this->entityManager),
+                new WebsitePageReindexTaxonomyEnhancer(),
             ],
         );
 

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Search/WebsitePageReindexProviderTest.php
@@ -18,8 +18,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Tests\Traits\CreateCategoryTrait;
+use Sulu\Content\Tests\Traits\CreateTagTrait;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexExcerptEnhancer;
+use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexTaxonomyEnhancer;
 use Sulu\Page\Infrastructure\Sulu\Search\WebsitePageReindexProvider;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
 use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
@@ -29,6 +32,8 @@ class WebsitePageReindexProviderTest extends SuluTestCase
     use CreatePageTrait;
     use CreatePageWithPermissionsTrait;
     use SetGetPrivatePropertyTrait;
+    use CreateCategoryTrait;
+    use CreateTagTrait;
 
     private EntityManagerInterface $entityManager;
     private WebsitePageReindexProvider $provider;
@@ -299,5 +304,203 @@ class WebsitePageReindexProviderTest extends SuluTestCase
         $result = $results[0];
         $this->assertSame('No Excerpt Page', $result['title']);
         $this->assertSame([], $result['properties']);
+    }
+
+    public function testTaxonomyEnhancerPopulatesCategoriesAndTags(): void
+    {
+        $category1 = static::createCategory(['en' => ['title' => 'Category 1']]);
+        $category2 = static::createCategory(['en' => ['title' => 'Category 2']]);
+        $tag1 = static::createTag(['name' => 'tag-one']);
+        $tag2 = static::createTag(['name' => 'tag-two']);
+
+        $this->entityManager->flush();
+
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [new WebsitePageReindexTaxonomyEnhancer($this->entityManager)],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Page With Taxonomy',
+                    'url' => '/page-taxonomy',
+                    'excerptCategories' => [$category1->getId(), $category2->getId()],
+                    'excerptTags' => [$tag1->getName(), $tag2->getName()],
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertSame([$category1->getId(), $category2->getId()], $excerpt['categoryIds']);
+        $this->assertSame(['tag-one', 'tag-two'], $excerpt['tagNames']);
+    }
+
+    public function testTaxonomyEnhancerPopulatesOnlyCategories(): void
+    {
+        $category1 = static::createCategory(['en' => ['title' => 'Category 1']]);
+        $category2 = static::createCategory(['en' => ['title' => 'Category 2']]);
+
+        $this->entityManager->flush();
+
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [new WebsitePageReindexTaxonomyEnhancer($this->entityManager)],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Page With Categories',
+                    'url' => '/page-categories',
+                    'excerptCategories' => [$category1->getId(), $category2->getId()],
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertSame([$category1->getId(), $category2->getId()], $excerpt['categoryIds']);
+        $this->assertArrayNotHasKey('tagNames', $excerpt);
+    }
+
+    public function testTaxonomyEnhancerPopulatesOnlyTags(): void
+    {
+        $tag1 = static::createTag(['name' => 'php']);
+        $tag2 = static::createTag(['name' => 'sulu']);
+
+        $this->entityManager->flush();
+
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [new WebsitePageReindexTaxonomyEnhancer($this->entityManager)],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Page With Tags',
+                    'url' => '/page-tags',
+                    'excerptTags' => [$tag1->getName(), $tag2->getName()],
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertArrayNotHasKey('categoryIds', $excerpt);
+        $this->assertSame(['php', 'sulu'], $excerpt['tagNames']);
+    }
+
+    public function testTaxonomyEnhancerWithEmptyTaxonomyDoesNotAddKeys(): void
+    {
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [new WebsitePageReindexTaxonomyEnhancer($this->entityManager)],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Page Without Taxonomy',
+                    'url' => '/page-no-taxonomy',
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $this->assertArrayNotHasKey('excerpt', $result['properties']);
+    }
+
+    public function testTaxonomyEnhancerPreservesExistingExcerptProperties(): void
+    {
+        $category = static::createCategory(['en' => ['title' => 'Category 1']]);
+        $tag = static::createTag(['name' => 'test-tag']);
+
+        $this->entityManager->flush();
+
+        $provider = new WebsitePageReindexProvider(
+            $this->entityManager,
+            [
+                new WebsitePageReindexExcerptEnhancer(),
+                new WebsitePageReindexTaxonomyEnhancer($this->entityManager),
+            ],
+        );
+
+        $page = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Page With Excerpt and Taxonomy',
+                    'url' => '/page-excerpt-taxonomy',
+                    'excerpt' => [
+                        'title' => 'Excerpt Title',
+                        'description' => '<p>Excerpt description</p>',
+                    ],
+                    'excerptCategories' => [$category->getId()],
+                    'excerptTags' => [$tag->getName()],
+                ],
+            ],
+        ], 'sulu-io');
+        $this->entityManager->clear();
+
+        $config = ReindexConfig::create()->withIndex('website');
+        /** @var array<array<string, mixed>> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+
+        $result = $results[0];
+        $this->assertIsArray($result['properties']);
+        $excerpt = $result['properties']['excerpt'];
+        $this->assertIsArray($excerpt);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Excerpt description', $excerpt['description']);
+        $this->assertSame([$category->getId()], $excerpt['categoryIds']);
+        $this->assertSame(['test-tag'], $excerpt['tagNames']);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
@@ -412,6 +412,229 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         ];
     }
 
+    public function testRoleImageSingleMediaSelectionSetsMediaId(): void
+    {
+        $imageField = new FieldMetadata('header_image');
+        $imageField->setType('single_media_selection');
+        $imageField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'image'));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($imageField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'header_image' => ['id' => 42],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame('42', $returnedData['mediaId']);
+    }
+
+    public function testRoleImageMediaSelectionSetsMediaIdFromFirstId(): void
+    {
+        $imageField = new FieldMetadata('images');
+        $imageField->setType('media_selection');
+        $imageField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'image'));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($imageField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'images' => ['ids' => [10, 20, 30]],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame('10', $returnedData['mediaId']);
+    }
+
+    public function testRoleImageWithEmptyDataDoesNotSetMediaId(): void
+    {
+        $imageField = new FieldMetadata('header_image');
+        $imageField->setType('single_media_selection');
+        $imageField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'image'));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($imageField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'header_image' => [],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertArrayNotHasKey('mediaId', $returnedData);
+    }
+
+    public function testRoleTitleOverridesDocumentTitle(): void
+    {
+        $titleField = new FieldMetadata('headline');
+        $titleField->setType('text_line');
+        $titleField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'title'));
+
+        $descriptionField = new FieldMetadata('description');
+        $descriptionField->setType('text_area');
+        $descriptionField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($titleField);
+        $formMetadata->addItem($descriptionField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'headline' => 'Custom Headline',
+                'description' => 'Some description',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => [], 'title' => 'Original Title']);
+
+        $this->assertSame('Custom Headline', $returnedData['title']);
+        $this->assertSame(['Some description'], $returnedData['content']);
+    }
+
+    public function testRoleTitleFieldExcludedFromContent(): void
+    {
+        $titleField = new FieldMetadata('headline');
+        $titleField->setType('text_line');
+        $titleField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'title'));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($titleField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'headline' => 'Custom Headline',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame([], $returnedData['content']);
+    }
+
+    public function testRoleUrlFieldExcludedFromContent(): void
+    {
+        $urlField = new FieldMetadata('custom_url');
+        $urlField->setType('text_line');
+        $urlField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG, 'url'));
+
+        $descriptionField = new FieldMetadata('description');
+        $descriptionField->setType('text_area');
+        $descriptionField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($urlField);
+        $formMetadata->addItem($descriptionField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'custom_url' => '/some-url',
+                'description' => 'Some description',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['Some description'], $returnedData['content']);
+    }
+
+    public function testNoRoleFieldIncludedInContent(): void
+    {
+        $textField = new FieldMetadata('body');
+        $textField->setType('text_editor');
+        $textField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($textField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en')
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'body' => '<p>Body content</p>',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['Body content'], $returnedData['content']);
+    }
+
     private function createBlockFormMetadata(): FormMetadata
     {
         $titleField = new FieldMetadata('title');
@@ -469,10 +692,14 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         return $formMetadata;
     }
 
-    private function createTag(string $name): TagMetadata
+    private function createTag(string $name, ?string $role = null): TagMetadata
     {
         $tag = new TagMetadata();
         $tag->setName($name);
+
+        if (null !== $role) {
+            $tag->setAttributes(['role' => $role]);
+        }
 
         return $tag;
     }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancerTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexExcerptEnhancer;
+
+class WebsitePageReindexExcerptEnhancerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private WebsitePageReindexExcerptEnhancer $enhancer;
+
+    protected function setUp(): void
+    {
+        $this->enhancer = new WebsitePageReindexExcerptEnhancer();
+    }
+
+    public function testEnhanceQueryAddsExcerptData(): void
+    {
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->addSelect('dimensionContent.excerptData')->willReturn($queryBuilder)->shouldBeCalled();
+
+        $this->enhancer->enhanceQuery($queryBuilder->reveal());
+    }
+
+    public function testExcerptDataIsNullReturnsUnchanged(): void
+    {
+        $queryResult = ['excerptData' => null];
+        $document = ['content' => [], 'title' => '', 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertSame('', $returnedData['title']);
+        $this->assertSame('', $returnedData['mediaId']);
+    }
+
+    public function testExcerptDataMissingReturnsUnchanged(): void
+    {
+        $queryResult = [];
+        $document = ['content' => [], 'title' => '', 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertSame('', $returnedData['title']);
+        $this->assertSame('', $returnedData['mediaId']);
+    }
+
+    public function testExcerptTitleSetsExcerptTitleAndFallsBackToTitle(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => 'Excerpt Title'],
+        ];
+        $document = ['content' => [], 'title' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Excerpt Title', $returnedData['title']);
+    }
+
+    public function testExcerptTitleDoesNotOverrideExistingTitle(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => 'Excerpt Title'],
+        ];
+        $document = ['content' => [], 'title' => 'Tagged Title'];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Tagged Title', $returnedData['title']);
+    }
+
+    public function testExcerptTitleEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => ''],
+        ];
+        $document = ['content' => [], 'title' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertSame('', $returnedData['title']);
+    }
+
+    public function testExcerptTitleWhitespaceIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => '   '],
+        ];
+        $document = ['content' => [], 'title' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptDescriptionSetsField(): void
+    {
+        $queryResult = [
+            'excerptData' => ['description' => '<p>Some <strong>rich</strong> description</p>'],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Some rich description', $excerpt['description']);
+    }
+
+    public function testExcerptDescriptionEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['description' => ''],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptMoreSetsField(): void
+    {
+        $queryResult = [
+            'excerptData' => ['more' => 'Read more'],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Read more', $excerpt['more']);
+    }
+
+    public function testExcerptMoreEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['more' => ''],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptImageSetsExcerptImageIdAndFallsBackToMediaId(): void
+    {
+        $queryResult = [
+            'excerptData' => ['image' => ['id' => 99]],
+        ];
+        $document = ['content' => [], 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame(99, $excerpt['imageId']);
+        $this->assertSame('99', $returnedData['mediaId']);
+    }
+
+    public function testExcerptImageDoesNotOverrideExistingMediaId(): void
+    {
+        $queryResult = [
+            'excerptData' => ['image' => ['id' => 99]],
+        ];
+        $document = ['content' => [], 'mediaId' => '42'];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame(99, $excerpt['imageId']);
+        $this->assertSame('42', $returnedData['mediaId']);
+    }
+
+    public function testExcerptImageEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['image' => []],
+        ];
+        $document = ['content' => [], 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptImageNonNumericIdIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['image' => ['id' => 'invalid']],
+        ];
+        $document = ['content' => [], 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptIconSetsField(): void
+    {
+        $queryResult = [
+            'excerptData' => ['icon' => ['id' => 77]],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame(77, $excerpt['iconId']);
+    }
+
+    public function testExcerptIconEmptyIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['icon' => []],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testExcerptIconNonNumericIdIsSkipped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['icon' => ['id' => 'invalid']],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertArrayNotHasKey('properties', $returnedData);
+    }
+
+    public function testAllExcerptFieldsPopulated(): void
+    {
+        $queryResult = [
+            'excerptData' => [
+                'title' => 'Excerpt Title',
+                'description' => '<p>Description</p>',
+                'more' => 'Read more',
+                'image' => ['id' => 55],
+                'icon' => ['id' => 33],
+            ],
+        ];
+        $document = ['content' => [], 'title' => '', 'mediaId' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('Excerpt Title', $excerpt['title']);
+        $this->assertSame('Excerpt Title', $returnedData['title']);
+        $this->assertSame('Description', $excerpt['description']);
+        $this->assertSame('Read more', $excerpt['more']);
+        $this->assertSame(55, $excerpt['imageId']);
+        $this->assertSame('55', $returnedData['mediaId']);
+        $this->assertSame(33, $excerpt['iconId']);
+    }
+
+    /**
+     * @param array<string, mixed> $returnedData
+     *
+     * @return array<string, mixed>
+     */
+    private function getExcerpt(array $returnedData): array
+    {
+        $properties = $returnedData['properties'] ?? null;
+        $this->assertIsArray($properties);
+
+        $excerpt = $properties['excerpt'] ?? null;
+        $this->assertIsArray($excerpt);
+
+        /** @var array<string, mixed> $excerpt */
+        return $excerpt;
+    }
+}

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexExcerptEnhancerTest.php
@@ -96,7 +96,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
         $this->assertSame('', $returnedData['title']);
     }
 
@@ -109,7 +109,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptDescriptionSetsField(): void
@@ -122,7 +122,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
         $excerpt = $this->getExcerpt($returnedData);
 
-        $this->assertSame('Some rich description', $excerpt['description']);
+        $this->assertSame('<p>Some <strong>rich</strong> description</p>', $excerpt['description']);
     }
 
     public function testExcerptDescriptionEmptyIsSkipped(): void
@@ -134,7 +134,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptMoreSetsField(): void
@@ -159,7 +159,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptImageSetsExcerptImageIdAndFallsBackToMediaId(): void
@@ -199,7 +199,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptImageNonNumericIdIsSkipped(): void
@@ -211,7 +211,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptIconSetsField(): void
@@ -236,7 +236,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
     }
 
     public function testExcerptIconNonNumericIdIsSkipped(): void
@@ -248,7 +248,47 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
 
-        $this->assertArrayNotHasKey('properties', $returnedData);
+        $this->assertArrayNotHasKey('metadata', $returnedData);
+    }
+
+    public function testExcerptTitleAddedToContent(): void
+    {
+        $queryResult = [
+            'excerptData' => ['title' => 'Excerpt Title'],
+        ];
+        $document = ['content' => ['existing content'], 'title' => ''];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertIsArray($returnedData['content']);
+        $this->assertContains('Excerpt Title', $returnedData['content']);
+        $this->assertContains('existing content', $returnedData['content']);
+    }
+
+    public function testExcerptDescriptionAddedToContentStripped(): void
+    {
+        $queryResult = [
+            'excerptData' => ['description' => '<p>Some <strong>rich</strong> description</p>'],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+
+        $this->assertIsArray($returnedData['content']);
+        $this->assertContains('Some rich description', $returnedData['content']);
+    }
+
+    public function testExcerptDescriptionInMetadataKeepsHtml(): void
+    {
+        $queryResult = [
+            'excerptData' => ['description' => '<p>Some <strong>rich</strong> description</p>'],
+        ];
+        $document = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($queryResult, $document);
+        $excerpt = $this->getExcerpt($returnedData);
+
+        $this->assertSame('<p>Some <strong>rich</strong> description</p>', $excerpt['description']);
     }
 
     public function testAllExcerptFieldsPopulated(): void
@@ -269,7 +309,7 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
 
         $this->assertSame('Excerpt Title', $excerpt['title']);
         $this->assertSame('Excerpt Title', $returnedData['title']);
-        $this->assertSame('Description', $excerpt['description']);
+        $this->assertSame('<p>Description</p>', $excerpt['description']);
         $this->assertSame('Read more', $excerpt['more']);
         $this->assertSame(55, $excerpt['imageId']);
         $this->assertSame('55', $returnedData['mediaId']);
@@ -283,10 +323,10 @@ class WebsitePageReindexExcerptEnhancerTest extends TestCase
      */
     private function getExcerpt(array $returnedData): array
     {
-        $properties = $returnedData['properties'] ?? null;
-        $this->assertIsArray($properties);
+        $metadata = $returnedData['metadata'] ?? null;
+        $this->assertIsArray($metadata);
 
-        $excerpt = $properties['excerpt'] ?? null;
+        $excerpt = $metadata['excerpt'] ?? null;
         $this->assertIsArray($excerpt);
 
         /** @var array<string, mixed> $excerpt */

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
@@ -68,7 +68,7 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
     {
         $enhancer = $this->createEnhancerWithTaxonomyResult(
             categoryIds: null,
-            tagNames: 'php||sulu',
+            tagNames: 'php,sulu',
         );
 
         $document = ['title' => 'Test', 'metadata' => []];
@@ -84,7 +84,7 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
     {
         $enhancer = $this->createEnhancerWithTaxonomyResult(
             categoryIds: '5,10',
-            tagNames: 'cms||web',
+            tagNames: 'cms,web',
         );
 
         $document = ['title' => 'Test', 'metadata' => []];

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
@@ -29,17 +29,26 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
         $this->enhancer = new WebsitePageReindexTaxonomyEnhancer();
     }
 
-    public function testEnhanceQueryAddsJoinsAndGroupConcat(): void
+    public function testEnhanceQueryAddsSubqueries(): void
     {
-        $queryBuilder = $this->prophesize(QueryBuilder::class);
-        $queryBuilder->addSelect('dimensionContent.id AS dimensionContentId')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->leftJoin('dimensionContent.excerptCategories', 'category')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->leftJoin('dimensionContent.excerptTags', 'tag')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->addSelect('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')->willReturn($queryBuilder)->shouldBeCalled();
-        $queryBuilder->addGroupBy('dimensionContent.id')->willReturn($queryBuilder)->shouldBeCalled();
+        // Create a real EntityManager and QueryBuilder for this test
+        // since mocking the nested QueryBuilder creation is too complex
+        $entityManager = $this->prophesize(\Doctrine\ORM\EntityManagerInterface::class);
 
-        $this->enhancer->enhanceQuery($queryBuilder->reveal());
+        $categorySubQueryBuilder = new QueryBuilder($entityManager->reveal());
+        $tagSubQueryBuilder = new QueryBuilder($entityManager->reveal());
+
+        $entityManager->createQueryBuilder()
+            ->willReturn($categorySubQueryBuilder, $tagSubQueryBuilder);
+
+        $queryBuilder = new QueryBuilder($entityManager->reveal());
+        $queryBuilder->from('TestEntity', 't');
+
+        $this->enhancer->enhanceQuery($queryBuilder);
+
+        // Verify that dimensionContentId was added to select
+        $dql = $queryBuilder->getDQL();
+        $this->assertStringContainsString('dimensionContent.id AS dimensionContentId', $dql);
     }
 
     public function testMissingTaxonomyDataReturnsUnchanged(): void

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexTaxonomyEnhancer;
+
+class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testEnhanceQueryAddsDimensionContentId(): void
+    {
+        $entityManager = $this->prophesize(EntityManagerInterface::class);
+        $enhancer = new WebsitePageReindexTaxonomyEnhancer($entityManager->reveal());
+
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->addSelect('dimensionContent.id AS dimensionContentId')
+            ->willReturn($queryBuilder)
+            ->shouldBeCalled();
+
+        $enhancer->enhanceQuery($queryBuilder->reveal());
+    }
+
+    public function testMissingDimensionContentIdReturnsUnchanged(): void
+    {
+        $entityManager = $this->prophesize(EntityManagerInterface::class);
+        $enhancer = new WebsitePageReindexTaxonomyEnhancer($entityManager->reveal());
+
+        $document = ['title' => 'Test'];
+
+        $result = $enhancer->enhanceDocument([], $document);
+
+        $this->assertSame($document, $result);
+    }
+
+    public function testCategoriesPopulated(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => 1], ['id' => 2], ['id' => 3]],
+            tagResults: [['name' => null]],
+        );
+
+        $document = ['title' => 'Test', 'properties' => []];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertIsArray($result['properties']['excerpt']);
+        $this->assertSame([1, 2, 3], $result['properties']['excerpt']['categoryIds']);
+        $this->assertArrayNotHasKey('tagNames', $result['properties']['excerpt']);
+    }
+
+    public function testTagsPopulated(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => null]],
+            tagResults: [['name' => 'php'], ['name' => 'sulu']],
+        );
+
+        $document = ['title' => 'Test', 'properties' => []];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertIsArray($result['properties']['excerpt']);
+        $this->assertArrayNotHasKey('categoryIds', $result['properties']['excerpt']);
+        $this->assertSame(['php', 'sulu'], $result['properties']['excerpt']['tagNames']);
+    }
+
+    public function testBothCategoriesAndTagsPopulated(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => 5], ['id' => 10]],
+            tagResults: [['name' => 'cms'], ['name' => 'web']],
+        );
+
+        $document = ['title' => 'Test', 'properties' => []];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertIsArray($result['properties']['excerpt']);
+        $this->assertSame([5, 10], $result['properties']['excerpt']['categoryIds']);
+        $this->assertSame(['cms', 'web'], $result['properties']['excerpt']['tagNames']);
+    }
+
+    public function testEmptyTaxonomyDoesNotAddKeys(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => null]],
+            tagResults: [['name' => null]],
+        );
+
+        $document = ['title' => 'Test', 'properties' => []];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertArrayNotHasKey('excerpt', $result['properties']);
+    }
+
+    public function testPreservesExistingExcerptProperties(): void
+    {
+        $enhancer = $this->createEnhancerWithResults(
+            categoryResults: [['id' => 1]],
+            tagResults: [['name' => 'tag1']],
+        );
+
+        $document = [
+            'title' => 'Test',
+            'properties' => [
+                'excerpt' => [
+                    'title' => 'Existing Excerpt Title',
+                ],
+            ],
+        ];
+        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+
+        $this->assertIsArray($result['properties']);
+        $this->assertIsArray($result['properties']['excerpt']);
+        $this->assertSame('Existing Excerpt Title', $result['properties']['excerpt']['title']);
+        $this->assertSame([1], $result['properties']['excerpt']['categoryIds']);
+        $this->assertSame(['tag1'], $result['properties']['excerpt']['tagNames']);
+    }
+
+    /**
+     * @param list<array{id: int|null}> $categoryResults
+     * @param list<array{name: string|null}> $tagResults
+     */
+    private function createEnhancerWithResults(array $categoryResults, array $tagResults): WebsitePageReindexTaxonomyEnhancer
+    {
+        $categoryQb = $this->createQueryBuilderStub($categoryResults);
+        $tagQb = $this->createQueryBuilderStub($tagResults);
+
+        $entityManager = $this->prophesize(EntityManagerInterface::class);
+        $entityManager->createQueryBuilder()->willReturn($categoryQb, $tagQb);
+
+        return new WebsitePageReindexTaxonomyEnhancer($entityManager->reveal());
+    }
+
+    /**
+     * @param list<array<string, mixed>> $scalarResult
+     */
+    private function createQueryBuilderStub(array $scalarResult): QueryBuilder
+    {
+        $query = $this->prophesize(Query::class);
+        $query->getScalarResult()->willReturn($scalarResult);
+
+        $qb = $this->prophesize(QueryBuilder::class);
+        $qb->select(Argument::any())->willReturn($qb);
+        $qb->from(Argument::any(), Argument::any())->willReturn($qb);
+        $qb->leftJoin(Argument::any(), Argument::any())->willReturn($qb);
+        $qb->where(Argument::any())->willReturn($qb);
+        $qb->setParameter(Argument::any(), Argument::any())->willReturn($qb);
+        $qb->getQuery()->willReturn($query->reveal());
+
+        return $qb->reveal();
+    }
+}

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
@@ -31,9 +31,7 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
         $enhancer = new WebsitePageReindexTaxonomyEnhancer($entityManager->reveal());
 
         $queryBuilder = $this->prophesize(QueryBuilder::class);
-        $queryBuilder->addSelect('dimensionContent.id AS dimensionContentId')
-            ->willReturn($queryBuilder)
-            ->shouldBeCalled();
+        $queryBuilder->addSelect('dimensionContent.id AS dimensionContentId')->willReturn($queryBuilder)->shouldBeCalled();
 
         $enhancer->enhanceQuery($queryBuilder->reveal());
     }
@@ -52,76 +50,76 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
 
     public function testCategoriesPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => 1], ['id' => 2], ['id' => 3]],
-            tagResults: [['name' => null]],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: '1,2,3',
+            tagNames: null,
         );
 
-        $document = ['title' => 'Test', 'properties' => []];
+        $document = ['title' => 'Test', 'metadata' => []];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertIsArray($result['properties']['excerpt']);
-        $this->assertSame([1, 2, 3], $result['properties']['excerpt']['categoryIds']);
-        $this->assertArrayNotHasKey('tagNames', $result['properties']['excerpt']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertIsArray($result['metadata']['excerpt']);
+        $this->assertSame([1, 2, 3], $result['metadata']['excerpt']['categoryIds']);
+        $this->assertArrayNotHasKey('tagNames', $result['metadata']['excerpt']);
     }
 
     public function testTagsPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => null]],
-            tagResults: [['name' => 'php'], ['name' => 'sulu']],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: null,
+            tagNames: 'php||sulu',
         );
 
-        $document = ['title' => 'Test', 'properties' => []];
+        $document = ['title' => 'Test', 'metadata' => []];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertIsArray($result['properties']['excerpt']);
-        $this->assertArrayNotHasKey('categoryIds', $result['properties']['excerpt']);
-        $this->assertSame(['php', 'sulu'], $result['properties']['excerpt']['tagNames']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertIsArray($result['metadata']['excerpt']);
+        $this->assertArrayNotHasKey('categoryIds', $result['metadata']['excerpt']);
+        $this->assertSame(['php', 'sulu'], $result['metadata']['excerpt']['tagNames']);
     }
 
     public function testBothCategoriesAndTagsPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => 5], ['id' => 10]],
-            tagResults: [['name' => 'cms'], ['name' => 'web']],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: '5,10',
+            tagNames: 'cms||web',
         );
 
-        $document = ['title' => 'Test', 'properties' => []];
+        $document = ['title' => 'Test', 'metadata' => []];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertIsArray($result['properties']['excerpt']);
-        $this->assertSame([5, 10], $result['properties']['excerpt']['categoryIds']);
-        $this->assertSame(['cms', 'web'], $result['properties']['excerpt']['tagNames']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertIsArray($result['metadata']['excerpt']);
+        $this->assertSame([5, 10], $result['metadata']['excerpt']['categoryIds']);
+        $this->assertSame(['cms', 'web'], $result['metadata']['excerpt']['tagNames']);
     }
 
     public function testEmptyTaxonomyDoesNotAddKeys(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => null]],
-            tagResults: [['name' => null]],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: null,
+            tagNames: null,
         );
 
-        $document = ['title' => 'Test', 'properties' => []];
+        $document = ['title' => 'Test', 'metadata' => []];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertArrayNotHasKey('excerpt', $result['properties']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertArrayNotHasKey('excerpt', $result['metadata']);
     }
 
-    public function testPreservesExistingExcerptProperties(): void
+    public function testPreservesExistingExcerptMetadata(): void
     {
-        $enhancer = $this->createEnhancerWithResults(
-            categoryResults: [['id' => 1]],
-            tagResults: [['name' => 'tag1']],
+        $enhancer = $this->createEnhancerWithTaxonomyResult(
+            categoryIds: '1',
+            tagNames: 'tag1',
         );
 
         $document = [
             'title' => 'Test',
-            'properties' => [
+            'metadata' => [
                 'excerpt' => [
                     'title' => 'Existing Excerpt Title',
                 ],
@@ -129,38 +127,34 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
         ];
         $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
 
-        $this->assertIsArray($result['properties']);
-        $this->assertIsArray($result['properties']['excerpt']);
-        $this->assertSame('Existing Excerpt Title', $result['properties']['excerpt']['title']);
-        $this->assertSame([1], $result['properties']['excerpt']['categoryIds']);
-        $this->assertSame(['tag1'], $result['properties']['excerpt']['tagNames']);
+        $this->assertIsArray($result['metadata']);
+        $this->assertIsArray($result['metadata']['excerpt']);
+        $this->assertSame('Existing Excerpt Title', $result['metadata']['excerpt']['title']);
+        $this->assertSame([1], $result['metadata']['excerpt']['categoryIds']);
+        $this->assertSame(['tag1'], $result['metadata']['excerpt']['tagNames']);
     }
 
-    /**
-     * @param list<array{id: int|null}> $categoryResults
-     * @param list<array{name: string|null}> $tagResults
-     */
-    private function createEnhancerWithResults(array $categoryResults, array $tagResults): WebsitePageReindexTaxonomyEnhancer
+    private function createEnhancerWithTaxonomyResult(?string $categoryIds, ?string $tagNames): WebsitePageReindexTaxonomyEnhancer
     {
-        $categoryQb = $this->createQueryBuilderStub($categoryResults);
-        $tagQb = $this->createQueryBuilderStub($tagResults);
+        $qb = $this->createQueryBuilderStub(['categoryIds' => $categoryIds, 'tagNames' => $tagNames]);
 
         $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $entityManager->createQueryBuilder()->willReturn($categoryQb, $tagQb);
+        $entityManager->createQueryBuilder()->willReturn($qb);
 
         return new WebsitePageReindexTaxonomyEnhancer($entityManager->reveal());
     }
 
     /**
-     * @param list<array<string, mixed>> $scalarResult
+     * @param array<string, mixed> $singleResult
      */
-    private function createQueryBuilderStub(array $scalarResult): QueryBuilder
+    private function createQueryBuilderStub(array $singleResult): QueryBuilder
     {
         $query = $this->prophesize(Query::class);
-        $query->getScalarResult()->willReturn($scalarResult);
+        $query->getSingleResult()->willReturn($singleResult);
 
         $qb = $this->prophesize(QueryBuilder::class);
         $qb->select(Argument::any())->willReturn($qb);
+        $qb->addSelect(Argument::any())->willReturn($qb);
         $qb->from(Argument::any(), Argument::any())->willReturn($qb);
         $qb->leftJoin(Argument::any(), Argument::any())->willReturn($qb);
         $qb->where(Argument::any())->willReturn($qb);

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexTaxonomyEnhancerTest.php
@@ -13,11 +13,8 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Search\Visitor;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexTaxonomyEnhancer;
 
@@ -25,38 +22,39 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testEnhanceQueryAddsDimensionContentId(): void
+    private WebsitePageReindexTaxonomyEnhancer $enhancer;
+
+    protected function setUp(): void
     {
-        $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $enhancer = new WebsitePageReindexTaxonomyEnhancer($entityManager->reveal());
-
-        $queryBuilder = $this->prophesize(QueryBuilder::class);
-        $queryBuilder->addSelect('dimensionContent.id AS dimensionContentId')->willReturn($queryBuilder)->shouldBeCalled();
-
-        $enhancer->enhanceQuery($queryBuilder->reveal());
+        $this->enhancer = new WebsitePageReindexTaxonomyEnhancer();
     }
 
-    public function testMissingDimensionContentIdReturnsUnchanged(): void
+    public function testEnhanceQueryAddsJoinsAndGroupConcat(): void
     {
-        $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $enhancer = new WebsitePageReindexTaxonomyEnhancer($entityManager->reveal());
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->addSelect('dimensionContent.id AS dimensionContentId')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->leftJoin('dimensionContent.excerptCategories', 'category')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->leftJoin('dimensionContent.excerptTags', 'tag')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->addSelect('GROUP_CONCAT(DISTINCT category.id) AS categoryIds')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->addSelect('GROUP_CONCAT(DISTINCT tag.name) AS tagNames')->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->addGroupBy('dimensionContent.id')->willReturn($queryBuilder)->shouldBeCalled();
 
-        $document = ['title' => 'Test'];
+        $this->enhancer->enhanceQuery($queryBuilder->reveal());
+    }
 
-        $result = $enhancer->enhanceDocument([], $document);
+    public function testMissingTaxonomyDataReturnsUnchanged(): void
+    {
+        $document = ['title' => 'Test', 'metadata' => []];
+
+        $result = $this->enhancer->enhanceDocument([], $document);
 
         $this->assertSame($document, $result);
     }
 
     public function testCategoriesPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: '1,2,3',
-            tagNames: null,
-        );
-
         $document = ['title' => 'Test', 'metadata' => []];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => '1,2,3', 'tagNames' => null], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertIsArray($result['metadata']['excerpt']);
@@ -66,13 +64,8 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
 
     public function testTagsPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: null,
-            tagNames: 'php,sulu',
-        );
-
         $document = ['title' => 'Test', 'metadata' => []];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => null, 'tagNames' => 'php,sulu'], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertIsArray($result['metadata']['excerpt']);
@@ -82,13 +75,8 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
 
     public function testBothCategoriesAndTagsPopulated(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: '5,10',
-            tagNames: 'cms,web',
-        );
-
         $document = ['title' => 'Test', 'metadata' => []];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => '5,10', 'tagNames' => 'cms,web'], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertIsArray($result['metadata']['excerpt']);
@@ -98,13 +86,8 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
 
     public function testEmptyTaxonomyDoesNotAddKeys(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: null,
-            tagNames: null,
-        );
-
         $document = ['title' => 'Test', 'metadata' => []];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => null, 'tagNames' => null], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertArrayNotHasKey('excerpt', $result['metadata']);
@@ -112,11 +95,6 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
 
     public function testPreservesExistingExcerptMetadata(): void
     {
-        $enhancer = $this->createEnhancerWithTaxonomyResult(
-            categoryIds: '1',
-            tagNames: 'tag1',
-        );
-
         $document = [
             'title' => 'Test',
             'metadata' => [
@@ -125,42 +103,12 @@ class WebsitePageReindexTaxonomyEnhancerTest extends TestCase
                 ],
             ],
         ];
-        $result = $enhancer->enhanceDocument(['dimensionContentId' => 42], $document);
+        $result = $this->enhancer->enhanceDocument(['categoryIds' => '1', 'tagNames' => 'tag1'], $document);
 
         $this->assertIsArray($result['metadata']);
         $this->assertIsArray($result['metadata']['excerpt']);
         $this->assertSame('Existing Excerpt Title', $result['metadata']['excerpt']['title']);
         $this->assertSame([1], $result['metadata']['excerpt']['categoryIds']);
         $this->assertSame(['tag1'], $result['metadata']['excerpt']['tagNames']);
-    }
-
-    private function createEnhancerWithTaxonomyResult(?string $categoryIds, ?string $tagNames): WebsitePageReindexTaxonomyEnhancer
-    {
-        $qb = $this->createQueryBuilderStub(['categoryIds' => $categoryIds, 'tagNames' => $tagNames]);
-
-        $entityManager = $this->prophesize(EntityManagerInterface::class);
-        $entityManager->createQueryBuilder()->willReturn($qb);
-
-        return new WebsitePageReindexTaxonomyEnhancer($entityManager->reveal());
-    }
-
-    /**
-     * @param array<string, mixed> $singleResult
-     */
-    private function createQueryBuilderStub(array $singleResult): QueryBuilder
-    {
-        $query = $this->prophesize(Query::class);
-        $query->getSingleResult()->willReturn($singleResult);
-
-        $qb = $this->prophesize(QueryBuilder::class);
-        $qb->select(Argument::any())->willReturn($qb);
-        $qb->addSelect(Argument::any())->willReturn($qb);
-        $qb->from(Argument::any(), Argument::any())->willReturn($qb);
-        $qb->leftJoin(Argument::any(), Argument::any())->willReturn($qb);
-        $qb->where(Argument::any())->willReturn($qb);
-        $qb->setParameter(Argument::any(), Argument::any())->willReturn($qb);
-        $qb->getQuery()->willReturn($query->reveal());
-
-        return $qb->reveal();
     }
 }

--- a/packages/search/config/schemas/website.php
+++ b/packages/search/config/schemas/website.php
@@ -23,4 +23,5 @@ return new Index('website', [
     'content' => new Field\TextField('content', multiple: true),
     'mediaId' => new Field\IntegerField('mediaId'),
     'authoredAt' => new Field\DateTimeField('authoredAt'),
+    'properties' => new Field\JsonObjectField('properties'),
 ]);

--- a/packages/search/config/schemas/website.php
+++ b/packages/search/config/schemas/website.php
@@ -23,5 +23,5 @@ return new Index('website', [
     'content' => new Field\TextField('content', multiple: true),
     'mediaId' => new Field\IntegerField('mediaId'),
     'authoredAt' => new Field\DateTimeField('authoredAt'),
-    'properties' => new Field\JsonObjectField('properties'),
+    'metadata' => new Field\JsonObjectField('metadata'),
 ]);


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Added support for search field tag roles (`title`, `image`, `url`) in content enhancers for both articles and pages
  - Content enhancers now extract `title` and `mediaId` from template fields tagged with the appropriate role, with fallback to the existing dimension content values
  - Fields with `title`, `image`, or `url` roles are excluded from the generic `content` array to avoid duplication
  - Added excerpt data enhancers (`WebsiteArticleReindexExcerptEnhancer` / `WebsitePageReindexExcerptEnhancer`) that populate excerpt properties (title, description, more, image, icon) and provide fallback values
  for document title and mediaId
  - Added `properties` JSON object field to the website search index schema for storing excerpt metadata

  #### Why?

  The website search index was missing excerpt data and had no mechanism to let templates control which fields map to the document title or image. By reading the `role` attribute from the `sulu.search.field` tag,
  templates can now designate specific fields as the search title or image, giving content editors more control over how their pages and articles appear in search results. Excerpt data provides additional metadata
  (description, icon, etc.) that can be used to enrich search result rendering.

  #### Example Usage

  In a Sulu template XML, tag a field with a role to control its search index behavior:

  ```xml
  <!-- Field used as the search document title -->
  <property name="headline" type="text_line">
      <tag name="sulu.search.field" role="title"/>
  </property>

  <!-- Field used as the search document image -->
  <property name="header_image" type="single_media_selection">
      <tag name="sulu.search.field" role="image"/>
  </property>

  <!-- Regular searchable content field (no role, included in content array) -->
  <property name="description" type="text_area">
      <tag name="sulu.search.field"/>
  </property>
```

  To Do

  - Create a documentation PR
  - Add breaking changes to UPGRADE.md