### PR TITLE
Allow to remove types from FieldMetaData

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
@@ -98,9 +98,6 @@ class FieldMetadata extends ItemMetadata
 
     public function removeType(string $type): void
     {
-        if (!isset($this->types[$type])) {
-            return;
-        }
         unset($this->types[$type]);
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FieldMetadata.php
@@ -96,6 +96,14 @@ class FieldMetadata extends ItemMetadata
         $this->types[$type->getName()] = $type;
     }
 
+    public function removeType(string $type): void
+    {
+        if (!isset($this->types[$type])) {
+            return;
+        }
+        unset($this->types[$type]);
+    }
+
     public function isRequired(): bool
     {
         return $this->required;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FieldMetaDataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FieldMetaDataTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+
+class FieldMetaDataTest extends TestCase
+{
+    public function testAddTypeAddsToTypes(): void
+    {
+        $formMetadata1 = $this->setupFormMetadata('dummy1');
+        $formMetadata2 = $this->setupFormMetadata('dummy2');
+
+        $metaData = new FieldMetadata('dummy');
+        $metaData->addType($formMetadata1);
+        $metaData->addType($formMetadata2);
+
+        $this->assertSame([
+            'dummy1' => $formMetadata1,
+            'dummy2' => $formMetadata2,
+        ], $metaData->getTypes());
+    }
+
+    public function testRemoveTypeRemovesFromTypes(): void
+    {
+        $formMetadata1 = $this->setupFormMetadata('dummy1');
+        $formMetadata2 = $this->setupFormMetadata('dummy2');
+
+        $metaData = new FieldMetadata('dummy');
+        $metaData->addType($formMetadata1);
+        $metaData->addType($formMetadata2);
+
+        $metaData->removeType('dummy1');
+
+        $this->assertSame([
+            'dummy2' => $formMetadata2,
+        ], $metaData->getTypes());
+    }
+
+    public function testRemoveTypeIgnoresUnknownType(): void
+    {
+        $formMetadata1 = $this->setupFormMetadata('dummy1');
+        $formMetadata2 = $this->setupFormMetadata('dummy2');
+
+        $metaData = new FieldMetadata('dummy');
+        $metaData->addType($formMetadata1);
+        $metaData->addType($formMetadata2);
+
+        $metaData->removeType('unknown');
+
+        $this->assertSame([
+            'dummy1' => $formMetadata1,
+            'dummy2' => $formMetadata2,
+        ], $metaData->getTypes());
+    }
+
+    private function setupFormMetadata(string $name): FormMetadata
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setName($name);
+
+        return $formMetadata;
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes
| Related issues/PRs | 
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

This PR allows to remove a FormMetaData type item from a FieldMetaData item.

#### Why?

As discussed, we are modifying the global blocks list depending on role permissions, so we can hide custom modules from some users. But since there were no setters, we need to use reflection to update the containing types inside of a FieldMetaData item. With this PR, we could remove the reflection part from our code.

#### Example Usage

I added unit tests to test the new method.

```php
[...]
    public function testRemoveTypeRemovesFromTypes(): void
    {
        $formMetadata1 = $this->setupFormMetadata('dummy1');
        $formMetadata2 = $this->setupFormMetadata('dummy2');

        $metaData = new FieldMetadata('dummy');
        $metaData->addType($formMetadata1);
        $metaData->addType($formMetadata2);

        $metaData->removeType('dummy1');

        $this->assertSame([
            'dummy2' => $formMetadata2,
        ], $metaData->getTypes());
[...]
```
