### PR TITLE
Fix apply query and anchor to internal page links also

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -103,7 +103,7 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         $targetDimensionContent = $this->contentAggregator->aggregate($page, $dimensionAttributes);
 
         $url = $targetDimensionContent->getTemplateData()['url'] ?? null;
-        if (\is_string($url)) {
+        if (\is_string($url) && null !== $linkData) {
             $url = $this->appendQueryAndAnchor($url, $linkData);
         }
 
@@ -143,7 +143,10 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
             return $pageDimensionContent;
         }
 
-        $url = $this->appendQueryAndAnchor($linkItem->getUrl(), $linkData);
+        $url = $linkItem->getUrl();
+        if (null !== $linkData) {
+            $url = $this->appendQueryAndAnchor($url, $linkData);
+        }
 
         $pageDimensionContent->setTemplateData([
             ...$pageDimensionContent->getTemplateData(),

--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -102,10 +102,16 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         /** @var PageDimensionContentInterface $targetDimensionContent */
         $targetDimensionContent = $this->contentAggregator->aggregate($page, $dimensionAttributes);
 
+        $url = $targetDimensionContent->getTemplateData()['url'] ?? null;
+        if (\is_string($url)) {
+            $url = $this->appendQueryAndAnchor($url, $linkData);
+        }
+
         $targetDimensionContent->setTemplateData([
             ...$targetDimensionContent->getTemplateData(),
             ...[
                 'title' => $pageDimensionContent->getTitle(),
+                'url' => $url,
             ],
         ]);
 
@@ -137,13 +143,7 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
             return $pageDimensionContent;
         }
 
-        $url = $linkItem->getUrl();
-        if (isset($linkData['query']) && \is_string($linkData['query'])) {
-            $url = \sprintf('%s?%s', $url, \ltrim($linkData['query'], '?'));
-        }
-        if (isset($linkData['anchor']) && \is_string($linkData['anchor'])) {
-            $url = \sprintf('%s#%s', $url, \ltrim($linkData['anchor'], '#'));
-        }
+        $url = $this->appendQueryAndAnchor($linkItem->getUrl(), $linkData);
 
         $pageDimensionContent->setTemplateData([
             ...$pageDimensionContent->getTemplateData(),
@@ -153,5 +153,22 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         ]);
 
         return $pageDimensionContent;
+    }
+
+    /**
+     * Append query string and anchor to a URL based on linkData.
+     *
+     * @param array<string, mixed> $linkData
+     */
+    private function appendQueryAndAnchor(string $url, array $linkData): string
+    {
+        if (isset($linkData['query']) && \is_string($linkData['query'])) {
+            $url = \sprintf('%s?%s', $url, \ltrim($linkData['query'], '?'));
+        }
+        if (isset($linkData['anchor']) && \is_string($linkData['anchor'])) {
+            $url = \sprintf('%s#%s', $url, \ltrim($linkData['anchor'], '#'));
+        }
+
+        return $url;
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | - <!-- no existing issue -->
| Related issues/PRs | - <!-- none -->
| License | MIT
| Documentation PR | - <!-- not needed for bug fix -->

#### What's in this PR?

This PR fixes a bug where query parameters and anchors configured in custom page links are not appended to internal page link URLs.

**Changes:**
- Extracted query/anchor appending logic into a new `appendQueryAndAnchor()` method
- Applied this method to both `resolvePage()` (internal page links) and `resolveLink()` (external links)
- This ensures consistent behavior across all link types

#### Why?

When configuring a custom link on a page with query parameters and/or anchors:
- ✅ External links correctly get query/anchor appended  
- ❌ Internal page links ignore query/anchor settings

This creates inconsistent behavior and makes it impossible to use query parameters or anchors with internal page links (e.g., in navigation menus).

The root cause is that the `PageLinkDimensionContentEnhancer` class had the query/anchor appending logic in `resolveLink()` (for external links) but not in `resolvePage()` (for internal links).

#### Example Usage

**Before this fix:**
```php
// Page with custom internal link to another page
// Link settings: query = "category=2", anchor = "test"
// Result: /target-page (query and anchor are lost ❌)
```

**After this fix:**
```php
// Same configuration as above
// Result: /target-page?category=2#test (query and anchor preserved ✅)
```

#### To Do

- [x] Bug fix does not require documentation changes
- [x] No breaking changes to add to UPGRADE.md