### PR TITLE
Fix the ORM 3 integration for extended Entities with relations

### DIFF
--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
@@ -100,13 +100,16 @@ class MetadataSubscriber
 
             // map relations
             foreach ($parentMetadata->getAssociationMappings() as $key => $value) {
-                // can be changed to $value->type and $value->sourceEntity if min version is doctrine/orm 3+
+                // The following code is littered with phpstan-ignore-next-line because of doctrine/orm 2/3 compat
+                // doctrine/orm 3: changed to $value->type and $value->sourceEntity (AssociationMapping object)
+                // doctrine/orm 2: changed to $value['type'] and $value['sourceEntity'] (array/ArrayAccess object)
+
                 // @phpstan-ignore-next-line argument.type
                 if ($this->hasRelation($value['type'])) {
                     $value['sourceEntity'] = $metadata->getName();
-                    // can be removed if min version is doctrine/orm 3+
-                    // @phpstan-ignore-next-line function.impossibleType
+                    // @phpstan-ignore-next-line
                     if (\is_array($value) || $value instanceof \Doctrine\ORM\Mapping\AssociationMapping) {
+                        // @phpstan-ignore-next-line
                         $metadata->associationMappings[$key] = $value;
                     }
                 }

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
@@ -106,7 +106,7 @@ class MetadataSubscriber
                     $value['sourceEntity'] = $metadata->getName();
                     // can be removed if min version is doctrine/orm 3+
                     // @phpstan-ignore-next-line function.impossibleType
-                    if (\is_array($value)) {
+                    if (\is_array($value) || $value instanceof \Doctrine\ORM\Mapping\AssociationMapping) {
                         $metadata->associationMappings[$key] = $value;
                     }
                 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| Fixed tickets | fixes #8483
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Fix for the copying of association mapping.

#### Why?
In doctrine 3 the metadata are now an object so checking if the $value variable is an array will return false. We should also check if it's an AssociationMapping class. 

### BC
I don't know if the `AssociationMapping` class exists in doctrine 2 but since it should be lazily evaluated, for doctrine 2 the first part should be true and it should not come to the second part.