### PR TITLE
Fix test namespaces

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3247,7 +3247,7 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewRegistryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Tests\\Admin\\View\\ViewRegistryTest\:\:readObjectAttribute\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AdminBundle\\Tests\\Unit\\Admin\\View\\ViewRegistryTest\:\:readObjectAttribute\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewRegistryTest.php
@@ -6121,37 +6121,37 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/EventListener/TargetGroupSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Unit\\Analyzer\\Attributes\\ForwardedUrlRequestProcessorTest\:\:provideProcess\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AudienceTargetingBundle\\Tests\\Unit\\Request\\ForwardedUrlRequestProcessorTest\:\:provideProcess\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Unit\\Analyzer\\Attributes\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$host with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AudienceTargetingBundle\\Tests\\Unit\\Request\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$host with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Unit\\Analyzer\\Attributes\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$path with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AudienceTargetingBundle\\Tests\\Unit\\Request\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$path with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Unit\\Analyzer\\Attributes\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$port with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AudienceTargetingBundle\\Tests\\Unit\\Request\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$port with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Unit\\Analyzer\\Attributes\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$url with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AudienceTargetingBundle\\Tests\\Unit\\Request\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$url with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Unit\\Analyzer\\Attributes\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$urlHeader with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\AudienceTargetingBundle\\Tests\\Unit\\Request\\ForwardedUrlRequestProcessorTest\:\:testProcess\(\) has parameter \$urlHeader with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
@@ -18613,43 +18613,43 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/ContactTwigExtensionTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\CustomerIdConverterTest\:\:convertGroupedIdsToIdsProvider\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\CustomerIdConverterTest\:\:convertGroupedIdsToIdsProvider\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\CustomerIdConverterTest\:\:convertIdsToGroupedIdsProvider\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\CustomerIdConverterTest\:\:convertIdsToGroupedIdsProvider\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\CustomerIdConverterTest\:\:testConvertGroupedIdsToIds\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\CustomerIdConverterTest\:\:testConvertGroupedIdsToIds\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\CustomerIdConverterTest\:\:testConvertGroupedIdsToIds\(\) has parameter \$groupedIds with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\CustomerIdConverterTest\:\:testConvertGroupedIdsToIds\(\) has parameter \$groupedIds with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\CustomerIdConverterTest\:\:testConvertIdsToGroupedIds\(\) has parameter \$default with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\CustomerIdConverterTest\:\:testConvertIdsToGroupedIds\(\) has parameter \$default with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\CustomerIdConverterTest\:\:testConvertIdsToGroupedIds\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\CustomerIdConverterTest\:\:testConvertIdsToGroupedIds\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\CustomerIdConverterTest\:\:testConvertIdsToGroupedIds\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\CustomerIdConverterTest\:\:testConvertIdsToGroupedIds\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
@@ -18661,31 +18661,31 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\IndexComparatorTest\:\:testUsortCallback\(\) has parameter \$array with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\IndexComparatorTest\:\:testUsortCallback\(\) has parameter \$array with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\IndexComparatorTest\:\:testUsortCallback\(\) has parameter \$contains with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\IndexComparatorTest\:\:testUsortCallback\(\) has parameter \$contains with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\IndexComparatorTest\:\:testUsortCallback\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\IndexComparatorTest\:\:testUsortCallback\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\IndexComparatorTest\:\:testUsortCallback\(\) has parameter \$startsWith with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\IndexComparatorTest\:\:testUsortCallback\(\) has parameter \$startsWith with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\Util\\IndexComparatorTest\:\:usortProvider\(\) return type has no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Bundle\\ContactBundle\\Tests\\Unit\\IndexComparatorTest\:\:usortProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
@@ -31867,49 +31867,49 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Method Functional\\Controller\\MediaRedirectControllerTest\:\:cleanImage\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:cleanImage\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Method Functional\\Controller\\MediaRedirectControllerTest\:\:createMedia\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:createMedia\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Method Functional\\Controller\\MediaRedirectControllerTest\:\:createMedia\(\) has parameter \$locale with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:createMedia\(\) has parameter \$locale with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Method Functional\\Controller\\MediaRedirectControllerTest\:\:createMedia\(\) has parameter \$name with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:createMedia\(\) has parameter \$name with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Method Functional\\Controller\\MediaRedirectControllerTest\:\:recursiveRemoveDirectory\(\) has parameter \$counter with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:recursiveRemoveDirectory\(\) has parameter \$counter with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Method Functional\\Controller\\MediaRedirectControllerTest\:\:recursiveRemoveDirectory\(\) has parameter \$directory with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:recursiveRemoveDirectory\(\) has parameter \$directory with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Method Functional\\Controller\\MediaRedirectControllerTest\:\:setUpCollection\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:setUpCollection\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Method Functional\\Controller\\MediaRedirectControllerTest\:\:setUpMedia\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:setUpMedia\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
@@ -31933,7 +31933,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
 
 		-
-			message: '#^Property Functional\\Controller\\MediaRedirectControllerTest\:\:\$em \(Doctrine\\ORM\\EntityManager\) does not accept Doctrine\\ORM\\EntityManagerInterface\.$#'
+			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\MediaRedirectControllerTest\:\:\$em \(Doctrine\\ORM\\EntityManager\) does not accept Doctrine\\ORM\\EntityManagerInterface\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
@@ -33439,7 +33439,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
 
 		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Media\\FormatManager\\FormatManagerTest\:\:\$formats type has no value type specified in iterable type array\.$#'
+			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Unit\\Media\\FormatManager\\FormatManagerTest\:\:\$formats type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -33493,7 +33493,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatOptionsManager/FormatOptionsManagerTest.php
 
 		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Media\\FormatOptionsManager\\FormatOptionsManagerTest\:\:\$formatOptionsRepository with generic class Doctrine\\ORM\\EntityRepository does not specify its types\: TEntityClass$#'
+			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Unit\\Media\\FormatOptionsManager\\FormatOptionsManagerTest\:\:\$formatOptionsRepository with generic class Doctrine\\ORM\\EntityRepository does not specify its types\: TEntityClass$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatOptionsManager/FormatOptionsManagerTest.php
@@ -33835,7 +33835,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
 
 		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Media\\TypeManager\\TypeManagerTest\:\:\$mediaTypes has no type specified\.$#'
+			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Unit\\Media\\TypeManager\\TypeManagerTest\:\:\$mediaTypes has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
@@ -33907,13 +33907,13 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/Subscriber/MediaSearchSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Twig\\DispositionTypeTwigExtensionTest\:\:getMediaMock\(\) return type with generic class Prophecy\\Prophecy\\ObjectProphecy does not specify its types\: T$#'
+			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Unit\\Twig\\DispositionTypeTwigExtensionTest\:\:getMediaMock\(\) return type with generic class Prophecy\\Prophecy\\ObjectProphecy does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/DispositionTypeTwigExtensionTest.php
 
 		-
-			message: '#^Parameter \#1 \$media of method Sulu\\Bundle\\MediaBundle\\Twig\\DispositionTypeTwigExtensionTest\:\:getExtensionGetMediaUrlResult\(\) expects Sulu\\Bundle\\MediaBundle\\Api\\Media, object given\.$#'
+			message: '#^Parameter \#1 \$media of method Sulu\\Bundle\\MediaBundle\\Tests\\Unit\\Twig\\DispositionTypeTwigExtensionTest\:\:getExtensionGetMediaUrlResult\(\) expects Sulu\\Bundle\\MediaBundle\\Api\\Media, object given\.$#'
 			identifier: argument.type
 			count: 4
 			path: src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/DispositionTypeTwigExtensionTest.php
@@ -46855,25 +46855,25 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Search\\EventSubscriber\\StructureSubscriberTest\:\:getPersistEventMock\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Search\\EventSubscriber\\StructureSubscriberTest\:\:getPersistEventMock\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Search\\EventSubscriber\\StructureSubscriberTest\:\:getPersistEventMock\(\) has parameter \$document with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Search\\EventSubscriber\\StructureSubscriberTest\:\:getPersistEventMock\(\) has parameter \$document with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Search\\EventSubscriber\\StructureSubscriberTest\:\:getPublishEventMock\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Search\\EventSubscriber\\StructureSubscriberTest\:\:getPublishEventMock\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Search\\EventSubscriber\\StructureSubscriberTest\:\:getPublishEventMock\(\) has parameter \$document with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Search\\EventSubscriber\\StructureSubscriberTest\:\:getPublishEventMock\(\) has parameter \$document with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
@@ -46891,19 +46891,19 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Sulu\\Bundle\\WebsiteBundle\\Sitemap\\PagesSitemapProviderTest\:\:createContent\(\) has parameter \$locale with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Sitemap\\PagesSitemapProviderTest\:\:createContent\(\) has parameter \$locale with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Sulu\\Bundle\\WebsiteBundle\\Sitemap\\PagesSitemapProviderTest\:\:createContent\(\) has parameter \$permissions with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Sitemap\\PagesSitemapProviderTest\:\:createContent\(\) has parameter \$permissions with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Sulu\\Bundle\\WebsiteBundle\\Sitemap\\PagesSitemapProviderTest\:\:createContent\(\) has parameter \$urls with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Unit\\Sitemap\\PagesSitemapProviderTest\:\:createContent\(\) has parameter \$urls with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
@@ -53455,49 +53455,49 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/PermissionInheritanceSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SecurityBundle\\EventListener\\SuluSecurityListenerTest\:\:createControllerEvent\(\) has parameter \$controller with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Tests\\Unit\\EventListener\\SuluSecurityListenerTest\:\:createControllerEvent\(\) has parameter \$controller with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SecurityBundle\\EventListener\\SuluSecurityListenerTest\:\:provideInvokeMethodActionMapping\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Tests\\Unit\\EventListener\\SuluSecurityListenerTest\:\:provideInvokeMethodActionMapping\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SecurityBundle\\EventListener\\SuluSecurityListenerTest\:\:provideMethodActionMapping\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Tests\\Unit\\EventListener\\SuluSecurityListenerTest\:\:provideMethodActionMapping\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SecurityBundle\\EventListener\\SuluSecurityListenerTest\:\:testCallableControllerPermission\(\) has parameter \$method with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Tests\\Unit\\EventListener\\SuluSecurityListenerTest\:\:testCallableControllerPermission\(\) has parameter \$method with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SecurityBundle\\EventListener\\SuluSecurityListenerTest\:\:testCallableControllerPermission\(\) has parameter \$permission with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Tests\\Unit\\EventListener\\SuluSecurityListenerTest\:\:testCallableControllerPermission\(\) has parameter \$permission with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SecurityBundle\\EventListener\\SuluSecurityListenerTest\:\:testMethodPermissionMapping\(\) has parameter \$action with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Tests\\Unit\\EventListener\\SuluSecurityListenerTest\:\:testMethodPermissionMapping\(\) has parameter \$action with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SecurityBundle\\EventListener\\SuluSecurityListenerTest\:\:testMethodPermissionMapping\(\) has parameter \$method with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Tests\\Unit\\EventListener\\SuluSecurityListenerTest\:\:testMethodPermissionMapping\(\) has parameter \$method with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SecurityBundle\\EventListener\\SuluSecurityListenerTest\:\:testMethodPermissionMapping\(\) has parameter \$permission with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Tests\\Unit\\EventListener\\SuluSecurityListenerTest\:\:testMethodPermissionMapping\(\) has parameter \$permission with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
@@ -56575,13 +56575,13 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Functional\\Export\\SnippetTest\:\:getExportResultData\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Export\\SnippetTest\:\:getExportResultData\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PageBundle\\Tests\\Functional\\Export\\SnippetTest\:\:prepareData\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Export\\SnippetTest\:\:prepareData\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
@@ -56695,61 +56695,61 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:provideGetSnippets\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:provideGetSnippets\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:provideGetSnippetsByUuids\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:provideGetSnippetsByUuids\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$expectedCount with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$expectedCount with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$limit with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$limit with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$offset with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$offset with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$search with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$search with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$type with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:testGetSnippets\(\) has parameter \$type with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:testGetSnippetsByUuids\(\) has parameter \$expectedCount with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:testGetSnippetsByUuids\(\) has parameter \$expectedCount with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:testGetSnippetsByUuids\(\) has parameter \$languageCode with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:testGetSnippetsByUuids\(\) has parameter \$languageCode with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Content\\SnippetRepositoryTest\:\:testGetSnippetsByUuids\(\) has parameter \$snippets with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Functional\\Snippet\\SnippetRepositoryTest\:\:testGetSnippetsByUuids\(\) has parameter \$snippets with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
@@ -57475,25 +57475,25 @@ parameters:
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Snippet\\SnippetResolverTest\:\:dataProvider\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Unit\\Snippet\\SnippetResolverTest\:\:dataProvider\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Snippet\\SnippetResolverTest\:\:testResolve\(\) has parameter \$locale with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Unit\\Snippet\\SnippetResolverTest\:\:testResolve\(\) has parameter \$locale with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Snippet\\SnippetResolverTest\:\:testResolve\(\) has parameter \$uuids with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Unit\\Snippet\\SnippetResolverTest\:\:testResolve\(\) has parameter \$uuids with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Snippet\\SnippetResolverTest\:\:testResolve\(\) has parameter \$webspaceKey with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\SnippetBundle\\Tests\\Unit\\Snippet\\SnippetResolverTest\:\:testResolve\(\) has parameter \$webspaceKey with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -62719,7 +62719,7 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/SegmentSubscriberTest.php
 
 		-
-			message: '#^Method RequestAnalyzerResolverTest\:\:prepareWebspaceManager\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Tests\\Unit\\Resolver\\RequestAnalyzerResolverTest\:\:prepareWebspaceManager\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/RequestAnalyzerResolverTest.php
@@ -62983,25 +62983,25 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/ContentTwigExtensionTest.php
 
 		-
-			message: '#^Method NavigationTwigExtensionTest\:\:activeElementProvider\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Tests\\Unit\\Twig\\NavigationTwigExtensionTest\:\:activeElementProvider\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
 
 		-
-			message: '#^Method NavigationTwigExtensionTest\:\:testActiveElement\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Tests\\Unit\\Twig\\NavigationTwigExtensionTest\:\:testActiveElement\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
 
 		-
-			message: '#^Method NavigationTwigExtensionTest\:\:testActiveElement\(\) has parameter \$itemPath with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Tests\\Unit\\Twig\\NavigationTwigExtensionTest\:\:testActiveElement\(\) has parameter \$itemPath with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
 
 		-
-			message: '#^Method NavigationTwigExtensionTest\:\:testActiveElement\(\) has parameter \$requestPath with no type specified\.$#'
+			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Tests\\Unit\\Twig\\NavigationTwigExtensionTest\:\:testActiveElement\(\) has parameter \$requestPath with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
@@ -63685,25 +63685,25 @@ parameters:
 			path: src/Sulu/Component/Cache/MemoizeInterface.php
 
 		-
-			message: '#^Method Sulu\\Component\\Cache\\Tests\\Unit\\DataCacheTest\:\:provideIsFreshData\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Cache\\Tests\\Unit\\Cache\\DataCacheTest\:\:provideIsFreshData\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Cache\\Tests\\Unit\\DataCacheTest\:\:testIsFresh\(\) has parameter \$createFile with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Cache\\Tests\\Unit\\Cache\\DataCacheTest\:\:testIsFresh\(\) has parameter \$createFile with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Cache\\Tests\\Unit\\DataCacheTest\:\:testIsFresh\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Cache\\Tests\\Unit\\Cache\\DataCacheTest\:\:testIsFresh\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Cache\\Tests\\Unit\\DataCacheTest\:\:testIsFresh\(\) has parameter \$file with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Cache\\Tests\\Unit\\Cache\\DataCacheTest\:\:testIsFresh\(\) has parameter \$file with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
@@ -74635,31 +74635,31 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Property\\ManagedStructureTest\:\:doGetProperty\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Structure\\ManagedStructureTest\:\:doGetProperty\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Property\\ManagedStructureTest\:\:doGetProperty\(\) has parameter \$contentTypeName with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Structure\\ManagedStructureTest\:\:doGetProperty\(\) has parameter \$contentTypeName with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Property\\ManagedStructureTest\:\:doGetProperty\(\) has parameter \$locale with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Structure\\ManagedStructureTest\:\:doGetProperty\(\) has parameter \$locale with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Property\\ManagedStructureTest\:\:doGetProperty\(\) has parameter \$localized with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Structure\\ManagedStructureTest\:\:doGetProperty\(\) has parameter \$localized with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Property\\ManagedStructureTest\:\:doGetProperty\(\) has parameter \$name with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Document\\Structure\\ManagedStructureTest\:\:doGetProperty\(\) has parameter \$name with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
@@ -74671,7 +74671,7 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\Content\\Tests\\Unit\\Document\\Property\\ManagedStructureTest\:\:\$encoder is never read, only written\.$#'
+			message: '#^Property Sulu\\Component\\Content\\Tests\\Unit\\Document\\Structure\\ManagedStructureTest\:\:\$encoder is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
@@ -75433,7 +75433,7 @@ parameters:
 			path: src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\Content\\Tests\\Unit\\ResourceLocator\\Strategy\\TreeFullEditStrategyTest\:\:\$treeStrategy \(Sulu\\Component\\Content\\Types\\ResourceLocator\\Strategy\\TreeLeafEditStrategy\) does not accept Sulu\\Component\\Content\\Types\\ResourceLocator\\Strategy\\TreeFullEditStrategy\.$#'
+			message: '#^Property Sulu\\Component\\Content\\Tests\\Unit\\Rlp\\Strategy\\TreeFullEditStrategyTest\:\:\$treeStrategy \(Sulu\\Component\\Content\\Types\\ResourceLocator\\Strategy\\TreeLeafEditStrategy\) does not accept Sulu\\Component\\Content\\Types\\ResourceLocator\\Strategy\\TreeFullEditStrategy\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
@@ -77671,13 +77671,13 @@ parameters:
 			path: src/Sulu/Component/CustomUrl/Tests/Functional/Generator/GeneratorTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\CustomUrl\\Tests\\Unit\\Manager\\CustomUrlManagerTest\:\:getMapping\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\CustomUrl\\Tests\\Unit\\Manager\\Manager\\CustomUrlManagerTest\:\:getMapping\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\CustomUrl\\Tests\\Unit\\Manager\\CustomUrlManagerTest\:\:\$environment is never written, only read\.$#'
+			message: '#^Property Sulu\\Component\\CustomUrl\\Tests\\Unit\\Manager\\Manager\\CustomUrlManagerTest\:\:\$environment is never written, only read\.$#'
 			identifier: property.onlyRead
 			count: 1
 			path: src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
@@ -80941,7 +80941,7 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/PathBuilderTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\tests\\Unit\\PathBuilderTest\:\:\$pathBuilder has no type specified\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\PathBuilderTest\:\:\$pathBuilder has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/PathBuilderTest.php
@@ -81073,19 +81073,19 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Slugifier\\NodeNameSlugifierTest\:\:provide10eData\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Slugifier\\NodeNameSlugifierTest\:\:provide10eData\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Slugifier\\NodeNameSlugifierTest\:\:testSlugify10e\(\) has parameter \$actual with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Slugifier\\NodeNameSlugifierTest\:\:testSlugify10e\(\) has parameter \$actual with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Slugifier\\NodeNameSlugifierTest\:\:testSlugify10e\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Slugifier\\NodeNameSlugifierTest\:\:testSlugify10e\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -81097,61 +81097,61 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\TestLocaleDocument\:\:getLocale\(\) should return string but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestLocaleDocument\:\:getLocale\(\) should return string but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\TestLocaleDocument\:\:getOriginalLocale\(\) should return string but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestLocaleDocument\:\:getOriginalLocale\(\) should return string but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\TestLocaleDocument\:\:setLocale\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestLocaleDocument\:\:setLocale\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\TestLocaleDocument\:\:setOriginalLocale\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestLocaleDocument\:\:setOriginalLocale\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\LocaleSubscriberTest\:\:\$node is never read, only written\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\LocaleSubscriberTest\:\:\$node is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\TestLocaleDocument\:\:\$locale has no type specified\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestLocaleDocument\:\:\$locale has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\TestLocaleDocument\:\:\$originalLocale has no type specified\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestLocaleDocument\:\:\$originalLocale has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\Mapping\\TestNodeNameDocument\:\:getNodeName\(\) should return string but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestNodeNameDocument\:\:getNodeName\(\) should return string but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\Mapping\\TestNodeNameDocument\:\:\$nodeName has no type specified\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestNodeNameDocument\:\:\$nodeName has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\Mapping\\TestNodeNameDocument\:\:\$nodeName is never written, only read\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Mapping\\TestNodeNameDocument\:\:\$nodeName is never written, only read\.$#'
 			identifier: property.onlyRead
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
@@ -81193,13 +81193,13 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/UuidSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Audit\\Path\\AliasFilingSubscriberTest\:\:\$documentManager is never read, only written\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AliasFilingSubscriberTest\:\:\$documentManager is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AliasFilingSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Audit\\Path\\AliasFilingSubscriberTest\:\:\$parentDocument is never read, only written\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AliasFilingSubscriberTest\:\:\$parentDocument is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AliasFilingSubscriberTest.php
@@ -81211,55 +81211,55 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$create with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$create with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$expectedName with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$expectedName with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$hasNode with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$hasNode with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$slugifiedName with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$slugifiedName with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$title with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:doTestAutoName\(\) has parameter \$title with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:\$metadata is never read, only written\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:\$metadata is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:\$parentDocument is never read, only written\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\AutoNameSubscriberTest\:\:\$parentDocument is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Audit\\Path\\BasePathSubscriberTest\:\:\$subscriber \(Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Path\\AliasFilingSubscriber\) does not accept Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Path\\BasePathSubscriber\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\BasePathSubscriberTest\:\:\$subscriber \(Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Path\\AliasFilingSubscriber\) does not accept Sulu\\Component\\DocumentManager\\Subscriber\\Behavior\\Path\\BasePathSubscriber\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/BasePathSubscriberTest.php
@@ -81271,13 +81271,13 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Audit\\Path\\ExplicitSubscriberTest\:\:resolveOptions\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\ExplicitSubscriberTest\:\:resolveOptions\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Audit\\Path\\ExplicitSubscriberTest\:\:resolveOptions\(\) has parameter \$options with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Behavior\\Path\\ExplicitSubscriberTest\:\:resolveOptions\(\) has parameter \$options with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
@@ -81307,37 +81307,37 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Comonent\\DocumentManager\\tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:doTestFind\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:doTestFind\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Comonent\\DocumentManager\\tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:doTestFind\(\) has parameter \$options with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:doTestFind\(\) has parameter \$options with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Comonent\\DocumentManager\\tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:provideFindWithTypeOrClass\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:provideFindWithTypeOrClass\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Comonent\\DocumentManager\\tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:testFindWithTypeOrClass\(\) has parameter \$shouldThrow with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:testFindWithTypeOrClass\(\) has parameter \$shouldThrow with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Comonent\\DocumentManager\\tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:testFindWithTypeOrClass\(\) has parameter \$type with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:testFindWithTypeOrClass\(\) has parameter \$type with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
-			message: '#^Method Sulu\\Comonent\\DocumentManager\\tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:testFindWithTypeOrClass\(\) has parameter \$typeOrClass with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Phpcr\\FindSubscriberTest\:\:testFindWithTypeOrClass\(\) has parameter \$typeOrClass with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -81349,7 +81349,7 @@ parameters:
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
 
 		-
-			message: '#^Property Sulu\\Comonent\\DocumentManager\\Tests\\Unit\\Subscriber\\GeneralSubscriberTest\:\:\$refreshEvent is never read, only written\.$#'
+			message: '#^Property Sulu\\Component\\DocumentManager\\Tests\\Unit\\Subscriber\\Phpcr\\GeneralSubscriberTest\:\:\$refreshEvent is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
@@ -87259,109 +87259,109 @@ parameters:
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertConcatenationMetadata\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertConcatenationMetadata\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertConcatenationMetadata\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertConcatenationMetadata\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertCountMetadata\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertCountMetadata\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertCountMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertCountMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertFieldMetadata\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertFieldMetadata\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertFieldMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertFieldMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertGroupConcatMetadata\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertGroupConcatMetadata\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertGroupConcatMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertGroupConcatMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertIdentityMetadata\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertIdentityMetadata\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertIdentityMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertIdentityMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertJoin\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertJoin\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertJoin\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertJoin\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertPropertyMetadata\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertPropertyMetadata\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertPropertyMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertPropertyMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertSingleMetadata\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertSingleMetadata\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertSingleMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertSingleMetadata\(\) has parameter \$expected with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Parameter \#1 \$expected of method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertFieldMetadata\(\) expects array, mixed given\.$#'
+			message: '#^Parameter \#1 \$expected of method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertFieldMetadata\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Parameter \#1 \$expected of method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertJoin\(\) expects array, mixed given\.$#'
+			message: '#^Parameter \#1 \$expected of method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertJoin\(\) expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
@@ -87373,7 +87373,7 @@ parameters:
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
 
 		-
-			message: '#^Parameter \#2 \$fieldMetadata of method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\General\\Driver\\ListXmlLoaderTest\:\:assertFieldMetadata\(\) expects Sulu\\Component\\Rest\\ListBuilder\\Metadata\\FieldMetadata, mixed given\.$#'
+			message: '#^Parameter \#2 \$fieldMetadata of method Sulu\\Component\\Rest\\Tests\\Unit\\ListBuilder\\Metadata\\ListXmlLoaderTest\:\:assertFieldMetadata\(\) expects Sulu\\Component\\Rest\\ListBuilder\\Metadata\\FieldMetadata, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
@@ -89287,13 +89287,13 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\SmartContent\\Tests\\Orm\\DataProviderRepositoryTraitTest\:\:findByFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\DataProviderRepositoryTraitTest\:\:findByFilters\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\SmartContent\\Tests\\Orm\\DataProviderRepositoryTraitTest\:\:findByFiltersIds\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
+			message: '#^Method Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\DataProviderRepositoryTraitTest\:\:findByFiltersIds\(\) has parameter \$filters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89311,7 +89311,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#1 \$datasource of method Sulu\\Component\\SmartContent\\Tests\\Orm\\DataProviderRepositoryTraitTest\:\:appendDatasource\(\) expects int\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$datasource of method Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\DataProviderRepositoryTraitTest\:\:appendDatasource\(\) expects int\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89329,7 +89329,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#1 \$sortBy of method Sulu\\Component\\SmartContent\\Tests\\Orm\\DataProviderRepositoryTraitTest\:\:appendSortBy\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$sortBy of method Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\DataProviderRepositoryTraitTest\:\:appendSortBy\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89347,7 +89347,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#1 \$value of method Sulu\\Component\\SmartContent\\Tests\\Orm\\DataProviderRepositoryTraitTest\:\:getBoolean\(\) expects bool\|string, mixed given\.$#'
+			message: '#^Parameter \#1 \$value of method Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\DataProviderRepositoryTraitTest\:\:getBoolean\(\) expects bool\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89359,7 +89359,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#2 \$sortMethod of method Sulu\\Component\\SmartContent\\Tests\\Orm\\DataProviderRepositoryTraitTest\:\:appendSortBy\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#2 \$sortMethod of method Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\DataProviderRepositoryTraitTest\:\:appendSortBy\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89371,13 +89371,13 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#3 \$values of method Sulu\\Component\\SmartContent\\Tests\\Orm\\DataProviderRepositoryTraitTest\:\:appendRelation\(\) expects array\<int\>, array\<int, mixed\> given\.$#'
+			message: '#^Parameter \#3 \$values of method Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\DataProviderRepositoryTraitTest\:\:appendRelation\(\) expects array\<int\>, array\<int, mixed\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Parameter \#3 \$values of method Sulu\\Component\\SmartContent\\Tests\\Orm\\DataProviderRepositoryTraitTest\:\:appendRelation\(\) expects array\<int\>, mixed given\.$#'
+			message: '#^Parameter \#3 \$values of method Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\DataProviderRepositoryTraitTest\:\:appendRelation\(\) expects array\<int\>, mixed given\.$#'
 			identifier: argument.type
 			count: 5
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -89983,79 +89983,79 @@ parameters:
 			path: src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:provideExtractSnippetTypeFromPath\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:provideExtractSnippetTypeFromPath\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:provideExtractWebspaceFromPath\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:provideExtractWebspaceFromPath\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:provideGetStructureTypeForNode\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:provideGetStructureTypeForNode\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:provideHasSuluNodeType\(\) has no return type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:provideHasSuluNodeType\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testExtractSnippetTypeFromPath\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testExtractSnippetTypeFromPath\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testExtractSnippetTypeFromPath\(\) has parameter \$path with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testExtractSnippetTypeFromPath\(\) has parameter \$path with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testExtractSnippetTypeFromPath\(\) has parameter \$valid with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testExtractSnippetTypeFromPath\(\) has parameter \$valid with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testExtractWebspaceFromPath\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testExtractWebspaceFromPath\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testExtractWebspaceFromPath\(\) has parameter \$path with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testExtractWebspaceFromPath\(\) has parameter \$path with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testGetStructureTypeForNode\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testGetStructureTypeForNode\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testGetStructureTypeForNode\(\) has parameter \$nodeType with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testGetStructureTypeForNode\(\) has parameter \$nodeType with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testHasSuluNodeType\(\) has parameter \$expected with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testHasSuluNodeType\(\) has parameter \$expected with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Tests\\Unit\\Mapper\\Translation\\SuluNodeHelperTest\:\:testHasSuluNodeType\(\) has parameter \$nodeTypes with no type specified\.$#'
+			message: '#^Method Sulu\\Component\\Util\\Tests\\Unit\\SuluNodeHelperTest\:\:testHasSuluNodeType\(\) has parameter \$nodeTypes with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
@@ -92755,19 +92755,7 @@ parameters:
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
 
 		-
-			message: '#^Property Sulu\\Component\\Webspace\\Tests\\Unit\\WebspaceCollectionBuilderTest\:\:\$logger \(PHPUnit\\Framework\\MockObject_MockObject\) does not accept PHPUnit\\Framework\\MockObject\\MockObject&Psr\\Log\\LoggerInterface\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Property Sulu\\Component\\Webspace\\Tests\\Unit\\WebspaceCollectionBuilderTest\:\:\$logger has unknown class PHPUnit\\Framework\\MockObject_MockObject as its type\.$#'
-			identifier: class.notFound
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Property Sulu\\Component\\Webspace\\Tests\\Unit\\WebspaceCollectionBuilderTest\:\:\$logger is never read, only written\.$#'
+			message: '#^Property Sulu\\Component\\Webspace\\Tests\\Unit\\Manager\\WebspaceCollectionBuilderTest\:\:\$logger is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27325,24 +27325,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Entity/Collection.php
 
 		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Entity\\Collection\:\:\$changer type mapping mismatch\: property can contain Sulu\\Component\\Security\\Authentication\\UserInterface\|null but database expects Sulu\\Bundle\\SecurityBundle\\Entity\\User\|null\.$#'
-			identifier: doctrine.associationType
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/Collection.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Entity\\Collection\:\:\$children type mapping mismatch\: property can contain Doctrine\\Common\\Collections\\Collection\<int, Sulu\\Bundle\\MediaBundle\\Entity\\CollectionInterface\> but database expects Doctrine\\Common\\Collections\\Collection&iterable\<Sulu\\Bundle\\MediaBundle\\Entity\\Collection\>\.$#'
-			identifier: doctrine.associationType
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/Collection.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Entity\\Collection\:\:\$creator type mapping mismatch\: property can contain Sulu\\Component\\Security\\Authentication\\UserInterface\|null but database expects Sulu\\Bundle\\SecurityBundle\\Entity\\User\|null\.$#'
-			identifier: doctrine.associationType
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/Collection.php
-
-		-
 			message: '#^Property Sulu\\Bundle\\MediaBundle\\Entity\\Collection\:\:\$defaultMeta \(Sulu\\Bundle\\MediaBundle\\Entity\\CollectionMeta\) does not accept Sulu\\Bundle\\MediaBundle\\Entity\\CollectionMeta\|null\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -27350,12 +27332,6 @@ parameters:
 
 		-
 			message: '#^Property Sulu\\Bundle\\MediaBundle\\Entity\\Collection\:\:\$defaultMeta type mapping mismatch\: database can contain Sulu\\Bundle\\MediaBundle\\Entity\\CollectionMeta\|null but property expects Sulu\\Bundle\\MediaBundle\\Entity\\CollectionMeta\.$#'
-			identifier: doctrine.associationType
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Entity/Collection.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Entity\\Collection\:\:\$media type mapping mismatch\: property can contain Doctrine\\Common\\Collections\\Collection\<int, Sulu\\Bundle\\MediaBundle\\Entity\\MediaInterface\> but database expects Doctrine\\Common\\Collections\\Collection&iterable\<Sulu\\Bundle\\MediaBundle\\Entity\\Media\>\.$#'
 			identifier: doctrine.associationType
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Entity/Collection.php
@@ -58969,12 +58945,6 @@ parameters:
 			path: src/Sulu/Bundle/TrashBundle/Application/TrashManager/TrashManager.php
 
 		-
-			message: '#^Property Sulu\\Bundle\\TrashBundle\\Domain\\Model\\TrashItem\:\:\$user type mapping mismatch\: property can contain Sulu\\Component\\Security\\Authentication\\UserInterface\|null but database expects Sulu\\Bundle\\SecurityBundle\\Entity\\User\|null\.$#'
-			identifier: doctrine.associationType
-			count: 1
-			path: src/Sulu/Bundle/TrashBundle/Domain/Model/TrashItem.php
-
-		-
 			message: '#^Call to method getUser\(\) on an unknown class Symfony\\Component\\Security\\Core\\Security\.$#'
 			identifier: class.notFound
 			count: 1
@@ -89281,7 +89251,7 @@ parameters:
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
 
 		-
-			message: '#^Class Sulu\\Component\\SmartContent\\Tests\\Orm\\Query extends generic class Doctrine\\ORM\\AbstractQuery but does not specify its types\: TKey, TResult$#'
+			message: '#^Class Sulu\\Component\\SmartContent\\Tests\\Unit\\Orm\\Query extends generic class Doctrine\\ORM\\AbstractQuery but does not specify its types\: TKey, TResult$#'
 			identifier: missingType.generics
 			count: 1
 			path: src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Application/Collector/DomainEventCollectorTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Application/Collector/DomainEventCollectorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ActivityBundle\Tests\Unit\Application\Dispatcher;
+namespace Sulu\Bundle\ActivityBundle\Tests\Unit\Application\Collector;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Domain/Model/ActivityTest.php
+++ b/src/Sulu/Bundle/ActivityBundle/Tests/Unit/Domain/Model/ActivityTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ActivityBundle\Tests\Unit\Model\Event;
+namespace Sulu\Bundle\ActivityBundle\Tests\Unit\Domain\Model;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewRegistryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewRegistryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\AdminBundle\Tests\Admin\View;
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\View;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/FieldType/FieldTypeOptionRegistryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/FieldType/FieldTypeOptionRegistryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\AdminBundle\Tests\FieldType;
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\FieldType;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\FieldType\FieldTypeOptionRegistry;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Navigation/NavigationItemTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\AdminBundle\Tests\Navigation;
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Navigation;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/Block/TargetGroupBlockVisitorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Content/Types/Block/TargetGroupBlockVisitorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Tests\Unit\Types\Block;
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Content\Types\Block;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/Request/ForwardedUrlRequestProcessorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Webspace\Tests\Unit\Analyzer\Attributes;
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Request;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AudienceTargetingBundle\Request\ForwardedUrlRequestProcessor;

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/UserContext/TargetGroupStoreTest.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Unit/UserContext/TargetGroupStoreTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\Request;
+namespace Sulu\Bundle\AudienceTargetingBundle\Tests\Unit\UserContext;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AudienceTargetingBundle\TargetGroup\TargetGroupStore;

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/CustomerIdConverterTest.php
@@ -9,9 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ContactBundle\Util;
+namespace Sulu\Bundle\ContactBundle\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContactBundle\Util\CustomerIdConverter;
 
 class CustomerIdConverterTest extends TestCase
 {

--- a/src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Unit/IndexComparatorTest.php
@@ -9,9 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\ContactBundle\Util;
+namespace Sulu\Bundle\ContactBundle\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\ContactBundle\Util\IndexComparator;
 
 class IndexComparatorTest extends TestCase
 {

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Collector/DocumentDomainEventCollectorSubscriberTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Collector/DocumentDomainEventCollectorSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\TagBundle\Tests\Unit\Application\Dispatcher;
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Collector;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Collector/DocumentDomainEventCollectorTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Collector/DocumentDomainEventCollectorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\TagBundle\Tests\Unit\Application\Dispatcher;
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Collector;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/InitializerTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Initialalizer/InitializerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace vendor\sulu\sulu\src\Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Initialalizer;
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Initialalizer;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/Tests/Unit/EventSubscriber/TagsSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\HttpCacheBundle\Tests\Unit\EventListener;
+namespace Sulu\Bundle\HttpCacheBundle\Tests\Unit\EventSubscriber;
 
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaRedirectControllerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Functional\Controller;
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Controller;
 
 use Doctrine\ORM\EntityManager;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatCache/LocalFormatCacheTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatCache/LocalFormatCacheTest.php
@@ -9,10 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\FormatCache;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\FormatCache;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\MediaBundle\Media\FormatCache\LocalFormatCache;
 use Symfony\Component\Filesystem\Filesystem;
 
 class LocalFormatCacheTest extends TestCase

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader10Test.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader10Test.php
@@ -9,12 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\FormatLoader;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\FormatLoader;
 
 use Imagine\Image\ImageInterface;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\MissingScaleDimensionException;
+use Sulu\Bundle\MediaBundle\Media\FormatLoader\XmlFormatLoader10;
 use Sulu\Component\Webspace\Tests\Unit\WebspaceTestCase;
 use Symfony\Component\Config\FileLocatorInterface;
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader11Test.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatLoader/XmlFormatLoader11Test.php
@@ -9,12 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\FormatLoader;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\FormatLoader;
 
 use Imagine\Image\ImageInterface;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\MediaBundle\Media\FormatLoader\Exception\MissingScaleDimensionException;
+use Sulu\Bundle\MediaBundle\Media\FormatLoader\XmlFormatLoader11;
 use Sulu\Component\Webspace\Tests\Unit\WebspaceTestCase;
 use Symfony\Component\Config\FileLocatorInterface;
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatManager/FormatManagerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\FormatManager;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\FormatManager;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -20,6 +20,7 @@ use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatCache\FormatCacheInterface;
+use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManager;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\ImageConverterInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Symfony\Component\ErrorHandler\BufferingLogger;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatOptionsManager/FormatOptionsManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/FormatOptionsManager/FormatOptionsManagerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\FormatOptionsManager;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\FormatOptionsManager;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/AzureBlobStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/AzureBlobStorageTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\Storage;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\Storage;
 
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter;
@@ -19,6 +19,8 @@ use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\MediaBundle\Media\Storage\AzureBlobStorage;
+use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 
 class AzureBlobStorageTest extends TestCase

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/GoogleCloudStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/GoogleCloudStorageTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\Storage;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\Storage;
 
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\FileNotFoundException;
@@ -17,6 +17,8 @@ use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\MediaBundle\Media\Storage\GoogleCloudStorage;
+use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
 use Symfony\Component\Filesystem\Exception\IOException;
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/S3StorageTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\Storage;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\Storage;
 
 use Aws\S3\S3Client;
 use League\Flysystem\AdapterInterface;
@@ -19,6 +19,8 @@ use League\Flysystem\Filesystem;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\MediaBundle\Media\Storage\S3Storage;
+use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 
 class S3StorageTest extends TestCase

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/TypeManager/TypeManagerTest.php
@@ -9,10 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Media\TypeManager;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\TypeManager;
 
 use Doctrine\Persistence\ObjectManager;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
+use Sulu\Bundle\MediaBundle\Media\TypeManager\TypeManager;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 
 class TypeManagerTest extends SuluTestCase

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/EventListener/PermissionListenerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Search/EventListener/PermissionListenerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Search\EventListener;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Search\EventListener;
 
 use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -18,6 +18,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\FileVersionMetaRepository;
+use Sulu\Bundle\MediaBundle\Search\EventListener\PermissionListener;
 use Sulu\Component\Security\Event\PermissionUpdateEvent;
 
 class PermissionListenerTest extends TestCase

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/DispositionTypeTwigExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Twig/DispositionTypeTwigExtensionTest.php
@@ -9,12 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\MediaBundle\Twig;
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MediaBundle\Api\Media;
+use Sulu\Bundle\MediaBundle\Twig\DispositionTypeTwigExtension;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class DispositionTypeTwigExtensionTest extends TestCase

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Structure/SeoStructureExtensionTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Content/Structure/SeoStructureExtensionTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\PageBundle\Tests\Unit\Structure;
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Content\Structure;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventListener/PermissionListenerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventListener/PermissionListenerTest.php
@@ -9,13 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\PageBundle\Search\EventListener;
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Search\EventListener;
 
 use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\PageBundle\Search\EventListener\PermissionListener;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Security\Event\PermissionUpdateEvent;

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Search/EventSubscriber/StructureSubscriberTest.php
@@ -9,12 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\PageBundle\Search\EventSubscriber;
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Search\EventSubscriber;
 
 use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\PageBundle\Search\EventSubscriber\StructureSubscriber;
 use Sulu\Component\Content\Document\Behavior\SecurityBehavior;
 use Sulu\Component\Content\Document\Behavior\StructureBehavior;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Sitemap/PagesSitemapProviderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\PageBundle\Tests\Unit\Sulu\Bundle\WebsiteBundle\Sitemap;
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Sitemap;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/PersistenceBundle/Tests/Unit/DependencyInjection/PersistenceExtensionTraitTest.php
+++ b/src/Sulu/Bundle/PersistenceBundle/Tests/Unit/DependencyInjection/PersistenceExtensionTraitTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\LocationBundle\Tests\Unit\DependencyInjection;
+namespace Sulu\Bundle\PersistenceBundle\Tests\Unit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractContainerBuilderTestCase;
 use Sulu\Bundle\PersistenceBundle\Tests\Unit\Fixture\DependencyInjection\UsingPersistenceExtensionTrait;

--- a/src/Sulu/Bundle/RouteBundle/Tests/Functional/Entity/RouteRepositoryTest.php
+++ b/src/Sulu/Bundle/RouteBundle/Tests/Functional/Entity/RouteRepositoryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\RouteBundle\Tests\Functional\Controller;
+namespace Sulu\Bundle\RouteBundle\Tests\Functional\Entity;
 
 use Sulu\Bundle\RouteBundle\Entity\Route;
 use Sulu\Bundle\RouteBundle\Entity\RouteRepositoryInterface;

--- a/src/Sulu/Bundle/SearchBundle/Tests/Unit/Search/Configuration/IndexConfigurationProviderTest.php
+++ b/src/Sulu/Bundle/SearchBundle/Tests/Unit/Search/Configuration/IndexConfigurationProviderTest.php
@@ -9,12 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SearchBundle\Search\Configuration;
+namespace Sulu\Bundle\SearchBundle\Tests\Unit\Search\Configuration;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\SearchBundle\Search\Configuration\IndexConfigurationProvider;
+use Sulu\Bundle\SearchBundle\Search\Configuration\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class IndexConfigurationProviderTest extends TestCase

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/AdminControllerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Controller;
+namespace Sulu\Bundle\SecurityBundle\Tests\Functional;
 
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SuluSecurityListenerTest.php
@@ -9,12 +9,13 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\EventListener;
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\SecurityBundle\EventListener\SuluSecurityListener;
 use Sulu\Component\Security\Authorization\AccessControl\SecuredObjectControllerInterface;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SystemListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/SystemListenerTest.php
@@ -9,11 +9,12 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\EventListener;
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\SecurityBundle\EventListener\SystemListener;
 use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationEntryPointTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationEntryPointTest.php
@@ -9,10 +9,11 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\Security;
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\Security;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\SecurityBundle\Security\AuthenticationEntryPoint;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationHandlerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Security/AuthenticationHandlerTest.php
@@ -9,11 +9,12 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\Security;
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\Security;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\SecurityBundle\Security\AuthenticationHandler;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginRequestSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginRequestSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\Tests\Unit\SingleSignOn\Adapter\OpenId;
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\SingleSignOn;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnTokeExtractorTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnTokeExtractorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\Tests\Unit\SingleSignOn\Adapter\OpenId;
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\SingleSignOn;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/System/SystemStoreTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/System/SystemStoreTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\Tests\System;
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\System;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Util/TokenGeneratorTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/Util/TokenGeneratorTest.php
@@ -9,9 +9,10 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SecurityBundle\Util;
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\Util;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\SecurityBundle\Util\TokenGenerator;
 
 class TokenGeneratorTest extends TestCase
 {

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Export/SnippetTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\PageBundle\Tests\Functional\Export;
+namespace Sulu\Bundle\SnippetBundle\Tests\Functional\Export;
 
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Functional/Snippet/SnippetRepositoryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SnippetBundle\Tests\Functional\Content;
+namespace Sulu\Bundle\SnippetBundle\Tests\Functional\Snippet;
 
 use PHPCR\SessionInterface;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;

--- a/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
+++ b/src/Sulu/Bundle/SnippetBundle/Tests/Unit/Snippet/SnippetResolverTest.php
@@ -9,13 +9,14 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\SnippetBundle\Snippet;
+namespace Sulu\Bundle\SnippetBundle\Tests\Unit\Snippet;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\SnippetBundle\Document\SnippetDocument;
+use Sulu\Bundle\SnippetBundle\Snippet\SnippetResolver;
 use Sulu\Bundle\WebsiteBundle\Resolver\StructureResolverInterface;
 use Sulu\Component\Content\Compat\Structure\SnippetBridge;
 use Sulu\Component\Content\Compat\StructureInterface;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/EventListener/SecurityListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/EventListener/SecurityListenerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Bundle\WebsiteBundle\Tests\Functional;
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\EventListener;
 
 use Sulu\Bundle\PageBundle\Document\BasePageDocument;
 use Sulu\Bundle\PageBundle\Document\PageDocument;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/DependencyInjection/SuluWebsiteExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/DependencyInjection/SuluWebsiteExtensionTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Unit\Sulu\Bundle\WebsiteBundle\EventListener;
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sulu\Bundle\WebsiteBundle\DependencyInjection\SuluWebsiteExtension;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/RouterListenerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/EventListener/RouterListenerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Unit\Sulu\Bundle\WebsiteBundle\EventListener;
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/RequestAnalyzerResolverTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Resolver/RequestAnalyzerResolverTest.php
@@ -9,6 +9,8 @@
  * with this source code in the file LICENSE.
  */
 
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Resolver;
+
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/NavigationTwigExtensionTest.php
@@ -9,6 +9,8 @@
  * with this source code in the file LICENSE.
  */
 
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Twig;
+
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\WebsiteBundle\Navigation\NavigationMapperInterface;

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/DataCacheTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Cache\Tests\Unit;
+namespace Sulu\Component\Cache\Tests\Unit\Cache;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Cache\CacheInterface;

--- a/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTest.php
+++ b/src/Sulu/Component/Cache/Tests/Unit/Cache/MemoizeTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Cache\Tests\Unit;
+namespace Sulu\Component\Cache\Tests\Unit\Cache;
 
 use Doctrine\Common\Cache\CacheProvider;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Document/Structure/ManagedStructureTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Tests\Unit\Document\Property;
+namespace Sulu\Component\Content\Tests\Unit\Document\Structure;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/Content/Tests/Unit/ResourceLocator/Strategy/TreeGeneratorTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/ResourceLocator/Strategy/TreeGeneratorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Tests\Functional\ResourceLocator\Strategy;
+namespace Sulu\Component\Content\Tests\Unit\ResourceLocator\Strategy;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\Content\Types\ResourceLocator\Strategy\TreeGenerator;

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/ResourceLocatorStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/ResourceLocatorStrategyTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Tests\Unit\ResourceLocator\Strategy;
+namespace Sulu\Component\Content\Tests\Unit\Rlp\Strategy;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeFullEditStrategyTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Tests\Unit\ResourceLocator\Strategy;
+namespace Sulu\Component\Content\Tests\Unit\Rlp\Strategy;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
+++ b/src/Sulu/Component/Content/Tests/Unit/Rlp/Strategy/TreeLeafEditStrategyTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Tests\Unit\ResourceLocator\Strategy;
+namespace Sulu\Component\Content\Tests\Unit\Rlp\Strategy;
 
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;

--- a/src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
+++ b/src/Sulu/Component/CustomUrl/Tests/Unit/Manager/Manager/CustomUrlManagerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\CustomUrl\Tests\Unit\Manager;
+namespace Sulu\Component\CustomUrl\Tests\Unit\Manager\Manager;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/ClassNameInflectorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/ClassNameInflectorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\ClassNameInflector;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ChildrenCollectionTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Collection;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/QueryResultCollectionTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Collection;
 
 use PHPCR\NodeInterface;
 use PHPCR\Query\QueryResultInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Collection/ReferrerCollectionTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\tests\Unit\Collection;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Collection;
 
 use PHPCR\NodeInterface;
 use PHPCR\PropertyInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentHelperTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentInspectorTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/DocumentRegistryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/BaseMetadataFactoryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit\Metadata;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Metadata;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/MetadataFactoryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Metadata/MetadataFactoryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit\Metadata;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Metadata;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NameResolverTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NameResolverTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NamespaceRegistryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\Exception\DocumentManagerException;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/NodeManagerTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/NodeManagerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPCR\NodeInterface;
 use PHPCR\PathNotFoundException;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PathBuilderTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PathBuilderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\PathBuilder;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PathSegmentRegistryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PathSegmentRegistryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Component\DocumentManager\PathSegmentRegistry;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/PropertyEncoderTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/PropertyEncoderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit;
+namespace Sulu\Component\DocumentManager\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Query/QueryTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\tests\Unit\Query;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Query;
 
 use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryResultInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Slugifier/NodeNameSlugifierTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit\Slugifier;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Slugifier;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/LocaleSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Mapping/NodeNameSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping\Mapping;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Mapping;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AliasFilingSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AliasFilingSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Path;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Path;
 
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/AutoNameSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Behavior\Path;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Path;
 
 use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/BasePathSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/BasePathSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Path;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Path;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Behavior/Path/ExplicitSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Audit\Path;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Behavior\Path;
 
 use PHPCR\ItemExistsException;
 use PHPCR\NodeInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/InstantiatorSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Core;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Core;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Core/RegistratorSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\DocumentManager\tests\Unit\Subscriber\Core;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Core;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/FindSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/GeneralSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/QuerySubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\Query\QueryInterface;
 use PHPCR\Query\QueryManagerInterface;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RefreshSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\tests\Unit\Subscriber\Phpcr;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/RemoveSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/ReorderSubscriberTest.php
+++ b/src/Sulu/Component/DocumentManager/Tests/Unit/Subscriber/Phpcr/ReorderSubscriberTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Comonent\DocumentManager\Tests\Unit\Subscriber;
+namespace Sulu\Component\DocumentManager\Tests\Unit\Subscriber\Phpcr;
 
 use PHPCR\NodeInterface;
 use PHPUnit\Framework\TestCase;

--- a/src/Sulu/Component/Rest/Tests/Unit/FlattenExceptionNormalizerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/FlattenExceptionNormalizerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Filter;
+namespace Sulu\Component\Rest\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Metadata/ListXmlLoaderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Metadata\General\Driver;
+namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Metadata;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;

--- a/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
+++ b/src/Sulu/Component/SmartContent/Tests/Unit/Orm/DataProviderRepositoryTraitTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\SmartContent\Tests\Orm;
+namespace Sulu\Component\SmartContent\Tests\Unit\Orm;
 
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SuluNodeHelperTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Content\Tests\Unit\Mapper\Translation;
+namespace Sulu\Component\Util\Tests\Unit;
 
 use Jackalope\Node;
 use PHPCR\NodeInterface;

--- a/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Document/Initializer/WebspaceInitializerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Webspace\Document\Initializer;
+namespace Sulu\Component\Webspace\Tests\Unit\Document\Initializer;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
@@ -23,6 +23,7 @@ use Sulu\Component\DocumentManager\Exception\DocumentNotFoundException;
 use Sulu\Component\DocumentManager\NodeManager;
 use Sulu\Component\DocumentManager\PathBuilder;
 use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Document\Initializer\WebspaceInitializer;
 use Sulu\Component\Webspace\Manager\WebspaceCollection;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Webspace\Tests\Unit;
+namespace Sulu\Component\Webspace\Tests\Unit\Manager;
 
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -19,6 +19,7 @@ use Sulu\Component\Webspace\Exception\InvalidTemplateException;
 use Sulu\Component\Webspace\Loader\XmlFileLoader10;
 use Sulu\Component\Webspace\Loader\XmlFileLoader11;
 use Sulu\Component\Webspace\Manager\WebspaceCollectionBuilder;
+use Sulu\Component\Webspace\Tests\Unit\WebspaceTestCase;
 use Sulu\Component\Webspace\Url\Replacer;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\DelegatingLoader;
@@ -34,7 +35,7 @@ class WebspaceCollectionBuilderTest extends WebspaceTestCase
     private $loader;
 
     /**
-     * @var \PHPUnit\Framework\MockObject_MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject&LoggerInterface
      */
     private $logger;
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceManagerTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Sulu\Component\Webspace\Tests\Unit;
+namespace Sulu\Component\Webspace\Tests\Unit\Manager;
 
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -23,6 +23,7 @@ use Sulu\Component\Webspace\Loader\XmlFileLoader11;
 use Sulu\Component\Webspace\Manager\WebspaceManager;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Tests\Unit\WebspaceTestCase;
 use Sulu\Component\Webspace\Url\Replacer;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\Config\FileLocatorInterface;


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Fixed namespaces in 91 test files to match PSR-4 autoloading conventions
  - Regenerated phpstan baseline to match corrected namespaces

  #### Why?

  Many test files had namespaces that didn't match their file paths according to PSR-4
  autoloading standards. Common issues included:

  - Missing `Tests\Unit` segment in namespace (e.g., `Sulu\Bundle\XBundle\Foo` instead of
  `Sulu\Bundle\XBundle\Tests\Unit\Foo`)
  - Lowercase `tests` instead of `Tests`
  - Typos like `Comonent` instead of `Component`
  - Double directory names in namespace

  These incorrect namespaces prevented proper autoloading and caused issues when trying to
  add tools like the Roave backwards compatibility checker. The phpstan baseline also needed
   regeneration since it referenced the old (incorrect) namespaces.