### PR TITLE
Allow to load excerpt via sulu_snippet_load_by_area twig function

### DIFF
--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
@@ -247,7 +247,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             $this->snippetAreaReferenceStore
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             ['title' => 'Test Snippet EN'],
             $twigExtension->loadByArea('test', 'demo_io', null, true)
         );

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
@@ -222,7 +222,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
         );
     }
 
-    public function testLoadByAreWithLoadExcerpt(): void
+    public function testLoadByAreaWithLoadExcerpt(): void
     {
         $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Twig/SnippetAreaTwigExtensionTest.php
@@ -82,7 +82,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $snippet->getUuid()->willReturn('1234');
 
         $this->defaultSnippetManager->load('sulu_io', 'test', 'de')->shouldBeCalled()->willReturn($snippet->reveal());
-        $this->snippetResolver->resolve(['1234'], 'sulu_io', 'de')->shouldBeCalled()->willReturn([['title' => 'Test Snippet']]);
+        $this->snippetResolver->resolve(['1234'], 'sulu_io', 'de', null, false)->shouldBeCalled()->willReturn([['title' => 'Test Snippet']]);
 
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
@@ -120,7 +120,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
             ->shouldBeCalled()
             ->willThrow(new WrongSnippetTypeException('', '', $snippet->reveal()));
 
-        $this->snippetResolver->resolve(['1234'], 'sulu_io', 'de')->shouldNotBeCalled();
+        $this->snippetResolver->resolve(['1234'], 'sulu_io', 'de', null, false)->shouldNotBeCalled();
 
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
@@ -176,7 +176,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $snippet->getUuid()->willReturn('1234');
 
         $this->defaultSnippetManager->load('sulu_io', 'test', 'en')->shouldBeCalled()->willReturn($snippet->reveal());
-        $this->snippetResolver->resolve(['1234'], 'sulu_io', 'en')->shouldBeCalled()->willReturn([['title' => 'Test Snippet EN']]);
+        $this->snippetResolver->resolve(['1234'], 'sulu_io', 'en', null, false)->shouldBeCalled()->willReturn([['title' => 'Test Snippet EN']]);
 
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
@@ -207,7 +207,7 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $snippet->getUuid()->willReturn('1234');
 
         $this->defaultSnippetManager->load('demo_io', 'test', 'en')->shouldBeCalled()->willReturn($snippet->reveal());
-        $this->snippetResolver->resolve(['1234'], 'demo_io', 'en')->shouldBeCalled()->willReturn([['title' => 'Test Snippet EN']]);
+        $this->snippetResolver->resolve(['1234'], 'demo_io', 'en', null, false)->shouldBeCalled()->willReturn([['title' => 'Test Snippet EN']]);
 
         $twigExtension = new SnippetAreaTwigExtension(
             $this->defaultSnippetManager->reveal(),
@@ -219,6 +219,37 @@ class SnippetAreaTwigExtensionTest extends TestCase
         $this->assertEquals(
             ['title' => 'Test Snippet EN'],
             $twigExtension->loadByArea('test', 'demo_io', 'en')
+        );
+    }
+
+    public function testLoadByAreWithLoadExcerpt(): void
+    {
+        $this->defaultSnippetManager = $this->prophesize(DefaultSnippetManagerInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->webspace = $this->prophesize(Webspace::class);
+        $this->webspace->getKey()->willReturn('sulu_io');
+        $this->localization = $this->prophesize(Localization::class);
+        $this->localization->getLocale()->willReturn('de');
+        $this->requestAnalyzer->getWebspace()->willReturn($this->webspace->reveal());
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn($this->localization);
+        $this->snippetResolver = $this->prophesize(SnippetResolverInterface::class);
+
+        $snippet = $this->prophesize(SnippetDocument::class);
+        $snippet->getUuid()->willReturn('1234');
+
+        $this->defaultSnippetManager->load('demo_io', 'test', 'de')->shouldBeCalled()->willReturn($snippet->reveal());
+        $this->snippetResolver->resolve(['1234'], 'demo_io', 'de', null, true)->shouldBeCalled()->willReturn([['title' => 'Test Snippet EN']]);
+
+        $twigExtension = new SnippetAreaTwigExtension(
+            $this->defaultSnippetManager->reveal(),
+            $this->requestAnalyzer->reveal(),
+            $this->snippetResolver->reveal(),
+            $this->snippetAreaReferenceStore
+        );
+
+        $this->assertEquals(
+            ['title' => 'Test Snippet EN'],
+            $twigExtension->loadByArea('test', 'demo_io', null, true)
         );
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
@@ -46,10 +46,11 @@ class SnippetAreaTwigExtension extends AbstractExtension
      * @param string $area
      * @param string $webspaceKey
      * @param string $locale
+     * @param bool $loadExcerpt
      *
      * @return array
      */
-    public function loadByArea($area, $webspaceKey = null, $locale = null)
+    public function loadByArea($area, $webspaceKey = null, $locale = null, $loadExcerpt = false)
     {
         if (!$webspaceKey) {
             $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
@@ -72,7 +73,7 @@ class SnippetAreaTwigExtension extends AbstractExtension
             return null;
         }
 
-        $snippets = $this->snippetResolver->resolve([$snippet->getUuid()], $webspaceKey, $locale);
+        $snippets = $this->snippetResolver->resolve([$snippet->getUuid()], $webspaceKey, $locale, null, $loadExcerpt);
 
         if (!\array_key_exists(0, $snippets)) {
             return null;

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
@@ -46,13 +46,12 @@ class SnippetAreaTwigExtension extends AbstractExtension
      * @param string $area
      * @param string $webspaceKey
      * @param string $locale
-     * @param bool $loadExcerpt
      *
      * @return array
      */
     public function loadByArea($area, $webspaceKey = null, $locale = null/*, $loadExcerpt = false */)
-{
-         $loadExcerpt = func_num_args() > 3 ? func_get_args()[3] : false;
+    {
+        $loadExcerpt = \func_num_args() > 3 ? \func_get_args()[3] : false;
         if (!$webspaceKey) {
             $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
@@ -50,8 +50,9 @@ class SnippetAreaTwigExtension extends AbstractExtension
      *
      * @return array
      */
-    public function loadByArea($area, $webspaceKey = null, $locale = null, $loadExcerpt = false)
-    {
+    public function loadByArea($area, $webspaceKey = null, $locale = null/*, $loadExcerpt = false */)
+{
+         $loadExcerpt = func_num_args() > 3 ? func_get_args()[3] : false;
         if (!$webspaceKey) {
             $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#883

#### What's in this PR?

This PR allows to load a default snippet with "sulu_snippet_load_by_area" optionally with its excerpt information.

#### Why?

When loading a default snippet via the new sulu_snippet_load_by_area method, it is currently not possible to load the extension data. To get those data, one would currently need to load the default snippet first, and then issue another load via sulu_snippet_load, because the loadExcerpt parameter is present in this method. 
So for consistency and easier use, I added this parameter.

#### Example Usage

```
{% set snippet = sulu_snippet_load_by_area('footer_social_media_links', null, null, true); %}
```

#### To Do

- [x] Create a documentation PR

