### PR TITLE
Fix performance improvements for metadata loading

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
@@ -53,9 +53,13 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
 
         $this->warmUp($this->cacheDir);
 
-        $typedFormMetadata = @include $path;
+        // we know that the file need exist because of $templateDirectories
+        // so we can include without "@" operator here:
+        $typedFormMetadata = include $path;
 
-        return $typedFormMetadata instanceof TypedFormMetadata ? $typedFormMetadata : null;
+        \assert($typedFormMetadata instanceof TypedFormMetadata, 'The cache file must return an instance of TypedFormMetadata.');
+
+        return $typedFormMetadata;
     }
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/XmlTemplateFormMetadataLoader.php
@@ -36,6 +36,10 @@ class XmlTemplateFormMetadataLoader implements FormMetadataLoaderInterface, Cach
 
     public function getMetadata(string $key, ?string $locale = null, array $metadataOptions = []): ?TypedFormMetadata
     {
+        if (false === \array_key_exists($key, $this->templateDirectories)) {
+            return null;
+        }
+
         $path = $this->getCachePath($key);
 
         $typedFormMetadata = @include $path;

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -149,7 +149,7 @@
             <argument>%sulu.cache_dir%/forms</argument>
             <argument>%kernel.debug%</argument>
 
-            <tag name="sulu_admin.form_metadata_loader" priority="256"/>
+            <tag name="sulu_admin.form_metadata_loader" priority="-64"/>
             <tag name="kernel.cache_warmer" />
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -149,7 +149,7 @@
             <argument>%sulu.cache_dir%/forms</argument>
             <argument>%kernel.debug%</argument>
 
-            <tag name="sulu_admin.form_metadata_loader"/>
+            <tag name="sulu_admin.form_metadata_loader" priority="256"/>
             <tag name="kernel.cache_warmer" />
         </service>
 
@@ -160,7 +160,7 @@
             <argument>%sulu.cache_dir%/templates</argument>
             <argument>%kernel.debug%</argument>
 
-            <tag name="sulu_admin.form_metadata_loader"/>
+            <tag name="sulu_admin.form_metadata_loader" priority="512"/>
             <tag name="kernel.cache_warmer" priority="512" />
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlTemplateFormMetadataLoaderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/XmlTemplateFormMetadataLoaderTest.php
@@ -177,4 +177,33 @@ class XmlTemplateFormMetadataLoaderTest extends TestCase
 
         $this->assertInstanceOf(TypedFormMetadata::class, $loadedMetadata);
     }
+
+    public function testGetMetadataNoAutoRebuildsInDebugModeUnknownKey(): void
+    {
+        $debugLoader = new XmlTemplateFormMetadataLoader(
+            $this->templateXmlLoader->reveal(),
+            $this->fieldMetadataValidator->reveal(),
+            [
+                'page' => [
+                    'default_type' => 'default',
+                    'directories' => [__DIR__ . '/dummy-templates'],
+                ],
+            ],
+            self::getCacheDir(),
+            true
+        );
+
+        $this->templateXmlLoader->load(Argument::cetera())
+            ->willReturn($this->createFormMetadata('default', [
+                $this->createFieldMetadata('title', 'text_line'),
+            ]))
+            ->shouldNotBeCalled();
+        $this->fieldMetadataValidator->validate(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $loadedMetadata = $debugLoader->getMetadata('contact_details', 'en');
+
+        $this->assertNull($loadedMetadata);
+        $this->assertFileDoesNotExist(self::getCacheDir() . '/page.php');
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/8448
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix performance improvements for metadata loading by change priority between `XmlTemplateFormMetadataLoader` and `XmlFormMetadataLoader` and early return if type in unknown.

#### Why?

What currently happens is:

 - FormMetadataLoader is called:
   - FormMetadataLoader has No Cached Version of `block`, `page`, `article` type
   - FormMetadataLoader on debug warmups the cache to check if really does not have it
      - Parses lot of XML files always
   - Returns null
 - TemplateMetadataLoader is called:
   - Returns cached Version
   
#### Todo

 - [x] Add test to early return and not create any cache warmup fils