### PR TITLE
No useless return (the fixed version)

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -48,8 +48,6 @@ $config->setRiskyAllowed(true)
         'new_with_parentheses' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match']],
         'no_useless_else' => false,
-        // Disabling this because php-cs-fixer doesn't know that it implicitly returns null
-        'no_useless_return' => false
     ])
     ->setFinder($finder);
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11017,26 +11017,8 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
 
 		-
-			message: '#^If condition is always true\.$#'
-			identifier: if.alwaysTrue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Contact\:\:getAccount\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Contact\:\:getAddresses\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Contact\:\:getAvatar\(\) should return Sulu\\Bundle\\MediaBundle\\Api\\Media but returns array\<string, array\|int\|string\>\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
 
@@ -11127,12 +11109,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Contact\:\:getLocales\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Contact\:\:getMainAddress\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
 
@@ -13251,7 +13227,7 @@ parameters:
 		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6655,25 +6655,7 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getMeta\(\) should return array but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getName\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getParent\(\) should return Sulu\\Bundle\\CategoryBundle\\Api\\Category\|null but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getParentId\(\) should return Sulu\\Bundle\\CategoryBundle\\Api\\Category\|null but empty return statement found\.$#'
 			identifier: return.empty
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
@@ -9769,18 +9751,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Account\:\:getParent\(\) should return Sulu\\Bundle\\ContactBundle\\Entity\\AccountInterface but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Account\:\:getParent\(\) should return Sulu\\Bundle\\ContactBundle\\Entity\\AccountInterface but returns Sulu\\Bundle\\ContactBundle\\Api\\Account\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Account\:\:getPhones\(\) should return array\<Sulu\\Bundle\\ContactBundle\\Entity\\Phone\> but returns list\<Sulu\\Bundle\\ContactBundle\\Api\\Phone\>\.$#'
 			identifier: return.type
 			count: 1
@@ -9963,12 +9933,6 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
@@ -11451,12 +11415,6 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$array of function array_map expects array, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Contact.php
 
@@ -13321,12 +13279,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Contact\\AccountManager\:\:findAll\(\) should return array\|null but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Contact\\AccountManager\:\:findByFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -13335,12 +13287,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Contact\\AccountManager\:\:findContactsByAccountId\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Contact\\AccountManager\:\:findContactsByAccountId\(\) should return array\|null but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
 
@@ -13455,12 +13401,6 @@ parameters:
 		-
 			message: '#^Unable to resolve the template type TMaybeContained in call to method Doctrine\\Common\\Collections\\ReadableCollection\<int,Sulu\\Bundle\\MediaBundle\\Entity\\MediaInterface\>\:\:contains\(\)$#'
 			identifier: argument.templateType
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
 
@@ -21475,20 +21415,8 @@ parameters:
 			path: src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\DocumentManagerBundle\\Bridge\\DocumentInspector\:\:extractWebspaceFromPath\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\DocumentManagerBundle\\Bridge\\DocumentInspector\:\:getConcreteLocales\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\DocumentManagerBundle\\Bridge\\DocumentInspector\:\:getLocale\(\) should return string\|null but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
 
@@ -21513,6 +21441,12 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\DocumentManagerBundle\\Bridge\\DocumentInspector\:\:getStructureMetadata\(\) should return Sulu\\Component\\Content\\Metadata\\StructureMetadata\|null but empty return statement found\.$#'
 			identifier: return.empty
+			count: 1
+			path: src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\DocumentManagerBundle\\Bridge\\DocumentInspector\:\:getWebspace\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
 
@@ -24955,18 +24889,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Api/Media.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Api\\Media\:\:getCollection\(\) should return int but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Api/Media.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Api\\Media\:\:getCollection\(\) should return int but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Api/Media.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Api\\Media\:\:getContentLanguages\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -25323,12 +25245,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManager\:\:getPreview\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManager\:\:getPreview\(\) should return array but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
 
@@ -28513,12 +28429,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Media\\FormatLoader\\XmlFormatLoader10\:\:getScaleFromFormatNode\(\) should return array but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Media\\FormatLoader\\XmlFormatLoader10\:\:getTransformationsFromFormatNode\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -28575,12 +28485,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Media\\FormatLoader\\XmlFormatLoader11\:\:getScaleFromFormatNode\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Media\\FormatLoader\\XmlFormatLoader11\:\:getScaleFromFormatNode\(\) should return array but returns array\<string, mixed\>\|null\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader11.php
 
@@ -65035,12 +64939,6 @@ parameters:
 			path: src/Sulu/Component/Content/Compat/PropertyType.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Compat\\PropertyType\:\:getProperty\(\) should return Sulu\\Component\\Content\\Compat\\PropertyInterface\|null but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Component/Content/Compat/PropertyType.php
-
-		-
 			message: '#^Parameter \#1 \$metadata of class Sulu\\Component\\Content\\Compat\\Metadata constructor expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -65235,18 +65133,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Component\\Content\\Compat\\Structure\:\:copyFrom\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Content/Compat/Structure.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Compat\\Structure\:\:findProperty\(\) never returns null so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: src/Sulu/Component/Content/Compat/Structure.php
-
-		-
-			message: '#^Method Sulu\\Component\\Content\\Compat\\Structure\:\:findProperty\(\) should return Sulu\\Component\\Content\\Compat\\PropertyInterface\|null but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Component/Content/Compat/Structure.php
 
@@ -76783,18 +76669,6 @@ parameters:
 			path: src/Sulu/Component/CustomUrl/Document/CustomUrlDocument.php
 
 		-
-			message: '#^Method Sulu\\Component\\CustomUrl\\Document\\CustomUrlNodeType\:\:getPrimaryItemName\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Component/CustomUrl/Document/CustomUrlNodeType.php
-
-		-
-			message: '#^Method Sulu\\Component\\CustomUrl\\Document\\CustomUrlRouteNodeType\:\:getPrimaryItemName\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Component/CustomUrl/Document/CustomUrlRouteNodeType.php
-
-		-
 			message: '#^Method Sulu\\Component\\CustomUrl\\Document\\Initializer\\CustomUrlInitializer\:\:initialize\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -82093,12 +81967,6 @@ parameters:
 			path: src/Sulu/Component/Localization/Localization.php
 
 		-
-			message: '#^Method Sulu\\Component\\Localization\\Localization\:\:findLocalization\(\) should return Sulu\\Component\\Localization\\Localization\|null but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Component/Localization/Localization.php
-
-		-
 			message: '#^Method Sulu\\Component\\Localization\\Localization\:\:setChildren\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -83173,20 +83041,8 @@ parameters:
 			path: src/Sulu/Component/PHPCR/NodeTypes/Base/SuluNodeType.php
 
 		-
-			message: '#^Method Sulu\\Component\\PHPCR\\NodeTypes\\Base\\SuluNodeType\:\:getPrimaryItemName\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Component/PHPCR/NodeTypes/Base/SuluNodeType.php
-
-		-
 			message: '#^Method Sulu\\Component\\PHPCR\\NodeTypes\\Content\\ContentNodeType\:\:getDeclaredSupertypeNames\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/PHPCR/NodeTypes/Content/ContentNodeType.php
-
-		-
-			message: '#^Method Sulu\\Component\\PHPCR\\NodeTypes\\Content\\ContentNodeType\:\:getPrimaryItemName\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Component/PHPCR/NodeTypes/Content/ContentNodeType.php
 
@@ -83259,12 +83115,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Component\\PHPCR\\NodeTypes\\Path\\PathNodeType\:\:getDeclaredSupertypeNames\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/PHPCR/NodeTypes/Path/PathNodeType.php
-
-		-
-			message: '#^Method Sulu\\Component\\PHPCR\\NodeTypes\\Path\\PathNodeType\:\:getPrimaryItemName\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Component/PHPCR/NodeTypes/Path/PathNodeType.php
 
@@ -84139,20 +83989,8 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\AbstractListBuilder\:\:getFieldDescriptor\(\) should return Sulu\\Component\\Rest\\ListBuilder\\FieldDescriptorInterface\|null but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
-
-		-
 			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\AbstractListBuilder\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\AbstractListBuilder\:\:getSelectField\(\) should return Sulu\\Component\\Rest\\ListBuilder\\FieldDescriptorInterface but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
 
@@ -89251,7 +89089,6 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Class Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\Query extends generic class Doctrine\\ORM\\AbstractQuery but does not specify its types\: TKey, TResult$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89719,12 +89556,6 @@ parameters:
 			path: src/Sulu/Component/Util/SuluNodeHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Util\\SuluNodeHelper\:\:getStructureTypeForNode\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
-			count: 1
-			path: src/Sulu/Component/Util/SuluNodeHelper.php
-
-		-
 			message: '#^Method Sulu\\Component\\Util\\SuluNodeHelper\:\:hasSuluNodeType\(\) has parameter \$suluNodeTypes with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -90171,12 +90002,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Component\\Util\\WildcardUrlUtil\:\:match\(\) should return bool but returns int\|false\.$#'
 			identifier: return.type
-			count: 1
-			path: src/Sulu/Component/Util/WildcardUrlUtil.php
-
-		-
-			message: '#^Method Sulu\\Component\\Util\\WildcardUrlUtil\:\:resolve\(\) should return string but empty return statement found\.$#'
-			identifier: return.empty
 			count: 1
 			path: src/Sulu/Component/Util/WildcardUrlUtil.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9595,12 +9595,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
 		-
-			message: '#^If condition is always true\.$#'
-			identifier: if.alwaysTrue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Account\:\:getAddresses\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -9669,18 +9663,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Account\:\:getId\(\) should return int but returns mixed\.$#'
 			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Account\:\:getLogo\(\) should return Sulu\\Bundle\\MediaBundle\\Api\\Media but returns array\<string, array\|int\|string\>\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Api\\Account\:\:getMainAddress\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Api/Account.php
 
@@ -66759,7 +66741,7 @@ parameters:
 		-
 			message: '#^Possibly invalid array key type mixed\.$#'
 			identifier: offsetAccess.invalidOffset
-			count: 5
+			count: 4
 			path: src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
 
 		-
@@ -89089,6 +89071,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
+			message: '#^Class Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\Query extends generic class Doctrine\\ORM\\AbstractQuery but does not specify its types\: TKey, TResult$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php

--- a/src/Sulu/Bundle/CategoryBundle/Api/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Api/Category.php
@@ -181,7 +181,7 @@ class Category extends ApiEntityWrapper
     /**
      * Returns the name of the Category dependent on the locale.
      *
-     * @return array
+     * @return array|null
      */
     #[VirtualProperty]
     #[SerializedName('meta')]
@@ -206,7 +206,7 @@ class Category extends ApiEntityWrapper
             return $arrReturn;
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -355,7 +355,7 @@ class Category extends ApiEntityWrapper
             return new self($parent, $this->locale);
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -373,7 +373,7 @@ class Category extends ApiEntityWrapper
             return $parent->getId();
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -191,7 +191,7 @@ class Account extends ApiWrapper
     /**
      * Get parent.
      *
-     * @return AccountInterface
+     * @return self|null
      */
     #[VirtualProperty]
     #[SerializedName('parent')]
@@ -203,7 +203,7 @@ class Account extends ApiWrapper
             return new self($account, $this->locale);
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -951,8 +951,6 @@ class Account extends ApiWrapper
                 }
             }
         }
-
-        return;
     }
 
     /**
@@ -1003,8 +1001,6 @@ class Account extends ApiWrapper
                 'thumbnails' => $this->logo->getFormats(),
             ];
         }
-
-        return;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -43,7 +43,7 @@ class Account extends ApiWrapper
     public const TYPE = 'account';
 
     /**
-     * @var Media
+     * @var Media|null
      */
     private $logo = null;
 
@@ -992,7 +992,7 @@ class Account extends ApiWrapper
     /**
      * Get the accounts logo and return the array of different formats.
      *
-     * @return Media
+     * @return array{id: int, url: string, thumbnails: array<mixed>}|null
      */
     #[VirtualProperty]
     #[SerializedName('logo')]
@@ -1006,6 +1006,8 @@ class Account extends ApiWrapper
                 'thumbnails' => $this->logo->getFormats(),
             ];
         }
+
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Bundle\ContactBundle\Entity\AccountAddress as AccountAddressEntity;
 use Sulu\Bundle\ContactBundle\Entity\AccountContact as AccountContactEntity;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Bundle\ContactBundle\Entity\Address as AddressEntity;
 use Sulu\Bundle\ContactBundle\Entity\BankAccount as BankAccountEntity;
 use Sulu\Bundle\ContactBundle\Entity\Contact as ContactEntity;
 use Sulu\Bundle\ContactBundle\Entity\ContactAddress;
@@ -935,6 +936,8 @@ class Account extends ApiWrapper
 
     /**
      * Returns the main address.
+     *
+     * @return null|AddressEntity
      */
     #[VirtualProperty]
     #[SerializedName('mainAddress')]
@@ -951,6 +954,8 @@ class Account extends ApiWrapper
                 }
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -17,6 +17,7 @@ use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\VirtualProperty;
 use Sulu\Bundle\CategoryBundle\Api\Category;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface as CategoryEntity;
+use Sulu\Bundle\ContactBundle\Entity\Address as AddressEntity;
 use Sulu\Bundle\ContactBundle\Entity\BankAccount as BankAccountEntity;
 use Sulu\Bundle\ContactBundle\Entity\ContactAddress as ContactAddressEntity;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface as ContactEntity;
@@ -43,7 +44,7 @@ class Contact extends ApiWrapper
     public const TYPE = 'contact';
 
     /**
-     * @var Media
+     * @var Media|null
      */
     private $avatar = null;
 
@@ -717,7 +718,7 @@ class Contact extends ApiWrapper
     /**
      * Get the contacts avatar and return the array of different formats.
      *
-     * @return Media
+     * @return array{id: int, url: string, thumbnails: array<mixed>}|null
      */
     #[VirtualProperty]
     #[SerializedName('avatar')]
@@ -731,6 +732,8 @@ class Contact extends ApiWrapper
                 'thumbnails' => $this->avatar->getFormats(),
             ];
         }
+
+        return null;
     }
 
     /**
@@ -843,6 +846,8 @@ class Contact extends ApiWrapper
 
     /**
      * Returns main account.
+     *
+     * @return Account|null
      */
     #[VirtualProperty]
     #[SerializedName('account')]
@@ -853,6 +858,8 @@ class Contact extends ApiWrapper
         if (!\is_null($mainAccount)) {
             return new Account($mainAccount, $this->locale);
         }
+
+        return null;
     }
 
     /**
@@ -988,6 +995,8 @@ class Contact extends ApiWrapper
 
     /**
      * Returns the main address.
+     *
+     * @return AddressEntity|null
      */
     #[VirtualProperty]
     #[SerializedName('mainAddress')]
@@ -1004,6 +1013,8 @@ class Contact extends ApiWrapper
                 }
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Api/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Contact.php
@@ -731,8 +731,6 @@ class Contact extends ApiWrapper
                 'thumbnails' => $this->avatar->getFormats(),
             ];
         }
-
-        return;
     }
 
     /**
@@ -855,8 +853,6 @@ class Contact extends ApiWrapper
         if (!\is_null($mainAccount)) {
             return new Account($mainAccount, $this->locale);
         }
-
-        return;
     }
 
     /**
@@ -1008,8 +1004,6 @@ class Contact extends ApiWrapper
                 }
             }
         }
-
-        return;
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -227,7 +227,7 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
             return $contacts;
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -315,7 +315,7 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
             return $accounts;
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -331,8 +331,6 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
         if ($account) {
             return $this->getApiObject($account, $locale);
         }
-
-        return;
     }
 
     public function deleteAllRelations($entity)

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -321,7 +321,7 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
     /**
      * Returns an api entity for an doctrine entity.
      *
-     * @param AccountInterface $account
+     * @param AccountInterface|null $account
      * @param string $locale
      *
      * @return null|AccountApi
@@ -331,6 +331,8 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
         if ($account) {
             return $this->getApiObject($account, $locale);
         }
+
+        return null;
     }
 
     public function deleteAllRelations($entity)

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -161,7 +161,7 @@ class DocumentInspector extends BaseDocumentInspector
             return $this->documentRegistry->getLocaleForDocument($document);
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -346,7 +346,7 @@ class DocumentInspector extends BaseDocumentInspector
      *
      * @param string $path path of node
      *
-     * @return string
+     * @return string|null
      */
     private function extractWebspaceFromPath($path)
     {
@@ -363,6 +363,6 @@ class DocumentInspector extends BaseDocumentInspector
             return $matches[1];
         }
 
-        return;
+        return null;
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/FooFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/FooFixture.php
@@ -18,7 +18,6 @@ class FooFixture implements DocumentFixtureInterface
 {
     public function load(DocumentManager $documentManager): void
     {
-        return;
     }
 
     public function getOrder()

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/GroupBarFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/GroupBarFixture.php
@@ -19,7 +19,6 @@ class GroupBarFixture implements DocumentFixtureInterface, DocumentFixtureGroupI
 {
     public function load(DocumentManager $documentManager): void
     {
-        return;
     }
 
     public function getOrder()

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/GroupFooFixture.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/DataFixtures/GroupFooFixture.php
@@ -19,7 +19,6 @@ class GroupFooFixture implements DocumentFixtureInterface, DocumentFixtureGroupI
 {
     public function load(DocumentManager $documentManager): void
     {
-        return;
     }
 
     public function getOrder()

--- a/src/Sulu/Bundle/MediaBundle/Api/Collection.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Collection.php
@@ -29,7 +29,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
 class Collection extends ApiWrapper
 {
     /**
-     * @var array|null
+     * @var array
      */
     protected $preview = [];
 
@@ -273,7 +273,7 @@ class Collection extends ApiWrapper
     }
 
     /**
-     * @return array|null
+     * @return array
      */
     #[VirtualProperty]
     #[SerializedName('preview')]
@@ -283,7 +283,7 @@ class Collection extends ApiWrapper
     }
 
     /**
-     * @param array|null $preview
+     * @param array $preview
      *
      * @return $this
      */

--- a/src/Sulu/Bundle/MediaBundle/Api/Collection.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Collection.php
@@ -29,7 +29,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
 class Collection extends ApiWrapper
 {
     /**
-     * @var array
+     * @var array|null
      */
     protected $preview = [];
 
@@ -273,7 +273,7 @@ class Collection extends ApiWrapper
     }
 
     /**
-     * @return array
+     * @return array|null
      */
     #[VirtualProperty]
     #[SerializedName('preview')]
@@ -283,7 +283,7 @@ class Collection extends ApiWrapper
     }
 
     /**
-     * @param array $preview
+     * @param array|null $preview
      *
      * @return $this
      */

--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -159,7 +159,7 @@ class Media extends ApiWrapper
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     #[VirtualProperty]
     #[SerializedName('collection')]
@@ -167,10 +167,11 @@ class Media extends ApiWrapper
     {
         $collection = $this->entity->getCollection();
         if ($collection) {
+            /** @var int */
             return $collection->getId();
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -665,7 +665,7 @@ class CollectionManager implements CollectionManagerInterface
      * @param int $id
      * @param string $locale
      *
-     * @return array
+     * @return array|null
      */
     protected function getPreview($id, $locale)
     {
@@ -687,7 +687,7 @@ class CollectionManager implements CollectionManagerInterface
             }
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManager.php
@@ -665,7 +665,7 @@ class CollectionManager implements CollectionManagerInterface
      * @param int $id
      * @param string $locale
      *
-     * @return array|null
+     * @return array
      */
     protected function getPreview($id, $locale)
     {
@@ -687,7 +687,7 @@ class CollectionManager implements CollectionManagerInterface
             }
         }
 
-        return null;
+        return [];
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/BaseXmlFormatLoader.php
@@ -243,7 +243,7 @@ abstract class BaseXmlFormatLoader extends FileLoader
     /**
      * For a given format node returns the scale information of the format.
      *
-     * @return array
+     * @return array|null
      */
     abstract protected function getScaleFromFormatNode(\DOMNode $formatNode);
 

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatLoader/XmlFormatLoader10.php
@@ -98,7 +98,7 @@ class XmlFormatLoader10 extends BaseXmlFormatLoader
             }
         }
 
-        return;
+        return null;
     }
 
     protected function getTransformationsFromFormatNode(\DOMNode $formatNode)

--- a/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
@@ -109,7 +109,5 @@ class MediaTwigExtension extends AbstractExtension
         } elseif ($media instanceof MediaApi) {
             return $this->mediaManager->addFormatsAndUrl($media);
         }
-
-        return;
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/Twig/MediaTwigExtension.php
@@ -109,5 +109,7 @@ class MediaTwigExtension extends AbstractExtension
         } elseif ($media instanceof MediaApi) {
             return $this->mediaManager->addFormatsAndUrl($media);
         }
+
+        return null;
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -187,6 +187,8 @@ class PageSelectionContainer implements ArrayableInterface
             case 'data':
                 return $this->getData();
         }
+
+        return null;
     }
 
     /**

--- a/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
+++ b/src/Sulu/Bundle/PageBundle/Content/PageSelectionContainer.php
@@ -187,8 +187,6 @@ class PageSelectionContainer implements ArrayableInterface
             case 'data':
                 return $this->getData();
         }
-
-        return;
     }
 
     /**

--- a/src/Sulu/Component/Content/Compat/PropertyType.php
+++ b/src/Sulu/Component/Content/Compat/PropertyType.php
@@ -83,7 +83,7 @@ class PropertyType
             }
         }
 
-        return;
+        return null;
     }
 
     public function addChild(PropertyInterface $property)

--- a/src/Sulu/Component/Content/Compat/Structure.php
+++ b/src/Sulu/Component/Content/Compat/Structure.php
@@ -544,7 +544,7 @@ abstract class Structure implements StructureInterface
             }
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
+++ b/src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
@@ -50,9 +50,7 @@ class ExtensionContainer implements \ArrayAccess, \Iterator
     #[\ReturnTypeWillChange]
     public function offsetGet($extensionName)
     {
-        if (isset($this->data[$extensionName])) {
-            return $this->data[$extensionName];
-        }
+        return $this->data[$extensionName] ?? null;
     }
 
     #[\ReturnTypeWillChange]

--- a/src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
+++ b/src/Sulu/Component/Content/Document/Extension/ExtensionContainer.php
@@ -53,8 +53,6 @@ class ExtensionContainer implements \ArrayAccess, \Iterator
         if (isset($this->data[$extensionName])) {
             return $this->data[$extensionName];
         }
-
-        return;
     }
 
     #[\ReturnTypeWillChange]

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -805,6 +805,8 @@ class ContentMapper implements ContentMapperInterface
             // not extension data but property of node
             return $this->getPropertyData($document, $field['property']);
         }
+
+        return null;
     }
 
     /**

--- a/src/Sulu/Component/Content/Mapper/ContentMapper.php
+++ b/src/Sulu/Component/Content/Mapper/ContentMapper.php
@@ -805,8 +805,6 @@ class ContentMapper implements ContentMapperInterface
             // not extension data but property of node
             return $this->getPropertyData($document, $field['property']);
         }
-
-        return;
     }
 
     /**

--- a/src/Sulu/Component/CustomUrl/Document/CustomUrlNodeType.php
+++ b/src/Sulu/Component/CustomUrl/Document/CustomUrlNodeType.php
@@ -50,9 +50,24 @@ class CustomUrlNodeType implements NodeTypeDefinitionInterface
         return false;
     }
 
+    /**
+     * Returns the name of the primary item (one of the child items of the nodes
+     * of this node type).
+     *
+     * If this node has no primary item, then this method returns null. This
+     * indicator is used by the method NodeInterface::getPrimaryItem().
+     *
+     * In implementations that support node type registration, if this
+     * NodeTypeDefinitionInterface object is actually a newly-created empty
+     * NodeTypeTemplateInterface, then this method will return null.
+     *
+     * @return string|null the name of the primary item
+     *
+     * @api
+     */
     public function getPrimaryItemName()
     {
-        return;
+        return null;
     }
 
     public function getDeclaredPropertyDefinitions()

--- a/src/Sulu/Component/CustomUrl/Document/CustomUrlRouteNodeType.php
+++ b/src/Sulu/Component/CustomUrl/Document/CustomUrlRouteNodeType.php
@@ -50,9 +50,24 @@ class CustomUrlRouteNodeType implements NodeTypeDefinitionInterface
         return false;
     }
 
+    /**
+     * Returns the name of the primary item (one of the child items of the nodes
+     * of this node type).
+     *
+     * If this node has no primary item, then this method returns null. This
+     * indicator is used by the method NodeInterface::getPrimaryItem().
+     *
+     * In implementations that support node type registration, if this
+     * NodeTypeDefinitionInterface object is actually a newly-created empty
+     * NodeTypeTemplateInterface, then this method will return null.
+     *
+     * @return string|null the name of the primary item
+     *
+     * @api
+     */
     public function getPrimaryItemName()
     {
-        return;
+        return null;
     }
 
     public function getDeclaredPropertyDefinitions()

--- a/src/Sulu/Component/Localization/Localization.php
+++ b/src/Sulu/Component/Localization/Localization.php
@@ -354,7 +354,7 @@ class Localization implements \Stringable, \JsonSerializable, ArrayableInterface
             }
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Component/PHPCR/NodeTypes/Base/SuluNodeType.php
+++ b/src/Sulu/Component/PHPCR/NodeTypes/Base/SuluNodeType.php
@@ -150,13 +150,13 @@ class SuluNodeType implements NodeTypeDefinitionInterface
      * NodeTypeDefinitionInterface object is actually a newly-created empty
      * NodeTypeTemplateInterface, then this method will return null.
      *
-     * @return string The name of the primary item
+     * @return string|null The name of the primary item
      *
      * @api
      */
     public function getPrimaryItemName()
     {
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Component/PHPCR/NodeTypes/Content/ContentNodeType.php
+++ b/src/Sulu/Component/PHPCR/NodeTypes/Content/ContentNodeType.php
@@ -150,13 +150,13 @@ class ContentNodeType implements NodeTypeDefinitionInterface
      * NodeTypeDefinitionInterface object is actually a newly-created empty
      * NodeTypeTemplateInterface, then this method will return null.
      *
-     * @return string The name of the primary item
+     * @return string|null The name of the primary item
      *
      * @api
      */
     public function getPrimaryItemName()
     {
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Component/PHPCR/NodeTypes/Path/PathNodeType.php
+++ b/src/Sulu/Component/PHPCR/NodeTypes/Path/PathNodeType.php
@@ -150,13 +150,13 @@ class PathNodeType implements NodeTypeDefinitionInterface
      * NodeTypeDefinitionInterface object is actually a newly-created empty
      * NodeTypeTemplateInterface, then this method will return null.
      *
-     * @return string The name of the primary item
+     * @return string|null The name of the primary item
      *
      * @api
      */
     public function getPrimaryItemName()
     {
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -168,7 +168,7 @@ abstract class AbstractListBuilder implements ListBuilderInterface
             return $this->selectFields[$fieldName];
         }
 
-        return;
+        return null;
     }
 
     public function hasSelectField($name)
@@ -195,7 +195,7 @@ abstract class AbstractListBuilder implements ListBuilderInterface
             return $this->fieldDescriptors[$fieldName];
         }
 
-        return;
+        return null;
     }
 
     public function addSearchField(FieldDescriptorInterface $fieldDescriptor)

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -74,7 +74,7 @@ interface ListBuilderInterface
      *
      * @param string $fieldName
      *
-     * @return FieldDescriptorInterface
+     * @return FieldDescriptorInterface|null
      */
     public function getSelectField($fieldName);
 

--- a/src/Sulu/Component/Rest/Tests/Unit/AbstractRestControllerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/AbstractRestControllerTest.php
@@ -42,9 +42,7 @@ class AbstractRestControllerTest extends TestCase
         $method->setAccessible(true);
 
         $id = 1;
-        $findCallback = function($id) {
-            return ['id' => $id];
-        };
+        $findCallback = fn ($id) => ['id' => $id];
 
         /** @var View $view */
         $view = $method->invoke($this->controller, $id, $findCallback);
@@ -59,9 +57,7 @@ class AbstractRestControllerTest extends TestCase
         $method->setAccessible(true);
 
         $id = 1;
-        $findCallback = function($id) {
-            return;
-        };
+        $findCallback = fn ($id) => null;
 
         /** @var View $view */
         $view = $method->invoke($this->controller, $id, $findCallback);

--- a/src/Sulu/Component/Util/SuluNodeHelper.php
+++ b/src/Sulu/Component/Util/SuluNodeHelper.php
@@ -72,7 +72,7 @@ class SuluNodeHelper
     /**
      * Return the structure type for the given node.
      *
-     * @return string
+     * @return string|null
      */
     public function getStructureTypeForNode(NodeInterface $node)
     {
@@ -86,7 +86,7 @@ class SuluNodeHelper
             return Structure::TYPE_SNIPPET;
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/src/Sulu/Component/Util/WildcardUrlUtil.php
+++ b/src/Sulu/Component/Util/WildcardUrlUtil.php
@@ -58,7 +58,7 @@ final class WildcardUrlUtil
      * @param string $url
      * @param string $portalUrl
      *
-     * @return string
+     * @return string|null
      */
     public static function resolve($url, $portalUrl)
     {
@@ -75,6 +75,6 @@ final class WildcardUrlUtil
             return $portalUrl;
         }
 
-        return;
+        return null;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | refs #8568 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing useless returns and updating the useful ones.

#### Why?
Implicit php behaviour is never a good thing, and running php-cs shouldn't make phpstan unhappy.

Updating the documentation to also include null in those cases where it is used.