### PR TITLE
Fix block field defaults issue

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, observable, toJS, reaction, computed} from 'mobx';
+import {action, observable, toJS, reaction, computed, runInAction} from 'mobx';
 import {observer} from 'mobx-react';
 import classNames from 'classnames';
 import {arrayMove, translate, clipboard} from '../../utils';
@@ -158,8 +158,8 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
         }
     };
 
-    fillArrays = () => {
-        const {collapsable, defaultType, onChange, minOccurs, value} = this.props;
+    @action fillArrays = async() => {
+        const {collapsable, defaultType, generateBlockIds, minOccurs, onChange, value} = this.props;
         const {expandedBlocks, generatedBlockIds, selectedBlocks} = this;
 
         if (!value) {
@@ -180,26 +180,43 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
         const collapsed = collapsable ? false : true;
 
+        // Fill existing blocks' observables
         expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(collapsed));
         selectedBlocks.push(...new Array(value.length - selectedBlocks.length).fill(false));
         generatedBlockIds.push(
             ...new Array(value.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
         );
+
+        // For minOccurs blocks, generate IDs and update everything atomically
         if (minOccurs && value.length < minOccurs) {
-            expandedBlocks.push(...new Array(minOccurs - value.length).fill(true));
-            selectedBlocks.push(...new Array(minOccurs - value.length).fill(false));
-            generatedBlockIds.push(
-                ...new Array(minOccurs - value.length).fill(false).map(() => ++BlockCollection.idCounter)
+            const newBlockCount = minOccurs - value.length;
+
+            // Create new blocks with just the type
+            const newBlocks = Array.from(
+                {length: newBlockCount},
+                // $FlowFixMe
+                () => ({type: defaultType})
             );
 
-            onChange([
-                ...value,
-                ...Array.from(
-                    {length: minOccurs - value.length},
-                    // $FlowFixMe
-                    () => ({type: defaultType})
-                ),
-            ]);
+            // Generate IDs for new blocks if needed
+            if (generateBlockIds) {
+                const blockIds = await generateBlockIds(newBlockCount);
+                newBlocks.forEach((block, index) => {
+                    block._id = blockIds[index];
+                });
+            }
+
+            runInAction(() => {
+                // Update observables
+                expandedBlocks.push(...new Array(newBlockCount).fill(true));
+                selectedBlocks.push(...new Array(newBlockCount).fill(false));
+                generatedBlockIds.push(
+                    ...new Array(newBlockCount).fill(false).map(() => ++BlockCollection.idCounter)
+                );
+
+                // Update value array - field components will apply defaults in their constructors
+                onChange([...value, ...newBlocks]);
+            });
         }
     };
 
@@ -223,22 +240,29 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
         }
 
         if (value) {
-            this.expandedBlocks.splice(insertionIndex, 0, true);
-            this.selectedBlocks.splice(insertionIndex, 0, false);
-            this.generatedBlockIds.splice(insertionIndex, 0, ++BlockCollection.idCounter);
-
             const elementsBefore = value.slice(0, insertionIndex);
             const elementsAfter = value.slice(insertionIndex);
 
-            const newBlock: { _id?: string, type: string } = {type: defaultType};
+            // Create new block with just the type - field components will apply defaults in their constructors
+            const newBlock = {
+                type: defaultType,
+            };
 
             if (generateBlockIds) {
                 const [newBlockId] = await generateBlockIds(1);
                 newBlock._id = newBlockId;
             }
 
-            // $FlowFixMe
-            onChange([...elementsBefore, newBlock, ...elementsAfter]);
+            // Wrap post-await code in runInAction to maintain action context
+            runInAction(() => {
+                // Update MobX observables AFTER async operation to ensure atomic state update
+                this.expandedBlocks.splice(insertionIndex, 0, true);
+                this.selectedBlocks.splice(insertionIndex, 0, false);
+                this.generatedBlockIds.splice(insertionIndex, 0, ++BlockCollection.idCounter);
+
+                // $FlowFixMe
+                onChange([...elementsBefore, newBlock, ...elementsAfter]);
+            });
         }
     };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -51,6 +51,7 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     @observable selectedBlocks: Array<boolean> = [];
     @observable mode: BlockMode = 'sortable';
     @observable isGeneratingIds: boolean = false;
+    @observable isFillingArrays: boolean = false;
 
     fillArraysDisposer: ?() => *;
     setPasteableBlocksDisposer: ?() => *;
@@ -162,61 +163,87 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
         const {collapsable, defaultType, generateBlockIds, minOccurs, onChange, value} = this.props;
         const {expandedBlocks, generatedBlockIds, selectedBlocks} = this;
 
-        if (!value) {
+        // Prevent concurrent executions
+        if (this.isFillingArrays || !value) {
             return;
         }
 
-        if (expandedBlocks.length > value.length) {
-            expandedBlocks.splice(value.length);
-        }
+        this.isFillingArrays = true;
 
-        if (selectedBlocks.length > value.length) {
-            selectedBlocks.splice(value.length);
-        }
-
-        if (generatedBlockIds.length > value.length) {
-            generatedBlockIds.splice(value.length);
-        }
-
-        const collapsed = collapsable ? false : true;
-
-        // Fill existing blocks' observables
-        expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(collapsed));
-        selectedBlocks.push(...new Array(value.length - selectedBlocks.length).fill(false));
-        generatedBlockIds.push(
-            ...new Array(value.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
-        );
-
-        // For minOccurs blocks, generate IDs and update everything atomically
-        if (minOccurs && value.length < minOccurs) {
-            const newBlockCount = minOccurs - value.length;
-
-            // Create new blocks with just the type
-            const newBlocks = Array.from(
-                {length: newBlockCount},
-                // $FlowFixMe
-                () => ({type: defaultType})
-            );
-
-            // Generate IDs for new blocks if needed
-            if (generateBlockIds) {
-                const blockIds = await generateBlockIds(newBlockCount);
-                newBlocks.forEach((block, index) => {
-                    block._id = blockIds[index];
-                });
+        try {
+            if (expandedBlocks.length > value.length) {
+                expandedBlocks.splice(value.length);
             }
 
-            runInAction(() => {
-                // Update observables
-                expandedBlocks.push(...new Array(newBlockCount).fill(true));
-                selectedBlocks.push(...new Array(newBlockCount).fill(false));
-                generatedBlockIds.push(
-                    ...new Array(newBlockCount).fill(false).map(() => ++BlockCollection.idCounter)
-                );
+            if (selectedBlocks.length > value.length) {
+                selectedBlocks.splice(value.length);
+            }
 
-                // Update value array - field components will apply defaults in their constructors
-                onChange([...value, ...newBlocks]);
-            });
+            if (generatedBlockIds.length > value.length) {
+                generatedBlockIds.splice(value.length);
+            }
+
+            const collapsed = collapsable ? false : true;
+
+            expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(collapsed));
+            selectedBlocks.push(...new Array(value.length - selectedBlocks.length).fill(false));
+            generatedBlockIds.push(
+                ...new Array(value.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
+            );
+
+            if (minOccurs && value.length < minOccurs) {
+                const newBlockCount = minOccurs - value.length;
+
+                // Create blocks and generate IDs if needed
+                let newBlocks;
+                if (generateBlockIds) {
+                    try {
+                        const blockIds = await generateBlockIds(newBlockCount);
+
+                        if (!blockIds || !Array.isArray(blockIds) || blockIds.length !== newBlockCount) {
+                            throw new Error(
+                                `generateBlockIds must return an array with exactly ${newBlockCount} elements`
+                            );
+                        }
+
+                        // Create blocks with IDs
+                        newBlocks = Array.from(
+                            {length: newBlockCount},
+                            (_, index) => {
+                                if (blockIds[index] === undefined || blockIds[index] === null) {
+                                    throw new Error(`generateBlockIds returned an invalid ID at index ${index}`);
+                                }
+                                // $FlowFixMe
+                                return {type: defaultType, _id: blockIds[index]};
+                            }
+                        );
+                    } catch (error) {
+                        // On error, don't add blocks to maintain consistent state
+                        // Return early to prevent adding blocks with invalid or missing IDs
+                        return;
+                    }
+                } else {
+                    // Create blocks without IDs when generateBlockIds is not provided
+                    newBlocks = Array.from(
+                        {length: newBlockCount},
+                        // $FlowFixMe
+                        () => ({type: defaultType})
+                    );
+                }
+
+                runInAction(() => {
+                    expandedBlocks.push(...new Array(newBlockCount).fill(true));
+                    selectedBlocks.push(...new Array(newBlockCount).fill(false));
+                    generatedBlockIds.push(
+                        ...new Array(newBlockCount).fill(false).map(() => ++BlockCollection.idCounter)
+                    );
+
+                    // $FlowFixMe
+                    onChange([...value, ...newBlocks]);
+                });
+            }
+        } finally {
+            this.isFillingArrays = false;
         }
     };
 
@@ -243,19 +270,26 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
             const elementsBefore = value.slice(0, insertionIndex);
             const elementsAfter = value.slice(insertionIndex);
 
-            // Create new block with just the type - field components will apply defaults in their constructors
-            const newBlock = {
-                type: defaultType,
-            };
-
+            // Create new block - field components will apply defaults in their constructors
+            let newBlock;
             if (generateBlockIds) {
-                const [newBlockId] = await generateBlockIds(1);
-                newBlock._id = newBlockId;
+                const newBlockIds = await generateBlockIds(1);
+
+                if (!newBlockIds || !Array.isArray(newBlockIds) || newBlockIds.length !== 1) {
+                    throw new Error('generateBlockIds must return an array with exactly 1 element');
+                }
+
+                if (newBlockIds[0] === undefined || newBlockIds[0] === null) {
+                    throw new Error('generateBlockIds returned an invalid ID');
+                }
+
+                newBlock = {type: defaultType, _id: newBlockIds[0]};
+            } else {
+                // Create block without ID when generateBlockIds is not provided
+                newBlock = {type: defaultType};
             }
 
-            // Wrap post-await code in runInAction to maintain action context
             runInAction(() => {
-                // Update MobX observables AFTER async operation to ensure atomic state update
                 this.expandedBlocks.splice(insertionIndex, 0, true);
                 this.selectedBlocks.splice(insertionIndex, 0, false);
                 this.generatedBlockIds.splice(insertionIndex, 0, ++BlockCollection.idCounter);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -204,6 +204,34 @@ test('Should add at least the minOccurs amount of blocks with types', () => {
     ]);
 });
 
+test('Should generate IDs for minOccurs blocks with generateBlockIds enabled', async() => {
+    const mockIds = ['id1', 'id2', 'id3'];
+    const generateBlockIdsSpy = jest.fn().mockReturnValue(Promise.resolve(mockIds));
+    const changeSpy = jest.fn();
+    const value = [];
+
+    mount(
+        <BlockCollection
+            defaultType="editor"
+            generateBlockIds={generateBlockIdsSpy}
+            minOccurs={3}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    // Wait for async fillArrays to complete
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(generateBlockIdsSpy).toHaveBeenCalledWith(3);
+    expect(changeSpy).toHaveBeenCalledWith([
+        {type: 'editor', _id: 'id1'},
+        {type: 'editor', _id: 'id2'},
+        {type: 'editor', _id: 'id3'},
+    ]);
+});
+
 test('Choosing a different type should call the onChange callback', () => {
     const changeSpy = jest.fn();
     const renderBlockContent = jest.fn();
@@ -1579,6 +1607,175 @@ test('Should not generate ID when adding block without generateBlockIds', async(
         {content: 'Test 1', type: 'editor'},
         {type: 'editor'},
     ]);
+});
+
+test('Should create blocks with minimal structure to allow field components to apply defaults', async() => {
+    const changeSpy = jest.fn();
+    const value = [{content: 'Test 1', type: 'editor'}];
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    await blockCollection.instance().handleAddBlock(1);
+
+    // Verify block is created with only type (no field values pre-populated)
+    // This allows field components to apply defaults in their constructors
+    expect(changeSpy).toHaveBeenCalledWith([
+        {content: 'Test 1', type: 'editor'},
+        {type: 'editor'},
+    ]);
+});
+
+test('Should synchronize observables atomically when adding block', async() => {
+    const changeSpy = jest.fn();
+    const value = [{content: 'Test 1', type: 'editor'}];
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    const instance = blockCollection.instance();
+
+    // Verify observables are empty initially (only for existing block)
+    expect(instance.expandedBlocks.length).toBe(1);
+    expect(instance.selectedBlocks.length).toBe(1);
+    expect(instance.generatedBlockIds.length).toBe(1);
+
+    await instance.handleAddBlock(1);
+
+    // After adding block, observables should be updated to match new value length
+    expect(instance.expandedBlocks.length).toBe(2);
+    expect(instance.selectedBlocks.length).toBe(2);
+    expect(instance.generatedBlockIds.length).toBe(2);
+});
+
+test('Should synchronize observables atomically when adding block with generateBlockIds', async() => {
+    const mockId = 'test123';
+    const generateBlockIdsSpy = jest.fn().mockReturnValue(Promise.resolve([mockId]));
+    const changeSpy = jest.fn();
+    const value = [{content: 'Test 1', type: 'editor'}];
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            generateBlockIds={generateBlockIdsSpy}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    const instance = blockCollection.instance();
+
+    // Capture observable lengths before operation
+    const expandedBefore = instance.expandedBlocks.length;
+    const selectedBefore = instance.selectedBlocks.length;
+    const generatedIdsBefore = instance.generatedBlockIds.length;
+
+    await instance.handleAddBlock(1);
+
+    // Observables should be updated atomically AFTER async operation
+    // No intermediate state where observables have different lengths than value
+    expect(instance.expandedBlocks.length).toBe(expandedBefore + 1);
+    expect(instance.selectedBlocks.length).toBe(selectedBefore + 1);
+    expect(instance.generatedBlockIds.length).toBe(generatedIdsBefore + 1);
+
+    expect(changeSpy).toHaveBeenCalledWith([
+        {content: 'Test 1', type: 'editor'},
+        {type: 'editor', _id: mockId},
+    ]);
+});
+
+test('Should create minOccurs blocks with minimal structure for field component defaults', async() => {
+    const changeSpy = jest.fn();
+    const value = [];
+
+    mount(
+        <BlockCollection
+            defaultType="editor"
+            minOccurs={2}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    // fillArrays runs automatically via reaction
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Verify blocks created with only type to allow field components to apply defaults
+    expect(changeSpy).toHaveBeenCalledWith([
+        {type: 'editor'},
+        {type: 'editor'},
+    ]);
+});
+
+test('Should synchronize observables atomically when creating minOccurs blocks', async() => {
+    const changeSpy = jest.fn();
+    const value = [];
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            minOccurs={3}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    // fillArrays runs automatically via reaction
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const instance = blockCollection.instance();
+
+    // All observables should have same length as value after fillArrays
+    expect(instance.expandedBlocks.length).toBe(3);
+    expect(instance.selectedBlocks.length).toBe(3);
+    expect(instance.generatedBlockIds.length).toBe(3);
+});
+
+test('Should generate IDs for minOccurs blocks atomically', async() => {
+    const mockIds = ['id1', 'id2', 'id3'];
+    const generateBlockIdsSpy = jest.fn().mockReturnValue(Promise.resolve(mockIds));
+    const changeSpy = jest.fn();
+    const value = [];
+
+    const blockCollection = mount(
+        <BlockCollection
+            defaultType="editor"
+            generateBlockIds={generateBlockIdsSpy}
+            minOccurs={3}
+            onChange={changeSpy}
+            renderBlockContent={jest.fn()}
+            value={value}
+        />
+    );
+
+    // fillArrays runs automatically and generates IDs
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const instance = blockCollection.instance();
+
+    // Verify IDs were generated before onChange was called
+    expect(generateBlockIdsSpy).toHaveBeenCalledWith(3);
+    expect(changeSpy).toHaveBeenCalledWith([
+        {type: 'editor', _id: 'id1'},
+        {type: 'editor', _id: 'id2'},
+        {type: 'editor', _id: 'id3'},
+    ]);
+
+    // Observables should be synchronized with value
+    expect(instance.expandedBlocks.length).toBe(3);
+    expect(instance.selectedBlocks.length).toBe(3);
+    expect(instance.generatedBlockIds.length).toBe(3);
 });
 
 test('Should generate new ID when pasting cut blocks', async() => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8512
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

**Root Cause:**
MobX observable arrays (expandedBlocks, selectedBlocks, generatedBlockIds) were updated BEFORE async block-id generation, creating an inconsistent state that prevented field components from properly initializing their defaults via onChange in their constructors.

**Solution:**
1. Move MobX observable updates to AFTER async operations (using runInAction)
2. Make fillArrays async and generate block IDs before calling onChange
3. Remove getBlockDefaults workaround - field components now handle defaults via constructor logic (consistent with root form fields)

This ensures atomic state updates and allows field components to properly apply their default values when blocks are created.
