### PR TITLE
Switch composer autoload setting from psr-0 to psr-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -221,8 +221,8 @@
         "symfony/monolog-bundle": "^3.1"
     },
     "autoload": {
-        "psr-0": {
-            "Sulu\\": "src/"
+        "psr-4": {
+            "Sulu\\": "src/Sulu/"
         },
         "exclude-from-classmap": [
             "src/Sulu/Component/*/Tests/",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Switch composer autoload setting from psr-0 to psr-4.

#### Why?

Avoid deprecation notices about PSR-0 for different tools.
