### PR TITLE
Replace all Request->get calls in csv handler with Request->query->get for Symfony 8 compatibility

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7941,25 +7941,13 @@ parameters:
 		-
 			message: '#^Binary operation "\." between ''/api/categories/'' and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 27
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
-
-		-
-			message: '#^Binary operation "\." between ''/api/categories…'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 16
+			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
 			message: '#^Binary operation "\." between mixed and ''\.'' results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
-
-		-
-			message: '#^Binary operation "\." between non\-falsy\-string and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 4
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
@@ -8091,12 +8079,6 @@ parameters:
 		-
 			message: '#^Cannot call method getId\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 63
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
-
-		-
-			message: '#^Cannot call method getKey\(\) on mixed\.$#'
-			identifier: method.nonObject
 			count: 9
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
@@ -8109,13 +8091,7 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 3
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Tests\\Functional\\Controller\\CategoryControllerTest\:\:createCategory\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
@@ -8182,18 +8158,6 @@ parameters:
 			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(mixed\)\: mixed\)\|null, Closure\(Sulu\\Bundle\\MediaBundle\\Entity\\Media\)\: int given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
-
-		-
-			message: '#^Parameter \#1 \$category of method Sulu\\Bundle\\CategoryBundle\\Tests\\Functional\\Controller\\CategoryControllerTest\:\:createCategoryMeta\(\) expects Sulu\\Bundle\\CategoryBundle\\Entity\\CategoryInterface, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
-
-		-
-			message: '#^Parameter \#1 \$category of method Sulu\\Bundle\\CategoryBundle\\Tests\\Functional\\Controller\\CategoryControllerTest\:\:createCategoryTranslation\(\) expects Sulu\\Bundle\\CategoryBundle\\Entity\\CategoryInterface, mixed given\.$#'
-			identifier: argument.type
-			count: 110
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
@@ -8266,12 +8230,6 @@ parameters:
 			message: '#^Parameter \#2 \$string2 of function strcmp expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
-
-		-
-			message: '#^Parameter \#3 \$parentCategory of method Sulu\\Bundle\\CategoryBundle\\Tests\\Functional\\Controller\\CategoryControllerTest\:\:createCategory\(\) expects Sulu\\Bundle\\CategoryBundle\\Entity\\CategoryInterface\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 40
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/CategoryControllerTest.php
 
 		-
@@ -40729,12 +40687,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
 
 		-
-			message: '#^Cannot access property \$webspaces on mixed\.$#'
-			identifier: property.nonObject
-			count: 23
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/AdminControllerTest.php
-
-		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 9
@@ -41791,87 +41743,9 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/VersionControllerTest.php
 
 		-
-			message: '#^Cannot access offset ''_embedded'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset ''allLocalizations'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset ''inputType'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset ''key'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 6
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset ''localization'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset ''name'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset ''navigations'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 9
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset ''resourceLocatorStrategy'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset ''webspaces'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset 0 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 6
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset 1 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 6
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Cannot access offset 2 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
-
-		-
-			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
-			identifier: argument.type
-			count: 5
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/WebspaceControllerTest.php
 
 		-
@@ -43999,12 +43873,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
 
 		-
-			message: '#^Cannot access offset ''_embedded'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
-
-		-
 			message: '#^Cannot access offset ''a'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
@@ -44061,7 +43929,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''pages'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 25
+			count: 21
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
 
 		-
@@ -44073,7 +43941,7 @@ parameters:
 		-
 			message: '#^Cannot access offset ''title'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 23
+			count: 19
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
 
 		-
@@ -44097,19 +43965,19 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 17
+			count: 15
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
 
 		-
 			message: '#^Cannot access offset 1 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
 
 		-
 			message: '#^Cannot access offset 2 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 2
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/NodeRepositoryTest.php
 
 		-
@@ -82507,14 +82375,8 @@ parameters:
 			path: src/Sulu/Component/Rest/ApiWrapper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Csv\\CsvHandler\:\:convertValue\(\) has parameter \$map with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/Csv/CsvHandler.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\Csv\\CsvHandler\:\:convertValue\(\) should return string but returns mixed\.$#'
-			identifier: return.type
+			message: '#^Call to function method_exists\(\) with Symfony\\Component\\HttpFoundation\\InputBag\<string\> and ''getString'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Sulu/Component/Rest/Csv/CsvHandler.php
 
@@ -82539,36 +82401,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$array of function array_keys expects array, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Rest/Csv/CsvHandler.php
-
-		-
-			message: '#^Parameter \#1 \$enclosure of method Goodby\\CSV\\Export\\Standard\\ExporterConfig\:\:setEnclosure\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Rest/Csv/CsvHandler.php
-
-		-
-			message: '#^Parameter \#1 \$escape of method Goodby\\CSV\\Export\\Standard\\ExporterConfig\:\:setEscape\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Rest/Csv/CsvHandler.php
-
-		-
-			message: '#^Parameter \#1 \$value of method Sulu\\Component\\Rest\\Csv\\CsvHandler\:\:convertValue\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Sulu/Component/Rest/Csv/CsvHandler.php
-
-		-
-			message: '#^Property Sulu\\Component\\Rest\\Csv\\CsvHandler\:\:\$delimiterMap type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/Csv/CsvHandler.php
-
-		-
-			message: '#^Property Sulu\\Component\\Rest\\Csv\\CsvHandler\:\:\$newLineMap type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Csv/CsvHandler.php
 
@@ -85107,7 +84939,7 @@ parameters:
 		-
 			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|null given\.$#'
 			identifier: argument.type
-			count: 5
+			count: 1
 			path: src/Sulu/Component/Rest/Tests/Unit/Csv/CsvHandlerTest.php
 
 		-

--- a/src/Sulu/Component/Rest/Csv/CsvHandler.php
+++ b/src/Sulu/Component/Rest/Csv/CsvHandler.php
@@ -32,7 +32,7 @@ class CsvHandler
     /**
      * Translates request value to real new-lines.
      *
-     * @var array
+     * @var array<string, string>
      */
     public static $newLineMap = [
         '\\n' => "\n",
@@ -43,7 +43,7 @@ class CsvHandler
     /**
      * Translates request value to real delimiter.
      *
-     * @var array
+     * @var array<string, string>
      */
     public static $delimiterMap = [
         '\\t' => "\t",
@@ -80,10 +80,10 @@ class CsvHandler
             $config->setColumnHeaders(\array_keys($row));
         }
 
-        $config->setDelimiter($this->convertValue($request->get('delimiter', ';'), self::$delimiterMap));
-        $config->setNewline($this->convertValue($request->get('newLine', '\\n'), self::$newLineMap));
-        $config->setEnclosure($request->get('enclosure', '"'));
-        $config->setEscape($request->get('escape', '\\'));
+        $config->setDelimiter($this->convertValue($this->getString($request, 'delimiter', ';'), self::$delimiterMap));
+        $config->setNewline($this->convertValue($this->getString($request, 'newLine', '\\n'), self::$newLineMap));
+        $config->setEnclosure($this->getString($request, 'enclosure', '"'));
+        $config->setEscape($this->getString($request, 'escape', '\\'));
 
         $response = new StreamedResponse();
         $disposition = $response->headers->makeDisposition(
@@ -100,6 +100,18 @@ class CsvHandler
         );
 
         return $response;
+    }
+
+    /**
+     * BC Layer: Symfony 5.4 doesn't have the getString function.
+     */
+    private function getString(Request $request, string $property, string $default): string
+    {
+        if (\method_exists($request->query, 'getString')) {
+            return $request->query->getString($property, $default);
+        }
+
+        return (string) $request->query->get($property, $default);
     }
 
     /**
@@ -133,11 +145,9 @@ class CsvHandler
     /**
      * Return mapped value or value itself.
      *
-     * @param string $value
-     *
-     * @return string
+     * @param array<string, string> $map
      */
-    private function convertValue($value, array $map)
+    private function convertValue(string $value, array $map): string
     {
         if (\array_key_exists($value, $map)) {
             return $map[$value];

--- a/src/Sulu/Component/Rest/Tests/Unit/Csv/CsvHandlerTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/Csv/CsvHandlerTest.php
@@ -13,36 +13,49 @@ namespace Sulu\Component\Rest\Tests\Unit\Csv;
 
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Rest\Csv\CsvHandler;
 use Sulu\Component\Rest\Csv\ObjectNotSupportedException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\ListBuilder\ListRepresentation;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class CsvHandlerTest extends TestCase
 {
     use ProphecyTrait;
 
+    private CsvHandler $handler;
+
+    /** @var ObjectProphecy<ViewHandlerInterface> */
+    private ObjectProphecy $viewHandler;
+
+    public function setUp(): void
+    {
+        $serializer = $this->prophesize(ArraySerializerInterface::class);
+        $this->handler = new CsvHandler($serializer->reveal());
+        $this->viewHandler = $this->prophesize(ViewHandlerInterface::class);
+    }
+
     public function testNonListResponse(): void
     {
         $this->expectException(ObjectNotSupportedException::class);
         $object = new \stdClass();
 
-        $viewHandler = $this->prophesize(ViewHandlerInterface::class);
         $view = new View($object);
-        $request = $this->prophesize(Request::class);
-        $serializer = $this->prophesize(ArraySerializerInterface::class);
         $format = 'csv';
+        $request = self::createRequest();
 
-        $handler = new CsvHandler($serializer->reveal());
-        $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $this->handler->createResponse($this->viewHandler->reveal(), $view, $request, $format);
     }
 
-    public function testListRepresentation(): void
+    #[DataProvider('dataListRepresentation')]
+    public function testListRepresentation(Request $request): void
     {
         $listRepresentation = $this->prophesize(ListRepresentation::class);
         $listRepresentation->getRel()->willReturn('contacts');
@@ -53,36 +66,31 @@ class CsvHandlerTest extends TestCase
             ]
         );
 
-        $viewHandler = $this->prophesize(ViewHandlerInterface::class);
         $view = new View($listRepresentation->reveal());
-        $request = $this->prophesize(Request::class);
-        $serializer = $this->prophesize(ArraySerializerInterface::class);
         $format = 'csv';
 
-        $request->get('delimiter', ';')->willReturn(';');
-        $request->get('enclosure', '"')->willReturn('"');
-        $request->get('escape', '\\')->willReturn('\\');
-        $request->get('newLine', '\\n')->willReturn('\\n');
-
-        $handler = new CsvHandler($serializer->reveal());
-
         \ob_start();
-        $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response = $this->handler->createResponse($this->viewHandler->reveal(), $view, $request, $format);
         $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals($response->headers->get('Content-Type'), 'text/csv');
-        $this->assertEquals(
-            \str_replace('"', '', $response->headers->get('Content-Disposition')),
-            'attachment; filename=contacts.csv'
-        );
-
+        $this->assertHeaders($response);
         $this->assertEquals(
             "id;fullName;birthday;enabled\n1;\"Max Mustermann\";1976-02-01T00:00:00+01:00;1\n2;\"Erika Mustermann\";1964-08-12T00:00:00+01:00;0\n",
             $content
         );
+    }
+
+    /**
+     * @return \Generator<array{Request}>
+     */
+    public static function dataListRepresentation(): \Generator
+    {
+        yield 'empty query parameters should not crash' => [new Request()];
+
+        yield 'request with query parameters' => [self::createRequest()];
     }
 
     public function testCollectionRepresentation(): void
@@ -96,32 +104,19 @@ class CsvHandlerTest extends TestCase
             ]
         );
 
-        $viewHandler = $this->prophesize(ViewHandlerInterface::class);
         $view = new View($collectionRepresentation->reveal());
-        $request = $this->prophesize(Request::class);
-        $serializer = $this->prophesize(ArraySerializerInterface::class);
         $format = 'csv';
 
-        $request->get('delimiter', ';')->willReturn(';');
-        $request->get('enclosure', '"')->willReturn('"');
-        $request->get('escape', '\\')->willReturn('\\');
-        $request->get('newLine', '\\n')->willReturn('\\n');
-
-        $handler = new CsvHandler($serializer->reveal());
+        $request = self::createRequest();
 
         \ob_start();
-        $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response = $this->handler->createResponse($this->viewHandler->reveal(), $view, $request, $format);
         $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals($response->headers->get('Content-Type'), 'text/csv');
-        $this->assertEquals(
-            \str_replace('"', '', $response->headers->get('Content-Disposition')),
-            'attachment; filename=contacts.csv'
-        );
-
+        $this->assertHeaders($response);
         $this->assertEquals(
             "id;fullName;birthday;enabled\n1;\"Max Mustermann\";1976-02-01T00:00:00+01:00;1\n2;\"Erika Mustermann\";1964-08-12T00:00:00+01:00;0\n",
             $content
@@ -139,32 +134,19 @@ class CsvHandlerTest extends TestCase
             ]
         );
 
-        $viewHandler = $this->prophesize(ViewHandlerInterface::class);
         $view = new View($listRepresentation->reveal());
-        $request = $this->prophesize(Request::class);
-        $serializer = $this->prophesize(ArraySerializerInterface::class);
         $format = 'csv';
 
-        $request->get('delimiter', ';')->willReturn(',');
-        $request->get('enclosure', '"')->willReturn('\'');
-        $request->get('escape', '\\')->willReturn('"');
-        $request->get('newLine', '\\n')->willReturn('\\r\\n');
-
-        $handler = new CsvHandler($serializer->reveal());
+        $request = self::createRequest(['delimiter' => ',', 'enclosure' => '\'', 'escape' => '!', 'newLine' => '\\r\\n']);
 
         \ob_start();
-        $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response = $this->handler->createResponse($this->viewHandler->reveal(), $view, $request, $format);
         $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals($response->headers->get('Content-Type'), 'text/csv');
-        $this->assertEquals(
-            \str_replace('"', '', $response->headers->get('Content-Disposition')),
-            'attachment; filename=contacts.csv'
-        );
-
+        $this->assertHeaders($response);
         $this->assertEquals(
             "id,fullName,birthday\r\n1,'Max Mustermann',1976-02-01T00:00:00+01:00\r\n2,'Erika Mustermann',1964-08-12T00:00:00+01:00\r\n",
             $content
@@ -182,32 +164,18 @@ class CsvHandlerTest extends TestCase
             ]
         );
 
-        $viewHandler = $this->prophesize(ViewHandlerInterface::class);
         $view = new View($listRepresentation->reveal());
-        $request = $this->prophesize(Request::class);
-        $serializer = $this->prophesize(ArraySerializerInterface::class);
         $format = 'csv';
-
-        $request->get('delimiter', ';')->willReturn(';');
-        $request->get('enclosure', '"')->willReturn('"');
-        $request->get('escape', '\\')->willReturn('\\');
-        $request->get('newLine', '\\n')->willReturn('\\n');
-
-        $handler = new CsvHandler($serializer->reveal());
+        $request = self::createRequest();
 
         \ob_start();
-        $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response = $this->handler->createResponse($this->viewHandler->reveal(), $view, $request, $format);
         $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals($response->headers->get('Content-Type'), 'text/csv');
-        $this->assertEquals(
-            \str_replace('"', '', $response->headers->get('Content-Disposition')),
-            'attachment; filename=contacts.csv'
-        );
-
+        $this->assertHeaders($response);
         $this->assertEquals(
             "id;fullName;properties\n1;\"Max Mustermann\";\"{\"\"test\"\":1}\"\n2;\"Erika Mustermann\";\"{\"\"test\"\":2}\"\n",
             $content
@@ -220,32 +188,45 @@ class CsvHandlerTest extends TestCase
         $listRepresentation->getRel()->willReturn('contacts');
         $listRepresentation->getData()->willReturn([]);
 
-        $viewHandler = $this->prophesize(ViewHandlerInterface::class);
         $view = new View($listRepresentation->reveal());
-        $request = $this->prophesize(Request::class);
-        $serializer = $this->prophesize(ArraySerializerInterface::class);
         $format = 'csv';
 
-        $request->get('delimiter', ';')->willReturn(';');
-        $request->get('enclosure', '"')->willReturn('"');
-        $request->get('escape', '\\')->willReturn('\\');
-        $request->get('newLine', '\\n')->willReturn('\\n');
-
-        $handler = new CsvHandler($serializer->reveal());
+        $request = self::createRequest();
 
         \ob_start();
-        $response = $handler->createResponse($viewHandler->reveal(), $view, $request->reveal(), $format);
+        $response = $this->handler->createResponse($this->viewHandler->reveal(), $view, $request, $format);
         $response->send();
         $content = \ob_get_contents();
         \ob_end_clean();
 
         $this->assertInstanceOf(StreamedResponse::class, $response);
-        $this->assertEquals($response->headers->get('Content-Type'), 'text/csv');
-        $this->assertEquals(
-            \str_replace('"', '', $response->headers->get('Content-Disposition')),
-            'attachment; filename=contacts.csv'
-        );
-
+        $this->assertHeaders($response);
         $this->assertEquals('', $content);
+    }
+
+    /**
+     * @param array<string, string> $config
+     */
+    private static function createRequest(array $config = []): Request
+    {
+        $request = new Request();
+        $request->query->add([
+            'delimiter' => ';',
+            'enclosure' => '"',
+            'escape' => '\\',
+            'newLine' => '\\n',
+            ...$config,
+        ]);
+
+        return $request;
+    }
+
+    private function assertHeaders(Response $response): void
+    {
+        $this->assertEquals('text/csv', $response->headers->get('Content-Type'));
+        $this->assertEquals(
+            'attachment; filename=contacts.csv',
+            \str_replace('"', '', $response->headers->get('Content-Disposition'))
+        );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | #8216 
| License | MIT
| Documentation PR | -

#### What's in this PR?
* Replacing `$request->get` with `$request->query->getString` in the CSV handler.
* Updating the `convertValue` function to have stricter types now (no BC break, cause private)
* Refactoring the tests
    * Extracting the instanciation of the CsvHandler into the setup method
    * Moving the header checks into it's own function
    * Replacing mocking the Request with an actual request.

#### Why?
It's deprecated in Symfony 8