### PR TITLE
Fix PDF thumbnail generation by using separate input/output files

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -74,7 +74,7 @@ class MediaImageExtractor implements MediaImageExtractorInterface
     {
         // Create temporary file for source PDF
         $sourcePdfPath = $this->createTemporaryFile($resource);
-        
+
         // Create a separate temporary file for output image
         $outputImagePath = \tempnam(\sys_get_temp_dir(), 'media') . '.jpg';
 
@@ -83,10 +83,10 @@ class MediaImageExtractor implements MediaImageExtractorInterface
             '-dJPEGQ=100 -r300x300 -q ' . $sourcePdfPath . ' -c quit';
 
         \shell_exec($command);
-        
+
         // Read generated image
         $output = \file_get_contents($outputImagePath);
-        
+
         // Clean up temporary files
         \unlink($sourcePdfPath);
         \unlink($outputImagePath);

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/MediaImageExtractor.php
@@ -72,15 +72,24 @@ class MediaImageExtractor implements MediaImageExtractorInterface
      */
     private function convertPdfToImage($resource)
     {
-        $temporaryFilePath = $this->createTemporaryFile($resource);
+        // Create temporary file for source PDF
+        $sourcePdfPath = $this->createTemporaryFile($resource);
+        
+        // Create a separate temporary file for output image
+        $outputImagePath = \tempnam(\sys_get_temp_dir(), 'media') . '.jpg';
 
         $command = $this->ghostScriptPath .
-            ' -dNOPAUSE -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 -sOutputFile=' . $temporaryFilePath . ' ' .
-            '-dJPEGQ=100 -r300x300 -q ' . $temporaryFilePath . ' -c quit';
+            ' -dNOPAUSE -sDEVICE=jpeg -dFirstPage=1 -dLastPage=1 -sOutputFile=' . $outputImagePath . ' ' .
+            '-dJPEGQ=100 -r300x300 -q ' . $sourcePdfPath . ' -c quit';
 
         \shell_exec($command);
-        $output = \file_get_contents($temporaryFilePath);
-        \unlink($temporaryFilePath);
+        
+        // Read generated image
+        $output = \file_get_contents($outputImagePath);
+        
+        // Clean up temporary files
+        \unlink($sourcePdfPath);
+        \unlink($outputImagePath);
 
         if (!$output) {
             throw new GhostScriptNotFoundException(


### PR DESCRIPTION
The convertPdfToImage() method was using the same temporary file path for both Ghostscript input and output, causing the command to fail silently as it tried to read an empty output file instead of the source PDF.

This fix creates two separate temporary files:
- sourcePdfPath: for the input PDF file
- outputImagePath: for the generated JPEG thumbnail

Fixes #8588

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8588
| Related issues/PRs | N/A
| License | MIT
| Documentation PR | N/A

#### What's in this PR?

This PR fixes a critical bug in the `MediaImageExtractor::convertPdfToImage()` method where PDF thumbnail generation was failing silently.

**The Problem:**
The method was using the same `$temporaryFilePath` variable for both:
1. The Ghostscript output file (`-sOutputFile=`)
2. The Ghostscript input file (the PDF to convert)

This caused Ghostscript to attempt reading an empty output file instead of the source PDF, resulting in no thumbnail being generated.

**The Solution:**
- Created two separate temporary files with distinct purposes:
  - `$sourcePdfPath`: stores the input PDF file
  - `$outputImagePath`: stores the generated JPEG thumbnail
- Added clear comments to document the purpose of each file
- Ensured proper cleanup of both temporary files

#### Why?

When users upload PDF files through the Sulu admin interface, they expect to see a thumbnail preview. This bug prevented any PDF thumbnails from being generated, even when Ghostscript was properly installed and configured.

The issue affects all Sulu installations using PDF uploads with Ghostscript-based thumbnail generation.

#### Example Usage

No API changes - this is a transparent bug fix. PDF thumbnails will now be generated automatically when:

```yaml
# config/packages/sulu_media.yaml
sulu_media:
    ghost_script:
        path: /usr/bin/gs  # or your Ghostscript path
```

After this fix, uploading a PDF file will correctly generate a JPEG thumbnail of the first page.

#### To Do

- [x] Bug fix implemented and tested
- [x] No breaking changes
- [x] No deprecations
- [x] No documentation changes needed (internal bug fix)
