### PR TITLE
Fix phpstan issues after dependency upadte

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -193,7 +193,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
             $this->em->remove($contact);
 
             $this->domainEventCollector->collect(
-                new ContactRemovedEvent($contactId, $contactFullName)
+                new ContactRemovedEvent((int) $contactId, $contactFullName)
             );
 
             /** @var UserInterface|null $user */

--- a/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/Contact.php
@@ -252,6 +252,9 @@ class Contact extends ApiEntity implements ContactInterface
         $this->medias = new ArrayCollection();
     }
 
+    /**
+     * @return int|null
+     */
     public function getId()
     {
         return $this->id;

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactControllerTest.php
@@ -1822,7 +1822,7 @@ class ContactControllerTest extends SuluTestCase
         $this->em->persist($contact3);
         $this->em->flush();
 
-        $ids = \sprintf('%s,%s,%s', $contact1->getId(), $contact2->getId(), $contact3->getId());
+        $ids = \sprintf('%s,%s,%s', (int) $contact1->getId(), (int) $contact2->getId(), (int) $contact3->getId());
 
         $this->client->jsonRequest('GET', '/api/contacts?flat=true&ids=' . $ids . '&fields=id');
         $response = \json_decode($this->client->getResponse()->getContent());
@@ -1860,7 +1860,7 @@ class ContactControllerTest extends SuluTestCase
         $this->em->persist($contact3);
         $this->em->flush();
 
-        $ids = \sprintf('%s,%s,%s', $contact3->getId(), $contact1->getId(), $contact2->getId());
+        $ids = \sprintf('%s,%s,%s', (int) $contact3->getId(), (int) $contact1->getId(), (int) $contact2->getId());
 
         $this->client->jsonRequest('GET', '/api/contacts?flat=true&ids=' . $ids . '&fields=id');
         $response = \json_decode($this->client->getResponse()->getContent());

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactMediaControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/ContactMediaControllerTest.php
@@ -87,7 +87,7 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->em->flush();
 
-        $this->client->jsonRequest('GET', '/api/contacts/' . $this->contact->getId() . '/medias?flat=true');
+        $this->client->jsonRequest('GET', '/api/contacts/' . (int) $this->contact->getId() . '/medias?flat=true');
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals(1, $response->total);
@@ -108,7 +108,7 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'GET',
-            '/api/contacts/' . $this->contact->getId()
+            '/api/contacts/' . (int) $this->contact->getId()
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());
@@ -116,7 +116,7 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/contacts/' . $this->contact->getId() . '/medias',
+            '/api/contacts/' . (int) $this->contact->getId() . '/medias',
             [
                 'mediaId' => $media2->getId(),
             ]
@@ -127,7 +127,7 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'GET',
-            '/api/contacts/' . $this->contact->getId()
+            '/api/contacts/' . (int) $this->contact->getId()
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());
@@ -146,7 +146,7 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'GET',
-            '/api/contacts/' . $this->contact->getId()
+            '/api/contacts/' . (int) $this->contact->getId()
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());
@@ -154,7 +154,7 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/contacts/' . $this->contact->getId() . '/medias',
+            '/api/contacts/' . (int) $this->contact->getId() . '/medias',
             [
                 'mediaId' => 99,
             ]
@@ -164,7 +164,7 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'GET',
-            '/api/contacts/' . $this->contact->getId()
+            '/api/contacts/' . (int) $this->contact->getId()
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());
@@ -180,14 +180,14 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'DELETE',
-            '/api/contacts/' . $this->contact->getId() . '/medias/' . $media1->getId()
+            '/api/contacts/' . (int) $this->contact->getId() . '/medias/' . $media1->getId()
         );
 
         $this->assertHttpStatusCode(204, $this->client->getResponse());
 
         $this->client->jsonRequest(
             'GET',
-            '/api/contacts/' . $this->contact->getId()
+            '/api/contacts/' . (int) $this->contact->getId()
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());
@@ -203,14 +203,14 @@ class ContactMediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'DELETE',
-            '/api/contacts/' . $this->contact->getId() . '/medias/99'
+            '/api/contacts/' . (int) $this->contact->getId() . '/medias/99'
         );
 
         $this->assertHttpStatusCode(404, $this->client->getResponse());
 
         $this->client->jsonRequest(
             'GET',
-            '/api/contacts/' . $this->contact->getId()
+            '/api/contacts/' . (int) $this->contact->getId()
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());

--- a/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
@@ -175,6 +175,9 @@ class CustomUrlController extends AbstractRestController implements SecuredContr
         return CustomUrlAdmin::getCustomUrlSecurityContext($request->get('webspace'));
     }
 
+    /**
+     * @return string|null
+     */
     public function getLocale(Request $request)
     {
         return null;

--- a/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlRouteController.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlRouteController.php
@@ -78,6 +78,9 @@ class CustomUrlRouteController extends AbstractRestController implements Secured
         return CustomUrlAdmin::getCustomUrlSecurityContext($request->get('webspace'));
     }
 
+    /**
+     * @return string|null
+     */
     public function getLocale(Request $request)
     {
         return null;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
@@ -279,7 +279,7 @@ class UserControllerTest extends SuluTestCase
     {
         $this->client->jsonRequest(
             'POST',
-            '/api/users?contactId=' . $this->contact1->getId(),
+            '/api/users?contactId=' . (int) $this->contact1->getId(),
             [
                 'username' => 'manager',
                 'email' => 'manager@test.com',
@@ -844,7 +844,7 @@ class UserControllerTest extends SuluTestCase
     {
         $this->client->jsonRequest(
             'GET',
-            '/api/users?contactId=' . $this->contact2->getId()
+            '/api/users?contactId=' . (int) $this->contact2->getId()
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | no
  | BC breaks? | no
  | License | MIT

  #### What's in this PR?

  - Added PHPDoc return type annotations to methods with implicit nullable return types (`Contact::getId()`, `CustomUrlController::getLocale()`, `CustomUrlRouteController::getLocale()`)
  - Fixed type coercion in `ContactManager` by casting `$contactId` to `int` when constructing `ContactRemovedEvent`
  - Updated functional tests to explicitly cast `Contact::getId()` returns to `int` when used in string interpolation

  #### Why?

  PHPStan's stricter analysis after dependency updates flagged implicit type issues. Methods returning `int|null` without explicit return type annotations cause type inference problems, and passing potentially
  nullable values where integers are expected triggers errors. These changes satisfy PHPStan's type checking requirements without changing runtime behavior.