### PR TITLE
Change apiKey type to string

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+## 2.6.21
+
+The type of the `apiKey` in the `se_users` table has been changed to `string`.
+
+```sql
+ALTER TABLE se_users CHANGE apiKey apiKey VARCHAR(128) DEFAULT NULL;
+```
+
 ## 2.6.16
 
 * Deprecated \Sulu\Bundle\MediaBundle\Controller\AbstractMediaController::getTitleFromUpload -> MediaManager::getTitleFromUpload

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/User.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/User.orm.xml
@@ -31,7 +31,7 @@
             </options>
         </field>
         <field name="privateKey" type="string" column="privateKey" length="2000" nullable="true"/>
-        <field name="apiKey" type="guid" column="apiKey" length="128" nullable="true"/>
+        <field name="apiKey" type="string" column="apiKey" length="128" nullable="true"/>
         <field name="email" column="email" type="string" length="191" unique="true" nullable="true"/>
 
         <one-to-one field="contact" target-entity="Sulu\Bundle\ContactBundle\Entity\ContactInterface">


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | no
  | BC breaks? | yes
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Changed the `apiKey` field type in the `User` entity from `guid` to `string` (Doctrine ORM mapping in `User.orm.xml`)

  #### Why?

  The `apiKey` field was mapped as `guid` type in Doctrine, which restricts the format to UUID/GUID values. Changing it to `string` allows more flexible API key formats while keeping the same database column
  constraints (VARCHAR 128, nullable).

  #### To Do

  - [x] Add breaking changes to UPGRADE.md