### PR TITLE
Fix AccessControlQueryEnhancer for multiple roles

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -15,6 +15,12 @@ The type of the `apiKey` in the `se_users` table has been changed to `string`.
 ALTER TABLE se_users CHANGE apiKey apiKey VARCHAR(128) DEFAULT NULL;
 ```
 
+An index on the `idRoles` column has been added to the `se_access_controls` table to improve query performance for permission checks with multiple roles.
+
+```sql
+CREATE INDEX IDX_C526DC5238C751C4 ON se_access_controls (idRoles);
+```
+
 ## 2.6.16
 
 * Deprecated \Sulu\Bundle\MediaBundle\Controller\AbstractMediaController::getTitleFromUpload -> MediaManager::getTitleFromUpload

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -17,6 +17,8 @@ ALTER TABLE se_users CHANGE apiKey apiKey VARCHAR(128) DEFAULT NULL;
 
 An index on the `idRoles` column has been added to the `se_access_controls` table to improve query performance for permission checks with multiple roles.
 
+The access control query logic for doctrine entities with multiple roles has been fixed. Access is now granted if any assigned role grants the requested permission for an entity, instead of incorrectly denying access when another assigned role has no permission for the same entity.
+
 ```sql
 CREATE INDEX IDX_C526DC5238C751C4 ON se_access_controls (idRoles);
 ```

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -69,12 +69,11 @@ class AccessControlQueryEnhancer implements AccessControlQueryEnhancerInterface
     }
 
     /**
-     * Following function uses an own query to load the restricted (not accessible ids). This is faster as embedding the
-     * query as subquery. Also loading the "accessible" ids would be more performance intense because sulu has more
-     * "accessible" entities that not accessible. Optimized embedded queries are mostly not compatible for MySQL 5.7
-     * because of restrictions.
+     * Following function uses an EXISTS subquery to find entities where at least one of the user's roles
+     * has the required permission. This fixes the issue where users with multiple roles would lose access
+     * if any role lacked permission, instead of maintaining access if any role had permission.
      *
-     * As long as we dont have thousands of not "accessible" ids this approach should be faster.
+     * The EXISTS approach ensures correct permission logic while maintaining good performance.
      *
      * @param class-string $entityClass
      */
@@ -87,39 +86,70 @@ class AccessControlQueryEnhancer implements AccessControlQueryEnhancerInterface
         string $entityIdField = 'id',
         ?string $entityClassField = null
     ): void {
-        $subQueryBuilder = $this->entityManager->createQueryBuilder()
-            ->from($entityClass, 'entity')
-            ->select('entity.id');
+        $roleIds = $this->getUserRoleIds($user);
 
-        $accessClassCondition = 'accessControl.entityClass = :entityClass';
-        if ($entityClassField) {
-            $accessClassCondition = 'accessControl.entityClass = entity.' . $entityClassField;
-        } else {
-            $subQueryBuilder->setParameter('entityClass', $entityClass);
+        if (empty($roleIds)) {
+            $queryBuilder->andWhere('1 = 0');
+            return;
         }
 
-        $subQueryBuilder->innerJoin(
-            AccessControl::class,
-            'accessControl',
-            'WITH',
-            $accessClassCondition . ' AND ' . $this->getEntityIdCondition($entityClass, 'entity', $entityIdField)
-        );
-        $subQueryBuilder->innerJoin('accessControl.role', 'role');
-        $subQueryBuilder->andWhere(
-            'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        );
+        $existsSubQuery = $this->entityManager->createQueryBuilder()
+            ->select('1')
+            ->from(AccessControl::class, 'acl')
+            ->innerJoin('acl.role', 'role')
+            ->where('role.id IN (:roleIds)')
+            ->andWhere('BIT_AND(acl.permissions, :permission) = :permission')
+            ->andWhere('acl.permissions IS NOT NULL');
 
-        $subQueryBuilder->andWhere('role.id IN(:roleIds)');
+        if ($entityClassField) {
+            $existsSubQuery->andWhere('acl.entityClass = ' . $entityAlias . '.' . $entityClassField);
+        } else {
+            $existsSubQuery->andWhere('acl.entityClass = :entityClass');
+        }
 
-        $subQueryBuilder->setParameter('roleIds', $this->getUserRoleIds($user));
-        $subQueryBuilder->setParameter('permission', $permission);
+        $entityIdCondition = $this->getEntityIdCondition($entityClass, $entityAlias, $entityIdField);
+        $existsSubQuery->andWhere($entityIdCondition);
 
-        $result = $subQueryBuilder->getQuery()->getScalarResult();
-        $ids = \array_column($result, 'id');
+        // Create a subquery to check if ANY AccessControl records exist for this entity
+        // This allows unrestricted entities (without any permission records) to be visible
+        $noRestrictionsSubQuery = $this->entityManager->createQueryBuilder()
+            ->select('1')
+            ->from(AccessControl::class, 'acl_check')
+            ->where($this->getEntityIdConditionWithAlias($entityClass, $entityAlias, $entityIdField, 'acl_check'));
 
-        if (\count($ids) > 0) {
-            $queryBuilder->andWhere(\sprintf('(%s.id NOT IN (:accessControlIds) OR %s.id IS NULL)', $entityAlias, $entityAlias));
-            $queryBuilder->setParameter('accessControlIds', $ids);
+        if ($entityClassField) {
+            $noRestrictionsSubQuery->andWhere('acl_check.entityClass = ' . $entityAlias . '.' . $entityClassField);
+        } else {
+            $noRestrictionsSubQuery->andWhere('acl_check.entityClass = :entityClass');
+        }
+
+        // Set parameters before adding WHERE clause
+        $queryBuilder->setParameter('roleIds', $roleIds);
+        $queryBuilder->setParameter('permission', $permission);
+
+        if (!$entityClassField) {
+            $queryBuilder->setParameter('entityClass', $entityClass);
+        }
+
+        // Show entities if:
+        // 1. No AccessControl records exist (unrestricted), OR
+        // 2. Dynamic entity class field is NULL (no permission check needed), OR
+        // 3. User has permission via at least one of their roles
+        if ($entityClassField) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->orX(
+                    $entityAlias . '.' . $entityClassField . ' IS NULL',
+                    $queryBuilder->expr()->not($queryBuilder->expr()->exists($noRestrictionsSubQuery->getDQL())),
+                    $queryBuilder->expr()->exists($existsSubQuery->getDQL())
+                )
+            );
+        } else {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->orX(
+                    $queryBuilder->expr()->not($queryBuilder->expr()->exists($noRestrictionsSubQuery->getDQL())),
+                    $queryBuilder->expr()->exists($existsSubQuery->getDQL())
+                )
+            );
         }
     }
 
@@ -128,11 +158,19 @@ class AccessControlQueryEnhancer implements AccessControlQueryEnhancerInterface
      */
     private function getEntityIdCondition(string $entityClass, string $entityAlias, string $entityIdField = 'id'): string
     {
-        $entityIdCondition = 'accessControl.entityId = ' . $entityAlias . '.' . $entityIdField;
+        return $this->getEntityIdConditionWithAlias($entityClass, $entityAlias, $entityIdField, 'acl');
+    }
+
+    /**
+     * @param class-string $entityClass
+     */
+    private function getEntityIdConditionWithAlias(string $entityClass, string $entityAlias, string $entityIdField, string $aclAlias): string
+    {
+        $entityIdCondition = $aclAlias . '.entityId = ' . $entityAlias . '.' . $entityIdField;
         try {
             $metadata = $this->entityManager->getClassMetadata($entityClass);
             if ('integer' === $metadata->getTypeOfField($entityIdField)) {
-                $entityIdCondition = 'accessControl.entityIdInteger = ' . $entityAlias . '.' . $entityIdField;
+                $entityIdCondition = $aclAlias . '.entityIdInteger = ' . $entityAlias . '.' . $entityIdField;
             }
         } catch (MappingException $e) {
             $metadata = null;

--- a/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
+++ b/src/Sulu/Bundle/SecurityBundle/AccessControl/AccessControlQueryEnhancer.php
@@ -87,19 +87,21 @@ class AccessControlQueryEnhancer implements AccessControlQueryEnhancerInterface
         ?string $entityClassField = null
     ): void {
         $roleIds = $this->getUserRoleIds($user);
+        $system = $this->systemStore->getSystem();
 
-        if (empty($roleIds)) {
-            $queryBuilder->andWhere('1 = 0');
-            return;
+        $existsSubQuery = $this->entityManager->createQueryBuilder();
+        $existsSubQuery->select('1');
+        $existsSubQuery->from(AccessControl::class, 'acl');
+        $existsSubQuery->innerJoin('acl.role', 'role');
+
+        $existsSubQuery->andWhere('acl.permissions IS NOT NULL');
+
+        if ([] !== $roleIds) {
+            $existsSubQuery->andWhere('role.id IN (:roleIds)');
+            $existsSubQuery->andWhere('BIT_AND(acl.permissions, :permission) = :permission');
+        } else {
+            $existsSubQuery->andWhere('1 = 0');
         }
-
-        $existsSubQuery = $this->entityManager->createQueryBuilder()
-            ->select('1')
-            ->from(AccessControl::class, 'acl')
-            ->innerJoin('acl.role', 'role')
-            ->where('role.id IN (:roleIds)')
-            ->andWhere('BIT_AND(acl.permissions, :permission) = :permission')
-            ->andWhere('acl.permissions IS NOT NULL');
 
         if ($entityClassField) {
             $existsSubQuery->andWhere('acl.entityClass = ' . $entityAlias . '.' . $entityClassField);
@@ -112,10 +114,14 @@ class AccessControlQueryEnhancer implements AccessControlQueryEnhancerInterface
 
         // Create a subquery to check if ANY AccessControl records exist for this entity
         // This allows unrestricted entities (without any permission records) to be visible
-        $noRestrictionsSubQuery = $this->entityManager->createQueryBuilder()
-            ->select('1')
-            ->from(AccessControl::class, 'acl_check')
-            ->where($this->getEntityIdConditionWithAlias($entityClass, $entityAlias, $entityIdField, 'acl_check'));
+        $noRestrictionsSubQuery = $this->entityManager->createQueryBuilder();
+        $noRestrictionsSubQuery->select('1');
+        $noRestrictionsSubQuery->from(AccessControl::class, 'acl_check');
+        $noRestrictionsSubQuery->innerJoin('acl_check.role', 'role_check');
+
+        $noRestrictionsSubQuery->where(
+            $this->getEntityIdConditionWithAlias($entityClass, $entityAlias, $entityIdField, 'acl_check')
+        );
 
         if ($entityClassField) {
             $noRestrictionsSubQuery->andWhere('acl_check.entityClass = ' . $entityAlias . '.' . $entityClassField);
@@ -123,9 +129,15 @@ class AccessControlQueryEnhancer implements AccessControlQueryEnhancerInterface
             $noRestrictionsSubQuery->andWhere('acl_check.entityClass = :entityClass');
         }
 
-        // Set parameters before adding WHERE clause
-        $queryBuilder->setParameter('roleIds', $roleIds);
-        $queryBuilder->setParameter('permission', $permission);
+        if (null !== $system) {
+            $noRestrictionsSubQuery->andWhere('role_check.system = :system');
+            $queryBuilder->setParameter('system', $system);
+        }
+
+        if ([] !== $roleIds) {
+            $queryBuilder->setParameter('roleIds', $roleIds);
+            $queryBuilder->setParameter('permission', $permission);
+        }
 
         if (!$entityClassField) {
             $queryBuilder->setParameter('entityClass', $entityClass);

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/AccessControl.orm.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/doctrine/AccessControl.orm.xml
@@ -7,6 +7,7 @@
             <index columns="entityId"/>
             <index columns="entityClass"/>
             <index columns="entityIdInteger"/>
+            <index columns="idRoles"/>
         </indexes>
 
         <id name="id" type="integer" column="id">

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\Rest\Tests\Unit\ListBuilder\Doctrine;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
@@ -1527,72 +1528,114 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->setPermissionCheck($user->reveal(), PermissionTypes::VIEW);
 
         $accessQueryBuilder = $this->prophesize(QueryBuilder::class);
+        $noRestrictionsQueryBuilder = $this->prophesize(QueryBuilder::class);
+        $expr = $this->prophesize(Expr::class);
+
         $this->entityManager->createQueryBuilder()->willReturn(
             $this->queryBuilder->reveal(),
             $accessQueryBuilder->reveal(),
+            $noRestrictionsQueryBuilder->reveal(),
             $this->queryBuilder->reveal()
         );
 
-        $accessQueryBuilder->from(self::$entityName, 'entity')
+        // New EXISTS-based query structure
+        $accessQueryBuilder->select('1')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
 
-        $accessQueryBuilder->select('entity.id')
+        $accessQueryBuilder->from(AccessControl::class, 'acl')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('entityClass', self::$entityName)
+        $accessQueryBuilder->innerJoin('acl.role', 'role')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin(
-            AccessControl::class,
-            'accessControl',
-            'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
-        )
+        $accessQueryBuilder->where('role.id IN (:roleIds)')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin('accessControl.role', 'role')
+        $accessQueryBuilder->andWhere('BIT_AND(acl.permissions, :permission) = :permission')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere(
-            'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        )
+        $accessQueryBuilder->andWhere('acl.permissions IS NOT NULL')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')
+        $accessQueryBuilder->andWhere('acl.entityClass = :entityClass')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('roleIds', [1])
+        $accessQueryBuilder->andWhere('acl.entityId = ' . self::$entityNameAlias . '.id')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
-        $accessQueryBuilder->setParameter('permission', 64)
-            ->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(AbstractQuery::class);
-        $accessQueryBuilder->getQuery()
-            ->willReturn($accessQueryBuilder->reveal())
-            ->willReturn($accessQuery->reveal());
-        $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
+        $accessQueryBuilder->getDQL()
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->shouldBeCalled();
+
+        // Mock for NOT EXISTS subquery (checking if any AccessControl records exist)
+        $noRestrictionsQueryBuilder->select('1')
+            ->shouldBeCalled()
+            ->willReturn($noRestrictionsQueryBuilder->reveal());
+
+        $noRestrictionsQueryBuilder->from(AccessControl::class, 'acl_check')
+            ->shouldBeCalled()
+            ->willReturn($noRestrictionsQueryBuilder->reveal());
+
+        $noRestrictionsQueryBuilder->where('acl_check.entityId = ' . self::$entityNameAlias . '.id')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->andWhere('acl_check.entityClass = :entityClass')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->getDQL()
+            ->willReturn('SELECT 1 FROM AccessControl acl_check ...')
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('roleIds', [1])
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('permission', 64)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('entityClass', self::$entityName)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->expr()
+            ->willReturn($expr->reveal())
+            ->shouldBeCalled();
+
+        $expr->exists('SELECT 1 FROM AccessControl acl_check ...')
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
+            ->shouldBeCalled();
+
+        $expr->not('EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
+            ->willReturn('NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
+            ->shouldBeCalled();
+
+        $expr->exists('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->shouldBeCalled();
+
+        $expr->orX('NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...)', 'EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->willReturn('(NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...) OR EXISTS (SELECT 1 FROM AccessControl acl ...))')
+            ->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...) OR EXISTS (SELECT 1 FROM AccessControl acl ...))')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
-
-        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds) OR Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')
-            ->willReturn($this->queryBuilder->reveal())
-            ->shouldBeCalled();
-
-        $this->queryBuilder->setParameter('accessControlIds', [42])
-            ->willReturn($this->queryBuilder->reveal())
-            ->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1608,9 +1651,13 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->setPermissionCheck($user->reveal(), PermissionTypes::VIEW);
 
         $accessQueryBuilder = $this->prophesize(QueryBuilder::class);
+        $noRestrictionsQueryBuilder = $this->prophesize(QueryBuilder::class);
+        $expr = $this->prophesize(Expr::class);
+
         $this->entityManager->createQueryBuilder()->willReturn(
             $this->queryBuilder->reveal(),
             $accessQueryBuilder->reveal(),
+            $noRestrictionsQueryBuilder->reveal(),
             $this->queryBuilder->reveal()
         );
 
@@ -1618,67 +1665,106 @@ class DoctrineListBuilderTest extends TestCase
             ->willReturn('integer')
             ->shouldBeCalled();
 
-        $accessQueryBuilder->from(self::$entityName, 'entity')
+        // New EXISTS-based query structure
+        $accessQueryBuilder->select('1')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
 
-        $accessQueryBuilder->select('entity.id')
+        $accessQueryBuilder->from(AccessControl::class, 'acl')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('entityClass', self::$entityName)
+        $accessQueryBuilder->innerJoin('acl.role', 'role')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin(
-            AccessControl::class,
-            'accessControl',
-            'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityIdInteger = entity.id'
-        )
+        $accessQueryBuilder->where('role.id IN (:roleIds)')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin('accessControl.role', 'role')
+        $accessQueryBuilder->andWhere('BIT_AND(acl.permissions, :permission) = :permission')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere(
-            'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        )
+        $accessQueryBuilder->andWhere('acl.permissions IS NOT NULL')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')
+        $accessQueryBuilder->andWhere('acl.entityClass = :entityClass')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('roleIds', [1])
-            ->willReturn($accessQueryBuilder->reveal())
-            ->shouldBeCalled();
-        $accessQueryBuilder->setParameter('permission', 64)
+        // For integer ID, use entityIdInteger
+        $accessQueryBuilder->andWhere('acl.entityIdInteger = ' . self::$entityNameAlias . '.id')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(AbstractQuery::class);
-        $accessQueryBuilder->getQuery()
-            ->willReturn($accessQueryBuilder->reveal())
-            ->willReturn($accessQuery->reveal());
-        $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
+        $accessQueryBuilder->getDQL()
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->shouldBeCalled();
+
+        // Mock for NOT EXISTS subquery (checking if any AccessControl records exist)
+        $noRestrictionsQueryBuilder->select('1')
+            ->shouldBeCalled()
+            ->willReturn($noRestrictionsQueryBuilder->reveal());
+
+        $noRestrictionsQueryBuilder->from(AccessControl::class, 'acl_check')
+            ->shouldBeCalled()
+            ->willReturn($noRestrictionsQueryBuilder->reveal());
+
+        // For integer ID, use entityIdInteger in noRestrictionsQueryBuilder too
+        $noRestrictionsQueryBuilder->where('acl_check.entityIdInteger = ' . self::$entityNameAlias . '.id')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->andWhere('acl_check.entityClass = :entityClass')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->getDQL()
+            ->willReturn('SELECT 1 FROM AccessControl acl_check ...')
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('roleIds', [1])
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('permission', 64)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('entityClass', self::$entityName)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->expr()
+            ->willReturn($expr->reveal())
+            ->shouldBeCalled();
+
+        $expr->exists('SELECT 1 FROM AccessControl acl_check ...')
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
+            ->shouldBeCalled();
+
+        $expr->not('EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
+            ->willReturn('NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
+            ->shouldBeCalled();
+
+        $expr->exists('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->shouldBeCalled();
+
+        $expr->orX('NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...)', 'EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->willReturn('(NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...) OR EXISTS (SELECT 1 FROM AccessControl acl ...))')
+            ->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...) OR EXISTS (SELECT 1 FROM AccessControl acl ...))')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
-
-        $this->queryBuilder->andWhere('(Sulu_Bundle_CoreBundle_Entity_Example.id NOT IN (:accessControlIds) OR Sulu_Bundle_CoreBundle_Entity_Example.id IS NULL)')
-            ->willReturn($this->queryBuilder->reveal())
-            ->shouldBeCalled();
-
-        $this->queryBuilder->setParameter('accessControlIds', [42])
-            ->willReturn($this->queryBuilder->reveal())
-            ->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1694,72 +1780,114 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->setPermissionCheck($user->reveal(), PermissionTypes::VIEW, \stdClass::class);
 
         $accessQueryBuilder = $this->prophesize(QueryBuilder::class);
+        $noRestrictionsQueryBuilder = $this->prophesize(QueryBuilder::class);
+        $expr = $this->prophesize(Expr::class);
+
         $this->entityManager->createQueryBuilder()->willReturn(
             $this->queryBuilder->reveal(),
             $accessQueryBuilder->reveal(),
+            $noRestrictionsQueryBuilder->reveal(),
             $this->queryBuilder->reveal()
         );
 
-        $accessQueryBuilder->from(\stdClass::class, 'entity')
+        $accessQueryBuilder->select('1')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
 
-        $accessQueryBuilder->select('entity.id')
+        $accessQueryBuilder->from(AccessControl::class, 'acl')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')
+
+        $accessQueryBuilder->innerJoin('acl.role', 'role')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->where('role.id IN (:roleIds)')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->andWhere('BIT_AND(acl.permissions, :permission) = :permission')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->andWhere('acl.permissions IS NOT NULL')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->andWhere('acl.entityClass = :entityClass')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->andWhere('acl.entityId = stdClass.id')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->getDQL()
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->shouldBeCalled();
+
+        // Mock for NOT EXISTS subquery (checking if any AccessControl records exist)
+        $noRestrictionsQueryBuilder->select('1')
+            ->shouldBeCalled()
+            ->willReturn($noRestrictionsQueryBuilder->reveal());
+
+        $noRestrictionsQueryBuilder->from(AccessControl::class, 'acl_check')
+            ->shouldBeCalled()
+            ->willReturn($noRestrictionsQueryBuilder->reveal());
+
+        // For stdClass tests, use 'stdClass' as the entity alias
+        $noRestrictionsQueryBuilder->where('acl_check.entityId = stdClass.id')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->andWhere('acl_check.entityClass = :entityClass')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->getDQL()
+            ->willReturn('SELECT 1 FROM AccessControl acl_check ...')
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('roleIds', [1])
             ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('entityClass', \stdClass::class)
+        $this->queryBuilder->setParameter('permission', 64)
             ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin(
-            AccessControl::class,
-            'accessControl',
-            'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
-        )
-            ->willReturn($accessQueryBuilder->reveal())
+        $this->queryBuilder->setParameter('entityClass', \stdClass::class)
+            ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin('accessControl.role', 'role')
-            ->willReturn($accessQueryBuilder->reveal())
+        $this->queryBuilder->expr()
+            ->willReturn($expr->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere(
-            'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        )
-            ->willReturn($accessQueryBuilder->reveal())
+        $expr->exists('SELECT 1 FROM AccessControl acl_check ...')
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
             ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')
-            ->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
-
-        $accessQueryBuilder->setParameter('roleIds', [1])
-            ->willReturn($accessQueryBuilder->reveal())
-            ->shouldBeCalled();
-        $accessQueryBuilder->setParameter('permission', 64)
-            ->willReturn($accessQueryBuilder->reveal())
+        $expr->not('EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
+            ->willReturn('NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
             ->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(AbstractQuery::class);
-        $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
-        $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
+        $expr->exists('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->shouldBeCalled();
+
+        $expr->orX('NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...)', 'EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->willReturn('(NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...) OR EXISTS (SELECT 1 FROM AccessControl acl ...))')
+            ->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...) OR EXISTS (SELECT 1 FROM AccessControl acl ...))')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
-
-        $this->queryBuilder->andWhere('(stdClass.id NOT IN (:accessControlIds) OR stdClass.id IS NULL)')
-            ->willReturn($this->queryBuilder->reveal())
-            ->shouldBeCalled();
-
-        $this->queryBuilder->setParameter('accessControlIds', [42])
-            ->willReturn($this->queryBuilder->reveal())
-            ->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1787,65 +1915,114 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->addPermissionCheckField($permissionCheckField->reveal());
 
         $accessQueryBuilder = $this->prophesize(QueryBuilder::class);
+        $noRestrictionsQueryBuilder = $this->prophesize(QueryBuilder::class);
+        $expr = $this->prophesize(Expr::class);
+
         $this->entityManager->createQueryBuilder()->willReturn(
             $this->queryBuilder->reveal(),
             $accessQueryBuilder->reveal(),
+            $noRestrictionsQueryBuilder->reveal(),
             $this->queryBuilder->reveal()
         );
 
-        $accessQueryBuilder->from(\stdClass::class, 'entity')
+        $accessQueryBuilder->select('1')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
 
-        $accessQueryBuilder->select('entity.id')
+        $accessQueryBuilder->from(AccessControl::class, 'acl')
             ->shouldBeCalled()
             ->willReturn($accessQueryBuilder->reveal());
-        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')
+
+        $accessQueryBuilder->innerJoin('acl.role', 'role')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->where('role.id IN (:roleIds)')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->andWhere('BIT_AND(acl.permissions, :permission) = :permission')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->andWhere('acl.permissions IS NOT NULL')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->andWhere('acl.entityClass = :entityClass')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->andWhere('acl.entityId = stdClass.id')
+            ->willReturn($accessQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $accessQueryBuilder->getDQL()
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->shouldBeCalled();
+
+        // Mock for NOT EXISTS subquery (checking if any AccessControl records exist)
+        $noRestrictionsQueryBuilder->select('1')
+            ->shouldBeCalled()
+            ->willReturn($noRestrictionsQueryBuilder->reveal());
+
+        $noRestrictionsQueryBuilder->from(AccessControl::class, 'acl_check')
+            ->shouldBeCalled()
+            ->willReturn($noRestrictionsQueryBuilder->reveal());
+
+        // For stdClass tests, use 'stdClass' as the entity alias
+        $noRestrictionsQueryBuilder->where('acl_check.entityId = stdClass.id')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->andWhere('acl_check.entityClass = :entityClass')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->getDQL()
+            ->willReturn('SELECT 1 FROM AccessControl acl_check ...')
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('roleIds', [1])
             ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('entityClass', \stdClass::class)
-            ->willReturn($accessQueryBuilder->reveal())
+        $this->queryBuilder->setParameter('permission', 64)
+            ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin(
-            AccessControl::class,
-            'accessControl',
-            'WITH',
-            'accessControl.entityClass = :entityClass AND accessControl.entityId = entity.id'
-        )
-            ->willReturn($accessQueryBuilder->reveal())
+        $this->queryBuilder->setParameter('entityClass', \stdClass::class)
+            ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->innerJoin('accessControl.role', 'role')
-            ->willReturn($accessQueryBuilder->reveal())
+        $this->queryBuilder->expr()
+            ->willReturn($expr->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere(
-            'BIT_AND(accessControl.permissions, :permission) <> :permission AND accessControl.permissions IS NOT NULL'
-        )
-            ->willReturn($accessQueryBuilder->reveal())
+        $expr->exists('SELECT 1 FROM AccessControl acl_check ...')
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
             ->shouldBeCalled();
 
-        $accessQueryBuilder->andWhere('role.id IN(:roleIds)')
-            ->willReturn($accessQueryBuilder->reveal())
+        $expr->not('EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
+            ->willReturn('NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...)')
             ->shouldBeCalled();
 
-        $accessQueryBuilder->setParameter('roleIds', [1])->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
-        $accessQueryBuilder->setParameter('permission', 64)->willReturn($accessQueryBuilder->reveal())->shouldBeCalled();
+        $expr->exists('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->willReturn('EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->shouldBeCalled();
 
-        $accessQuery = $this->prophesize(AbstractQuery::class);
-        $accessQueryBuilder->getQuery()->willReturn($accessQuery->reveal());
-        $accessQuery->getScalarResult()->willReturn([['id' => 42]]);
+        $expr->orX('NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...)', 'EXISTS (SELECT 1 FROM AccessControl acl ...)')
+            ->willReturn('(NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...) OR EXISTS (SELECT 1 FROM AccessControl acl ...))')
+            ->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(NOT EXISTS (SELECT 1 FROM AccessControl acl_check ...) OR EXISTS (SELECT 1 FROM AccessControl acl ...))')
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
 
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
-
-        $this->queryBuilder->andWhere('(stdClass.id NOT IN (:accessControlIds) OR stdClass.id IS NULL)')
-            ->willReturn($this->queryBuilder->reveal())
-            ->shouldBeCalled();
 
         $this->queryBuilder->leftJoin(
             'stdClass.myTest',
@@ -1853,10 +2030,6 @@ class DoctrineListBuilderTest extends TestCase
             'ON',
             'stdClass.id = MyTest.id'
         )
-            ->willReturn($this->queryBuilder->reveal())
-            ->shouldBeCalled();
-
-        $this->queryBuilder->setParameter('accessControlIds', [42])
             ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1551,7 +1551,7 @@ class DoctrineListBuilderTest extends TestCase
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->where('role.id IN (:roleIds)')
+        $accessQueryBuilder->andWhere('role.id IN (:roleIds)')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1584,11 +1584,19 @@ class DoctrineListBuilderTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($noRestrictionsQueryBuilder->reveal());
 
+        $noRestrictionsQueryBuilder->innerJoin('acl_check.role', 'role_check')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
         $noRestrictionsQueryBuilder->where('acl_check.entityId = ' . self::$entityNameAlias . '.id')
             ->willReturn($noRestrictionsQueryBuilder->reveal())
             ->shouldBeCalled();
 
         $noRestrictionsQueryBuilder->andWhere('acl_check.entityClass = :entityClass')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->andWhere('role_check.system = :system')
             ->willReturn($noRestrictionsQueryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1605,6 +1613,10 @@ class DoctrineListBuilderTest extends TestCase
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('entityClass', self::$entityName)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('system', 'Sulu')
             ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1678,7 +1690,7 @@ class DoctrineListBuilderTest extends TestCase
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->where('role.id IN (:roleIds)')
+        $accessQueryBuilder->andWhere('role.id IN (:roleIds)')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1712,12 +1724,20 @@ class DoctrineListBuilderTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($noRestrictionsQueryBuilder->reveal());
 
+        $noRestrictionsQueryBuilder->innerJoin('acl_check.role', 'role_check')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
         // For integer ID, use entityIdInteger in noRestrictionsQueryBuilder too
         $noRestrictionsQueryBuilder->where('acl_check.entityIdInteger = ' . self::$entityNameAlias . '.id')
             ->willReturn($noRestrictionsQueryBuilder->reveal())
             ->shouldBeCalled();
 
         $noRestrictionsQueryBuilder->andWhere('acl_check.entityClass = :entityClass')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->andWhere('role_check.system = :system')
             ->willReturn($noRestrictionsQueryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1734,6 +1754,10 @@ class DoctrineListBuilderTest extends TestCase
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('entityClass', self::$entityName)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('system', 'Sulu')
             ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1802,7 +1826,7 @@ class DoctrineListBuilderTest extends TestCase
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->where('role.id IN (:roleIds)')
+        $accessQueryBuilder->andWhere('role.id IN (:roleIds)')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1835,12 +1859,20 @@ class DoctrineListBuilderTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($noRestrictionsQueryBuilder->reveal());
 
+        $noRestrictionsQueryBuilder->innerJoin('acl_check.role', 'role_check')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
         // For stdClass tests, use 'stdClass' as the entity alias
         $noRestrictionsQueryBuilder->where('acl_check.entityId = stdClass.id')
             ->willReturn($noRestrictionsQueryBuilder->reveal())
             ->shouldBeCalled();
 
         $noRestrictionsQueryBuilder->andWhere('acl_check.entityClass = :entityClass')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->andWhere('role_check.system = :system')
             ->willReturn($noRestrictionsQueryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1857,6 +1889,10 @@ class DoctrineListBuilderTest extends TestCase
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('entityClass', \stdClass::class)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('system', 'Sulu')
             ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1937,7 +1973,7 @@ class DoctrineListBuilderTest extends TestCase
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
-        $accessQueryBuilder->where('role.id IN (:roleIds)')
+        $accessQueryBuilder->andWhere('role.id IN (:roleIds)')
             ->willReturn($accessQueryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1970,12 +2006,20 @@ class DoctrineListBuilderTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($noRestrictionsQueryBuilder->reveal());
 
+        $noRestrictionsQueryBuilder->innerJoin('acl_check.role', 'role_check')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
         // For stdClass tests, use 'stdClass' as the entity alias
         $noRestrictionsQueryBuilder->where('acl_check.entityId = stdClass.id')
             ->willReturn($noRestrictionsQueryBuilder->reveal())
             ->shouldBeCalled();
 
         $noRestrictionsQueryBuilder->andWhere('acl_check.entityClass = :entityClass')
+            ->willReturn($noRestrictionsQueryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $noRestrictionsQueryBuilder->andWhere('role_check.system = :system')
             ->willReturn($noRestrictionsQueryBuilder->reveal())
             ->shouldBeCalled();
 
@@ -1992,6 +2036,10 @@ class DoctrineListBuilderTest extends TestCase
             ->shouldBeCalled();
 
         $this->queryBuilder->setParameter('entityClass', \stdClass::class)
+            ->willReturn($this->queryBuilder->reveal())
+            ->shouldBeCalled();
+
+        $this->queryBuilder->setParameter('system', 'Sulu')
             ->willReturn($this->queryBuilder->reveal())
             ->shouldBeCalled();
 

--- a/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
+++ b/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
@@ -1,0 +1,335 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Tests\Functional\AccessControl;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\MediaBundle\Entity\Collection;
+use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
+use Sulu\Bundle\MediaBundle\Entity\CollectionType;
+use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
+use Sulu\Bundle\SecurityBundle\Entity\Permission;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRole;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+/**
+ * Functional test for AccessControlQueryEnhancer using profiler datacollector to verify actual SQL.
+ *
+ * This test validates that users with multiple roles can access entities when ANY role grants permission (OR logic).
+ */
+class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient();
+        $this->entityManager = $this->getEntityManager();
+        $this->purgeDatabase();
+    }
+
+    /**
+     * Test that a user with multiple roles can access a collection when ANY role grants permission.
+     *
+     * Scenario:
+     * - Create Collection A with AccessControl restricting to Admin role (VIEW permission)
+     * - Create user with both Admin role (has VIEW) and User role (no permission)
+     * - Expected: User can access Collection A because Admin role grants permission (OR logic)
+     * - Verify actual SQL uses EXISTS clause with role.id IN (:roleIds) condition
+     */
+    public function testUserWithMultipleRolesCanAccessWhenAnyRoleGrantsPermission(): void
+    {
+        // Create roles
+        $adminRole = $this->createRole('Admin');
+        $userRole = $this->createRole('User');
+
+        // Create collection type
+        $collectionType = new CollectionType();
+        $collectionType->setName('collection');
+        $collectionType->setKey('collection');
+        $this->entityManager->persist($collectionType);
+        $this->entityManager->flush();
+
+        // Create restricted collection
+        $collection = new Collection();
+        $collection->setType($collectionType);
+
+        $collectionMeta = new CollectionMeta();
+        $collectionMeta->setTitle('Test Collection');
+        $collectionMeta->setLocale('en');
+        $collectionMeta->setCollection($collection);
+        $collection->addMeta($collectionMeta);
+
+        $this->entityManager->persist($collection);
+        $this->entityManager->flush();
+
+        // Set permissions: Admin role has VIEW, User role has no permissions
+        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
+        \assert($accessControlManager instanceof AccessControlManagerInterface);
+        $accessControlManager->setPermissions(
+            Collection::class,
+            (string) $collection->getId(),
+            [
+                $adminRole->getId() => ['view' => true, 'edit' => false, 'delete' => false],
+                $userRole->getId() => ['view' => false, 'edit' => false, 'delete' => false],
+            ]
+        );
+
+        // Create user with both roles
+        $user = $this->createUser('testuser', [$adminRole, $userRole]);
+
+        // Enable profiler
+        $this->client->enableProfiler();
+
+        // Login as the test user
+        $this->client->loginUser($user);
+
+        // Request collections list
+        $this->client->request('GET', '/admin/api/collections?locale=en');
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $data = \json_decode($response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('_embedded', $data);
+
+        // Verify collection is accessible
+        $collections = $data['_embedded']['collections'];
+        $collectionIds = \array_column($collections, 'id');
+        $this->assertContains($collection->getId(), $collectionIds, 'User should be able to access collection through Admin role');
+
+        // Verify SQL uses EXISTS with role.id IN condition
+        /** @var Profile $profile */
+        $profile = $this->client->getProfile();
+        $this->assertNotNull($profile, 'Profiler should be enabled');
+
+        $queries = $profile->getCollector('db')->getQueries();
+        $this->assertNotEmpty($queries, 'Database queries should be logged');
+
+        // Find query that checks AccessControl
+        $accessControlQuery = null;
+        foreach ($queries['default'] as $query) {
+            if (\str_contains($query['sql'], 'se_access_controls') && \str_contains($query['sql'], 'EXISTS')) {
+                $accessControlQuery = $query['sql'];
+                break;
+            }
+        }
+
+        $this->assertNotNull($accessControlQuery, 'Query should contain AccessControl check with EXISTS');
+
+        // Verify EXISTS subquery structure
+        $this->assertStringContainsString('EXISTS', $accessControlQuery, 'Should use EXISTS clause');
+        $this->assertStringContainsString('se_access_controls', $accessControlQuery, 'Should query AccessControl table');
+        $this->assertStringContainsString('INNER JOIN', $accessControlQuery, 'Should join with roles table');
+        $this->assertStringContainsString('IN (?)', $accessControlQuery, 'Should check role IDs with IN clause');
+        $this->assertStringContainsString('BIT_AND', $accessControlQuery, 'Should use BIT_AND for permission check');
+
+        // Verify the query parameters contain both role IDs
+        $this->assertNotEmpty($query['params'] ?? [], 'Query should have parameters');
+        $roleIdsParam = null;
+        foreach ($query['params'] ?? [] as $param) {
+            if (\is_array($param) && \in_array($adminRole->getId(), $param, true)) {
+                $roleIdsParam = $param;
+                break;
+            }
+        }
+        $this->assertNotNull($roleIdsParam, 'Query parameters should contain role IDs');
+        $this->assertContains($adminRole->getId(), $roleIdsParam, 'Should include Admin role ID');
+        $this->assertContains($userRole->getId(), $roleIdsParam, 'Should include User role ID');
+    }
+
+    /**
+     * Test that a user with multiple roles CANNOT access when NO role grants permission.
+     *
+     * Scenario:
+     * - Create Collection B with AccessControl restricting to SuperAdmin role (VIEW permission)
+     * - Create user with Admin and User roles (neither has permission)
+     * - Expected: User CANNOT access Collection B (OR logic: no role grants access)
+     */
+    public function testUserWithMultipleRolesCannotAccessWhenNoRoleGrantsPermission(): void
+    {
+        // Create roles
+        $adminRole = $this->createRole('Admin');
+        $userRole = $this->createRole('User');
+        $superAdminRole = $this->createRole('SuperAdmin');
+
+        // Create collection type
+        $collectionType = new CollectionType();
+        $collectionType->setName('collection');
+        $collectionType->setKey('collection');
+        $this->entityManager->persist($collectionType);
+        $this->entityManager->flush();
+
+        // Create restricted collection
+        $collection = new Collection();
+        $collection->setType($collectionType);
+
+        $collectionMeta = new CollectionMeta();
+        $collectionMeta->setTitle('Super Admin Only Collection');
+        $collectionMeta->setLocale('en');
+        $collectionMeta->setCollection($collection);
+        $collection->addMeta($collectionMeta);
+
+        $this->entityManager->persist($collection);
+        $this->entityManager->flush();
+
+        // Set permissions: Only SuperAdmin role has VIEW
+        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
+        \assert($accessControlManager instanceof AccessControlManagerInterface);
+        $accessControlManager->setPermissions(
+            Collection::class,
+            (string) $collection->getId(),
+            [
+                $superAdminRole->getId() => ['view' => true, 'edit' => true, 'delete' => true],
+                $adminRole->getId() => ['view' => false, 'edit' => false, 'delete' => false],
+                $userRole->getId() => ['view' => false, 'edit' => false, 'delete' => false],
+            ]
+        );
+
+        // Create user with Admin and User roles (not SuperAdmin)
+        $user = $this->createUser('testuser', [$adminRole, $userRole]);
+
+        // Login as the test user
+        $this->client->loginUser($user);
+
+        // Request collections list
+        $this->client->request('GET', '/admin/api/collections?locale=en');
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $data = \json_decode($response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('_embedded', $data);
+
+        // Verify collection is NOT accessible
+        $collections = $data['_embedded']['collections'];
+        $collectionIds = \array_column($collections, 'id');
+        $this->assertNotContains(
+            $collection->getId(),
+            $collectionIds,
+            'User should NOT be able to access collection as no role grants permission'
+        );
+    }
+
+    /**
+     * Test SQL generation for single role scenario to ensure backwards compatibility.
+     */
+    public function testUserWithSingleRoleGeneratesCorrectSQL(): void
+    {
+        // Create role
+        $adminRole = $this->createRole('Admin');
+
+        // Create collection type
+        $collectionType = new CollectionType();
+        $collectionType->setName('collection');
+        $collectionType->setKey('collection');
+        $this->entityManager->persist($collectionType);
+        $this->entityManager->flush();
+
+        // Create restricted collection
+        $collection = new Collection();
+        $collection->setType($collectionType);
+
+        $collectionMeta = new CollectionMeta();
+        $collectionMeta->setTitle('Single Role Collection');
+        $collectionMeta->setLocale('en');
+        $collectionMeta->setCollection($collection);
+        $collection->addMeta($collectionMeta);
+
+        $this->entityManager->persist($collection);
+        $this->entityManager->flush();
+
+        // Set permissions: Admin role has VIEW
+        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
+        \assert($accessControlManager instanceof AccessControlManagerInterface);
+        $accessControlManager->setPermissions(
+            Collection::class,
+            (string) $collection->getId(),
+            [
+                $adminRole->getId() => ['view' => true, 'edit' => false, 'delete' => false],
+            ]
+        );
+
+        // Create user with single role
+        $user = $this->createUser('testuser', [$adminRole]);
+
+        // Enable profiler
+        $this->client->enableProfiler();
+
+        // Login as the test user
+        $this->client->loginUser($user);
+
+        // Request collections list
+        $this->client->request('GET', '/admin/api/collections?locale=en');
+
+        /** @var Profile $profile */
+        $profile = $this->client->getProfile();
+        $this->assertNotNull($profile);
+
+        $queries = $profile->getCollector('db')->getQueries();
+
+        // Find AccessControl query
+        $accessControlQuery = null;
+        foreach ($queries['default'] as $query) {
+            if (\str_contains($query['sql'], 'se_access_controls') && \str_contains($query['sql'], 'EXISTS')) {
+                $accessControlQuery = $query['sql'];
+                break;
+            }
+        }
+
+        $this->assertNotNull($accessControlQuery, 'Should generate AccessControl query');
+        $this->assertStringContainsString('EXISTS', $accessControlQuery, 'Should use EXISTS for single role too');
+    }
+
+    private function createRole(string $name): Role
+    {
+        $role = new Role();
+        $role->setName($name);
+        $role->setSystem('Sulu');
+
+        $this->entityManager->persist($role);
+        $this->entityManager->flush();
+
+        return $role;
+    }
+
+    private function createUser(string $username, array $roles): User
+    {
+        $user = new User();
+        $user->setUsername($username);
+        $user->setPassword('password');
+        $user->setLocale('en');
+        $user->setSalt('salt');
+
+        foreach ($roles as $role) {
+            $userRole = new UserRole();
+            $userRole->setRole($role);
+            $userRole->setUser($user);
+            $userRole->setLocale('["en"]');
+            $user->addUserRole($userRole);
+
+            $this->entityManager->persist($userRole);
+        }
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        return $user;
+    }
+}

--- a/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
+++ b/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpKernel\Profiler\Profile;
@@ -108,7 +109,6 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
 
         // Verify SQL uses EXISTS with role.id IN condition
         $queries = $this->getDoctrineQueries();
-        $this->assertNotEmpty($queries, 'Database queries should be logged');
 
         // Find query that checks AccessControl
         $accessControlQuery = null;
@@ -412,6 +412,9 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         return $role;
     }
 
+    /**
+     * @param list<RoleInterface> $roles
+     */
     private function createUser(string $username, array $roles): User
     {
         $user = new User();
@@ -420,7 +423,7 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $user->setLocale('en');
         $user->setSalt('salt');
 
-        foreach ($roles as $role) {
+        foreach ($roles as RoleInterface $role) {
             $userRole = new UserRole();
             $userRole->setRole($role);
             $userRole->setUser($user);

--- a/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
+++ b/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
@@ -11,12 +11,11 @@
 
 namespace Sulu\Bundle\SecurityBundle\Tests\Functional\AccessControl;
 
+use Doctrine\Bundle\DoctrineBundle\DataCollector\DoctrineDataCollector;
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
 use Sulu\Bundle\MediaBundle\Entity\CollectionType;
-use Sulu\Bundle\SecurityBundle\Entity\AccessControl;
-use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
@@ -78,9 +77,7 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $this->entityManager->flush();
 
         // Set permissions: Admin role has VIEW, User role has no permissions
-        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
-        \assert($accessControlManager instanceof AccessControlManagerInterface);
-        $accessControlManager->setPermissions(
+        $this->getAccessControlManager()->setPermissions(
             Collection::class,
             (string) $collection->getId(),
             [
@@ -104,33 +101,30 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
 
-        $data = \json_decode($response->getContent(), true);
-        $this->assertIsArray($data);
-        $this->assertArrayHasKey('_embedded', $data);
-
         // Verify collection is accessible
-        $collections = $data['_embedded']['collections'];
+        $collections = $this->getCollectionsFromResponse();
         $collectionIds = \array_column($collections, 'id');
         $this->assertContains($collection->getId(), $collectionIds, 'User should be able to access collection through Admin role');
 
         // Verify SQL uses EXISTS with role.id IN condition
-        /** @var Profile $profile */
-        $profile = $this->client->getProfile();
-        $this->assertNotNull($profile, 'Profiler should be enabled');
-
-        $queries = $profile->getCollector('db')->getQueries();
+        $queries = $this->getDoctrineQueries();
         $this->assertNotEmpty($queries, 'Database queries should be logged');
 
         // Find query that checks AccessControl
         $accessControlQuery = null;
+        $accessControlParams = null;
+
         foreach ($queries['default'] as $query) {
             if (\str_contains($query['sql'], 'se_access_controls') && \str_contains($query['sql'], 'EXISTS')) {
                 $accessControlQuery = $query['sql'];
+                $accessControlParams = $query['params'];
+
                 break;
             }
         }
 
         $this->assertNotNull($accessControlQuery, 'Query should contain AccessControl check with EXISTS');
+        $this->assertIsArray($accessControlParams, 'Query should have parameters');
 
         // Verify EXISTS subquery structure
         $this->assertStringContainsString('EXISTS', $accessControlQuery, 'Should use EXISTS clause');
@@ -140,14 +134,16 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $this->assertStringContainsString('BIT_AND', $accessControlQuery, 'Should use BIT_AND for permission check');
 
         // Verify the query parameters contain both role IDs
-        $this->assertNotEmpty($query['params'] ?? [], 'Query should have parameters');
         $roleIdsParam = null;
-        foreach ($query['params'] ?? [] as $param) {
+
+        foreach ($accessControlParams as $param) {
             if (\is_array($param) && \in_array($adminRole->getId(), $param, true)) {
                 $roleIdsParam = $param;
+
                 break;
             }
         }
+
         $this->assertNotNull($roleIdsParam, 'Query parameters should contain role IDs');
         $this->assertContains($adminRole->getId(), $roleIdsParam, 'Should include Admin role ID');
         $this->assertContains($userRole->getId(), $roleIdsParam, 'Should include User role ID');
@@ -189,9 +185,7 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $this->entityManager->flush();
 
         // Set permissions: Only SuperAdmin role has VIEW
-        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
-        \assert($accessControlManager instanceof AccessControlManagerInterface);
-        $accessControlManager->setPermissions(
+        $this->getAccessControlManager()->setPermissions(
             Collection::class,
             (string) $collection->getId(),
             [
@@ -213,12 +207,8 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
 
-        $data = \json_decode($response->getContent(), true);
-        $this->assertIsArray($data);
-        $this->assertArrayHasKey('_embedded', $data);
-
         // Verify collection is NOT accessible
-        $collections = $data['_embedded']['collections'];
+        $collections = $this->getCollectionsFromResponse();
         $collectionIds = \array_column($collections, 'id');
         $this->assertNotContains(
             $collection->getId(),
@@ -256,9 +246,7 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $this->entityManager->flush();
 
         // Set permissions: Admin role has VIEW
-        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
-        \assert($accessControlManager instanceof AccessControlManagerInterface);
-        $accessControlManager->setPermissions(
+        $this->getAccessControlManager()->setPermissions(
             Collection::class,
             (string) $collection->getId(),
             [
@@ -278,17 +266,15 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         // Request collections list
         $this->client->request('GET', '/admin/api/collections?locale=en');
 
-        /** @var Profile $profile */
-        $profile = $this->client->getProfile();
-        $this->assertNotNull($profile);
-
-        $queries = $profile->getCollector('db')->getQueries();
+        $queries = $this->getDoctrineQueries();
 
         // Find AccessControl query
         $accessControlQuery = null;
+
         foreach ($queries['default'] as $query) {
             if (\str_contains($query['sql'], 'se_access_controls') && \str_contains($query['sql'], 'EXISTS')) {
                 $accessControlQuery = $query['sql'];
+
                 break;
             }
         }
@@ -325,11 +311,7 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
 
-        $data = \json_decode($response->getContent(), true);
-        $this->assertIsArray($data);
-        $this->assertArrayHasKey('_embedded', $data);
-
-        $collections = $data['_embedded']['collections'];
+        $collections = $this->getCollectionsFromResponse();
         $collectionIds = \array_column($collections, 'id');
         $this->assertContains($collection->getId(), $collectionIds);
     }
@@ -357,9 +339,7 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $this->entityManager->persist($collection);
         $this->entityManager->flush();
 
-        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
-        \assert($accessControlManager instanceof AccessControlManagerInterface);
-        $accessControlManager->setPermissions(
+        $this->getAccessControlManager()->setPermissions(
             Collection::class,
             (string) $collection->getId(),
             [
@@ -375,13 +355,49 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
 
-        $data = \json_decode($response->getContent(), true);
-        $this->assertIsArray($data);
-        $this->assertArrayHasKey('_embedded', $data);
-
-        $collections = $data['_embedded']['collections'];
+        $collections = $this->getCollectionsFromResponse();
         $collectionIds = \array_column($collections, 'id');
         $this->assertContains($collection->getId(), $collectionIds);
+    }
+
+    private function getAccessControlManager(): AccessControlManagerInterface
+    {
+        /** @var AccessControlManagerInterface $accessControlManager */
+        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
+
+        return $accessControlManager;
+    }
+
+    /**
+     * @return array{default: list<array{sql: string, params: list<mixed>}>}
+     */
+    private function getDoctrineQueries(): array
+    {
+        /** @var Profile|null $profile */
+        $profile = $this->client->getProfile();
+        self::assertInstanceOf(Profile::class, $profile, 'Profiler should be enabled');
+
+        $collector = $profile->getCollector('db');
+        self::assertInstanceOf(DoctrineDataCollector::class, $collector);
+
+        /** @var array{default: list<array{sql: string, params: list<mixed>}>} $queries */
+        $queries = $collector->getQueries();
+
+        return $queries;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function getCollectionsFromResponse(): array
+    {
+        $content = $this->client->getResponse()->getContent();
+        self::assertIsString($content);
+
+        /** @var array{_embedded: array{collections: list<array<string, mixed>>}} $data */
+        $data = \json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        return $data['_embedded']['collections'];
     }
 
     private function createRole(string $name, string $system = 'Sulu'): Role

--- a/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
+++ b/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
@@ -423,7 +423,7 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $user->setLocale('en');
         $user->setSalt('salt');
 
-        foreach ($roles as RoleInterface $role) {
+        foreach ($roles as $role) {
             $userRole = new UserRole();
             $userRole->setRole($role);
             $userRole->setUser($user);

--- a/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
+++ b/tests/Functional/SecurityBundle/AccessControl/AccessControlQueryEnhancerIntegrationTest.php
@@ -297,11 +297,98 @@ class AccessControlQueryEnhancerIntegrationTest extends SuluTestCase
         $this->assertStringContainsString('EXISTS', $accessControlQuery, 'Should use EXISTS for single role too');
     }
 
-    private function createRole(string $name): Role
+    public function testUserWithoutRolesCanAccessUnrestrictedCollection(): void
+    {
+        $collectionType = new CollectionType();
+        $collectionType->setName('collection');
+        $collectionType->setKey('collection');
+        $this->entityManager->persist($collectionType);
+        $this->entityManager->flush();
+
+        $collection = new Collection();
+        $collection->setType($collectionType);
+
+        $collectionMeta = new CollectionMeta();
+        $collectionMeta->setTitle('Unrestricted Collection');
+        $collectionMeta->setLocale('en');
+        $collectionMeta->setCollection($collection);
+        $collection->addMeta($collectionMeta);
+
+        $this->entityManager->persist($collection);
+        $this->entityManager->flush();
+
+        $user = $this->createUser('testuser', []);
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/admin/api/collections?locale=en');
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $data = \json_decode($response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('_embedded', $data);
+
+        $collections = $data['_embedded']['collections'];
+        $collectionIds = \array_column($collections, 'id');
+        $this->assertContains($collection->getId(), $collectionIds);
+    }
+
+    public function testRestrictedCollectionInOtherSystemDoesNotHideEntity(): void
+    {
+        $suluRole = $this->createRole('Admin');
+        $websiteRole = $this->createRole('Website Admin', 'Website');
+
+        $collectionType = new CollectionType();
+        $collectionType->setName('collection');
+        $collectionType->setKey('collection');
+        $this->entityManager->persist($collectionType);
+        $this->entityManager->flush();
+
+        $collection = new Collection();
+        $collection->setType($collectionType);
+
+        $collectionMeta = new CollectionMeta();
+        $collectionMeta->setTitle('Website Restricted Collection');
+        $collectionMeta->setLocale('en');
+        $collectionMeta->setCollection($collection);
+        $collection->addMeta($collectionMeta);
+
+        $this->entityManager->persist($collection);
+        $this->entityManager->flush();
+
+        $accessControlManager = $this->getContainer()->get('sulu_security.access_control_manager');
+        \assert($accessControlManager instanceof AccessControlManagerInterface);
+        $accessControlManager->setPermissions(
+            Collection::class,
+            (string) $collection->getId(),
+            [
+                $websiteRole->getId() => ['view' => true, 'edit' => false, 'delete' => false],
+            ]
+        );
+
+        $user = $this->createUser('testuser', [$suluRole]);
+
+        $this->client->loginUser($user);
+        $this->client->request('GET', '/admin/api/collections?locale=en');
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $data = \json_decode($response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('_embedded', $data);
+
+        $collections = $data['_embedded']['collections'];
+        $collectionIds = \array_column($collections, 'id');
+        $this->assertContains($collection->getId(), $collectionIds);
+    }
+
+    private function createRole(string $name, string $system = 'Sulu'): Role
     {
         $role = new Role();
         $role->setName($name);
-        $role->setSystem('Sulu');
+        $role->setSystem($system);
 
         $this->entityManager->persist($role);
         $this->entityManager->flush();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Changes permission logic from blacklist (NOT IN) to whitelist (EXISTS) approach to correctly handle users with multiple roles.

Problem:
Users with multiple roles (e.g., Admin + Editor) would lose access to entities if ANY role lacked the required permission, even when another role granted full access. This occurred because the old logic excluded entities where any role failed the permission check.

Solution:
- Replaced NOT IN blacklist with EXISTS whitelist subquery
- Changed BIT_AND check from <> to = for correct permission matching
- Implements OR logic: user has access if ANY role grants permission
- Added handling for users with no roles (deny access)

Fixes #8499 

#### Why?

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->

#### Example Usage

<!--
```php
// If you added new features, show examples of how to use them here

$foo = new Foo();

// Now we can do
$foo->doSomething();
```
-->

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md

<!--

Dear Contributors,

Thank you for contributing to the Sulu ecosystem!

We appreciate your effort to improve our project.  
If you need assistance or have questions about your pull request, our team is here to help.  
Please join our Slack channel for support: https://sulu.io/services/support#chat.

Best Regards, 
The Sulu Core Team

-->
