### PR TITLE
Use system cache for Icons

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/SuluAdminExtension.php
@@ -58,7 +58,7 @@ class SuluAdminExtension extends Extension implements PrependExtensionInterface
                                 'adapter' => 'cache.app',
                             ],
                             'sulu_admin.icon_cache' => [
-                                'adapter' => 'cache.app',
+                                'adapter' => 'cache.system',
                             ],
                         ],
                     ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8585 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Using the system cache.

#### Why?
We don't need to clear the icon cache every time the cache:clear command is called.