### PR TITLE
Improve update build command fallback to latest 2.6 files

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -90,6 +90,7 @@ return $config
     ->ignoreErrorsOnPackages(
         [
             'doctrine/annotations',
+            'symfony/http-client', // required and used via symfony/http-client-contracts
             'guzzlehttp/promises', // required for faster fos http cache clearing
             'nyholm/psr7', // required for faster fos http cache clearing
             'symfony/css-selector', // kept for future usage

--- a/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
+++ b/src/Sulu/Bundle/AdminBundle/Command/UpdateBuildCommand.php
@@ -17,13 +17,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\Process\Process;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[AsCommand(name: 'sulu:admin:update-build', description: 'Updates the administration application JavaScript build by downloading the official build from the sulu/skeleton repository or building the assets via npm.')]
 class UpdateBuildCommand extends Command
 {
+    private const DEFAULT_DEV_VERSION = '2.6';
+
     public const EXIT_CODE_ABORTED_MANUAL_BUILD = 1;
     public const EXIT_CODE_COULD_NOT_INSTALL_NPM_PACKAGES = 2;
     public const EXIT_CODE_COULD_NOT_BUILD_ADMIN_ASSETS = 3;
@@ -79,7 +80,7 @@ class UpdateBuildCommand extends Command
             if (0 === \strpos($suluVersion, 'dev-')) {
                 $suluVersion = $ui->ask(
                     \sprintf('Cannot detect "sulu/skeleton" branch for version "%s". Which "sulu/skeleton" branch do you want to use to update your "assets/admin" folder?', $suluVersion),
-                    '2.x'
+                    self::DEFAULT_DEV_VERSION,
                 );
             }
 
@@ -257,13 +258,9 @@ class UpdateBuildCommand extends Command
     {
         $path = \str_replace(\DIRECTORY_SEPARATOR, '/', $path);
 
-        try {
-            $response = $this->httpClient->request('GET', $remoteRepository . $path);
+        $response = $this->httpClient->request('GET', $remoteRepository . $path);
 
-            return $response->getContent();
-        } catch (ClientException $e) {
-            return '';
-        }
+        return $response->getContent();
     }
 
     private function hash(string $content): string


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes 
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Improve update build command fallback to latest 2.6 files, currently it did use 2.x where the files not exist ending it to remove all files instead of updating them.

#### Why?

Improve update build command fallback to latest 2.6 files. Also currently the `2.x` would just remove all files instead of throw an error on not found file.