### PR TITLE
Add dynamic view resolving with access to the loaded entity

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,5 +1,38 @@
 # Upgrade
 
+## 3.0.7
+
+### Selection view structure changed (snippet, page, article)
+
+The `view` data emitted by `*_selection` and `single_*_selection` property resolvers now exposes the loaded entity's metadata and field-level view directly, restoring the Sulu 2.6 shape for multi-selections.
+
+Multi-selection (`snippet_selection`, `page_selection`, `article_selection`) now returns a flat numeric list:
+
+```php
+// before
+view.snippets => ['ids' => [...], 'types' => 'snippet-1', 0 => [...], 1 => [...]]
+
+// after
+view.snippets => [
+    ['uuid' => 'uuid-a', 'template' => 'snippet-1', ...],
+    ['uuid' => 'uuid-b', 'template' => 'snippet-1', ...],
+]
+```
+
+Templates that iterated `view.<field>` already worked, templates that read `view.<field>.ids` must switch to `view.<field>` directly.
+
+Single-selection (`single_snippet_selection`, `single_page_selection`, `single_article_selection`) exposes the resolved entity's metadata and per-field view alongside the existing keys:
+
+```php
+view.bannerSnippet => [
+    'uuid' => 'uuid-a',
+    'template' => 'snippet-1',
+    'title' => [],
+    'textboxButtons' => [...],
+    // plus 'id' and any params the resolver was already exposing
+]
+```
+
 ## 3.0.6
 
 ### CKEditor upgrade to 47

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver;
 
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
@@ -54,10 +55,7 @@ class ArticleSelectionPropertyResolver implements PropertyResolverInterface
             ids: $identifiers,
             resourceLoaderKey: $resourceLoaderKey,
             resourceKey: ArticleInterface::RESOURCE_KEY,
-            view: [
-                'ids' => $identifiers,
-                ...$params,
-            ],
+            view: [],
             priority: 100,
             metadata: [
                 'properties' => \array_merge(
@@ -67,7 +65,21 @@ class ArticleSelectionPropertyResolver implements PropertyResolverInterface
                         'url' => 'url',
                     ],
                 ),
-            ]
+            ],
+            viewCallback: static function(mixed $source): array {
+                if ($source instanceof ArticleDimensionContentInterface) {
+                    return [
+                        'uuid' => $source->getResource()->getUuid(),
+                        'template' => $source->getTemplateKey(),
+                        'mainWebspace' => $source->getMainWebspace(),
+                        'additionalWebspaces' => $source->getAdditionalWebspaces(),
+                        'authored' => $source->getAuthored()?->format('c'),
+                        'lastModified' => $source->getLastModified()?->format('c'),
+                    ];
+                }
+
+                return [];
+            },
         );
     }
 

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
@@ -65,7 +65,6 @@ class ArticleSelectionPropertyResolver implements PropertyResolverInterface
                     ],
                 ),
             ],
-            itemsPropertyName: 'items',
         );
     }
 

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolver.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
@@ -66,20 +65,7 @@ class ArticleSelectionPropertyResolver implements PropertyResolverInterface
                     ],
                 ),
             ],
-            viewCallback: static function(mixed $source): array {
-                if ($source instanceof ArticleDimensionContentInterface) {
-                    return [
-                        'uuid' => $source->getResource()->getUuid(),
-                        'template' => $source->getTemplateKey(),
-                        'mainWebspace' => $source->getMainWebspace(),
-                        'additionalWebspaces' => $source->getAdditionalWebspaces(),
-                        'authored' => $source->getAuthored()?->format('c'),
-                        'lastModified' => $source->getLastModified()?->format('c'),
-                    ];
-                }
-
-                return [];
-            },
+            itemsPropertyName: 'items',
         );
     }
 

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver;
 
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
@@ -55,7 +56,21 @@ class SingleArticleSelectionPropertyResolver implements PropertyResolverInterfac
                         'url' => 'url',
                     ],
                 ),
-            ]
+            ],
+            viewCallback: static function(mixed $source): array {
+                if ($source instanceof ArticleDimensionContentInterface) {
+                    return [
+                        'uuid' => $source->getResource()->getUuid(),
+                        'template' => $source->getTemplateKey(),
+                        'mainWebspace' => $source->getMainWebspace(),
+                        'additionalWebspaces' => $source->getAdditionalWebspaces(),
+                        'authored' => $source->getAuthored()?->format('c'),
+                        'lastModified' => $source->getLastModified()?->format('c'),
+                    ];
+                }
+
+                return [];
+            },
         );
     }
 

--- a/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PropertyResolver/SingleArticleSelectionPropertyResolver.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Article\Infrastructure\Sulu\Content\PropertyResolver;
 
-use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
@@ -57,20 +56,6 @@ class SingleArticleSelectionPropertyResolver implements PropertyResolverInterfac
                     ],
                 ),
             ],
-            viewCallback: static function(mixed $source): array {
-                if ($source instanceof ArticleDimensionContentInterface) {
-                    return [
-                        'uuid' => $source->getResource()->getUuid(),
-                        'template' => $source->getTemplateKey(),
-                        'mainWebspace' => $source->getMainWebspace(),
-                        'additionalWebspaces' => $source->getAdditionalWebspaces(),
-                        'authored' => $source->getAuthored()?->format('c'),
-                        'lastModified' => $source->getLastModified()?->format('c'),
-                    ];
-                }
-
-                return [];
-            },
         );
     }
 

--- a/packages/article/src/Infrastructure/Sulu/Content/ResourceLoader/ArticleResourceLoader.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ResourceLoader/ArticleResourceLoader.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader;
 
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 
 /**
@@ -22,7 +25,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
  *
  * @final
  */
-class ArticleResourceLoader implements ResourceLoaderInterface
+class ArticleResourceLoader implements ResourceLoaderContentViewInterface
 {
     public const RESOURCE_LOADER_KEY = 'article';
 
@@ -56,6 +59,30 @@ class ArticleResourceLoader implements ResourceLoaderInterface
         }
 
         return $mappedResult;
+    }
+
+    public function resolveContentView(mixed $source): ContentView
+    {
+        $view = [];
+        $content = [];
+
+        if ($source instanceof ArticleDimensionContentInterface) {
+            $view = [
+                'uuid' => $source->getResource()->getUuid(),
+                'template' => $source->getTemplateKey(),
+                'mainWebspace' => $source->getMainWebspace(),
+                'additionalWebspaces' => $source->getAdditionalWebspaces(),
+            ];
+        }
+
+        if ($source instanceof AuthorInterface) {
+            $content = [
+                'authored' => $source->getAuthored()?->format('c'),
+                'lastModified' => $source->getLastModified()?->format('c'),
+            ];
+        }
+
+        return ContentView::create($content, $view);
     }
 
     public static function getKey(): string

--- a/packages/article/src/Infrastructure/Sulu/Content/ResourceLoader/ArticleResourceLoader.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ResourceLoader/ArticleResourceLoader.php
@@ -16,7 +16,7 @@ namespace Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewEnhancementInterface;
 use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 
@@ -25,7 +25,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
  *
  * @final
  */
-class ArticleResourceLoader implements ResourceLoaderContentViewInterface
+class ArticleResourceLoader implements ResourceLoaderContentViewEnhancementInterface
 {
     public const RESOURCE_LOADER_KEY = 'article';
 
@@ -61,24 +61,24 @@ class ArticleResourceLoader implements ResourceLoaderContentViewInterface
         return $mappedResult;
     }
 
-    public function resolveContentView(mixed $source): ContentView
+    public function resolveContentViewEnhancement(mixed $resource): ContentView
     {
         $view = [];
         $content = [];
 
-        if ($source instanceof ArticleDimensionContentInterface) {
+        if ($resource instanceof ArticleDimensionContentInterface) {
             $view = [
-                'uuid' => $source->getResource()->getUuid(),
-                'template' => $source->getTemplateKey(),
-                'mainWebspace' => $source->getMainWebspace(),
-                'additionalWebspaces' => $source->getAdditionalWebspaces(),
+                'uuid' => $resource->getResource()->getUuid(),
+                'template' => $resource->getTemplateKey(),
+                'mainWebspace' => $resource->getMainWebspace(),
+                'additionalWebspaces' => $resource->getAdditionalWebspaces(),
             ];
         }
 
-        if ($source instanceof AuthorInterface) {
+        if ($resource instanceof AuthorInterface) {
             $content = [
-                'authored' => $source->getAuthored()?->format('c'),
-                'lastModified' => $source->getLastModified()?->format('c'),
+                'authored' => $resource->getAuthored()?->format('c'),
+                'lastModified' => $resource->getLastModified()?->format('c'),
             ];
         }
 

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ArticleSelectionPropertyResolverTest.php
@@ -36,7 +36,7 @@ class ArticleSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en');
 
         $this->assertEmpty($contentView->getContent());
-        $this->assertSame(['ids' => []], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
     }
 
     public function testResolveParams(): void
@@ -44,10 +44,7 @@ class ArticleSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
 
         $this->assertEmpty($contentView->getContent());
-        $this->assertSame([
-            'ids' => [],
-            'custom' => 'params',
-        ], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
     }
 
     /**
@@ -105,9 +102,7 @@ class ArticleSelectionPropertyResolverTest extends TestCase
             $this->assertSame(ArticleInterface::RESOURCE_KEY, $reference->getResourceKey());
         }
 
-        $this->assertSame([
-            'ids' => $data,
-        ], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
     }
 
     /**

--- a/packages/content/config/resolvers.xml
+++ b/packages/content/config/resolvers.xml
@@ -42,6 +42,7 @@
             <argument type="service" id="sulu_content.content_aggregator" />
             <argument /> <!-- See via SuluContentBundle config for: sulu_content.content_resolver.max_depth -->
             <argument type="service" id="sulu_content.content_enhancer"/>
+            <argument type="service" id="sulu_content.resource_loader_provider"/>
         </service>
         <service id="Sulu\Content\Application\ContentResolver\ContentResolverInterface" alias="sulu_content.content_resolver"/>
 

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -32,6 +32,9 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Webmozart\Assert\Assert;
 
+/**
+ * @final
+ */
 readonly class ContentResolver implements ContentResolverInterface
 {
     private PropertyAccessorInterface $propertyAccessor;

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -290,16 +290,21 @@ readonly class ContentResolver implements ContentResolverInterface
      */
     private function mergeViewEnhancement(array $existingView, array $items, ?string $itemsPropertyName): array
     {
+        // single resolvable: flat-merge the single item's view into the existing view
         if (null === $itemsPropertyName) {
             if (1 === \count($items) && \is_array($items[0])) {
                 return \array_merge($existingView, $items[0]);
             }
 
-            $existingView['items'] = $items;
-
             return $existingView;
         }
 
+        // multi resolvable without resolver-level view: emit a flat numeric list (Sulu 2.6-compatible shape)
+        if ([] === $existingView) {
+            return $items;
+        }
+
+        // multi resolvable with resolver-level view: wrap items under itemsPropertyName so both coexist
         $existingView[$itemsPropertyName] = $items;
 
         return $existingView;

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -309,8 +309,15 @@ readonly class ContentResolver implements ContentResolverInterface
 
             $existing = $this->propertyAccessor->getValue($resolvedContent['view'], $path);
             $existingView = \is_array($existing) ? $existing : [];
+            $resolvedContentValue = $this->propertyAccessor->getValue($finalContent, $path);
+            $isCollection = \is_array($resolvedContentValue) && \array_is_list($resolvedContentValue);
 
-            $merged = $this->mergeViewEnhancement($existingView, $items, $enhancement['itemsPropertyName']);
+            $merged = $this->mergeViewEnhancement(
+                $existingView,
+                $items,
+                $enhancement['itemsPropertyName'],
+                $isCollection
+            );
             $this->propertyAccessor->setValue($resolvedContent['view'], $path, $merged);
         }
 
@@ -382,26 +389,20 @@ readonly class ContentResolver implements ContentResolverInterface
      *
      * @return array<string|int, mixed>
      */
-    private function mergeViewEnhancement(array $existingView, array $items, ?string $itemsPropertyName): array
+    private function mergeViewEnhancement(array $existingView, array $items, ?string $itemsPropertyName, bool $isCollection): array
     {
-        // single resolvable: flat-merge the single item's view into the existing view
         if (null === $itemsPropertyName) {
-            if (1 === \count($items) && \is_array($items[0])) {
+            // Single selections are object-like and flat-merge their one resolved view.
+            // Collections stay list-like even when they currently contain only one item.
+            if (!$isCollection && 1 === \count($items) && \is_array($items[0])) {
                 return \array_merge($existingView, $items[0]);
             }
 
-            return $existingView;
+            return \array_merge($existingView, $items);
         }
 
-        // multi resolvable without resolver-level view: emit a flat numeric list (Sulu 2.6-compatible shape)
-        if ([] === $existingView) {
-            return $items;
-        }
-
-        // multi resolvable with resolver-level view: wrap items under itemsPropertyName so both coexist
-        $existingView[$itemsPropertyName] = $items;
-
-        return $existingView;
+        // A configured items property explicitly asks for nested collection view data.
+        return \array_merge($existingView, [$itemsPropertyName => $items]);
     }
 
     /**

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -401,7 +401,6 @@ readonly class ContentResolver implements ContentResolverInterface
             return \array_merge($existingView, $items);
         }
 
-        // A configured items property explicitly asks for nested collection view data.
         return \array_merge($existingView, [$itemsPropertyName => $items]);
     }
 

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -22,6 +22,8 @@ use Sulu\Content\Application\ContentResolver\ResolvableResourceQueue\ResolvableR
 use Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\ResolvableResourceReplacerInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\ShadowInterface;
@@ -42,7 +44,8 @@ readonly class ContentResolver implements ContentResolverInterface
         private ContentViewDataNormalizerInterface $contentViewDataNormalizer,
         private ContentAggregatorInterface $contentAggregator,
         private int $maxDepth,
-        private ContentEnhancerInterface $contentEnhancer
+        private ContentEnhancerInterface $contentEnhancer,
+        private ResourceLoaderProvider $resourceLoaderProvider
     ) {
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
     }
@@ -81,6 +84,9 @@ readonly class ContentResolver implements ContentResolverInterface
 
             // Process loaded resources
             foreach ($loadedResources as $loaderKey => $resources) {
+                $resourceLoader = $this->resourceLoaderProvider->getResourceLoader($loaderKey);
+                $supportsContentView = $resourceLoader instanceof ResourceLoaderContentViewInterface;
+
                 foreach ($resources as $id => $resourcePerMetadataIdentifier) {
                     $depth = $loaderIdDepths[$loaderKey][$id];
                     foreach ($resourcePerMetadataIdentifier as $metadataIdentifier => $resource) {
@@ -126,7 +132,28 @@ readonly class ContentResolver implements ContentResolverInterface
                                 );
                             }
 
-                            $sourceValue = $childContent;
+                            // Merge ResourceLoader content data into the resolved content
+                            // after property mapping so it's always present regardless of properties config
+                            if ($supportsContentView) {
+                                $entityContentView = $resourceLoader->resolveContentView($childContent);
+                                $entityContentData = $entityContentView->getContent();
+
+                                if (\is_array($entityContentData) && [] !== $entityContentData) {
+                                    /** @var array<string, mixed> $existingContent */
+                                    $existingContent = $resolvedValue['content'];
+                                    $resolvedValue['content'] = \array_merge($existingContent, $entityContentData);
+                                }
+
+                                $contentView = ContentView::create([], $entityContentView->getView());
+                            } else {
+                                $contentView = ContentView::create([], []);
+                            }
+
+                            $resolvedResources[$loaderKey][$id][$metadataIdentifier] = [
+                                'contentView' => $contentView,
+                                'resolved' => $resolvedValue,
+                            ];
+                            continue;
                         } elseif ($resource instanceof ContentView) {
                             /** @var array{
                              *     content: array{'0': array<string, mixed>},
@@ -153,8 +180,12 @@ readonly class ContentResolver implements ContentResolverInterface
                             $sourceValue = $resource;
                         }
 
+                        $contentView = $supportsContentView
+                            ? $resourceLoader->resolveContentView($sourceValue)
+                            : ContentView::create([], []);
+
                         $resolvedResources[$loaderKey][$id][$metadataIdentifier] = [
-                            'source' => $sourceValue,
+                            'contentView' => $contentView,
                             'resolved' => $resolvedValue,
                         ];
                     }
@@ -181,7 +212,7 @@ readonly class ContentResolver implements ContentResolverInterface
             $existing = $this->propertyAccessor->getValue($resolvedContent['view'], $path);
             $existingView = \is_array($existing) ? $existing : [];
 
-            $merged = $this->mergeViewEnhancement($existingView, $items, $enhancement['isList']);
+            $merged = $this->mergeViewEnhancement($existingView, $items, $enhancement['itemsPropertyName']);
             $this->propertyAccessor->setValue($resolvedContent['view'], $path, $merged);
         }
 
@@ -198,6 +229,8 @@ readonly class ContentResolver implements ContentResolverInterface
             $normalizedContentData,
             '[content]'
         );
+
+        $normalizedContentData = $this->mergeFieldViewDataIntoItems($normalizedContentData, $viewEnhancements);
 
         if (null !== $properties && [] !== $properties) {
             $this->contentViewDataNormalizer->recursivelyMapProperties(
@@ -251,37 +284,68 @@ readonly class ContentResolver implements ContentResolverInterface
      *
      * @return array<string|int, mixed>
      */
-    private function mergeViewEnhancement(array $existingView, array $items, bool $isList): array
+    private function mergeViewEnhancement(array $existingView, array $items, ?string $itemsPropertyName): array
     {
-        if ([] === $existingView) {
-            if (!$isList && 1 === \count($items) && \is_array($items[0])) {
-                return $items[0];
+        if (null === $itemsPropertyName) {
+            if (1 === \count($items) && \is_array($items[0])) {
+                return \array_merge($existingView, $items[0]);
             }
 
-            return $items;
-        }
-
-        if ($isList) {
-            if (\array_is_list($existingView)) {
-                return [...$existingView, ...$items];
-            }
-
-            $existingItems = $existingView['items'] ?? [];
-            if (\is_array($existingItems) && \array_is_list($existingItems)) {
-                $existingView['items'] = [...$existingItems, ...$items];
-            } else {
-                $existingView['items'] = $items;
-            }
+            $existingView['items'] = $items;
 
             return $existingView;
         }
 
-        if (1 === \count($items) && \is_array($items[0])) {
-            return \array_merge($existingView, $items[0]);
-        }
-
-        $existingView['items'] = $items;
+        $existingView[$itemsPropertyName] = $items;
 
         return $existingView;
+    }
+
+    /**
+     * After normalization, per-item field-level view data (e.g., title: [], url: []) lives at
+     * numeric indices alongside the 'items' array from viewEnhancements. This method merges
+     * those numeric entries into the corresponding 'items' entry for a clean structure.
+     *
+     * @param array{resource: object, content: array<string, mixed>, view: array<string, mixed>, extension: array<string, array<string, mixed>>} $normalizedContentData
+     * @param array<string, array{itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements
+     *
+     * @return array{resource: object, content: array<string, mixed>, view: array<string, mixed>, extension: array<string, array<string, mixed>>}
+     */
+    private function mergeFieldViewDataIntoItems(array $normalizedContentData, array $viewEnhancements): array
+    {
+        foreach ($viewEnhancements as $path => $enhancement) {
+            $itemsPropertyName = $enhancement['itemsPropertyName'];
+            if (null === $itemsPropertyName) {
+                continue;
+            }
+
+            // Strip the first path segment (resolver key like 'template') since
+            // normalizeContentViewData flattens it to the root level
+            $normalizedPath = \preg_replace('/^\[[^\]]+\]/', '', $path);
+            $viewPath = '[view]' . $normalizedPath;
+            if (!$this->propertyAccessor->isReadable($normalizedContentData, $viewPath)) {
+                continue;
+            }
+
+            $viewValue = $this->propertyAccessor->getValue($normalizedContentData, $viewPath);
+            if (!\is_array($viewValue) || !isset($viewValue[$itemsPropertyName])) {
+                continue;
+            }
+
+            /** @var list<array<string, mixed>> $items */
+            $items = $viewValue[$itemsPropertyName];
+            foreach ($items as $index => $item) {
+                if (isset($viewValue[$index]) && \is_array($viewValue[$index])) {
+                    $items[$index] = \array_merge($item, $viewValue[$index]);
+                    unset($viewValue[$index]);
+                }
+            }
+
+            $viewValue[$itemsPropertyName] = $items;
+            $this->propertyAccessor->setValue($normalizedContentData, $viewPath, $viewValue);
+        }
+
+        /** @var array{resource: object, content: array<string, mixed>, view: array<string, mixed>, extension: array<string, array<string, mixed>>} $normalizedContentData */
+        return $normalizedContentData;
     }
 }

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -228,7 +228,7 @@ readonly class ContentResolver implements ContentResolverInterface
 
         $this->contentViewDataNormalizer->replaceNestedContentViews(
             $normalizedContentData,
-            '[content]'
+            ['content']
         );
 
         $normalizedContentData = $this->mergeFieldViewDataIntoItems($normalizedContentData, $viewEnhancements);

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -26,10 +26,14 @@ use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\ShadowInterface;
 use Sulu\Content\Domain\Model\TemplateInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Webmozart\Assert\Assert;
 
 readonly class ContentResolver implements ContentResolverInterface
 {
+    private PropertyAccessorInterface $propertyAccessor;
+
     public function __construct(
         private ContentViewResolverInterface $contentViewResolver,
         private ResolvableResourceLoaderInterface $resolvableResourceLoader,
@@ -40,6 +44,7 @@ readonly class ContentResolver implements ContentResolverInterface
         private int $maxDepth,
         private ContentEnhancerInterface $contentEnhancer
     ) {
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
     }
 
     public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): array
@@ -100,6 +105,7 @@ readonly class ContentResolver implements ContentResolverInterface
 
                             /** @var ResolvableInterface $resolvableResource */
                             $resolvableResource = $resourcesToLoad[$loaderKey][$id][$metadataIdentifier];
+
                             $metadata = $resolvableResource->getMetadata();
                             /** @var array<string, string>|null $internalProperties */
                             $internalProperties = $metadata['properties'] ?? null;
@@ -119,6 +125,8 @@ readonly class ContentResolver implements ContentResolverInterface
                                     isRoot: false
                                 );
                             }
+
+                            $sourceValue = $childContent;
                         } elseif ($resource instanceof ContentView) {
                             /** @var array{
                              *     content: array{'0': array<string, mixed>},
@@ -138,28 +146,51 @@ readonly class ContentResolver implements ContentResolverInterface
                                 $normalizedContentData['resolvableResources'],
                                 $priorityQueue,
                             );
+
+                            $sourceValue = $resolvedValue;
                         } else {
-                            // For non-entity resources, just store the resource directly
                             $resolvedValue = $resource;
+                            $sourceValue = $resource;
                         }
 
-                        $resolvedResources[$loaderKey][$id][$metadataIdentifier] = $resolvedValue;
+                        $resolvedResources[$loaderKey][$id][$metadataIdentifier] = [
+                            'source' => $sourceValue,
+                            'resolved' => $resolvedValue,
+                        ];
                     }
                 }
             }
         }
 
-        // Replace all ResolvableResource references with their actual resolved values
-        $finalContent = $this->resolvableResourceReplacer->replaceResolvableResourcesWithResolvedValues(
+        $replacerResult = $this->resolvableResourceReplacer->replaceResolvableResourcesWithResolvedValues(
             $resolvedContent['content'],
             $resolvedResources,
             1, // Start at depth 1 since the initial resolution was at depth 0
             $this->maxDepth,
         );
 
+        $finalContent = $replacerResult['content'];
+        $viewEnhancements = $replacerResult['viewEnhancements'];
+
+        foreach ($viewEnhancements as $path => $enhancement) {
+            $items = $enhancement['items'];
+            if ([] === $items) {
+                continue;
+            }
+
+            $existing = $this->propertyAccessor->getValue($resolvedContent['view'], $path);
+            $existingView = \is_array($existing) ? $existing : [];
+
+            $merged = $this->mergeViewEnhancement($existingView, $items, $enhancement['isList']);
+            $this->propertyAccessor->setValue($resolvedContent['view'], $path, $merged);
+        }
+
+        /** @var array<string, mixed> $viewData */
+        $viewData = $resolvedContent['view'];
+
         $normalizedContentData = $this->contentViewDataNormalizer->normalizeContentViewData(
             $finalContent,
-            $resolvedContent['view'],
+            $viewData,
             $dimensionContent->getResource(),
         );
 
@@ -212,5 +243,45 @@ readonly class ContentResolver implements ContentResolverInterface
         );
 
         return $resolvedContent;
+    }
+
+    /**
+     * @param array<string|int, mixed> $existingView
+     * @param list<mixed> $items
+     *
+     * @return array<string|int, mixed>
+     */
+    private function mergeViewEnhancement(array $existingView, array $items, bool $isList): array
+    {
+        if ([] === $existingView) {
+            if (!$isList && 1 === \count($items) && \is_array($items[0])) {
+                return $items[0];
+            }
+
+            return $items;
+        }
+
+        if ($isList) {
+            if (\array_is_list($existingView)) {
+                return [...$existingView, ...$items];
+            }
+
+            $existingItems = $existingView['items'] ?? [];
+            if (\is_array($existingItems) && \array_is_list($existingItems)) {
+                $existingView['items'] = [...$existingItems, ...$items];
+            } else {
+                $existingView['items'] = $items;
+            }
+
+            return $existingView;
+        }
+
+        if (1 === \count($items) && \is_array($items[0])) {
+            return \array_merge($existingView, $items[0]);
+        }
+
+        $existingView['items'] = $items;
+
+        return $existingView;
     }
 }

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -201,6 +201,7 @@ readonly class ContentResolver implements ContentResolverInterface
         );
 
         $finalContent = $replacerResult['content'];
+        /** @var array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements */
         $viewEnhancements = $replacerResult['viewEnhancements'];
 
         foreach ($viewEnhancements as $path => $enhancement) {
@@ -302,27 +303,30 @@ readonly class ContentResolver implements ContentResolverInterface
     }
 
     /**
-     * After normalization, per-item field-level view data (e.g., title: [], url: []) lives at
-     * numeric indices alongside the 'items' array from viewEnhancements. This method merges
-     * those numeric entries into the corresponding 'items' entry for a clean structure.
+     * Folds per-item field-level view data sitting at numeric indices into the
+     * corresponding `items` entry produced by viewEnhancements.
      *
      * @param array{resource: object, content: array<string, mixed>, view: array<string, mixed>, extension: array<string, array<string, mixed>>} $normalizedContentData
-     * @param array<string, array{itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements
+     * @param array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements
      *
      * @return array{resource: object, content: array<string, mixed>, view: array<string, mixed>, extension: array<string, array<string, mixed>>}
      */
     private function mergeFieldViewDataIntoItems(array $normalizedContentData, array $viewEnhancements): array
     {
-        foreach ($viewEnhancements as $path => $enhancement) {
+        foreach ($viewEnhancements as $enhancement) {
             $itemsPropertyName = $enhancement['itemsPropertyName'];
             if (null === $itemsPropertyName) {
                 continue;
             }
 
-            // Strip the first path segment (resolver key like 'template') since
-            // normalizeContentViewData flattens it to the root level
-            $normalizedPath = \preg_replace('/^\[[^\]]+\]/', '', $path);
-            $viewPath = '[view]' . $normalizedPath;
+            // strip the resolver-key segment that normalizeContentViewData flattens into [view]
+            $pathSegments = $enhancement['path'];
+            \array_shift($pathSegments);
+            if ([] === $pathSegments) {
+                continue;
+            }
+
+            $viewPath = '[view]' . $this->buildPropertyPath($pathSegments);
             if (!$this->propertyAccessor->isReadable($normalizedContentData, $viewPath)) {
                 continue;
             }
@@ -347,5 +351,13 @@ readonly class ContentResolver implements ContentResolverInterface
 
         /** @var array{resource: object, content: array<string, mixed>, view: array<string, mixed>, extension: array<string, array<string, mixed>>} $normalizedContentData */
         return $normalizedContentData;
+    }
+
+    /**
+     * @param list<int|string> $segments
+     */
+    private function buildPropertyPath(array $segments): string
+    {
+        return '[' . \implode('][', $segments) . ']';
     }
 }

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -22,7 +22,7 @@ use Sulu\Content\Application\ContentResolver\ResolvableResourceQueue\ResolvableR
 use Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\ResolvableResourceReplacerInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewEnhancementInterface;
 use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
@@ -33,6 +33,99 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Webmozart\Assert\Assert;
 
 /**
+ * Resolves a DimensionContent into the API response data shape.
+ *
+ * Data flow:
+ *
+ *  +------------------+
+ *  | DimensionContent |
+ *  +------------------+
+ *           |
+ *           v
+ *  +--------------------------+
+ *  | ContentEnhancer::enhance |
+ *  +--------------------------+
+ *           |
+ *           | enriches DimensionContent before resolver extraction
+ *           v
+ *  +---------------------+
+ *  | ContentViewResolver |
+ *  +---------------------+
+ *           |
+ *           | calls content/property resolvers
+ *           | returns content + view + ResolvableResource queue
+ *           v
+ *  +----------------+
+ *  | priority queue |
+ *  +----------------+
+ *           |
+ *           | repeat: extract highest priority resources until empty
+ *           v
+ *  +----------------------+
+ *  | loadResources        |       uses ResourceLoader::load()
+ *  +----------------------+       hook: ResourceLoaderContentViewEnhancementInterface
+ *                                 adds metadata available only after loading
+ *           |
+ *           v
+ *  +------------------+
+ *  | loaded resource  |
+ *  +------------------+
+ *           |
+ *           +-- ContentRichEntityInterface ----------------------------+
+ *           |      |                                                   |
+ *           |      v                                                   |
+ *           |  aggregate child DimensionContent                        |
+ *           |      |                                                   |
+ *           |      v                                                   |
+ *           |  resolve child content recursively                       |
+ *           |      |                                                   |
+ *           |      v                                                   |
+ *           |  normalize child content/view with child resource        |
+ *           |      |                                                   |
+ *           |      v                                                   |
+ *           |  apply requested property mapping                        |
+ *           |      |                                                   |
+ *           |      +-- content enhancement: merge immediately          |
+ *           |      |   so loader-level metadata is always present      |
+ *           |      |                                                   |
+ *           |      +-- view enhancement: defer until parent path exists|
+ *           |                                                          |
+ *           +-- ContentView ------------------------------------------+
+ *           |      resolve nested ContentView content/view             |
+ *           |      merge newly queued ResolvableResource values        |
+ *           |      store resolved value + ContentView enhancement      |
+ *           |                                                          |
+ *           +-- raw resource -----------------------------------------+
+ *           |      store resource value + ContentView enhancement
+ *           |
+ *           v
+ *  +----------------------------+
+ *  | ResolvableResourceReplacer |
+ *  +----------------------------+
+ *           |
+ *           | replace content placeholders
+ *           | merge deferred content enhancements when possible
+ *           | collect view enhancements by original parent path
+ *           v
+ *  +--------------------------------------+
+ *  | apply viewEnhancements to root view  |
+ *  | via mergeViewEnhancement()           |
+ *  +--------------------------------------+
+ *           |
+ *           | resolvedContent['view']
+ *           v
+ *  +---------------------------+
+ *  | ContentViewDataNormalizer |
+ *  +---------------------------+
+ *           |
+ *           | normalize final content + view
+ *           | replace nested ContentView instances in content
+ *           | merge field-level item view data into items
+ *           | apply optional root property mapping
+ *           |
+ *           v
+ *  array{resource: object, content: array, view: array, extension: array}
+ *
  * @final
  */
 readonly class ContentResolver implements ContentResolverInterface
@@ -88,7 +181,7 @@ readonly class ContentResolver implements ContentResolverInterface
             // Process loaded resources
             foreach ($loadedResources as $loaderKey => $resources) {
                 $resourceLoader = $this->resourceLoaderProvider->getResourceLoader($loaderKey);
-                $supportsContentView = $resourceLoader instanceof ResourceLoaderContentViewInterface;
+                $supportsContentViewEnhancement = $resourceLoader instanceof ResourceLoaderContentViewEnhancementInterface;
 
                 foreach ($resources as $id => $resourcePerMetadataIdentifier) {
                     $depth = $loaderIdDepths[$loaderKey][$id];
@@ -135,25 +228,25 @@ readonly class ContentResolver implements ContentResolverInterface
                                 );
                             }
 
-                            // Merge ResourceLoader content data into the resolved content
-                            // after property mapping so it's always present regardless of properties config
-                            if ($supportsContentView) {
-                                $entityContentView = $resourceLoader->resolveContentView($childContent);
-                                $entityContentData = $entityContentView->getContent();
+                            // Content enhancements must be merged into normalized content after property mapping,
+                            // otherwise loader-level metadata could be filtered out or merged at the wrapper level later.
+                            // View enhancements depend on the parent property path and are applied after replacement.
+                            $deferredViewData = [];
+                            if ($supportsContentViewEnhancement) {
+                                $contentViewEnhancement = $resourceLoader->resolveContentViewEnhancement($childContent);
+                                $contentEnhancement = $contentViewEnhancement->getContent();
 
-                                if (\is_array($entityContentData) && [] !== $entityContentData) {
+                                if (\is_array($contentEnhancement) && [] !== $contentEnhancement) {
                                     /** @var array<string, mixed> $existingContent */
                                     $existingContent = $resolvedValue['content'];
-                                    $resolvedValue['content'] = \array_merge($existingContent, $entityContentData);
+                                    $resolvedValue['content'] = \array_merge($existingContent, $contentEnhancement);
                                 }
 
-                                $contentView = ContentView::create([], $entityContentView->getView());
-                            } else {
-                                $contentView = ContentView::create([], []);
+                                $deferredViewData = $contentViewEnhancement->getView();
                             }
 
                             $resolvedResources[$loaderKey][$id][$metadataIdentifier] = [
-                                'contentView' => $contentView,
+                                'contentViewEnhancement' => ContentView::create([], $deferredViewData),
                                 'resolved' => $resolvedValue,
                             ];
                             continue;
@@ -183,12 +276,12 @@ readonly class ContentResolver implements ContentResolverInterface
                             $sourceValue = $resource;
                         }
 
-                        $contentView = $supportsContentView
-                            ? $resourceLoader->resolveContentView($sourceValue)
+                        $contentViewEnhancement = $supportsContentViewEnhancement
+                            ? $resourceLoader->resolveContentViewEnhancement($sourceValue)
                             : ContentView::create([], []);
 
                         $resolvedResources[$loaderKey][$id][$metadataIdentifier] = [
-                            'contentView' => $contentView,
+                            'contentViewEnhancement' => $contentViewEnhancement,
                             'resolved' => $resolvedValue,
                         ];
                     }
@@ -203,6 +296,7 @@ readonly class ContentResolver implements ContentResolverInterface
             $this->maxDepth,
         );
 
+        /** @var array<string, mixed> $finalContent */
         $finalContent = $replacerResult['content'];
         /** @var array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements */
         $viewEnhancements = $replacerResult['viewEnhancements'];

--- a/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolver.php
@@ -153,10 +153,8 @@ class ContentViewResolver implements ContentViewResolverInterface
                 }
             }
 
-            // If the view is not set for this name, we can use the root view
-            if (($result['view'][$name] ?? null) === null) {
-                $result['view'][$name] = $view;
-            }
+            // Root view provides the base; per-key sub-item views take precedence on collision
+            $result['view'][$name] = \array_merge($view, $result['view'][$name] ?? []);
 
             $result['resolvableResources'] = $resolvableResources;
 

--- a/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizer.php
+++ b/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizer.php
@@ -126,9 +126,11 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
                     // Replace first 'content' with 'view' in the path
                     $viewPath = \substr_replace($viewPath, '[view]', 0, $contentLength);
 
-                    // Only override empty view paths
-                    if (($this->propertyAccessor->getValue($contentData, $viewPath) ?? []) === []) {
-                        $pathValues[$viewPath] = $value;
+                    $existingViewData = $this->propertyAccessor->getValue($contentData, $viewPath) ?? [];
+                    if (\is_array($existingViewData) && \is_array($value)) {
+                        $pathValues[$viewPath] = [] === $existingViewData
+                            ? $value
+                            : \array_merge($value, $existingViewData);
                     }
                 } elseif ('content' === $key) {
                     $value = $this->propertyAccessor->getValue($contentData, $path . '[' . $key . ']');

--- a/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizer.php
+++ b/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizer.php
@@ -87,11 +87,12 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
      *     view: array<string, mixed>,
      *     extension: array<string, array<string, mixed>>
      * } $contentData
+     * @param list<int|string> $path
      */
-    public function replaceNestedContentViews(array &$contentData, string $path = '[content]'): void
+    public function replaceNestedContentViews(array &$contentData, array $path = ['content']): void
     {
         $pathValues = [];
-        $iterable = $this->propertyAccessor->getValue($contentData, $path) ?? [];
+        $iterable = $this->propertyAccessor->getValue($contentData, $this->buildPropertyPath($path)) ?? [];
         if (!\is_array($iterable)) {
             return;
         }
@@ -100,7 +101,7 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
         foreach ($iterable as $key => $entry) {
             if (\is_array($entry)) {
                 if ([] !== $entry) {
-                    $this->replaceNestedContentViews($contentData, $path . '[' . $key . ']');
+                    $this->replaceNestedContentViews($contentData, [...$path, $key]);
                 }
 
                 if (!$this->isExtractableIterable($iterable)) {
@@ -108,39 +109,39 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
                 }
 
                 if ('view' === $key) {
-                    // If there are more [content] positions, we need to remove them, only keep the first one from the root property resolver
-                    $contentLength = \strlen('[content]');
-                    // search for the next occurrence of '[content]' after the current position
-                    $nextContentPosition = \strpos($path, '[content]', $contentLength);
-                    $viewPath = (false !== $nextContentPosition) ? \substr($path, 0, $nextContentPosition) : $path;
+                    // truncate at the next nested 'content' segment so we keep only the outermost resolver wrapper
+                    $nextContentIdx = $this->findSegmentAfter($path, 'content', 1);
+                    $viewPath = null === $nextContentIdx ? $path : \array_slice($path, 0, $nextContentIdx);
 
                     $value = null;
-                    if ($this->propertyAccessor->isReadable($contentData, $viewPath . '[' . $key . ']')) {
-                        $value = $this->propertyAccessor->getValue($contentData, $viewPath . '[' . $key . ']');
+                    $viewLookupPathStr = $this->buildPropertyPath([...$viewPath, $key]);
+                    if ($this->propertyAccessor->isReadable($contentData, $viewLookupPathStr)) {
+                        $value = $this->propertyAccessor->getValue($contentData, $viewLookupPathStr);
                     }
 
                     if (null === $value || [] === $value) {
-                        $value = $this->propertyAccessor->getValue($contentData, $path . '[' . $key . ']');
+                        $value = $this->propertyAccessor->getValue($contentData, $this->buildPropertyPath([...$path, $key]));
                     }
 
-                    // Replace first 'content' with 'view' in the path
-                    $viewPath = \substr_replace($viewPath, '[view]', 0, $contentLength);
+                    // swap the leading 'content' segment for 'view'
+                    $viewPath[0] = 'view';
+                    $viewPathStr = $this->buildPropertyPath($viewPath);
 
-                    $existingViewData = $this->propertyAccessor->getValue($contentData, $viewPath) ?? [];
+                    $existingViewData = $this->propertyAccessor->getValue($contentData, $viewPathStr) ?? [];
                     if (\is_array($existingViewData) && \is_array($value)) {
-                        $pathValues[$viewPath] = [] === $existingViewData
+                        $pathValues[$viewPathStr] = [] === $existingViewData
                             ? $value
                             : \array_merge($value, $existingViewData);
                     }
                 } elseif ('content' === $key) {
-                    $value = $this->propertyAccessor->getValue($contentData, $path . '[' . $key . ']');
-                    $pathValues[$path] = $value;
+                    $value = $this->propertyAccessor->getValue($contentData, $this->buildPropertyPath([...$path, $key]));
+                    $pathValues[$this->buildPropertyPath($path)] = $value;
                 }
             }
         }
 
-        foreach ($pathValues as $path => $value) {
-            $this->propertyAccessor->setValue($contentData, $path, $value); // @phpstan-ignore-line
+        foreach ($pathValues as $pathStr => $value) {
+            $this->propertyAccessor->setValue($contentData, $pathStr, $value); // @phpstan-ignore-line
         }
     }
 
@@ -166,15 +167,16 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
      *     extension: array<string, array<string, mixed>>
      * } &$data
      * @param array<string, mixed> $properties
+     * @param list<int|string> $path
      */
     public function recursivelyMapProperties(
         array &$data,
         array $properties,
-        string $path = '',
+        array $path = [],
         int $depth = 0,
         bool $isRoot = true
     ): void {
-        $iterable = '' === $path ? $data : ($this->propertyAccessor->getValue($data, $path) ?? []);
+        $iterable = [] === $path ? $data : ($this->propertyAccessor->getValue($data, $this->buildPropertyPath($path)) ?? []);
         if (!\is_array($iterable)) {
             return;
         }
@@ -182,22 +184,24 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
         foreach ($iterable as $key => $value) {
             if (
                 ($properties[$key] ?? null)
-                && $depth === (\substr_count($path, '][') + 1)
+                && $depth === \max(1, \count($path))
             ) {
-                $parent = $this->propertyAccessor->getValue($data, $path);
+                $pathStr = $this->buildPropertyPath($path);
+                $parent = $this->propertyAccessor->getValue($data, $pathStr);
                 if (!\is_array($parent)) {
                     continue;
                 }
                 unset($parent[$key]);
                 // @phpstan-ignore-next-line
-                $this->propertyAccessor->setValue($data, $path, $parent);
+                $this->propertyAccessor->setValue($data, $pathStr, $parent);
 
                 if (!\is_string($key)) {
                     continue;
                 }
-                $rootPath = ($isRoot ? '' : '[content]') . '[' . \implode('][', \explode('.', $key)) . ']';
+                $rootSegments = \explode('.', $key);
+                $rootPath = $isRoot ? $rootSegments : ['content', ...$rootSegments];
                 // @phpstan-ignore-next-line
-                $this->propertyAccessor->setValue($data, $rootPath, $value);
+                $this->propertyAccessor->setValue($data, $this->buildPropertyPath($rootPath), $value);
             }
 
             // do not walk into 'view' as views cannot be mapped via properties
@@ -208,11 +212,34 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
                 $this->recursivelyMapProperties(
                     $data, // @phpstan-ignore-line
                     $properties,
-                    $path . '[' . $key . ']',
+                    [...$path, $key],
                     $depth + 1,
                     $isRoot
                 );
             }
         }
+    }
+
+    /**
+     * @param list<int|string> $segments
+     */
+    private function buildPropertyPath(array $segments): string
+    {
+        return '[' . \implode('][', $segments) . ']';
+    }
+
+    /**
+     * @param list<int|string> $path
+     */
+    private function findSegmentAfter(array $path, string $segment, int $startIndex): ?int
+    {
+        $count = \count($path);
+        for ($i = $startIndex; $i < $count; ++$i) {
+            if ($path[$i] === $segment) {
+                return $i;
+            }
+        }
+
+        return null;
     }
 }

--- a/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerInterface.php
+++ b/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerInterface.php
@@ -51,8 +51,9 @@ interface ContentViewDataNormalizerInterface
      *     view: array<string, mixed>,
      *     extension: array<string, array<string, mixed>>
      * } $contentData
+     * @param list<int|string> $path
      */
-    public function replaceNestedContentViews(array &$contentData, string $path = '[content]'): void;
+    public function replaceNestedContentViews(array &$contentData, array $path = ['content']): void;
 
     /**
      * Recursively maps properties in the content data.
@@ -64,11 +65,12 @@ interface ContentViewDataNormalizerInterface
      *      extension: array<string, array<string, mixed>>,
      *  } $data
      * @param array<string, string> $properties
+     * @param list<int|string> $path
      */
     public function recursivelyMapProperties(
         array &$data,
         array $properties,
-        string $path = '',
+        array $path = [],
         int $depth = 0,
         bool $isRoot = true
     ): void;

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer;
 
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 
@@ -30,11 +31,11 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
 
     /**
      * @param array<int|string, mixed> $content
-     * @param array<string, array<string|int, array<string, array{source: mixed, resolved: mixed}>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
      *
      * @return array{
      *     content: array<int|string, mixed>,
-     *     viewEnhancements: array<string, array{items: list<mixed>, isList: bool}>,
+     *     viewEnhancements: array<string, array{itemsPropertyName: ?string, items: list<mixed>}>,
      * }
      */
     public function replaceResolvableResourcesWithResolvedValues(
@@ -43,7 +44,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
         int $depth,
         int $maxDepth
     ): array {
-        /** @var array<string, array{items: list<mixed>, isList: bool}> $viewEnhancements */
+        /** @var array<string, array{itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements */
         $viewEnhancements = [];
 
         $transformedContent = $this->replaceRecursively(
@@ -63,9 +64,9 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
 
     /**
      * @param array<int|string, mixed> $content
-     * @param array<string, array<string|int, array<string, array{source: mixed, resolved: mixed}>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
      * @param list<int|string> $path Current path in the content structure
-     * @param array<string, array{items: list<mixed>, isList: bool}> $viewEnhancements
+     * @param array<string, array{itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements
      *
      * @return array<int|string, mixed>
      */
@@ -92,23 +93,28 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
             if ($value instanceof ResolvableInterface) {
                 $resolveResult = $this->resolveValue($value, $resolvedResources);
                 $resolved = $resolveResult['resolved'];
-                $source = $resolveResult['source'];
+                $contentView = $resolveResult['contentView'];
 
-                if ($value instanceof ResolvableResource && null !== $source) {
-                    $viewData = $value->executeViewCallback($source);
-                    if (null !== $viewData) {
+                $contentData = $contentView->getContent();
+                if (\is_array($contentData) && [] !== $contentData && \is_array($resolved)) {
+                    $resolved = \array_merge($resolved, $contentData);
+                }
+
+                if ($value instanceof ResolvableResource) {
+                    $viewData = $contentView->getView();
+                    if ([] !== $viewData) {
                         $viewPath = \is_int($key) ? $path : $currentPath;
                         if ([] !== $viewPath) {
                             $pathKey = $this->buildPropertyPath($viewPath);
+                            $itemsPropertyName = $value->getItemsPropertyName();
 
                             if (!isset($viewEnhancements[$pathKey])) {
                                 $viewEnhancements[$pathKey] = [
+                                    'itemsPropertyName' => $itemsPropertyName,
                                     'items' => [],
-                                    'isList' => false,
                                 ];
                             }
                             $viewEnhancements[$pathKey]['items'][] = $viewData;
-                            $viewEnhancements[$pathKey]['isList'] = $viewEnhancements[$pathKey]['isList'] || \is_int($key);
                         }
                     }
                 }
@@ -164,9 +170,9 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
     }
 
     /**
-     * @param array<string, array<string|int, array<string, array{source: mixed, resolved: mixed}>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
      *
-     * @return array{source: mixed, resolved: mixed}
+     * @return array{contentView: ContentView, resolved: mixed}
      */
     private function resolveValue(
         ResolvableInterface $value,
@@ -179,7 +185,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
         $entry = $resolvedResources[$loaderKey][$id][$metadataIdentifier] ?? null;
 
         if (null === $entry) {
-            return ['source' => null, 'resolved' => null];
+            return ['contentView' => ContentView::create([], []), 'resolved' => null];
         }
 
         if ($value instanceof ResolvableResource && $value->getResourceKey()) {
@@ -187,7 +193,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
         }
 
         return [
-            'source' => $entry['source'],
+            'contentView' => $entry['contentView'],
             'resolved' => $value->executeResourceCallback($entry['resolved']),
         ];
     }

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -103,7 +103,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
                 if ($value instanceof ResolvableResource) {
                     $viewData = $contentViewEnhancement->getView();
                     if ([] !== $viewData) {
-                        // numeric keys share the parent bucket so multi-selection items aggregate
+                        // Numeric keys share the parent bucket so collection item views aggregate.
                         $viewPath = \is_int($key) ? $path : $currentPath;
                         if ([] !== $viewPath) {
                             $pathKey = $this->buildPropertyPath($viewPath);

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -35,7 +35,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
      *
      * @return array{
      *     content: array<int|string, mixed>,
-     *     viewEnhancements: array<string, array{itemsPropertyName: ?string, items: list<mixed>}>,
+     *     viewEnhancements: array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}>,
      * }
      */
     public function replaceResolvableResourcesWithResolvedValues(
@@ -44,7 +44,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
         int $depth,
         int $maxDepth
     ): array {
-        /** @var array<string, array{itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements */
+        /** @var array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements */
         $viewEnhancements = [];
 
         $transformedContent = $this->replaceRecursively(
@@ -66,7 +66,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
      * @param array<int|string, mixed> $content
      * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
      * @param list<int|string> $path Current path in the content structure
-     * @param array<string, array{itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements
+     * @param array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements
      *
      * @return array<int|string, mixed>
      */
@@ -103,6 +103,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
                 if ($value instanceof ResolvableResource) {
                     $viewData = $contentView->getView();
                     if ([] !== $viewData) {
+                        // numeric keys share the parent bucket so multi-selection items aggregate
                         $viewPath = \is_int($key) ? $path : $currentPath;
                         if ([] !== $viewPath) {
                             $pathKey = $this->buildPropertyPath($viewPath);
@@ -110,6 +111,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
 
                             if (!isset($viewEnhancements[$pathKey])) {
                                 $viewEnhancements[$pathKey] = [
+                                    'path' => $viewPath,
                                     'itemsPropertyName' => $itemsPropertyName,
                                     'items' => [],
                                 ];

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -31,7 +31,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
 
     /**
      * @param array<int|string, mixed> $content
-     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentViewEnhancement: ContentView}>>> $resolvedResources
      *
      * @return array{
      *     content: array<int|string, mixed>,
@@ -64,7 +64,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
 
     /**
      * @param array<int|string, mixed> $content
-     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentViewEnhancement: ContentView}>>> $resolvedResources
      * @param list<int|string> $path Current path in the content structure
      * @param array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}> $viewEnhancements
      *
@@ -93,15 +93,15 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
             if ($value instanceof ResolvableInterface) {
                 $resolveResult = $this->resolveValue($value, $resolvedResources);
                 $resolved = $resolveResult['resolved'];
-                $contentView = $resolveResult['contentView'];
+                $contentViewEnhancement = $resolveResult['contentViewEnhancement'];
 
-                $contentData = $contentView->getContent();
+                $contentData = $contentViewEnhancement->getContent();
                 if (\is_array($contentData) && [] !== $contentData && \is_array($resolved)) {
                     $resolved = \array_merge($resolved, $contentData);
                 }
 
                 if ($value instanceof ResolvableResource) {
-                    $viewData = $contentView->getView();
+                    $viewData = $contentViewEnhancement->getView();
                     if ([] !== $viewData) {
                         // numeric keys share the parent bucket so multi-selection items aggregate
                         $viewPath = \is_int($key) ? $path : $currentPath;
@@ -172,9 +172,9 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
     }
 
     /**
-     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentViewEnhancement: ContentView}>>> $resolvedResources
      *
-     * @return array{contentView: ContentView, resolved: mixed}
+     * @return array{contentViewEnhancement: ContentView, resolved: mixed}
      */
     private function resolveValue(
         ResolvableInterface $value,
@@ -187,7 +187,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
         $entry = $resolvedResources[$loaderKey][$id][$metadataIdentifier] ?? null;
 
         if (null === $entry) {
-            return ['contentView' => ContentView::create([], []), 'resolved' => null];
+            return ['contentViewEnhancement' => ContentView::create([], []), 'resolved' => null];
         }
 
         if ($value instanceof ResolvableResource && $value->getResourceKey()) {
@@ -195,7 +195,7 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
         }
 
         return [
-            'contentView' => $entry['contentView'],
+            'contentViewEnhancement' => $entry['contentViewEnhancement'],
             'resolved' => $value->executeResourceCallback($entry['resolved']),
         ];
     }

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -30,15 +30,52 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
 
     /**
      * @param array<int|string, mixed> $content
-     * @param array<string, array<string|int, array<string, mixed>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{source: mixed, resolved: mixed}>>> $resolvedResources
      *
-     * @return array<int|string, mixed>
+     * @return array{
+     *     content: array<int|string, mixed>,
+     *     viewEnhancements: array<string, array{items: list<mixed>, isList: bool}>,
+     * }
      */
     public function replaceResolvableResourcesWithResolvedValues(
         array $content,
         array $resolvedResources,
         int $depth,
         int $maxDepth
+    ): array {
+        /** @var array<string, array{items: list<mixed>, isList: bool}> $viewEnhancements */
+        $viewEnhancements = [];
+
+        $transformedContent = $this->replaceRecursively(
+            $content,
+            $resolvedResources,
+            $depth,
+            $maxDepth,
+            [],
+            $viewEnhancements
+        );
+
+        return [
+            'content' => $transformedContent,
+            'viewEnhancements' => $viewEnhancements,
+        ];
+    }
+
+    /**
+     * @param array<int|string, mixed> $content
+     * @param array<string, array<string|int, array<string, array{source: mixed, resolved: mixed}>>> $resolvedResources
+     * @param list<int|string> $path Current path in the content structure
+     * @param array<string, array{items: list<mixed>, isList: bool}> $viewEnhancements
+     *
+     * @return array<int|string, mixed>
+     */
+    private function replaceRecursively(
+        array $content,
+        array $resolvedResources,
+        int $depth,
+        int $maxDepth,
+        array $path,
+        array &$viewEnhancements
     ): array {
         if ($depth > $maxDepth) {
             return $this->replaceUnresolvedWithNull($content);
@@ -50,18 +87,42 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
 
         $onlyResolvableResources = true;
         foreach ($content as $key => $value) {
+            $currentPath = [...$path, $key];
+
             if ($value instanceof ResolvableInterface) {
-                $content[$key] = $this->resolveValue(
-                    $value,
-                    $resolvedResources
-                );
+                $resolveResult = $this->resolveValue($value, $resolvedResources);
+                $resolved = $resolveResult['resolved'];
+                $source = $resolveResult['source'];
+
+                if ($value instanceof ResolvableResource && null !== $source) {
+                    $viewData = $value->executeViewCallback($source);
+                    if (null !== $viewData) {
+                        $viewPath = \is_int($key) ? $path : $currentPath;
+                        if ([] !== $viewPath) {
+                            $pathKey = $this->buildPropertyPath($viewPath);
+
+                            if (!isset($viewEnhancements[$pathKey])) {
+                                $viewEnhancements[$pathKey] = [
+                                    'items' => [],
+                                    'isList' => false,
+                                ];
+                            }
+                            $viewEnhancements[$pathKey]['items'][] = $viewData;
+                            $viewEnhancements[$pathKey]['isList'] = $viewEnhancements[$pathKey]['isList'] || \is_int($key);
+                        }
+                    }
+                }
+
+                $content[$key] = $resolved;
 
                 if (\is_array($content[$key])) {
-                    $content[$key] = $this->replaceResolvableResourcesWithResolvedValues(
+                    $content[$key] = $this->replaceRecursively(
                         $content[$key],
                         $resolvedResources,
                         $depth + 1,
-                        $maxDepth
+                        $maxDepth,
+                        $currentPath,
+                        $viewEnhancements
                     );
                 }
                 continue;
@@ -69,11 +130,13 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
             $onlyResolvableResources = false;
 
             if (\is_array($value)) {
-                $content[$key] = $this->replaceResolvableResourcesWithResolvedValues(
+                $content[$key] = $this->replaceRecursively(
                     $value,
                     $resolvedResources,
                     $depth, // only increase depth for ResolvableInterface
-                    $maxDepth
+                    $maxDepth,
+                    $currentPath,
+                    $viewEnhancements
                 );
             }
         }
@@ -93,23 +156,40 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
     }
 
     /**
-     * @param array<string, array<string|int, array<string, mixed>>> $resolvedResources
+     * @param list<int|string> $path
+     */
+    private function buildPropertyPath(array $path): string
+    {
+        return '[' . \implode('][', $path) . ']';
+    }
+
+    /**
+     * @param array<string, array<string|int, array<string, array{source: mixed, resolved: mixed}>>> $resolvedResources
+     *
+     * @return array{source: mixed, resolved: mixed}
      */
     private function resolveValue(
         ResolvableInterface $value,
         array $resolvedResources
-    ): mixed {
+    ): array {
         $loaderKey = $value->getResourceLoaderKey();
         $id = $value->getId();
         $metadataIdentifier = $value->getMetadataIdentifier();
 
-        $resource = $resolvedResources[$loaderKey][$id][$metadataIdentifier] ?? null;
+        $entry = $resolvedResources[$loaderKey][$id][$metadataIdentifier] ?? null;
 
-        if (null !== $resource && $value instanceof ResolvableResource && $value->getResourceKey()) {
+        if (null === $entry) {
+            return ['source' => null, 'resolved' => null];
+        }
+
+        if ($value instanceof ResolvableResource && $value->getResourceKey()) {
             $this->populateReferenceStore($value->getId(), $value->getResourceKey());
         }
 
-        return null === $resource ? null : $value->executeResourceCallback($resource);
+        return [
+            'source' => $entry['source'],
+            'resolved' => $value->executeResourceCallback($entry['resolved']),
+        ];
     }
 
     /**

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
@@ -21,9 +21,12 @@ interface ResolvableResourceReplacerInterface
 {
     /**
      * @param array<string, mixed> $content
-     * @param array<string, array<string|int, array<string, mixed>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{source: mixed, resolved: mixed}>>> $resolvedResources
      *
-     * @return array<string, mixed>
+     * @return array{
+     *     content: array<string, mixed>,
+     *     viewEnhancements: array<string, array{items: list<mixed>, isList: bool}>,
+     * }
      */
     public function replaceResolvableResourcesWithResolvedValues(
         array $content,

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
@@ -22,11 +22,11 @@ use Sulu\Content\Application\ContentResolver\Value\ContentView;
 interface ResolvableResourceReplacerInterface
 {
     /**
-     * @param array<string, mixed> $content
-     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
+     * @param array<int|string, mixed> $content
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentViewEnhancement: ContentView}>>> $resolvedResources
      *
      * @return array{
-     *     content: array<string, mixed>,
+     *     content: array<int|string, mixed>,
      *     viewEnhancements: array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}>,
      * }
      */

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
@@ -27,7 +27,7 @@ interface ResolvableResourceReplacerInterface
      *
      * @return array{
      *     content: array<string, mixed>,
-     *     viewEnhancements: array<string, array{itemsPropertyName: ?string, items: list<mixed>}>,
+     *     viewEnhancements: array<string, array{path: list<int|string>, itemsPropertyName: ?string, items: list<mixed>}>,
      * }
      */
     public function replaceResolvableResourcesWithResolvedValues(

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer;
 
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+
 /**
  * @internal This interface is intended for internal use only within the package/library.
  * Modifying or depending on this interface may result in unexpected behavior and is not supported.
@@ -21,11 +23,11 @@ interface ResolvableResourceReplacerInterface
 {
     /**
      * @param array<string, mixed> $content
-     * @param array<string, array<string|int, array<string, array{source: mixed, resolved: mixed}>>> $resolvedResources
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentView: ContentView}>>> $resolvedResources
      *
      * @return array{
      *     content: array<string, mixed>,
-     *     viewEnhancements: array<string, array{items: list<mixed>, isList: bool}>,
+     *     viewEnhancements: array<string, array{itemsPropertyName: ?string, items: list<mixed>}>,
      * }
      */
     public function replaceResolvableResourcesWithResolvedValues(

--- a/packages/content/src/Application/ContentResolver/Value/ContentView.php
+++ b/packages/content/src/Application/ContentResolver/Value/ContentView.php
@@ -102,6 +102,7 @@ class ContentView
         int $priority = 0,
         ?\Closure $closure = null,
         ?array $metadata = null,
+        ?\Closure $viewCallback = null,
     ): self {
         return new self(
             new ResolvableResource(
@@ -111,6 +112,7 @@ class ContentView
                 resourceCallback: $closure,
                 metadata: $metadata,
                 resourceKey: $resourceKey,
+                viewCallback: $viewCallback,
             ),
             $view,
             [new Reference($id, $resourceKey)]
@@ -155,6 +157,7 @@ class ContentView
         array $view,
         int $priority = 0,
         ?array $metadata = null,
+        ?\Closure $viewCallback = null,
     ): self {
         $resolvableResources = [];
         $references = [];
@@ -164,7 +167,8 @@ class ContentView
                 resourceLoaderKey: $resourceLoaderKey,
                 priority: $priority,
                 metadata: $metadata,
-                resourceKey: $resourceKey
+                resourceKey: $resourceKey,
+                viewCallback: $viewCallback,
             );
             $references[] = new Reference($id, $resourceKey);
         }

--- a/packages/content/src/Application/ContentResolver/Value/ContentView.php
+++ b/packages/content/src/Application/ContentResolver/Value/ContentView.php
@@ -102,7 +102,7 @@ class ContentView
         int $priority = 0,
         ?\Closure $closure = null,
         ?array $metadata = null,
-        ?\Closure $viewCallback = null,
+        ?string $itemsPropertyName = null,
     ): self {
         return new self(
             new ResolvableResource(
@@ -112,7 +112,7 @@ class ContentView
                 resourceCallback: $closure,
                 metadata: $metadata,
                 resourceKey: $resourceKey,
-                viewCallback: $viewCallback,
+                itemsPropertyName: $itemsPropertyName,
             ),
             $view,
             [new Reference($id, $resourceKey)]
@@ -157,7 +157,7 @@ class ContentView
         array $view,
         int $priority = 0,
         ?array $metadata = null,
-        ?\Closure $viewCallback = null,
+        ?string $itemsPropertyName = null,
     ): self {
         $resolvableResources = [];
         $references = [];
@@ -168,7 +168,7 @@ class ContentView
                 priority: $priority,
                 metadata: $metadata,
                 resourceKey: $resourceKey,
-                viewCallback: $viewCallback,
+                itemsPropertyName: $itemsPropertyName,
             );
             $references[] = new Reference($id, $resourceKey);
         }

--- a/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
+++ b/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
@@ -18,7 +18,7 @@ namespace Sulu\Content\Application\ContentResolver\Value;
  */
 class ResolvableResource implements ResolvableInterface
 {
-    private \Closure $callback;
+    private \Closure $resourceCallback;
 
     /**
      * @param array<string, mixed>|null $metadata Optional metadata for additional context
@@ -30,8 +30,9 @@ class ResolvableResource implements ResolvableInterface
         ?\Closure $resourceCallback = null,
         private ?array $metadata = null,
         private ?string $resourceKey = null,
+        private ?\Closure $viewCallback = null,
     ) {
-        $this->callback = $resourceCallback ?? (static fn (mixed $resource) => $resource);
+        $this->resourceCallback = $resourceCallback ?? (static fn (mixed $resource) => $resource);
     }
 
     public function getId(): string|int
@@ -46,7 +47,16 @@ class ResolvableResource implements ResolvableInterface
 
     public function executeResourceCallback(mixed $resource): mixed
     {
-        return ($this->callback)($resource);
+        return ($this->resourceCallback)($resource);
+    }
+
+    public function executeViewCallback(mixed $source): mixed
+    {
+        if (null === $this->viewCallback) {
+            return null;
+        }
+
+        return ($this->viewCallback)($source);
     }
 
     public function getPriority(): int

--- a/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
+++ b/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
@@ -18,7 +18,7 @@ namespace Sulu\Content\Application\ContentResolver\Value;
  */
 class ResolvableResource implements ResolvableInterface
 {
-    private \Closure $resourceCallback;
+    private \Closure $callback;
 
     /**
      * @param array<string, mixed>|null $metadata Optional metadata for additional context
@@ -32,7 +32,7 @@ class ResolvableResource implements ResolvableInterface
         private ?string $resourceKey = null,
         private ?string $itemsPropertyName = null,
     ) {
-        $this->resourceCallback = $resourceCallback ?? (static fn (mixed $resource) => $resource);
+        $this->callback = $resourceCallback ?? (static fn (mixed $resource) => $resource);
     }
 
     public function getId(): string|int
@@ -47,7 +47,7 @@ class ResolvableResource implements ResolvableInterface
 
     public function executeResourceCallback(mixed $resource): mixed
     {
-        return ($this->resourceCallback)($resource);
+        return ($this->callback)($resource);
     }
 
     public function getItemsPropertyName(): ?string

--- a/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
+++ b/packages/content/src/Application/ContentResolver/Value/ResolvableResource.php
@@ -30,7 +30,7 @@ class ResolvableResource implements ResolvableInterface
         ?\Closure $resourceCallback = null,
         private ?array $metadata = null,
         private ?string $resourceKey = null,
-        private ?\Closure $viewCallback = null,
+        private ?string $itemsPropertyName = null,
     ) {
         $this->resourceCallback = $resourceCallback ?? (static fn (mixed $resource) => $resource);
     }
@@ -50,13 +50,9 @@ class ResolvableResource implements ResolvableInterface
         return ($this->resourceCallback)($resource);
     }
 
-    public function executeViewCallback(mixed $source): mixed
+    public function getItemsPropertyName(): ?string
     {
-        if (null === $this->viewCallback) {
-            return null;
-        }
-
-        return ($this->viewCallback)($source);
+        return $this->itemsPropertyName;
     }
 
     public function getPriority(): int

--- a/packages/content/src/Application/ResourceLoader/Loader/CachedResourceLoader.php
+++ b/packages/content/src/Application/ResourceLoader/Loader/CachedResourceLoader.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * @internal this class is internal and should not be used or extended in custom code
  */
-class CachedResourceLoader implements ResourceLoaderContentViewInterface, ResetInterface
+class CachedResourceLoader implements ResourceLoaderContentViewEnhancementInterface, ResetInterface
 {
     /**
      * @var array<string, mixed>
@@ -74,10 +74,10 @@ class CachedResourceLoader implements ResourceLoaderContentViewInterface, ResetI
         ]));
     }
 
-    public function resolveContentView(mixed $source): ContentView
+    public function resolveContentViewEnhancement(mixed $resource): ContentView
     {
-        if ($this->decoratedResourceLoader instanceof ResourceLoaderContentViewInterface) {
-            return $this->decoratedResourceLoader->resolveContentView($source);
+        if ($this->decoratedResourceLoader instanceof ResourceLoaderContentViewEnhancementInterface) {
+            return $this->decoratedResourceLoader->resolveContentViewEnhancement($resource);
         }
 
         return ContentView::create([], []);

--- a/packages/content/src/Application/ResourceLoader/Loader/CachedResourceLoader.php
+++ b/packages/content/src/Application/ResourceLoader/Loader/CachedResourceLoader.php
@@ -11,12 +11,13 @@
 
 namespace Sulu\Content\Application\ResourceLoader\Loader;
 
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @internal this class is internal and should not be used or extended in custom code
  */
-class CachedResourceLoader implements ResourceLoaderInterface, ResetInterface
+class CachedResourceLoader implements ResourceLoaderContentViewInterface, ResetInterface
 {
     /**
      * @var array<string, mixed>
@@ -71,6 +72,15 @@ class CachedResourceLoader implements ResourceLoaderInterface, ResetInterface
             'locale' => $locale,
             'params' => $params,
         ]));
+    }
+
+    public function resolveContentView(mixed $source): ContentView
+    {
+        if ($this->decoratedResourceLoader instanceof ResourceLoaderContentViewInterface) {
+            return $this->decoratedResourceLoader->resolveContentView($source);
+        }
+
+        return ContentView::create([], []);
     }
 
     public function reset(): void

--- a/packages/content/src/Application/ResourceLoader/Loader/ResourceLoaderContentViewEnhancementInterface.php
+++ b/packages/content/src/Application/ResourceLoader/Loader/ResourceLoaderContentViewEnhancementInterface.php
@@ -15,7 +15,7 @@ namespace Sulu\Content\Application\ResourceLoader\Loader;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 
-interface ResourceLoaderContentViewInterface extends ResourceLoaderInterface
+interface ResourceLoaderContentViewEnhancementInterface extends ResourceLoaderInterface
 {
-    public function resolveContentView(mixed $source): ContentView;
+    public function resolveContentViewEnhancement(mixed $resource): ContentView;
 }

--- a/packages/content/src/Application/ResourceLoader/Loader/ResourceLoaderContentViewInterface.php
+++ b/packages/content/src/Application/ResourceLoader/Loader/ResourceLoaderContentViewInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ResourceLoader\Loader;
+
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+
+interface ResourceLoaderContentViewInterface extends ResourceLoaderInterface
+{
+    public function resolveContentView(mixed $source): ContentView;
+}

--- a/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
+++ b/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
@@ -13,9 +13,6 @@ namespace Sulu\Content\Tests\Application\ExampleTestBundle\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
-use Sulu\Content\Domain\Model\AuthorInterface;
-use Sulu\Content\Domain\Model\TemplateInterface;
-use Sulu\Content\Domain\Model\WebspaceInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader\ExampleResourceLoader;
 
@@ -51,24 +48,7 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
             metadata: [
                 'properties' => $params['properties'] ?? null,
             ],
-            viewCallback: static function(mixed $source): array {
-                $view = [];
-
-                if ($source instanceof TemplateInterface) {
-                    $view['template'] = $source->getTemplateKey();
-                }
-
-                if ($source instanceof WebspaceInterface) {
-                    $view['mainWebspace'] = $source->getMainWebspace();
-                }
-
-                if ($source instanceof AuthorInterface) {
-                    $view['authored'] = $source->getAuthored()?->format('c');
-                    $view['lastModified'] = $source->getLastModified()?->format('c');
-                }
-
-                return $view;
-            },
+            itemsPropertyName: 'items',
         );
     }
 

--- a/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
+++ b/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
@@ -13,6 +13,9 @@ namespace Sulu\Content\Tests\Application\ExampleTestBundle\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Content\Domain\Model\AuthorInterface;
+use Sulu\Content\Domain\Model\TemplateInterface;
+use Sulu\Content\Domain\Model\WebspaceInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader\ExampleResourceLoader;
 
@@ -43,14 +46,29 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
             ids: $ids,
             resourceLoaderKey: $resourceLoaderKey,
             resourceKey: Example::RESOURCE_KEY,
-            view: [
-                'ids' => $ids,
-                ...$params,
-            ],
+            view: [],
             priority: 150,
             metadata: [
                 'properties' => $params['properties'] ?? null,
-            ]
+            ],
+            viewCallback: static function(mixed $source): array {
+                $view = [];
+
+                if ($source instanceof TemplateInterface) {
+                    $view['template'] = $source->getTemplateKey();
+                }
+
+                if ($source instanceof WebspaceInterface) {
+                    $view['mainWebspace'] = $source->getMainWebspace();
+                }
+
+                if ($source instanceof AuthorInterface) {
+                    $view['authored'] = $source->getAuthored()?->format('c');
+                    $view['lastModified'] = $source->getLastModified()?->format('c');
+                }
+
+                return $view;
+            },
         );
     }
 

--- a/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
+++ b/packages/content/tests/Application/ExampleTestBundle/PropertyResolver/ExampleSelectionPropertyResolver.php
@@ -48,7 +48,6 @@ class ExampleSelectionPropertyResolver implements PropertyResolverInterface
             metadata: [
                 'properties' => $params['properties'] ?? null,
             ],
-            itemsPropertyName: 'items',
         );
     }
 

--- a/packages/content/tests/Application/ExampleTestBundle/ResourceLoader/ExampleResourceLoader.php
+++ b/packages/content/tests/Application/ExampleTestBundle/ResourceLoader/ExampleResourceLoader.php
@@ -11,11 +11,15 @@
 
 namespace Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader;
 
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\TemplateInterface;
+use Sulu\Content\Domain\Model\WebspaceInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Repository\ExampleRepository;
 
-class ExampleResourceLoader implements ResourceLoaderInterface
+class ExampleResourceLoader implements ResourceLoaderContentViewInterface
 {
     public const RESOURCE_LOADER_KEY = 'example';
 
@@ -41,6 +45,27 @@ class ExampleResourceLoader implements ResourceLoaderInterface
         }
 
         return $mappedResult;
+    }
+
+    public function resolveContentView(mixed $source): ContentView
+    {
+        $view = [];
+        $content = [];
+
+        if ($source instanceof TemplateInterface) {
+            $view['template'] = $source->getTemplateKey();
+        }
+
+        if ($source instanceof WebspaceInterface) {
+            $view['mainWebspace'] = $source->getMainWebspace();
+        }
+
+        if ($source instanceof AuthorInterface) {
+            $content['authored'] = $source->getAuthored()?->format('c');
+            $content['lastModified'] = $source->getLastModified()?->format('c');
+        }
+
+        return ContentView::create($content, $view);
     }
 
     public static function getKey(): string

--- a/packages/content/tests/Application/ExampleTestBundle/ResourceLoader/ExampleResourceLoader.php
+++ b/packages/content/tests/Application/ExampleTestBundle/ResourceLoader/ExampleResourceLoader.php
@@ -12,14 +12,14 @@
 namespace Sulu\Content\Tests\Application\ExampleTestBundle\ResourceLoader;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewEnhancementInterface;
 use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\TemplateInterface;
 use Sulu\Content\Domain\Model\WebspaceInterface;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Repository\ExampleRepository;
 
-class ExampleResourceLoader implements ResourceLoaderContentViewInterface
+class ExampleResourceLoader implements ResourceLoaderContentViewEnhancementInterface
 {
     public const RESOURCE_LOADER_KEY = 'example';
 
@@ -47,22 +47,22 @@ class ExampleResourceLoader implements ResourceLoaderContentViewInterface
         return $mappedResult;
     }
 
-    public function resolveContentView(mixed $source): ContentView
+    public function resolveContentViewEnhancement(mixed $resource): ContentView
     {
         $view = [];
         $content = [];
 
-        if ($source instanceof TemplateInterface) {
-            $view['template'] = $source->getTemplateKey();
+        if ($resource instanceof TemplateInterface) {
+            $view['template'] = $resource->getTemplateKey();
         }
 
-        if ($source instanceof WebspaceInterface) {
-            $view['mainWebspace'] = $source->getMainWebspace();
+        if ($resource instanceof WebspaceInterface) {
+            $view['mainWebspace'] = $resource->getMainWebspace();
         }
 
-        if ($source instanceof AuthorInterface) {
-            $content['authored'] = $source->getAuthored()?->format('c');
-            $content['lastModified'] = $source->getLastModified()?->format('c');
+        if ($resource instanceof AuthorInterface) {
+            $content['authored'] = $resource->getAuthored()?->format('c');
+            $content['lastModified'] = $resource->getLastModified()?->format('c');
         }
 
         return ContentView::create($content, $view);

--- a/packages/content/tests/Application/config/templates/examples/default-example-with-snippets.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-example-with-snippets.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default-example-with-snippets</key>
+
+    <view>@ExampleTest/examples/default</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Example with Snippets</title>
+        <title lang="de">Beispiel mit Snippets</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="route" mandatory="true">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="snippets" type="snippet_selection">
+            <meta>
+                <title lang="en">Snippet Selection</title>
+                <title lang="de">Schnipsel Auswahl</title>
+            </meta>
+        </property>
+    </properties>
+</template>

--- a/packages/content/tests/Application/config/templates/examples/default-example-with-snippets.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-example-with-snippets.xml
@@ -42,5 +42,12 @@
                 <title lang="de">Schnipsel Auswahl</title>
             </meta>
         </property>
+
+        <property name="singleSnippet" type="single_snippet_selection">
+            <meta>
+                <title lang="en">Single Snippet</title>
+                <title lang="de">Einzelnes Schnipsel</title>
+            </meta>
+        </property>
     </properties>
 </template>

--- a/packages/content/tests/Application/config/templates/snippets/snippet-with-link.xml
+++ b/packages/content/tests/Application/config/templates/snippets/snippet-with-link.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>snippet-with-link</key>
+
+    <meta>
+        <title lang="en">Snippet with Link</title>
+        <title lang="de">Snippet mit Link</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+            <tag name="sulu.node.name"/>
+        </property>
+
+        <property name="link" type="link">
+            <meta>
+                <title lang="en">Link</title>
+                <title lang="de">Link</title>
+            </meta>
+        </property>
+    </properties>
+</template>

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -1604,11 +1604,8 @@ class ContentResolverTest extends SuluTestCase
 
     public function testResolveSingleAndMultiSnippetSelectionViewSymmetry(): void
     {
-        // Regression guard for the asymmetry between single_snippet_selection and
-        // snippet_selection (multi). Nested link metadata is only reachable on the
-        // view side (LinkPropertyResolver flattens links to URL strings on the data
-        // side via its closure), so view.singleSnippet.link must expose the same
-        // {provider, href, title} payload as view.snippets.items[0].link.
+        // view.singleSnippet.link must expose the same metadata as view.snippets.items[0].link
+        // (links get flattened to URL strings on the content side, view side is the only access)
         $snippet = static::createSnippet([
             'en' => [
                 'live' => [
@@ -1654,7 +1651,6 @@ class ContentResolverTest extends SuluTestCase
         /** @var array<string, mixed> $singleSnippetView */
         $singleSnippetView = $view['singleSnippet'];
 
-        // Sanity check: the multi-select view exposes the snippet's link metadata.
         self::assertArrayHasKey('link', $multiFirstItem);
         /** @var array<string, mixed> $multiLink */
         $multiLink = $multiFirstItem['link'];
@@ -1662,15 +1658,13 @@ class ContentResolverTest extends SuluTestCase
         self::assertSame('https://sulu.io', $multiLink['href']);
         self::assertSame('Sulu Website', $multiLink['title']);
 
-        // Bug L: the same metadata must be reachable via view.singleSnippet.link.
-        self::assertArrayHasKey('link', $singleSnippetView, 'Bug L: view.singleSnippet must expose nested link view, symmetric with view.snippets.items[0].link');
+        self::assertArrayHasKey('link', $singleSnippetView);
         /** @var array<string, mixed> $singleLink */
         $singleLink = $singleSnippetView['link'];
         self::assertSame('external', $singleLink['provider']);
         self::assertSame('https://sulu.io', $singleLink['href']);
         self::assertSame('Sulu Website', $singleLink['title']);
 
-        // Resource-level metadata must also be present and symmetric.
         self::assertSame($multiFirstItem['uuid'], $singleSnippetView['uuid']);
         self::assertSame($multiFirstItem['template'], $singleSnippetView['template']);
     }

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -1379,14 +1379,17 @@ class ContentResolverTest extends SuluTestCase
         $snippetsView = $view['snippets'];
         self::assertIsArray($snippetsView);
 
-        self::assertCount(3, $snippetsView);
+        self::assertArrayHasKey('items', $snippetsView);
+        $snippetItems = $snippetsView['items'];
+        self::assertIsArray($snippetItems);
+        self::assertCount(3, $snippetItems);
 
         /** @var array<string, mixed> $snippetView0 */
-        $snippetView0 = $snippetsView[0];
+        $snippetView0 = $snippetItems[0];
         /** @var array<string, mixed> $snippetView1 */
-        $snippetView1 = $snippetsView[1];
+        $snippetView1 = $snippetItems[1];
         /** @var array<string, mixed> $snippetView2 */
-        $snippetView2 = $snippetsView[2];
+        $snippetView2 = $snippetItems[2];
 
         self::assertSame($snippet1->getUuid(), $snippetView0['uuid']);
         self::assertSame('snippet-1', $snippetView0['template']);
@@ -1434,10 +1437,13 @@ class ContentResolverTest extends SuluTestCase
         $snippetsView = $view['snippets'];
         self::assertIsArray($snippetsView);
 
-        self::assertCount(1, $snippetsView);
+        self::assertArrayHasKey('items', $snippetsView);
+        $snippetItems = $snippetsView['items'];
+        self::assertIsArray($snippetItems);
+        self::assertCount(1, $snippetItems);
 
         /** @var array<string, mixed> $snippetView0 */
-        $snippetView0 = $snippetsView[0];
+        $snippetView0 = $snippetItems[0];
         self::assertSame($snippet->getUuid(), $snippetView0['uuid']);
         self::assertSame('snippet-1', $snippetView0['template']);
     }
@@ -1464,5 +1470,194 @@ class ContentResolverTest extends SuluTestCase
         $view = $result['view'];
         self::assertArrayHasKey('snippets', $view);
         self::assertSame([], $view['snippets']);
+    }
+
+    public function testResolveExampleSelectionWithViewAndContentData(): void
+    {
+        $example1 = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'First Selected Example',
+                    'url' => '/first-selected',
+                    'description' => 'First description',
+                ],
+            ],
+        ]);
+
+        $example2 = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'example-2',
+                    'title' => 'Second Selected Example',
+                    'url' => '/second-selected',
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $parentExample = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-selection',
+                    'title' => 'Parent Example',
+                    'url' => '/parent-example',
+                    'examples' => [$example1->getId(), $example2->getId()],
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($parentExample, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array<string, mixed> $content */
+        $content = $result['content'];
+        self::assertArrayHasKey('examples', $content);
+        $examples = $content['examples'];
+        self::assertIsArray($examples);
+        self::assertCount(2, $examples);
+
+        /** @var array<string, mixed> $example1Content */
+        $example1Content = $examples[0];
+        /** @var array<string, mixed> $example2Content */
+        $example2Content = $examples[1];
+
+        self::assertSame('First Selected Example', $example1Content['title']);
+        self::assertSame('Second Selected Example', $example2Content['title']);
+
+        self::assertArrayHasKey('authored', $example1Content);
+        self::assertArrayHasKey('lastModified', $example1Content);
+        self::assertArrayHasKey('authored', $example2Content);
+        self::assertArrayHasKey('lastModified', $example2Content);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('examples', $view);
+        $examplesView = $view['examples'];
+        self::assertIsArray($examplesView);
+
+        self::assertArrayHasKey('items', $examplesView);
+        $exampleItems = $examplesView['items'];
+        self::assertIsArray($exampleItems);
+        self::assertCount(2, $exampleItems);
+
+        /** @var array<string, mixed> $exampleView1 */
+        $exampleView1 = $exampleItems[0];
+        /** @var array<string, mixed> $exampleView2 */
+        $exampleView2 = $exampleItems[1];
+
+        self::assertSame('default', $exampleView1['template']);
+        self::assertSame('example-2', $exampleView2['template']);
+    }
+
+    public function testResolveSingleSnippetSelectionWithViewData(): void
+    {
+        $snippet = static::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet-1',
+                    'title' => 'My Single Snippet',
+                    'description' => '<p>Snippet content</p>',
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-with-snippets',
+                    'title' => 'Page with Single Snippet',
+                    'url' => '/page-with-single-snippet-view',
+                    'snippets' => [],
+                    'singleSnippet' => $snippet->getUuid(),
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array<string, mixed> $content */
+        $content = $result['content'];
+        self::assertArrayHasKey('singleSnippet', $content);
+        $singleSnippetContent = $content['singleSnippet'];
+        self::assertIsArray($singleSnippetContent);
+        self::assertSame('My Single Snippet', $singleSnippetContent['title']);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('singleSnippet', $view);
+        $singleSnippetView = $view['singleSnippet'];
+        self::assertIsArray($singleSnippetView);
+
+        self::assertSame($snippet->getUuid(), $singleSnippetView['uuid']);
+        self::assertSame('snippet-1', $singleSnippetView['template']);
+        self::assertSame($snippet->getUuid(), $singleSnippetView['id']);
+    }
+
+    public function testResolveSnippetAndExampleSelectionCombined(): void
+    {
+        $snippet = static::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet-1',
+                    'title' => 'Combined Snippet',
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-with-snippets',
+                    'title' => 'Combined Page',
+                    'url' => '/combined-page',
+                    'snippets' => [$snippet->getUuid()],
+                    'singleSnippet' => $snippet->getUuid(),
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array<string, mixed> $content */
+        $content = $result['content'];
+
+        $snippets = $content['snippets'];
+        self::assertIsArray($snippets);
+        self::assertCount(1, $snippets);
+
+        $singleSnippet = $content['singleSnippet'];
+        self::assertIsArray($singleSnippet);
+        self::assertSame('Combined Snippet', $singleSnippet['title']);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+
+        $snippetsView = $view['snippets'];
+        self::assertIsArray($snippetsView);
+        self::assertArrayHasKey('items', $snippetsView);
+        /** @var list<array<string, mixed>> $snippetItems */
+        $snippetItems = $snippetsView['items'];
+        self::assertCount(1, $snippetItems);
+        self::assertSame($snippet->getUuid(), $snippetItems[0]['uuid']);
+        self::assertSame('snippet-1', $snippetItems[0]['template']);
+
+        $singleSnippetView = $view['singleSnippet'];
+        self::assertIsArray($singleSnippetView);
+        self::assertSame($snippet->getUuid(), $singleSnippetView['uuid']);
+        self::assertSame('snippet-1', $singleSnippetView['template']);
     }
 }

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -412,6 +412,10 @@ class ContentResolverTest extends SuluTestCase
         $teasersView = $view['teasers'];
         self::assertSame('two-columns', $teasersView['presentAs']);
         self::assertCount(2, $teasersView['items']);
+        self::assertSame((string) $example1->getId(), $teasersView['items'][0]['id']);
+        self::assertSame('examples', $teasersView['items'][0]['type']);
+        self::assertSame((string) $example2->getId(), $teasersView['items'][1]['id']);
+        self::assertSame('examples', $teasersView['items'][1]['type']);
     }
 
     public function testResolveCollections(): void
@@ -1150,6 +1154,22 @@ class ContentResolverTest extends SuluTestCase
         self::assertCount(1, $advancedMedia);
         self::assertInstanceOf(Media::class, $advancedMedia[0]);
         self::assertSame($media1->getId(), $advancedMedia[0]->getId());
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('image_map', $view);
+        /** @var array<string, mixed> $imageMapView */
+        $imageMapView = $view['image_map'];
+
+        // image view mirrors single_media_selection shape (Sulu 2.6 compatible)
+        self::assertSame(['id' => $mainMedia->getId(), 'displayOption' => null], $imageMapView['image']);
+
+        // hotspot field views
+        /** @var array<int|string, array<string, mixed>> $hotspotsView */
+        $hotspotsView = $imageMapView['hotspots'];
+        self::assertSame([], $hotspotsView[0]['title']);
+        self::assertSame([], $hotspotsView[0]['description']);
+        self::assertSame(['ids' => [$media1->getId()], 'displayOption' => null], $hotspotsView[1]['media']);
     }
 
     public function testResolveLinkExternal(): void
@@ -1183,6 +1203,15 @@ class ContentResolverTest extends SuluTestCase
 
         self::assertArrayHasKey('link', $content);
         self::assertSame('https://sulu.io', $content['link']);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('link', $view);
+        /** @var array<string, mixed> $linkView */
+        $linkView = $view['link'];
+        self::assertSame('external', $linkView['provider']);
+        self::assertSame('https://sulu.io', $linkView['href']);
+        self::assertSame('Sulu Website', $linkView['title']);
     }
 
     public function testResolveLinkInternal(): void
@@ -1234,6 +1263,15 @@ class ContentResolverTest extends SuluTestCase
         self::assertArrayHasKey('link', $content);
         $link = $content['link'];
         self::assertSame('/linked-example', $link);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('link', $view);
+        /** @var array<string, mixed> $linkView */
+        $linkView = $view['link'];
+        self::assertSame('examples', $linkView['provider']);
+        self::assertSame($linkedExample->getId(), $linkView['href']);
+        self::assertSame('Linked Example', $linkView['title']);
     }
 
     public function testResolveNestedContentWithDraftStage(): void

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -1376,29 +1376,18 @@ class ContentResolverTest extends SuluTestCase
         /** @var array<string, mixed> $view */
         $view = $result['view'];
         self::assertArrayHasKey('snippets', $view);
+        /** @var list<array<string, mixed>> $snippetsView */
         $snippetsView = $view['snippets'];
-        self::assertIsArray($snippetsView);
+        self::assertCount(3, $snippetsView);
 
-        self::assertArrayHasKey('items', $snippetsView);
-        $snippetItems = $snippetsView['items'];
-        self::assertIsArray($snippetItems);
-        self::assertCount(3, $snippetItems);
+        self::assertSame($snippet1->getUuid(), $snippetsView[0]['uuid']);
+        self::assertSame('snippet-1', $snippetsView[0]['template']);
 
-        /** @var array<string, mixed> $snippetView0 */
-        $snippetView0 = $snippetItems[0];
-        /** @var array<string, mixed> $snippetView1 */
-        $snippetView1 = $snippetItems[1];
-        /** @var array<string, mixed> $snippetView2 */
-        $snippetView2 = $snippetItems[2];
+        self::assertSame($snippet2->getUuid(), $snippetsView[1]['uuid']);
+        self::assertSame('snippet-2', $snippetsView[1]['template']);
 
-        self::assertSame($snippet1->getUuid(), $snippetView0['uuid']);
-        self::assertSame('snippet-1', $snippetView0['template']);
-
-        self::assertSame($snippet2->getUuid(), $snippetView1['uuid']);
-        self::assertSame('snippet-2', $snippetView1['template']);
-
-        self::assertSame($snippet3->getUuid(), $snippetView2['uuid']);
-        self::assertSame('snippet-1', $snippetView2['template']);
+        self::assertSame($snippet3->getUuid(), $snippetsView[2]['uuid']);
+        self::assertSame('snippet-1', $snippetsView[2]['template']);
     }
 
     public function testResolveSnippetSelectionWithSingleSnippet(): void
@@ -1434,18 +1423,12 @@ class ContentResolverTest extends SuluTestCase
         /** @var array<string, mixed> $view */
         $view = $result['view'];
         self::assertArrayHasKey('snippets', $view);
+        /** @var list<array<string, mixed>> $snippetsView */
         $snippetsView = $view['snippets'];
-        self::assertIsArray($snippetsView);
+        self::assertCount(1, $snippetsView);
 
-        self::assertArrayHasKey('items', $snippetsView);
-        $snippetItems = $snippetsView['items'];
-        self::assertIsArray($snippetItems);
-        self::assertCount(1, $snippetItems);
-
-        /** @var array<string, mixed> $snippetView0 */
-        $snippetView0 = $snippetItems[0];
-        self::assertSame($snippet->getUuid(), $snippetView0['uuid']);
-        self::assertSame('snippet-1', $snippetView0['template']);
+        self::assertSame($snippet->getUuid(), $snippetsView[0]['uuid']);
+        self::assertSame('snippet-1', $snippetsView[0]['template']);
     }
 
     public function testResolveSnippetSelectionEmpty(): void
@@ -1538,16 +1521,12 @@ class ContentResolverTest extends SuluTestCase
         self::assertArrayHasKey('examples', $view);
         $examplesView = $view['examples'];
         self::assertIsArray($examplesView);
-
-        self::assertArrayHasKey('items', $examplesView);
-        $exampleItems = $examplesView['items'];
-        self::assertIsArray($exampleItems);
-        self::assertCount(2, $exampleItems);
+        self::assertCount(2, $examplesView);
 
         /** @var array<string, mixed> $exampleView1 */
-        $exampleView1 = $exampleItems[0];
+        $exampleView1 = $examplesView[0];
         /** @var array<string, mixed> $exampleView2 */
-        $exampleView2 = $exampleItems[1];
+        $exampleView2 = $examplesView[1];
 
         self::assertSame('default', $exampleView1['template']);
         self::assertSame('example-2', $exampleView2['template']);
@@ -1642,11 +1621,9 @@ class ContentResolverTest extends SuluTestCase
         /** @var array<string, mixed> $view */
         $view = $result['view'];
 
-        /** @var array<string, mixed> $multiSnippetsView */
+        /** @var list<array<string, mixed>> $multiSnippetsView */
         $multiSnippetsView = $view['snippets'];
-        /** @var list<array<string, mixed>> $multiItems */
-        $multiItems = $multiSnippetsView['items'];
-        $multiFirstItem = $multiItems[0];
+        $multiFirstItem = $multiSnippetsView[0];
 
         /** @var array<string, mixed> $singleSnippetView */
         $singleSnippetView = $view['singleSnippet'];
@@ -1713,14 +1690,11 @@ class ContentResolverTest extends SuluTestCase
         /** @var array<string, mixed> $view */
         $view = $result['view'];
 
+        /** @var list<array<string, mixed>> $snippetsView */
         $snippetsView = $view['snippets'];
-        self::assertIsArray($snippetsView);
-        self::assertArrayHasKey('items', $snippetsView);
-        /** @var list<array<string, mixed>> $snippetItems */
-        $snippetItems = $snippetsView['items'];
-        self::assertCount(1, $snippetItems);
-        self::assertSame($snippet->getUuid(), $snippetItems[0]['uuid']);
-        self::assertSame('snippet-1', $snippetItems[0]['template']);
+        self::assertCount(1, $snippetsView);
+        self::assertSame($snippet->getUuid(), $snippetsView[0]['uuid']);
+        self::assertSame('snippet-1', $snippetsView[0]['template']);
 
         $singleSnippetView = $view['singleSnippet'];
         self::assertIsArray($singleSnippetView);

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -26,6 +26,7 @@ use Sulu\Content\Tests\Functional\Traits\CreateCategoryTrait;
 use Sulu\Content\Tests\Functional\Traits\CreateMediaTrait;
 use Sulu\Content\Tests\Functional\Traits\CreateTagTrait;
 use Sulu\Content\Tests\Traits\CreateExampleTrait;
+use Sulu\Snippet\Tests\Traits\CreateSnippetTrait;
 use Symfony\Component\Routing\RequestContext;
 
 class ContentResolverTest extends SuluTestCase
@@ -33,6 +34,7 @@ class ContentResolverTest extends SuluTestCase
     use CreateCategoryTrait;
     use CreateExampleTrait;
     use CreateMediaTrait;
+    use CreateSnippetTrait;
     use CreateTagTrait;
 
     private ContentResolverInterface $contentResolver;
@@ -1302,5 +1304,165 @@ class ContentResolverTest extends SuluTestCase
         self::assertIsArray($resolvedNested);
         self::assertSame('Nested Example Live', $resolvedNested['title']);
         self::assertSame('Nested content live description', $resolvedNested['description']);
+    }
+
+    public function testResolveSnippetSelectionWithTemplateInView(): void
+    {
+        $snippet1 = static::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet-1',
+                    'title' => 'First Snippet',
+                    'description' => '<p>First snippet description</p>',
+                ],
+            ],
+        ]);
+
+        $snippet2 = static::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet-2',
+                    'title' => 'Second Snippet',
+                ],
+            ],
+        ]);
+
+        $snippet3 = static::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet-1',
+                    'title' => 'Third Snippet',
+                    'description' => '<p>Third snippet description</p>',
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-with-snippets',
+                    'title' => 'Page with Snippets',
+                    'url' => '/page-with-snippets',
+                    'snippets' => [$snippet1->getUuid(), $snippet2->getUuid(), $snippet3->getUuid()],
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array<string, mixed> $content */
+        $content = $result['content'];
+        self::assertArrayHasKey('snippets', $content);
+        $snippets = $content['snippets'];
+        self::assertIsArray($snippets);
+        self::assertCount(3, $snippets);
+
+        /** @var array<string, mixed> $snippet0 */
+        $snippet0 = $snippets[0];
+        /** @var array<string, mixed> $snippet1Data */
+        $snippet1Data = $snippets[1];
+        /** @var array<string, mixed> $snippet2Data */
+        $snippet2Data = $snippets[2];
+
+        self::assertSame('First Snippet', $snippet0['title']);
+        self::assertSame('Second Snippet', $snippet1Data['title']);
+        self::assertSame('Third Snippet', $snippet2Data['title']);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('snippets', $view);
+        $snippetsView = $view['snippets'];
+        self::assertIsArray($snippetsView);
+
+        self::assertCount(3, $snippetsView);
+
+        /** @var array<string, mixed> $snippetView0 */
+        $snippetView0 = $snippetsView[0];
+        /** @var array<string, mixed> $snippetView1 */
+        $snippetView1 = $snippetsView[1];
+        /** @var array<string, mixed> $snippetView2 */
+        $snippetView2 = $snippetsView[2];
+
+        self::assertSame($snippet1->getUuid(), $snippetView0['uuid']);
+        self::assertSame('snippet-1', $snippetView0['template']);
+
+        self::assertSame($snippet2->getUuid(), $snippetView1['uuid']);
+        self::assertSame('snippet-2', $snippetView1['template']);
+
+        self::assertSame($snippet3->getUuid(), $snippetView2['uuid']);
+        self::assertSame('snippet-1', $snippetView2['template']);
+    }
+
+    public function testResolveSnippetSelectionWithSingleSnippet(): void
+    {
+        $snippet = static::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet-1',
+                    'title' => 'Single Snippet',
+                    'description' => '<p>Single snippet test</p>',
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-with-snippets',
+                    'title' => 'Page with Single Snippet',
+                    'url' => '/page-with-single-snippet',
+                    'snippets' => [$snippet->getUuid()],
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('snippets', $view);
+        $snippetsView = $view['snippets'];
+        self::assertIsArray($snippetsView);
+
+        self::assertCount(1, $snippetsView);
+
+        /** @var array<string, mixed> $snippetView0 */
+        $snippetView0 = $snippetsView[0];
+        self::assertSame($snippet->getUuid(), $snippetView0['uuid']);
+        self::assertSame('snippet-1', $snippetView0['template']);
+    }
+
+    public function testResolveSnippetSelectionEmpty(): void
+    {
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-with-snippets',
+                    'title' => 'Page without Snippets',
+                    'url' => '/page-without-snippets',
+                    'snippets' => [],
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('snippets', $view);
+        self::assertSame([], $view['snippets']);
     }
 }

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -1602,6 +1602,79 @@ class ContentResolverTest extends SuluTestCase
         self::assertSame($snippet->getUuid(), $singleSnippetView['id']);
     }
 
+    public function testResolveSingleAndMultiSnippetSelectionViewSymmetry(): void
+    {
+        // Regression guard for the asymmetry between single_snippet_selection and
+        // snippet_selection (multi). Nested link metadata is only reachable on the
+        // view side (LinkPropertyResolver flattens links to URL strings on the data
+        // side via its closure), so view.singleSnippet.link must expose the same
+        // {provider, href, title} payload as view.snippets.items[0].link.
+        $snippet = static::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet-with-link',
+                    'title' => 'Symmetry Snippet',
+                    'link' => [
+                        'provider' => 'external',
+                        'href' => 'https://sulu.io',
+                        'title' => 'Sulu Website',
+                    ],
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-with-snippets',
+                    'title' => 'Symmetry Page',
+                    'url' => '/symmetry-page',
+                    'snippets' => [$snippet->getUuid()],
+                    'singleSnippet' => $snippet->getUuid(),
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+
+        /** @var array<string, mixed> $multiSnippetsView */
+        $multiSnippetsView = $view['snippets'];
+        /** @var list<array<string, mixed>> $multiItems */
+        $multiItems = $multiSnippetsView['items'];
+        $multiFirstItem = $multiItems[0];
+
+        /** @var array<string, mixed> $singleSnippetView */
+        $singleSnippetView = $view['singleSnippet'];
+
+        // Sanity check: the multi-select view exposes the snippet's link metadata.
+        self::assertArrayHasKey('link', $multiFirstItem);
+        /** @var array<string, mixed> $multiLink */
+        $multiLink = $multiFirstItem['link'];
+        self::assertSame('external', $multiLink['provider']);
+        self::assertSame('https://sulu.io', $multiLink['href']);
+        self::assertSame('Sulu Website', $multiLink['title']);
+
+        // Bug L: the same metadata must be reachable via view.singleSnippet.link.
+        self::assertArrayHasKey('link', $singleSnippetView, 'Bug L: view.singleSnippet must expose nested link view, symmetric with view.snippets.items[0].link');
+        /** @var array<string, mixed> $singleLink */
+        $singleLink = $singleSnippetView['link'];
+        self::assertSame('external', $singleLink['provider']);
+        self::assertSame('https://sulu.io', $singleLink['href']);
+        self::assertSame('Sulu Website', $singleLink['title']);
+
+        // Resource-level metadata must also be present and symmetric.
+        self::assertSame($multiFirstItem['uuid'], $singleSnippetView['uuid']);
+        self::assertSame($multiFirstItem['template'], $singleSnippetView['template']);
+    }
+
     public function testResolveSnippetAndExampleSelectionCombined(): void
     {
         $snippet = static::createSnippet([

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -29,6 +29,7 @@ use Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\Resolvab
 use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewEnhancementInterface;
 use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\ContentRichEntityTrait;
@@ -88,7 +89,9 @@ class ContentResolverTest extends TestCase
 
         $maxDepth = 5;
 
-        $resourceLoaderProvider = new ResourceLoaderProvider(new \ArrayIterator([]));
+        $resourceLoaderProvider = new ResourceLoaderProvider(new \ArrayIterator([
+            'example' => new TestResourceLoader(),
+        ]));
 
         $this->contentResolver = new ContentResolver(
             $this->contentViewResolver,
@@ -251,7 +254,7 @@ class ContentResolverTest extends TestCase
             'en',
             []
         )->willReturn(
-            ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => ['title' => 'Single Title']]]]
+            ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => ['id' => 'single-1', 'title' => 'Single Title']]]]
         );
 
         $result = $this->contentResolver->resolve($dimensionContent);
@@ -282,7 +285,6 @@ class ContentResolverTest extends TestCase
             },
             null,
             'examples',
-            'items',
         );
 
         $templateContentView = ContentView::create(
@@ -296,14 +298,109 @@ class ContentResolverTest extends TestCase
             'en',
             []
         )->willReturn(
-            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => ['title' => 'Multi Title']]]]
+            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => ['id' => 'multi-1', 'title' => 'Multi Title']]]]
         );
 
         $result = $this->contentResolver->resolve($dimensionContent);
 
         self::assertSame(['Multi Title'], $result['content']['multi_selection']);
         self::assertSame(
-            ['presentAs' => 'grid'],
+            ['presentAs' => 'grid', 0 => ['id' => 'multi-1']],
+            $result['view']['multi_selection']
+        );
+    }
+
+    public function testResolveMultiSelectionWithOneItemKeepsCollectionViewShape(): void
+    {
+        $example = new TestExample();
+        $example->id = 447;
+
+        $dimensionContent = new TestExampleDimensionContent($example);
+        $example->addDimensionContent($dimensionContent);
+        $dimensionContent->setStage('live');
+        $dimensionContent->setLocale('en');
+
+        $multiResource = new ResolvableResource(
+            'multi-1',
+            'example',
+            10,
+            static function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'examples',
+        );
+
+        $templateContentView = ContentView::create(
+            ['multi_selection' => ContentView::create([$multiResource], [])],
+            []
+        );
+        $this->templateResolver->setContentView($templateContentView);
+
+        $this->resolvableResourceLoader->loadResources(
+            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => $multiResource]]],
+            'en',
+            []
+        )->willReturn(
+            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => ['id' => 'multi-1', 'title' => 'Multi Title']]]]
+        );
+
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertSame(['Multi Title'], $result['content']['multi_selection']);
+        self::assertSame(
+            [
+                ['id' => 'multi-1'],
+            ],
+            $result['view']['multi_selection']
+        );
+    }
+
+    public function testResolveMultiSelectionWithItemsPropertyNameNestsViewShape(): void
+    {
+        $example = new TestExample();
+        $example->id = 448;
+
+        $dimensionContent = new TestExampleDimensionContent($example);
+        $example->addDimensionContent($dimensionContent);
+        $dimensionContent->setStage('live');
+        $dimensionContent->setLocale('en');
+
+        $multiResource = new ResolvableResource(
+            'multi-1',
+            'example',
+            10,
+            static function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'examples',
+            'items',
+        );
+
+        $templateContentView = ContentView::create(
+            ['multi_selection' => ContentView::create([$multiResource], [])],
+            []
+        );
+        $this->templateResolver->setContentView($templateContentView);
+
+        $this->resolvableResourceLoader->loadResources(
+            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => $multiResource]]],
+            'en',
+            []
+        )->willReturn(
+            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => ['id' => 'multi-1', 'title' => 'Multi Title']]]]
+        );
+
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertSame(['Multi Title'], $result['content']['multi_selection']);
+        self::assertSame(
+            [
+                'items' => [
+                    ['id' => 'multi-1'],
+                ],
+            ],
             $result['view']['multi_selection']
         );
     }
@@ -321,6 +418,28 @@ class TestTemplateResolver implements ResolverInterface
     public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): ?ContentView
     {
         return $this->contentView;
+    }
+}
+
+class TestResourceLoader implements ResourceLoaderContentViewEnhancementInterface
+{
+    public function load(array $ids, ?string $locale, array $params = []): array
+    {
+        return [];
+    }
+
+    public static function getKey(): string
+    {
+        return 'example';
+    }
+
+    public function resolveContentViewEnhancement(mixed $resource): ContentView
+    {
+        if (!\is_array($resource) || !isset($resource['id'])) {
+            return ContentView::create([], []);
+        }
+
+        return ContentView::create([], ['id' => $resource['id']]);
     }
 }
 

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -29,6 +29,7 @@ use Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\Resolvab
 use Sulu\Content\Application\ContentResolver\Resolver\ResolverInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\ContentRichEntityTrait;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
@@ -87,6 +88,8 @@ class ContentResolverTest extends TestCase
 
         $maxDepth = 5;
 
+        $resourceLoaderProvider = new ResourceLoaderProvider(new \ArrayIterator([]));
+
         $this->contentResolver = new ContentResolver(
             $this->contentViewResolver,
             $this->resolvableResourceLoader->reveal(),
@@ -95,7 +98,8 @@ class ContentResolverTest extends TestCase
             $this->contentViewDataNormalizer,
             $this->contentAggregator->reveal(),
             $maxDepth,
-            $this->contentEnhancer->reveal()
+            $this->contentEnhancer->reveal(),
+            $resourceLoaderProvider
         );
     }
 
@@ -215,7 +219,7 @@ class ContentResolverTest extends TestCase
         self::assertSame([], $result['extension']);
     }
 
-    public function testResolveSingleSelectionEnhancementMergesIntoObjectView(): void
+    public function testResolveSingleSelectionWithNoViewData(): void
     {
         $example = new TestExample();
         $example->id = 445;
@@ -234,9 +238,6 @@ class ContentResolverTest extends TestCase
             },
             null,
             'examples',
-            static function(array $source): array {
-                return ['uuid' => $source['uuid']];
-            }
         );
 
         $templateContentView = ContentView::create(
@@ -249,19 +250,19 @@ class ContentResolverTest extends TestCase
             ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => $singleResource]]],
             'en'
         )->willReturn(
-            ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => ['title' => 'Single Title', 'uuid' => 'uuid-single-1']]]]
+            ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => ['title' => 'Single Title']]]]
         );
 
         $result = $this->contentResolver->resolve($dimensionContent);
 
         self::assertSame('Single Title', $result['content']['single_selection']);
         self::assertSame(
-            ['id' => 'single-1', 'uuid' => 'uuid-single-1'],
+            ['id' => 'single-1'],
             $result['view']['single_selection']
         );
     }
 
-    public function testResolveMultiSelectionEnhancementWithSingleItemUsesItemsEnvelope(): void
+    public function testResolveMultiSelectionWithNoViewData(): void
     {
         $example = new TestExample();
         $example->id = 446;
@@ -280,9 +281,7 @@ class ContentResolverTest extends TestCase
             },
             null,
             'examples',
-            static function(array $source): array {
-                return ['uuid' => $source['uuid']];
-            }
+            'items',
         );
 
         $templateContentView = ContentView::create(
@@ -295,19 +294,14 @@ class ContentResolverTest extends TestCase
             ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => $multiResource]]],
             'en'
         )->willReturn(
-            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => ['title' => 'Multi Title', 'uuid' => 'uuid-multi-1']]]]
+            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => ['title' => 'Multi Title']]]]
         );
 
         $result = $this->contentResolver->resolve($dimensionContent);
 
         self::assertSame(['Multi Title'], $result['content']['multi_selection']);
         self::assertSame(
-            [
-                'presentAs' => 'grid',
-                'items' => [
-                    ['uuid' => 'uuid-multi-1'],
-                ],
-            ],
+            ['presentAs' => 'grid'],
             $result['view']['multi_selection']
         );
     }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -248,7 +248,8 @@ class ContentResolverTest extends TestCase
 
         $this->resolvableResourceLoader->loadResources(
             ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => $singleResource]]],
-            'en'
+            'en',
+            []
         )->willReturn(
             ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => ['title' => 'Single Title']]]]
         );
@@ -292,7 +293,8 @@ class ContentResolverTest extends TestCase
 
         $this->resolvableResourceLoader->loadResources(
             ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => $multiResource]]],
-            'en'
+            'en',
+            []
         )->willReturn(
             ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => ['title' => 'Multi Title']]]]
         );

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -214,6 +214,103 @@ class ContentResolverTest extends TestCase
         self::assertSame(['title' => 'Title Field', 'content' => 'Content Field'], $result['view']);
         self::assertSame([], $result['extension']);
     }
+
+    public function testResolveSingleSelectionEnhancementMergesIntoObjectView(): void
+    {
+        $example = new TestExample();
+        $example->id = 445;
+
+        $dimensionContent = new TestExampleDimensionContent($example);
+        $example->addDimensionContent($dimensionContent);
+        $dimensionContent->setStage('live');
+        $dimensionContent->setLocale('en');
+
+        $singleResource = new ResolvableResource(
+            'single-1',
+            'example',
+            10,
+            static function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'examples',
+            static function(array $source): array {
+                return ['uuid' => $source['uuid']];
+            }
+        );
+
+        $templateContentView = ContentView::create(
+            ['single_selection' => $singleResource],
+            ['single_selection' => ['id' => 'single-1']]
+        );
+        $this->templateResolver->setContentView($templateContentView);
+
+        $this->resolvableResourceLoader->loadResources(
+            ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => $singleResource]]],
+            'en'
+        )->willReturn(
+            ['example' => ['single-1' => [$singleResource->getMetadataIdentifier() => ['title' => 'Single Title', 'uuid' => 'uuid-single-1']]]]
+        );
+
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertSame('Single Title', $result['content']['single_selection']);
+        self::assertSame(
+            ['id' => 'single-1', 'uuid' => 'uuid-single-1'],
+            $result['view']['single_selection']
+        );
+    }
+
+    public function testResolveMultiSelectionEnhancementWithSingleItemUsesItemsEnvelope(): void
+    {
+        $example = new TestExample();
+        $example->id = 446;
+
+        $dimensionContent = new TestExampleDimensionContent($example);
+        $example->addDimensionContent($dimensionContent);
+        $dimensionContent->setStage('live');
+        $dimensionContent->setLocale('en');
+
+        $multiResource = new ResolvableResource(
+            'multi-1',
+            'example',
+            10,
+            static function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'examples',
+            static function(array $source): array {
+                return ['uuid' => $source['uuid']];
+            }
+        );
+
+        $templateContentView = ContentView::create(
+            ['multi_selection' => ContentView::create([$multiResource], ['presentAs' => 'grid'])],
+            []
+        );
+        $this->templateResolver->setContentView($templateContentView);
+
+        $this->resolvableResourceLoader->loadResources(
+            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => $multiResource]]],
+            'en'
+        )->willReturn(
+            ['example' => ['multi-1' => [$multiResource->getMetadataIdentifier() => ['title' => 'Multi Title', 'uuid' => 'uuid-multi-1']]]]
+        );
+
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertSame(['Multi Title'], $result['content']['multi_selection']);
+        self::assertSame(
+            [
+                'presentAs' => 'grid',
+                'items' => [
+                    ['uuid' => 'uuid-multi-1'],
+                ],
+            ],
+            $result['view']['multi_selection']
+        );
+    }
 }
 
 class TestTemplateResolver implements ResolverInterface

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerTest.php
@@ -110,6 +110,62 @@ class ContentViewDataNormalizerTest extends TestCase
         self::assertSame(['nested' => 'view data'], $formattedContentData['view']['items']);
     }
 
+    public function testReplaceNestedContentViewsMergesWithExistingViewData(): void
+    {
+        // existing outer view keys must win on collision; inner-only keys fill gaps
+        $formattedContentData = [
+            'resource' => new \stdClass(),
+            'content' => [
+                'snippet' => [
+                    'content' => ['title' => 'Snippet Title'],
+                    'view' => [
+                        'innerOnly' => 'fromInner',
+                        'shared' => 'innerLoses',
+                    ],
+                ],
+            ],
+            'view' => [
+                'snippet' => [
+                    'outerOnly' => 'fromOuter',
+                    'shared' => 'outerWins',
+                ],
+            ],
+            'extension' => [],
+        ];
+
+        $this->normalizer->replaceNestedContentViews($formattedContentData);
+
+        self::assertSame(['title' => 'Snippet Title'], $formattedContentData['content']['snippet']);
+
+        $mergedSnippetView = $formattedContentData['view']['snippet'];
+        self::assertSame('fromOuter', $mergedSnippetView['outerOnly']);
+        self::assertSame('fromInner', $mergedSnippetView['innerOnly']);
+        self::assertSame('outerWins', $mergedSnippetView['shared']);
+    }
+
+    public function testReplaceNestedContentViewsCopiesIntoEmptyView(): void
+    {
+        $formattedContentData = [
+            'resource' => new \stdClass(),
+            'content' => [
+                'snippet' => [
+                    'content' => ['title' => 'Snippet Title'],
+                    'view' => ['link' => ['provider' => 'page', 'href' => 'uuid-1']],
+                ],
+            ],
+            'view' => [],
+            'extension' => [],
+        ];
+
+        $this->normalizer->replaceNestedContentViews($formattedContentData);
+
+        self::assertSame(['title' => 'Snippet Title'], $formattedContentData['content']['snippet']);
+        self::assertSame(
+            ['link' => ['provider' => 'page', 'href' => 'uuid-1']],
+            $formattedContentData['view']['snippet']
+        );
+    }
+
     public function testFormatContentOutputWithEmptyTemplate(): void
     {
         // Use real Example entity instead of mock

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerTest.php
@@ -137,6 +137,7 @@ class ContentViewDataNormalizerTest extends TestCase
 
         self::assertSame(['title' => 'Snippet Title'], $formattedContentData['content']['snippet']);
 
+        /** @var array<string, mixed> $mergedSnippetView */
         $mergedSnippetView = $formattedContentData['view']['snippet'];
         self::assertSame('fromOuter', $mergedSnippetView['outerOnly']);
         self::assertSame('fromInner', $mergedSnippetView['innerOnly']);
@@ -201,7 +202,7 @@ class ContentViewDataNormalizerTest extends TestCase
         $result = $this->normalizer->normalizeContentViewData($content, $view, $resource);
 
         // Apply property mapping with non-root context
-        $this->normalizer->recursivelyMapProperties($result, $properties, '', 0, false);
+        $this->normalizer->recursivelyMapProperties($result, $properties, [], 0, false);
 
         // When not root, properties should be mapped under [content] path
         self::assertSame('Test Title', $result['content']['title']);

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
@@ -14,16 +14,15 @@ declare(strict_types=1);
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentResolver\ResolvableResourceReplacer;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStore;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\ResolvableResourceReplacer;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
 class ResolvableResourceReplacerTest extends TestCase
 {
-    use ProphecyTrait;
-
     private ResolvableResourceReplacer $replacer;
 
     private ReferenceStoreInterface $referenceStore;
@@ -32,6 +31,17 @@ class ResolvableResourceReplacerTest extends TestCase
     {
         $this->referenceStore = new ReferenceStore();
         $this->replacer = new ResolvableResourceReplacer($this->referenceStore);
+    }
+
+    /**
+     * @return array{source: mixed, resolved: mixed}
+     */
+    private function createResolvedEntry(mixed $resolved, mixed $source = null): array
+    {
+        return [
+            'source' => $source ?? $resolved,
+            'resolved' => $resolved,
+        ];
     }
 
     public function testReplaceResolvableResourcesWithResolvedValues(): void
@@ -60,7 +70,7 @@ class ResolvableResourceReplacerTest extends TestCase
         $resolvedResources = [
             'page' => [
                 '123' => [
-                    $metadataId => ['title' => 'Resolved Page Title'],
+                    $metadataId => $this->createResolvedEntry(['title' => 'Resolved Page Title']),
                 ],
             ],
         ];
@@ -72,12 +82,11 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertSame('Test', $result['title']);
-        self::assertSame('Resolved Page Title', $result['page']);
-        self::assertIsArray($result['nested']);
-        self::assertArrayHasKey('page', $result['nested']);
-        self::assertSame('Resolved Page Title', $result['nested']['page']);
-
+        self::assertSame('Test', $result['content']['title']);
+        self::assertSame('Resolved Page Title', $result['content']['page']);
+        self::assertIsArray($result['content']['nested']);
+        self::assertArrayHasKey('page', $result['content']['nested']);
+        self::assertSame('Resolved Page Title', $result['content']['nested']['page']);
         // Verify ReferenceStore was populated
         $tags = $this->referenceStore->getAll();
         self::assertContains('pages-123', $tags);
@@ -118,12 +127,12 @@ class ResolvableResourceReplacerTest extends TestCase
         $resolvedResources = [
             'page' => [
                 '123' => [
-                    $firstMetadataId => ['nested_resolvable' => $nestedResource],
+                    $firstMetadataId => $this->createResolvedEntry(['nested_resolvable' => $nestedResource]),
                 ],
             ],
             'article' => [
                 '456' => [
-                    $nestedMetadataId => ['title' => 'Article Title'],
+                    $nestedMetadataId => $this->createResolvedEntry(['title' => 'Article Title']),
                 ],
             ],
         ];
@@ -135,7 +144,7 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertSame(['nested_page' => 'Article Title'], $result['page']);
+        self::assertSame(['nested_page' => 'Article Title'], $result['content']['page']);
 
         // Verify ReferenceStore was populated for both resources
         $tags = $this->referenceStore->getAll();
@@ -167,7 +176,7 @@ class ResolvableResourceReplacerTest extends TestCase
         );
 
         // Should replace with null when max depth exceeded
-        self::assertNull($result['page']);
+        self::assertNull($result['content']['page']);
 
         // ReferenceStore should be empty when max depth exceeded
         $tags = $this->referenceStore->getAll();
@@ -198,7 +207,7 @@ class ResolvableResourceReplacerTest extends TestCase
         );
 
         // Should remain unchanged when no resolved resources
-        self::assertSame($resolvableResource, $result['page']);
+        self::assertSame($resolvableResource, $result['content']['page']);
 
         // ReferenceStore should be empty when no resources resolved
         $tags = $this->referenceStore->getAll();
@@ -240,10 +249,10 @@ class ResolvableResourceReplacerTest extends TestCase
 
         $resolvedResources = [
             'page' => [
-                '123' => [$pageMetadataId => ['title' => 'Page Title', 'content' => 'Page Content']],
+                '123' => [$pageMetadataId => $this->createResolvedEntry(['title' => 'Page Title', 'content' => 'Page Content'])],
             ],
             'article' => [
-                '456' => [$articleMetadataId => ['title' => 'Article Title']],
+                '456' => [$articleMetadataId => $this->createResolvedEntry(['title' => 'Article Title'])],
             ],
         ];
 
@@ -262,7 +271,7 @@ class ResolvableResourceReplacerTest extends TestCase
             'featured' => ['title' => 'Page Title', 'content' => 'Page Content'],
         ];
 
-        self::assertSame($expected, $result);
+        self::assertSame($expected, $result['content']);
 
         // Verify ReferenceStore was populated for both resources
         $tags = $this->referenceStore->getAll();
@@ -302,8 +311,8 @@ class ResolvableResourceReplacerTest extends TestCase
 
         $resolvedResources = [
             'page' => [
-                '123' => [$metadata1 => ['title' => 'First Page']],
-                '456' => [$metadata2 => ['title' => 'Second Page']],
+                '123' => [$metadata1 => $this->createResolvedEntry(['title' => 'First Page'])],
+                '456' => [$metadata2 => $this->createResolvedEntry(['title' => 'Second Page'])],
             ],
         ];
 
@@ -314,7 +323,7 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertSame(['First Page', 'Second Page'], $result['pages']);
+        self::assertSame(['First Page', 'Second Page'], $result['content']['pages']);
 
         // Verify ReferenceStore was populated for both pages
         $tags = $this->referenceStore->getAll();
@@ -344,7 +353,7 @@ class ResolvableResourceReplacerTest extends TestCase
         $resolvedResources = [
             'page' => [
                 $uuid => [
-                    $metadataId => ['title' => 'UUID Page Title'],
+                    $metadataId => $this->createResolvedEntry(['title' => 'UUID Page Title']),
                 ],
             ],
         ];
@@ -356,7 +365,7 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertSame('UUID Page Title', $result['page']);
+        self::assertSame('UUID Page Title', $result['content']['page']);
 
         // Verify ReferenceStore stores UUID directly without prefix
         $tags = $this->referenceStore->getAll();
@@ -383,7 +392,7 @@ class ResolvableResourceReplacerTest extends TestCase
         $resolvedResources = [
             'page' => [
                 '123' => [
-                    $metadataId => ['title' => 'Page Without Key'],
+                    $metadataId => $this->createResolvedEntry(['title' => 'Page Without Key']),
                 ],
             ],
         ];
@@ -395,10 +404,392 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertSame('Page Without Key', $result['page']);
+        self::assertSame('Page Without Key', $result['content']['page']);
 
         // Verify ReferenceStore is empty when resourceKey is not provided
         $tags = $this->referenceStore->getAll();
         self::assertEmpty($tags);
+    }
+
+    public function testViewCallbackExecutedWithSourceEntity(): void
+    {
+        $callbackCalled = false;
+        $receivedSource = null;
+
+        $example = new Example();
+        $example->id = '123';
+        $sourceEntity = new ExampleDimensionContent($example);
+        $sourceEntity->setTemplateKey('test-template');
+
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'snippet',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'snippets',
+            function(ExampleDimensionContent $source) use (&$callbackCalled, &$receivedSource) {
+                $callbackCalled = true;
+                $receivedSource = $source;
+
+                return [
+                    'id' => $source->getResource()->getId(),
+                    'template' => $source->getTemplateKey(),
+                ];
+            }
+        );
+
+        $content = [
+            'mySnippets' => [$resolvableResource],
+        ];
+
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'snippet' => [
+                '123' => [
+                    $metadataId => [
+                        'source' => $sourceEntity,
+                        'resolved' => ['title' => 'Snippet Title'],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertTrue($callbackCalled, 'viewCallback should be called');
+        self::assertSame($sourceEntity, $receivedSource);
+        self::assertSame(['Snippet Title'], $result['content']['mySnippets']);
+        self::assertArrayHasKey('[mySnippets]', $result['viewEnhancements']);
+        self::assertTrue($result['viewEnhancements']['[mySnippets]']['isList']);
+        self::assertCount(1, $result['viewEnhancements']['[mySnippets]']['items']);
+        self::assertSame(
+            ['id' => '123', 'template' => 'test-template'],
+            $result['viewEnhancements']['[mySnippets]']['items'][0]
+        );
+    }
+
+    public function testViewCallbackWithMultipleResources(): void
+    {
+        $example1 = new Example();
+        $example1->id = '123';
+        $source1 = new ExampleDimensionContent($example1);
+        $source1->setTemplateKey('template-a');
+
+        $example2 = new Example();
+        $example2->id = '456';
+        $source2 = new ExampleDimensionContent($example2);
+        $source2->setTemplateKey('template-b');
+
+        $viewCallback = static function(ExampleDimensionContent $source): array {
+            return [
+                'id' => $source->getResource()->getId(),
+                'template' => $source->getTemplateKey(),
+            ];
+        };
+
+        $resource1 = new ResolvableResource(
+            '123',
+            'snippet',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'snippets',
+            $viewCallback
+        );
+
+        $resource2 = new ResolvableResource(
+            '456',
+            'snippet',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'snippets',
+            $viewCallback
+        );
+
+        $content = [
+            'snippets' => [$resource1, $resource2],
+        ];
+
+        $metadata1 = $resource1->getMetadataIdentifier();
+        $metadata2 = $resource2->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'snippet' => [
+                '123' => [$metadata1 => ['source' => $source1, 'resolved' => ['title' => 'First Snippet']]],
+                '456' => [$metadata2 => ['source' => $source2, 'resolved' => ['title' => 'Second Snippet']]],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertSame(['First Snippet', 'Second Snippet'], $result['content']['snippets']);
+        self::assertArrayHasKey('[snippets]', $result['viewEnhancements']);
+        self::assertTrue($result['viewEnhancements']['[snippets]']['isList']);
+        self::assertCount(2, $result['viewEnhancements']['[snippets]']['items']);
+        self::assertSame(['id' => '123', 'template' => 'template-a'], $result['viewEnhancements']['[snippets]']['items'][0]);
+        self::assertSame(['id' => '456', 'template' => 'template-b'], $result['viewEnhancements']['[snippets]']['items'][1]);
+    }
+
+    public function testViewCallbackNotCalledWhenSourceIsNull(): void
+    {
+        $callbackCalled = false;
+
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'snippet',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'snippets',
+            function(ExampleDimensionContent $source) use (&$callbackCalled) {
+                $callbackCalled = true;
+
+                return ['id' => $source->getResource()->getId()];
+            }
+        );
+
+        $content = [
+            'mySnippets' => [$resolvableResource],
+        ];
+
+        $resolvedResources = [];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertFalse($callbackCalled);
+        $mySnippets = $result['content']['mySnippets'];
+        self::assertIsArray($mySnippets);
+        self::assertSame($resolvableResource, $mySnippets[0]);
+        self::assertEmpty($result['viewEnhancements']);
+    }
+
+    public function testViewCallbackWithNestedPath(): void
+    {
+        $example = new Example();
+        $example->id = '123';
+        $source = new ExampleDimensionContent($example);
+        $source->setTemplateKey('default');
+
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'snippet',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'snippets',
+            function(ExampleDimensionContent $source) {
+                return [
+                    'id' => $source->getResource()->getId(),
+                    'template' => $source->getTemplateKey(),
+                ];
+            }
+        );
+
+        $content = [
+            'template' => [
+                'snippets' => [$resolvableResource],
+            ],
+        ];
+
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'snippet' => [
+                '123' => [$metadataId => ['source' => $source, 'resolved' => ['title' => 'Snippet Title']]],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        $templateContent = $result['content']['template'];
+        self::assertIsArray($templateContent);
+        self::assertSame(['Snippet Title'], $templateContent['snippets']);
+        self::assertArrayHasKey('[template][snippets]', $result['viewEnhancements']);
+        self::assertTrue($result['viewEnhancements']['[template][snippets]']['isList']);
+        self::assertCount(1, $result['viewEnhancements']['[template][snippets]']['items']);
+        self::assertSame(
+            ['id' => '123', 'template' => 'default'],
+            $result['viewEnhancements']['[template][snippets]']['items'][0]
+        );
+    }
+
+    public function testViewCallbackWithIndexedNestedPath(): void
+    {
+        $resource1 = new ResolvableResource(
+            '123',
+            'snippet',
+            1,
+            static function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'snippets',
+            static function(array $source): array {
+                return ['uuid' => $source['uuid']];
+            }
+        );
+
+        $resource2 = new ResolvableResource(
+            '456',
+            'snippet',
+            1,
+            static function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'snippets',
+            static function(array $source): array {
+                return ['uuid' => $source['uuid']];
+            }
+        );
+
+        $content = [
+            'blocks' => [
+                ['snippets' => [$resource1]],
+                ['snippets' => [$resource2]],
+            ],
+        ];
+
+        $metadata1 = $resource1->getMetadataIdentifier();
+        $metadata2 = $resource2->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'snippet' => [
+                '123' => [
+                    $metadata1 => ['source' => ['uuid' => 'u-123'], 'resolved' => ['title' => 'Snippet 1']],
+                ],
+                '456' => [
+                    $metadata2 => ['source' => ['uuid' => 'u-456'], 'resolved' => ['title' => 'Snippet 2']],
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertArrayHasKey('[blocks][0][snippets]', $result['viewEnhancements']);
+        self::assertArrayHasKey('[blocks][1][snippets]', $result['viewEnhancements']);
+        self::assertArrayNotHasKey('[blocks][snippets]', $result['viewEnhancements']);
+
+        self::assertTrue($result['viewEnhancements']['[blocks][0][snippets]']['isList']);
+        self::assertSame(
+            ['uuid' => 'u-123'],
+            $result['viewEnhancements']['[blocks][0][snippets]']['items'][0]
+        );
+
+        self::assertTrue($result['viewEnhancements']['[blocks][1][snippets]']['isList']);
+        self::assertSame(
+            ['uuid' => 'u-456'],
+            $result['viewEnhancements']['[blocks][1][snippets]']['items'][0]
+        );
+    }
+
+    public function testViewCallbackReceivesSourceEntityNotResolvedValue(): void
+    {
+        $receivedSource = null;
+
+        $example = new Example();
+        $example->id = '123';
+        $dimensionContent = new ExampleDimensionContent($example);
+        $dimensionContent->setTemplateKey('custom-template');
+
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'snippet',
+            1,
+            function(array $resource) {
+                return [
+                    'content' => ['title' => $resource['rawTitle'], 'text' => $resource['rawText']],
+                    'view' => ['template' => $resource['template']],
+                    'id' => '123',
+                ];
+            },
+            null,
+            'snippets',
+            function(ExampleDimensionContent $source) use (&$receivedSource) {
+                $receivedSource = $source;
+
+                return [
+                    'id' => $source->getResource()->getId(),
+                    'template' => $source->getTemplateKey(),
+                ];
+            }
+        );
+
+        $content = [
+            'mySnippets' => [$resolvableResource],
+        ];
+
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'snippet' => [
+                '123' => [
+                    $metadataId => [
+                        'source' => $dimensionContent,
+                        'resolved' => [
+                            'rawTitle' => 'My Title',
+                            'rawText' => 'Some text',
+                            'template' => 'custom-template',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertSame($dimensionContent, $receivedSource);
+        self::assertSame('123', $receivedSource->getResource()->getId());
+        self::assertSame('custom-template', $receivedSource->getTemplateKey());
+
+        self::assertArrayHasKey('[mySnippets]', $result['viewEnhancements']);
+        self::assertTrue($result['viewEnhancements']['[mySnippets]']['isList']);
+        self::assertSame(
+            ['id' => '123', 'template' => 'custom-template'],
+            $result['viewEnhancements']['[mySnippets]']['items'][0]
+        );
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
@@ -17,9 +17,8 @@ use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStore;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Content\Application\ContentResolver\ResolvableResourceReplacer\ResolvableResourceReplacer;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
-use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
-use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
 class ResolvableResourceReplacerTest extends TestCase
 {
@@ -34,13 +33,16 @@ class ResolvableResourceReplacerTest extends TestCase
     }
 
     /**
-     * @return array{source: mixed, resolved: mixed}
+     * @param array<string, mixed> $content
+     * @param array<string, mixed> $view
+     *
+     * @return array{resolved: mixed, contentView: ContentView}
      */
-    private function createResolvedEntry(mixed $resolved, mixed $source = null): array
+    private function createResolvedEntry(mixed $resolved, array $view = [], array $content = []): array
     {
         return [
-            'source' => $source ?? $resolved,
             'resolved' => $resolved,
+            'contentView' => ContentView::create($content, $view),
         ];
     }
 
@@ -65,7 +67,6 @@ class ResolvableResourceReplacerTest extends TestCase
             ],
         ];
 
-        // Use the actual metadata identifier from the resource
         $metadataId = $resolvableResource->getMetadataIdentifier();
         $resolvedResources = [
             'page' => [
@@ -87,7 +88,6 @@ class ResolvableResourceReplacerTest extends TestCase
         self::assertIsArray($result['content']['nested']);
         self::assertArrayHasKey('page', $result['content']['nested']);
         self::assertSame('Resolved Page Title', $result['content']['nested']['page']);
-        // Verify ReferenceStore was populated
         $tags = $this->referenceStore->getAll();
         self::assertContains('pages-123', $tags);
         self::assertCount(1, $tags);
@@ -146,7 +146,6 @@ class ResolvableResourceReplacerTest extends TestCase
 
         self::assertSame(['nested_page' => 'Article Title'], $result['content']['page']);
 
-        // Verify ReferenceStore was populated for both resources
         $tags = $this->referenceStore->getAll();
         self::assertContains('pages-123', $tags);
         self::assertContains('articles-456', $tags);
@@ -175,10 +174,8 @@ class ResolvableResourceReplacerTest extends TestCase
             2
         );
 
-        // Should replace with null when max depth exceeded
         self::assertNull($result['content']['page']);
 
-        // ReferenceStore should be empty when max depth exceeded
         $tags = $this->referenceStore->getAll();
         self::assertEmpty($tags);
     }
@@ -206,10 +203,8 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        // Should remain unchanged when no resolved resources
         self::assertSame($resolvableResource, $result['content']['page']);
 
-        // ReferenceStore should be empty when no resources resolved
         $tags = $this->referenceStore->getAll();
         self::assertEmpty($tags);
     }
@@ -273,7 +268,6 @@ class ResolvableResourceReplacerTest extends TestCase
 
         self::assertSame($expected, $result['content']);
 
-        // Verify ReferenceStore was populated for both resources
         $tags = $this->referenceStore->getAll();
         self::assertContains('pages-123', $tags);
         self::assertContains('articles-456', $tags);
@@ -325,7 +319,6 @@ class ResolvableResourceReplacerTest extends TestCase
 
         self::assertSame(['First Page', 'Second Page'], $result['content']['pages']);
 
-        // Verify ReferenceStore was populated for both pages
         $tags = $this->referenceStore->getAll();
         self::assertContains('pages-123', $tags);
         self::assertContains('pages-456', $tags);
@@ -334,7 +327,6 @@ class ResolvableResourceReplacerTest extends TestCase
 
     public function testReferenceStoreWithUuidResources(): void
     {
-        // Create a ResolvableResource with a UUID as ID
         $uuid = '550e8400-e29b-41d4-a716-446655440000';
         $resolvableResource = new ResolvableResource(
             $uuid,
@@ -367,7 +359,6 @@ class ResolvableResourceReplacerTest extends TestCase
 
         self::assertSame('UUID Page Title', $result['content']['page']);
 
-        // Verify ReferenceStore stores UUID directly without prefix
         $tags = $this->referenceStore->getAll();
         self::assertContains($uuid, $tags);
         self::assertCount(1, $tags);
@@ -375,7 +366,6 @@ class ResolvableResourceReplacerTest extends TestCase
 
     public function testReferenceStoreNotPopulatedWithoutResourceKey(): void
     {
-        // Create a ResolvableResource without resourceKey
         $resolvableResource = new ResolvableResource(
             '123',
             'page',
@@ -383,7 +373,6 @@ class ResolvableResourceReplacerTest extends TestCase
             function(array $resource) {
                 return $resource['title'] ?? 'Default Title';
             }
-            // No metadata and no resourceKey provided
         );
 
         $content = ['page' => $resolvableResource];
@@ -406,21 +395,12 @@ class ResolvableResourceReplacerTest extends TestCase
 
         self::assertSame('Page Without Key', $result['content']['page']);
 
-        // Verify ReferenceStore is empty when resourceKey is not provided
         $tags = $this->referenceStore->getAll();
         self::assertEmpty($tags);
     }
 
-    public function testViewCallbackExecutedWithSourceEntity(): void
+    public function testViewDataFromResolvedResources(): void
     {
-        $callbackCalled = false;
-        $receivedSource = null;
-
-        $example = new Example();
-        $example->id = '123';
-        $sourceEntity = new ExampleDimensionContent($example);
-        $sourceEntity->setTemplateKey('test-template');
-
         $resolvableResource = new ResolvableResource(
             '123',
             'snippet',
@@ -430,15 +410,7 @@ class ResolvableResourceReplacerTest extends TestCase
             },
             null,
             'snippets',
-            function(ExampleDimensionContent $source) use (&$callbackCalled, &$receivedSource) {
-                $callbackCalled = true;
-                $receivedSource = $source;
-
-                return [
-                    'id' => $source->getResource()->getId(),
-                    'template' => $source->getTemplateKey(),
-                ];
-            }
+            'items',
         );
 
         $content = [
@@ -450,10 +422,10 @@ class ResolvableResourceReplacerTest extends TestCase
         $resolvedResources = [
             'snippet' => [
                 '123' => [
-                    $metadataId => [
-                        'source' => $sourceEntity,
-                        'resolved' => ['title' => 'Snippet Title'],
-                    ],
+                    $metadataId => $this->createResolvedEntry(
+                        ['title' => 'Snippet Title'],
+                        ['id' => '123', 'template' => 'test-template'],
+                    ),
                 ],
             ],
         ];
@@ -465,11 +437,9 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertTrue($callbackCalled, 'viewCallback should be called');
-        self::assertSame($sourceEntity, $receivedSource);
         self::assertSame(['Snippet Title'], $result['content']['mySnippets']);
         self::assertArrayHasKey('[mySnippets]', $result['viewEnhancements']);
-        self::assertTrue($result['viewEnhancements']['[mySnippets]']['isList']);
+        self::assertSame('items', $result['viewEnhancements']['[mySnippets]']['itemsPropertyName']);
         self::assertCount(1, $result['viewEnhancements']['[mySnippets]']['items']);
         self::assertSame(
             ['id' => '123', 'template' => 'test-template'],
@@ -477,25 +447,8 @@ class ResolvableResourceReplacerTest extends TestCase
         );
     }
 
-    public function testViewCallbackWithMultipleResources(): void
+    public function testViewDataWithMultipleResources(): void
     {
-        $example1 = new Example();
-        $example1->id = '123';
-        $source1 = new ExampleDimensionContent($example1);
-        $source1->setTemplateKey('template-a');
-
-        $example2 = new Example();
-        $example2->id = '456';
-        $source2 = new ExampleDimensionContent($example2);
-        $source2->setTemplateKey('template-b');
-
-        $viewCallback = static function(ExampleDimensionContent $source): array {
-            return [
-                'id' => $source->getResource()->getId(),
-                'template' => $source->getTemplateKey(),
-            ];
-        };
-
         $resource1 = new ResolvableResource(
             '123',
             'snippet',
@@ -505,7 +458,7 @@ class ResolvableResourceReplacerTest extends TestCase
             },
             null,
             'snippets',
-            $viewCallback
+            'items',
         );
 
         $resource2 = new ResolvableResource(
@@ -517,7 +470,7 @@ class ResolvableResourceReplacerTest extends TestCase
             },
             null,
             'snippets',
-            $viewCallback
+            'items',
         );
 
         $content = [
@@ -529,8 +482,18 @@ class ResolvableResourceReplacerTest extends TestCase
 
         $resolvedResources = [
             'snippet' => [
-                '123' => [$metadata1 => ['source' => $source1, 'resolved' => ['title' => 'First Snippet']]],
-                '456' => [$metadata2 => ['source' => $source2, 'resolved' => ['title' => 'Second Snippet']]],
+                '123' => [
+                    $metadata1 => $this->createResolvedEntry(
+                        ['title' => 'First Snippet'],
+                        ['id' => '123', 'template' => 'template-a'],
+                    ),
+                ],
+                '456' => [
+                    $metadata2 => $this->createResolvedEntry(
+                        ['title' => 'Second Snippet'],
+                        ['id' => '456', 'template' => 'template-b'],
+                    ),
+                ],
             ],
         ];
 
@@ -543,16 +506,14 @@ class ResolvableResourceReplacerTest extends TestCase
 
         self::assertSame(['First Snippet', 'Second Snippet'], $result['content']['snippets']);
         self::assertArrayHasKey('[snippets]', $result['viewEnhancements']);
-        self::assertTrue($result['viewEnhancements']['[snippets]']['isList']);
+        self::assertSame('items', $result['viewEnhancements']['[snippets]']['itemsPropertyName']);
         self::assertCount(2, $result['viewEnhancements']['[snippets]']['items']);
         self::assertSame(['id' => '123', 'template' => 'template-a'], $result['viewEnhancements']['[snippets]']['items'][0]);
         self::assertSame(['id' => '456', 'template' => 'template-b'], $result['viewEnhancements']['[snippets]']['items'][1]);
     }
 
-    public function testViewCallbackNotCalledWhenSourceIsNull(): void
+    public function testViewDataEmptyWhenResourceNotResolved(): void
     {
-        $callbackCalled = false;
-
         $resolvableResource = new ResolvableResource(
             '123',
             'snippet',
@@ -562,11 +523,7 @@ class ResolvableResourceReplacerTest extends TestCase
             },
             null,
             'snippets',
-            function(ExampleDimensionContent $source) use (&$callbackCalled) {
-                $callbackCalled = true;
-
-                return ['id' => $source->getResource()->getId()];
-            }
+            'items',
         );
 
         $content = [
@@ -582,20 +539,14 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertFalse($callbackCalled);
         $mySnippets = $result['content']['mySnippets'];
         self::assertIsArray($mySnippets);
         self::assertSame($resolvableResource, $mySnippets[0]);
         self::assertEmpty($result['viewEnhancements']);
     }
 
-    public function testViewCallbackWithNestedPath(): void
+    public function testViewDataWithNestedPath(): void
     {
-        $example = new Example();
-        $example->id = '123';
-        $source = new ExampleDimensionContent($example);
-        $source->setTemplateKey('default');
-
         $resolvableResource = new ResolvableResource(
             '123',
             'snippet',
@@ -605,12 +556,7 @@ class ResolvableResourceReplacerTest extends TestCase
             },
             null,
             'snippets',
-            function(ExampleDimensionContent $source) {
-                return [
-                    'id' => $source->getResource()->getId(),
-                    'template' => $source->getTemplateKey(),
-                ];
-            }
+            'items',
         );
 
         $content = [
@@ -623,7 +569,12 @@ class ResolvableResourceReplacerTest extends TestCase
 
         $resolvedResources = [
             'snippet' => [
-                '123' => [$metadataId => ['source' => $source, 'resolved' => ['title' => 'Snippet Title']]],
+                '123' => [
+                    $metadataId => $this->createResolvedEntry(
+                        ['title' => 'Snippet Title'],
+                        ['id' => '123', 'template' => 'default'],
+                    ),
+                ],
             ],
         ];
 
@@ -638,7 +589,7 @@ class ResolvableResourceReplacerTest extends TestCase
         self::assertIsArray($templateContent);
         self::assertSame(['Snippet Title'], $templateContent['snippets']);
         self::assertArrayHasKey('[template][snippets]', $result['viewEnhancements']);
-        self::assertTrue($result['viewEnhancements']['[template][snippets]']['isList']);
+        self::assertSame('items', $result['viewEnhancements']['[template][snippets]']['itemsPropertyName']);
         self::assertCount(1, $result['viewEnhancements']['[template][snippets]']['items']);
         self::assertSame(
             ['id' => '123', 'template' => 'default'],
@@ -646,7 +597,7 @@ class ResolvableResourceReplacerTest extends TestCase
         );
     }
 
-    public function testViewCallbackWithIndexedNestedPath(): void
+    public function testViewDataWithIndexedNestedPath(): void
     {
         $resource1 = new ResolvableResource(
             '123',
@@ -657,9 +608,7 @@ class ResolvableResourceReplacerTest extends TestCase
             },
             null,
             'snippets',
-            static function(array $source): array {
-                return ['uuid' => $source['uuid']];
-            }
+            'items',
         );
 
         $resource2 = new ResolvableResource(
@@ -671,9 +620,7 @@ class ResolvableResourceReplacerTest extends TestCase
             },
             null,
             'snippets',
-            static function(array $source): array {
-                return ['uuid' => $source['uuid']];
-            }
+            'items',
         );
 
         $content = [
@@ -689,10 +636,16 @@ class ResolvableResourceReplacerTest extends TestCase
         $resolvedResources = [
             'snippet' => [
                 '123' => [
-                    $metadata1 => ['source' => ['uuid' => 'u-123'], 'resolved' => ['title' => 'Snippet 1']],
+                    $metadata1 => $this->createResolvedEntry(
+                        ['title' => 'Snippet 1'],
+                        ['uuid' => 'u-123'],
+                    ),
                 ],
                 '456' => [
-                    $metadata2 => ['source' => ['uuid' => 'u-456'], 'resolved' => ['title' => 'Snippet 2']],
+                    $metadata2 => $this->createResolvedEntry(
+                        ['title' => 'Snippet 2'],
+                        ['uuid' => 'u-456'],
+                    ),
                 ],
             ],
         ];
@@ -708,28 +661,21 @@ class ResolvableResourceReplacerTest extends TestCase
         self::assertArrayHasKey('[blocks][1][snippets]', $result['viewEnhancements']);
         self::assertArrayNotHasKey('[blocks][snippets]', $result['viewEnhancements']);
 
-        self::assertTrue($result['viewEnhancements']['[blocks][0][snippets]']['isList']);
+        self::assertSame('items', $result['viewEnhancements']['[blocks][0][snippets]']['itemsPropertyName']);
         self::assertSame(
             ['uuid' => 'u-123'],
             $result['viewEnhancements']['[blocks][0][snippets]']['items'][0]
         );
 
-        self::assertTrue($result['viewEnhancements']['[blocks][1][snippets]']['isList']);
+        self::assertSame('items', $result['viewEnhancements']['[blocks][1][snippets]']['itemsPropertyName']);
         self::assertSame(
             ['uuid' => 'u-456'],
             $result['viewEnhancements']['[blocks][1][snippets]']['items'][0]
         );
     }
 
-    public function testViewCallbackReceivesSourceEntityNotResolvedValue(): void
+    public function testPreComputedViewDataAccumulated(): void
     {
-        $receivedSource = null;
-
-        $example = new Example();
-        $example->id = '123';
-        $dimensionContent = new ExampleDimensionContent($example);
-        $dimensionContent->setTemplateKey('custom-template');
-
         $resolvableResource = new ResolvableResource(
             '123',
             'snippet',
@@ -743,14 +689,7 @@ class ResolvableResourceReplacerTest extends TestCase
             },
             null,
             'snippets',
-            function(ExampleDimensionContent $source) use (&$receivedSource) {
-                $receivedSource = $source;
-
-                return [
-                    'id' => $source->getResource()->getId(),
-                    'template' => $source->getTemplateKey(),
-                ];
-            }
+            'items',
         );
 
         $content = [
@@ -762,14 +701,14 @@ class ResolvableResourceReplacerTest extends TestCase
         $resolvedResources = [
             'snippet' => [
                 '123' => [
-                    $metadataId => [
-                        'source' => $dimensionContent,
-                        'resolved' => [
+                    $metadataId => $this->createResolvedEntry(
+                        [
                             'rawTitle' => 'My Title',
                             'rawText' => 'Some text',
                             'template' => 'custom-template',
                         ],
-                    ],
+                        ['id' => '123', 'template' => 'custom-template'],
+                    ),
                 ],
             ],
         ];
@@ -781,15 +720,208 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertSame($dimensionContent, $receivedSource);
-        self::assertSame('123', $receivedSource->getResource()->getId());
-        self::assertSame('custom-template', $receivedSource->getTemplateKey());
-
         self::assertArrayHasKey('[mySnippets]', $result['viewEnhancements']);
-        self::assertTrue($result['viewEnhancements']['[mySnippets]']['isList']);
+        self::assertSame('items', $result['viewEnhancements']['[mySnippets]']['itemsPropertyName']);
         self::assertSame(
             ['id' => '123', 'template' => 'custom-template'],
             $result['viewEnhancements']['[mySnippets]']['items'][0]
         );
+    }
+
+    public function testViewDataWithNullItemsPropertyNameFlatMerge(): void
+    {
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'snippet',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'snippets',
+        );
+
+        $content = [
+            'mySnippet' => $resolvableResource,
+        ];
+
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'snippet' => [
+                '123' => [
+                    $metadataId => $this->createResolvedEntry(
+                        ['title' => 'Snippet Title'],
+                        ['id' => '123', 'template' => 'default'],
+                    ),
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertSame('Snippet Title', $result['content']['mySnippet']);
+        self::assertArrayHasKey('[mySnippet]', $result['viewEnhancements']);
+        self::assertNull($result['viewEnhancements']['[mySnippet]']['itemsPropertyName']);
+        self::assertCount(1, $result['viewEnhancements']['[mySnippet]']['items']);
+        self::assertSame(
+            ['id' => '123', 'template' => 'default'],
+            $result['viewEnhancements']['[mySnippet]']['items'][0]
+        );
+    }
+
+    public function testContentDataMergedIntoResolvedValue(): void
+    {
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            null,
+            null,
+            'pages'
+        );
+
+        $content = [
+            'page' => $resolvableResource,
+        ];
+
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+        $resolvedResources = [
+            'page' => [
+                '123' => [
+                    $metadataId => $this->createResolvedEntry(
+                        ['title' => 'Page Title', 'url' => '/page'],
+                        [],
+                        ['authored' => '2024-01-01T00:00:00+00:00', 'lastModified' => '2024-06-15T12:00:00+00:00'],
+                    ),
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertIsArray($result['content']['page']);
+        self::assertSame('Page Title', $result['content']['page']['title']);
+        self::assertSame('/page', $result['content']['page']['url']);
+        self::assertSame('2024-01-01T00:00:00+00:00', $result['content']['page']['authored']);
+        self::assertSame('2024-06-15T12:00:00+00:00', $result['content']['page']['lastModified']);
+    }
+
+    public function testContentDataNotMergedWhenResolvedIsNotArray(): void
+    {
+        $resolvableResource = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            function(array $resource) {
+                return $resource['title'];
+            },
+            null,
+            'pages'
+        );
+
+        $content = [
+            'page' => $resolvableResource,
+        ];
+
+        $metadataId = $resolvableResource->getMetadataIdentifier();
+        $resolvedResources = [
+            'page' => [
+                '123' => [
+                    $metadataId => $this->createResolvedEntry(
+                        ['title' => 'Page Title'],
+                        [],
+                        ['authored' => '2024-01-01T00:00:00+00:00'],
+                    ),
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        self::assertSame('Page Title', $result['content']['page']);
+    }
+
+    public function testContentDataMergedIntoEachItemInMultiSelection(): void
+    {
+        $resource1 = new ResolvableResource(
+            '123',
+            'page',
+            1,
+            null,
+            null,
+            'pages'
+        );
+
+        $resource2 = new ResolvableResource(
+            '456',
+            'page',
+            1,
+            null,
+            null,
+            'pages'
+        );
+
+        $content = [
+            'pages' => [$resource1, $resource2],
+        ];
+
+        $metadata1 = $resource1->getMetadataIdentifier();
+        $metadata2 = $resource2->getMetadataIdentifier();
+
+        $resolvedResources = [
+            'page' => [
+                '123' => [
+                    $metadata1 => $this->createResolvedEntry(
+                        ['title' => 'First Page'],
+                        [],
+                        ['authored' => '2024-01-01T00:00:00+00:00', 'lastModified' => '2024-03-01T00:00:00+00:00'],
+                    ),
+                ],
+                '456' => [
+                    $metadata2 => $this->createResolvedEntry(
+                        ['title' => 'Second Page'],
+                        [],
+                        ['authored' => '2024-06-01T00:00:00+00:00', 'lastModified' => '2024-09-01T00:00:00+00:00'],
+                    ),
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
+            $content,
+            $resolvedResources,
+            0,
+            5
+        );
+
+        $pages = $result['content']['pages'];
+        self::assertIsArray($pages);
+        self::assertCount(2, $pages);
+
+        self::assertIsArray($pages[0]);
+        self::assertSame('First Page', $pages[0]['title']);
+        self::assertSame('2024-01-01T00:00:00+00:00', $pages[0]['authored']);
+        self::assertSame('2024-03-01T00:00:00+00:00', $pages[0]['lastModified']);
+
+        self::assertIsArray($pages[1]);
+        self::assertSame('Second Page', $pages[1]['title']);
+        self::assertSame('2024-06-01T00:00:00+00:00', $pages[1]['authored']);
+        self::assertSame('2024-09-01T00:00:00+00:00', $pages[1]['lastModified']);
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
@@ -36,13 +36,13 @@ class ResolvableResourceReplacerTest extends TestCase
      * @param array<string, mixed> $content
      * @param array<string, mixed> $view
      *
-     * @return array{resolved: mixed, contentView: ContentView}
+     * @return array{resolved: mixed, contentViewEnhancement: ContentView}
      */
     private function createResolvedEntry(mixed $resolved, array $view = [], array $content = []): array
     {
         return [
             'resolved' => $resolved,
-            'contentView' => ContentView::create($content, $view),
+            'contentViewEnhancement' => ContentView::create($content, $view),
         ];
     }
 

--- a/packages/content/tests/Unit/Content/Application/ResourceLoader/CachedResourceLoaderTest.php
+++ b/packages/content/tests/Unit/Content/Application/ResourceLoader/CachedResourceLoaderTest.php
@@ -14,7 +14,7 @@ namespace Sulu\Content\Tests\Unit\Content\Application\ResourceLoader;
 use PHPUnit\Framework\TestCase;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ResourceLoader\Loader\CachedResourceLoader;
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewEnhancementInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 
 class CachedResourceLoaderTest extends TestCase
@@ -165,9 +165,9 @@ class CachedResourceLoaderTest extends TestCase
         CachedResourceLoader::getKey();
     }
 
-    public function testResolveContentViewForwardsToInnerLoader(): void
+    public function testResolveContentViewEnhancementForwardsToInnerLoader(): void
     {
-        $innerLoader = new class() implements ResourceLoaderContentViewInterface {
+        $innerLoader = new class() implements ResourceLoaderContentViewEnhancementInterface {
             public function load(array $ids, ?string $locale, array $params = []): array
             {
                 return [];
@@ -178,11 +178,11 @@ class CachedResourceLoaderTest extends TestCase
                 return 'test-content-view-loader';
             }
 
-            public function resolveContentView(mixed $source): ContentView
+            public function resolveContentViewEnhancement(mixed $resource): ContentView
             {
                 return ContentView::create(
-                    ['authored' => $source->getAuthored()], // @phpstan-ignore method.nonObject
-                    ['id' => $source->getId(), 'template' => 'forwarded-template'], // @phpstan-ignore method.nonObject
+                    ['authored' => $resource->getAuthored()], // @phpstan-ignore method.nonObject
+                    ['id' => $resource->getId(), 'template' => 'forwarded-template'], // @phpstan-ignore method.nonObject
                 );
             }
         };
@@ -200,13 +200,13 @@ class CachedResourceLoaderTest extends TestCase
             }
         };
 
-        $result = $cachedLoader->resolveContentView($dimensionContent);
+        $result = $cachedLoader->resolveContentViewEnhancement($dimensionContent);
 
         self::assertSame(['id' => '42', 'template' => 'forwarded-template'], $result->getView());
         self::assertSame(['authored' => '2024-01-01T00:00:00+00:00'], $result->getContent());
     }
 
-    public function testResolveContentViewReturnsEmptyWhenInnerDoesNotImplementInterface(): void
+    public function testResolveContentViewEnhancementReturnsEmptyWhenInnerDoesNotImplementInterface(): void
     {
         $innerLoader = new class() implements ResourceLoaderInterface {
             public function load(array $ids, ?string $locale, array $params = []): array
@@ -222,7 +222,7 @@ class CachedResourceLoaderTest extends TestCase
 
         $cachedLoader = new CachedResourceLoader($innerLoader);
 
-        $result = $cachedLoader->resolveContentView('some-dimension-content');
+        $result = $cachedLoader->resolveContentViewEnhancement('some-dimension-content');
 
         self::assertSame([], $result->getView());
         self::assertSame([], $result->getContent());

--- a/packages/content/tests/Unit/Content/Application/ResourceLoader/CachedResourceLoaderTest.php
+++ b/packages/content/tests/Unit/Content/Application/ResourceLoader/CachedResourceLoaderTest.php
@@ -12,7 +12,9 @@
 namespace Sulu\Content\Tests\Unit\Content\Application\ResourceLoader;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ResourceLoader\Loader\CachedResourceLoader;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 
 class CachedResourceLoaderTest extends TestCase
@@ -161,6 +163,69 @@ class CachedResourceLoaderTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         CachedResourceLoader::getKey();
+    }
+
+    public function testResolveContentViewForwardsToInnerLoader(): void
+    {
+        $innerLoader = new class() implements ResourceLoaderContentViewInterface {
+            public function load(array $ids, ?string $locale, array $params = []): array
+            {
+                return [];
+            }
+
+            public static function getKey(): string
+            {
+                return 'test-content-view-loader';
+            }
+
+            public function resolveContentView(mixed $source): ContentView
+            {
+                return ContentView::create(
+                    ['authored' => $source->getAuthored()], // @phpstan-ignore method.nonObject
+                    ['id' => $source->getId(), 'template' => 'forwarded-template'], // @phpstan-ignore method.nonObject
+                );
+            }
+        };
+
+        $cachedLoader = new CachedResourceLoader($innerLoader);
+        $dimensionContent = new class() {
+            public function getId(): string
+            {
+                return '42';
+            }
+
+            public function getAuthored(): string
+            {
+                return '2024-01-01T00:00:00+00:00';
+            }
+        };
+
+        $result = $cachedLoader->resolveContentView($dimensionContent);
+
+        self::assertSame(['id' => '42', 'template' => 'forwarded-template'], $result->getView());
+        self::assertSame(['authored' => '2024-01-01T00:00:00+00:00'], $result->getContent());
+    }
+
+    public function testResolveContentViewReturnsEmptyWhenInnerDoesNotImplementInterface(): void
+    {
+        $innerLoader = new class() implements ResourceLoaderInterface {
+            public function load(array $ids, ?string $locale, array $params = []): array
+            {
+                return [];
+            }
+
+            public static function getKey(): string
+            {
+                return 'test-basic-loader';
+            }
+        };
+
+        $cachedLoader = new CachedResourceLoader($innerLoader);
+
+        $result = $cachedLoader->resolveContentView('some-dimension-content');
+
+        self::assertSame([], $result->getView());
+        self::assertSame([], $result->getContent());
     }
 
     /**

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -13,6 +13,7 @@ namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
 
@@ -48,10 +49,7 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
             ids: $ids,
             resourceLoaderKey: $resourceLoaderKey,
             resourceKey: PageInterface::RESOURCE_KEY,
-            view: [
-                'ids' => $ids,
-                ...$params,
-            ],
+            view: [],
             priority: 150,
             metadata: [
                 'properties' => \array_merge(
@@ -61,7 +59,24 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
                         'url' => 'url',
                     ],
                 ),
-            ]
+            ],
+            viewCallback: static function(mixed $source): array {
+                if ($source instanceof PageDimensionContentInterface) {
+                    /** @var PageInterface $resource */
+                    $resource = $source->getResource();
+
+                    return [
+                        'uuid' => $resource->getUuid(),
+                        'template' => $source->getTemplateKey(),
+                        'webspaceKey' => $resource->getWebspaceKey(),
+                        'authored' => $source->getAuthored()?->format('c'),
+                        'lastModified' => $source->getLastModified()?->format('c'),
+                        'parent' => $resource->getParent()?->getUuid(),
+                    ];
+                }
+
+                return [];
+            },
         );
     }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -13,7 +13,6 @@ namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
-use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
 
@@ -60,23 +59,7 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
                     ],
                 ),
             ],
-            viewCallback: static function(mixed $source): array {
-                if ($source instanceof PageDimensionContentInterface) {
-                    /** @var PageInterface $resource */
-                    $resource = $source->getResource();
-
-                    return [
-                        'uuid' => $resource->getUuid(),
-                        'template' => $source->getTemplateKey(),
-                        'webspaceKey' => $resource->getWebspaceKey(),
-                        'authored' => $source->getAuthored()?->format('c'),
-                        'lastModified' => $source->getLastModified()?->format('c'),
-                        'parent' => $resource->getParent()?->getUuid(),
-                    ];
-                }
-
-                return [];
-            },
+            itemsPropertyName: 'items',
         );
     }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolver.php
@@ -59,7 +59,6 @@ class PageSelectionPropertyResolver implements PropertyResolverInterface
                     ],
                 ),
             ],
-            itemsPropertyName: 'items',
         );
     }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -13,6 +13,7 @@ namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
 
@@ -55,7 +56,24 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
                         'url' => 'url',
                     ],
                 ),
-            ]
+            ],
+            viewCallback: static function(mixed $source): array {
+                if ($source instanceof PageDimensionContentInterface) {
+                    /** @var PageInterface $resource */
+                    $resource = $source->getResource();
+
+                    return [
+                        'uuid' => $resource->getUuid(),
+                        'template' => $source->getTemplateKey(),
+                        'webspaceKey' => $resource->getWebspaceKey(),
+                        'authored' => $source->getAuthored()?->format('c'),
+                        'lastModified' => $source->getLastModified()?->format('c'),
+                        'parent' => $resource->getParent()?->getUuid(),
+                    ];
+                }
+
+                return [];
+            },
         );
     }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PropertyResolver/SinglePageSelectionPropertyResolver.php
@@ -13,7 +13,6 @@ namespace Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
-use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
 
@@ -57,23 +56,6 @@ class SinglePageSelectionPropertyResolver implements PropertyResolverInterface
                     ],
                 ),
             ],
-            viewCallback: static function(mixed $source): array {
-                if ($source instanceof PageDimensionContentInterface) {
-                    /** @var PageInterface $resource */
-                    $resource = $source->getResource();
-
-                    return [
-                        'uuid' => $resource->getUuid(),
-                        'template' => $source->getTemplateKey(),
-                        'webspaceKey' => $resource->getWebspaceKey(),
-                        'authored' => $source->getAuthored()?->format('c'),
-                        'lastModified' => $source->getLastModified()?->format('c'),
-                        'parent' => $resource->getParent()?->getUuid(),
-                    ];
-                }
-
-                return [];
-            },
         );
     }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
@@ -15,7 +15,7 @@ use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewEnhancementInterface;
 use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
@@ -27,7 +27,7 @@ use Symfony\Bundle\SecurityBundle\Security;
  *
  * @final
  */
-class PageResourceLoader implements ResourceLoaderContentViewInterface
+class PageResourceLoader implements ResourceLoaderContentViewEnhancementInterface
 {
     public const RESOURCE_LOADER_KEY = 'page';
 
@@ -88,25 +88,25 @@ class PageResourceLoader implements ResourceLoaderContentViewInterface
         return $mappedResult;
     }
 
-    public function resolveContentView(mixed $source): ContentView
+    public function resolveContentViewEnhancement(mixed $resource): ContentView
     {
         $view = [];
         $content = [];
 
-        if ($source instanceof PageDimensionContentInterface) {
-            $resource = $source->getResource();
+        if ($resource instanceof PageDimensionContentInterface) {
+            $page = $resource->getResource();
             $view = [
-                'uuid' => $resource->getUuid(),
-                'template' => $source->getTemplateKey(),
-                'webspaceKey' => $resource->getWebspaceKey(),
-                'parent' => $resource->getParent()?->getUuid(),
+                'uuid' => $page->getUuid(),
+                'template' => $resource->getTemplateKey(),
+                'webspaceKey' => $page->getWebspaceKey(),
+                'parent' => $page->getParent()?->getUuid(),
             ];
         }
 
-        if ($source instanceof AuthorInterface) {
+        if ($resource instanceof AuthorInterface) {
             $content = [
-                'authored' => $source->getAuthored()?->format('c'),
-                'lastModified' => $source->getLastModified()?->format('c'),
+                'authored' => $resource->getAuthored()?->format('c'),
+                'lastModified' => $resource->getLastModified()?->format('c'),
             ];
         }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ResourceLoader/PageResourceLoader.php
@@ -14,8 +14,11 @@ namespace Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Domain\Model\AuthorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 
@@ -24,7 +27,7 @@ use Symfony\Bundle\SecurityBundle\Security;
  *
  * @final
  */
-class PageResourceLoader implements ResourceLoaderInterface
+class PageResourceLoader implements ResourceLoaderContentViewInterface
 {
     public const RESOURCE_LOADER_KEY = 'page';
 
@@ -83,6 +86,31 @@ class PageResourceLoader implements ResourceLoaderInterface
         }
 
         return $mappedResult;
+    }
+
+    public function resolveContentView(mixed $source): ContentView
+    {
+        $view = [];
+        $content = [];
+
+        if ($source instanceof PageDimensionContentInterface) {
+            $resource = $source->getResource();
+            $view = [
+                'uuid' => $resource->getUuid(),
+                'template' => $source->getTemplateKey(),
+                'webspaceKey' => $resource->getWebspaceKey(),
+                'parent' => $resource->getParent()?->getUuid(),
+            ];
+        }
+
+        if ($source instanceof AuthorInterface) {
+            $content = [
+                'authored' => $source->getAuthored()?->format('c'),
+                'lastModified' => $source->getLastModified()?->format('c'),
+            ];
+        }
+
+        return ContentView::create($content, $view);
     }
 
     public static function getKey(): string

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/PageSelectionPropertyResolverTest.php
@@ -101,7 +101,7 @@ class PageSelectionPropertyResolverTest extends TestCase
             $this->assertSame(PageInterface::RESOURCE_KEY, $reference->getResourceKey());
         }
 
-        $this->assertSame(['ids' => $data], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
     }
 
     /**
@@ -111,7 +111,6 @@ class PageSelectionPropertyResolverTest extends TestCase
      */
     public static function provideResolvableData(): iterable
     {
-        yield 'empty' => [[]];
         yield 'string_list' => [['1', '2']];
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
@@ -13,6 +13,7 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
 
@@ -60,7 +61,17 @@ class SingleSnippetSelectionPropertyResolver implements PropertyResolverInterfac
             priority: 100,
             metadata: [
                 'properties' => $params['properties'] ?? null,
-            ]
+            ],
+            viewCallback: static function(mixed $source): array {
+                if ($source instanceof SnippetDimensionContentInterface) {
+                    return [
+                        'uuid' => $source->getResource()->getUuid(),
+                        'template' => $source->getTemplateKey(),
+                    ];
+                }
+
+                return [];
+            },
         );
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SingleSnippetSelectionPropertyResolver.php
@@ -13,7 +13,6 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
-use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
 
@@ -62,16 +61,6 @@ class SingleSnippetSelectionPropertyResolver implements PropertyResolverInterfac
             metadata: [
                 'properties' => $params['properties'] ?? null,
             ],
-            viewCallback: static function(mixed $source): array {
-                if ($source instanceof SnippetDimensionContentInterface) {
-                    return [
-                        'uuid' => $source->getResource()->getUuid(),
-                        'template' => $source->getTemplateKey(),
-                    ];
-                }
-
-                return [];
-            },
         );
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of Sulu.
  *
@@ -13,6 +15,7 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
 
@@ -65,14 +68,21 @@ class SnippetSelectionPropertyResolver implements PropertyResolverInterface
             ids: $identifiers,
             resourceLoaderKey: $resourceLoaderKey,
             resourceKey: SnippetInterface::RESOURCE_KEY,
-            view: [
-                'ids' => $identifiers,
-                ...$params,
-            ],
+            view: [],
             priority: 100,
             metadata: [
                 'properties' => $params['properties'] ?? null,
-            ]
+            ],
+            viewCallback: static function(mixed $source): array {
+                if ($source instanceof SnippetDimensionContentInterface) {
+                    return [
+                        'uuid' => $source->getResource()->getUuid(),
+                        'template' => $source->getTemplateKey(),
+                    ];
+                }
+
+                return [];
+            },
         );
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
@@ -72,7 +72,6 @@ class SnippetSelectionPropertyResolver implements PropertyResolverInterface
             metadata: [
                 'properties' => $params['properties'] ?? null,
             ],
-            itemsPropertyName: 'items',
         );
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolver.php
@@ -15,7 +15,6 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Content\PropertyResolver;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
-use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
 
@@ -73,16 +72,7 @@ class SnippetSelectionPropertyResolver implements PropertyResolverInterface
             metadata: [
                 'properties' => $params['properties'] ?? null,
             ],
-            viewCallback: static function(mixed $source): array {
-                if ($source instanceof SnippetDimensionContentInterface) {
-                    return [
-                        'uuid' => $source->getResource()->getUuid(),
-                        'template' => $source->getTemplateKey(),
-                    ];
-                }
-
-                return [];
-            },
+            itemsPropertyName: 'items',
         );
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader;
 
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewEnhancementInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
@@ -25,7 +25,7 @@ use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
  *
  * @final
  */
-class SnippetResourceLoader implements ResourceLoaderContentViewInterface
+class SnippetResourceLoader implements ResourceLoaderContentViewEnhancementInterface
 {
     public const RESOURCE_LOADER_KEY = 'snippet';
 
@@ -81,15 +81,15 @@ class SnippetResourceLoader implements ResourceLoaderContentViewInterface
         return $mappedResult;
     }
 
-    public function resolveContentView(mixed $source): ContentView
+    public function resolveContentViewEnhancement(mixed $resource): ContentView
     {
-        if (!$source instanceof SnippetDimensionContentInterface) {
+        if (!$resource instanceof SnippetDimensionContentInterface) {
             return ContentView::create([], []);
         }
 
         return ContentView::create([], [
-            'uuid' => $source->getResource()->getUuid(),
-            'template' => $source->getTemplateKey(),
+            'uuid' => $resource->getResource()->getUuid(),
+            'template' => $resource->getTemplateKey(),
         ]);
     }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader;
 
-use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 
@@ -23,7 +25,7 @@ use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
  *
  * @final
  */
-class SnippetResourceLoader implements ResourceLoaderInterface
+class SnippetResourceLoader implements ResourceLoaderContentViewInterface
 {
     public const RESOURCE_LOADER_KEY = 'snippet';
 
@@ -77,6 +79,18 @@ class SnippetResourceLoader implements ResourceLoaderInterface
         }
 
         return $mappedResult;
+    }
+
+    public function resolveContentView(mixed $source): ContentView
+    {
+        if (!$source instanceof SnippetDimensionContentInterface) {
+            return ContentView::create([], []);
+        }
+
+        return ContentView::create([], [
+            'uuid' => $source->getResource()->getUuid(),
+            'template' => $source->getTemplateKey(),
+        ]);
     }
 
     public static function getKey(): string

--- a/packages/snippet/tests/Application/config/templates/snippets/snippet-alternate.xml
+++ b/packages/snippet/tests/Application/config/templates/snippets/snippet-alternate.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
+
+    <key>snippet-alternate</key>
+
+    <view>views/snippets/snippet-alternate</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Alternate Snippet</title>
+        <title lang="de">Alternatives Schnipsel</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="text" type="text_area">
+            <meta>
+                <title lang="en">Text</title>
+                <title lang="de">Text</title>
+            </meta>
+        </property>
+    </properties>
+</template>

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/SnippetSelectionPropertyResolverTest.php
@@ -36,7 +36,7 @@ class SnippetSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en');
 
         $this->assertEmpty($contentView->getContent());
-        $this->assertSame(['ids' => []], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
     }
 
     public function testResolveParams(): void
@@ -44,10 +44,7 @@ class SnippetSelectionPropertyResolverTest extends TestCase
         $contentView = $this->resolver->resolve([], 'en', ['custom' => 'params']);
 
         $this->assertEmpty($contentView->getContent());
-        $this->assertSame([
-            'ids' => [],
-            'custom' => 'params',
-        ], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
     }
 
     /**
@@ -98,9 +95,7 @@ class SnippetSelectionPropertyResolverTest extends TestCase
             $this->assertSame('snippet', $resolvable->getResourceLoaderKey());
         }
 
-        $this->assertSame([
-            'ids' => $data,
-        ], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolver.php
@@ -20,7 +20,6 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Content\ResourceLoader\MediaResourceLoader;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
-use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Content\Application\MetadataResolver\MetadataResolver;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 
@@ -86,13 +85,15 @@ class ImageMapPropertyResolver implements PropertyResolverMetadataAwareInterface
 
         return ContentView::create(
             [
-                'image' => new ResolvableResource($imageId, $resourceLoaderKey, -50),
+                'image' => ContentView::createResolvable(
+                    id: $imageId,
+                    resourceLoaderKey: $resourceLoaderKey,
+                    view: ['id' => $imageId, 'displayOption' => null],
+                    priority: -50,
+                ),
                 'hotspots' => $hotspots,
             ],
-            [
-                'imageId' => $imageId,
-                ...$returnedParams,
-            ],
+            [...$returnedParams],
         );
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Infrastructure/Sulu/Content/PropertyResolver/ImageMapPropertyResolverTest.php
@@ -153,9 +153,12 @@ class ImageMapPropertyResolverTest extends TestCase
         if (null !== $imageId) {
             $imageId = (int) $imageId;
             $image = $content['image'] ?? null;
-            $this->assertInstanceOf(ResolvableResource::class, $image);
-            $this->assertSame($imageId, $image->getId());
-            $this->assertSame('media', $image->getResourceLoaderKey());
+            $this->assertInstanceOf(ContentView::class, $image);
+            $resolvable = $image->getContent();
+            $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+            $this->assertSame($imageId, $resolvable->getId());
+            $this->assertSame('media', $resolvable->getResourceLoaderKey());
+            $this->assertSame(['id' => $imageId, 'displayOption' => null], $image->getView());
         }
 
         $hotspotsContentView = $content['hotspots'] ?? null;
@@ -181,9 +184,9 @@ class ImageMapPropertyResolverTest extends TestCase
             }
         }
 
-        $this->assertSame([
-            'imageId' => $imageId,
-        ], $contentView->getView());
+        // unresolvable (no imageId in data) still carries imageId: null in the view; resolvable emits []
+        $expectedView = null !== $imageId ? [] : ['imageId' => null];
+        $this->assertSame($expectedView, $contentView->getView());
 
         $this->assertCount(0, $this->logger->cleanLogs());
     }
@@ -237,9 +240,12 @@ class ImageMapPropertyResolverTest extends TestCase
         $content = $contentView->getContent();
         $this->assertIsArray($content);
         $image = $content['image'] ?? null;
-        $this->assertInstanceOf(ResolvableResource::class, $image);
-        $this->assertSame(1, $image->getId());
-        $this->assertSame('custom_media', $image->getResourceLoaderKey());
+        $this->assertInstanceOf(ContentView::class, $image);
+        $resolvable = $image->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('custom_media', $resolvable->getResourceLoaderKey());
+        $this->assertSame(['id' => 1, 'displayOption' => null], $image->getView());
 
         $this->assertInstanceOf(ContentView::class, $content['hotspots'] ?? null);
         $hotspotsContentView = $content['hotspots'];
@@ -260,10 +266,7 @@ class ImageMapPropertyResolverTest extends TestCase
             $this->assertSame([], $hotspotContent['title']->getView());
         }
 
-        $this->assertSame([
-            'imageId' => 1,
-            'resourceLoader' => 'custom_media',
-        ], $contentView->getView());
+        $this->assertSame(['resourceLoader' => 'custom_media'], $contentView->getView());
         $this->assertCount(0, $this->logger->cleanLogs());
     }
 
@@ -285,9 +288,12 @@ class ImageMapPropertyResolverTest extends TestCase
         $content = $contentView->getContent();
         $this->assertIsArray($content);
         $image = $content['image'] ?? null;
-        $this->assertInstanceOf(ResolvableResource::class, $image);
-        $this->assertSame(1, $image->getId());
-        $this->assertSame('media', $image->getResourceLoaderKey());
+        $this->assertInstanceOf(ContentView::class, $image);
+        $resolvable = $image->getContent();
+        $this->assertInstanceOf(ResolvableResource::class, $resolvable);
+        $this->assertSame(1, $resolvable->getId());
+        $this->assertSame('media', $resolvable->getResourceLoaderKey());
+        $this->assertSame(['id' => 1, 'displayOption' => null], $image->getView());
 
         $hotspotsContentView = $content['hotspots'] ?? null;
         $this->assertInstanceOf(ContentView::class, $hotspotsContentView);
@@ -310,7 +316,7 @@ class ImageMapPropertyResolverTest extends TestCase
 
         $this->assertCount($expectedCount, $hotspots);
 
-        $this->assertSame(['imageId' => 1], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
         $logs = $this->logger->cleanLogs();
         $this->assertCount($expectedErrorLogs, $logs);
     }
@@ -357,8 +363,7 @@ class ImageMapPropertyResolverTest extends TestCase
 
         $content = $contentView->getContent();
         $this->assertIsArray($content);
-        $imageId = $data['imageId'];
-        $this->assertSame(['imageId' => $imageId], $contentView->getView());
+        $this->assertSame([], $contentView->getView());
 
         $hotspotsContentView = $content['hotspots'] ?? null;
         $this->assertInstanceOf(ContentView::class, $hotspotsContentView);


### PR DESCRIPTION
| Q                  | A
| ---                | ---
| Bug fix?           | yes
| New feature?       | yes
| BC breaks?         | yes (twig template view shape — see `UPGRADE-3.x.md`)
| Deprecations?      | no
| Fixed tickets      | fixes #8478
| Related issues/PRs | —
| License            | MIT
| Documentation PR   | sulu/sulu-docs#

#### What's in this PR?

This change introduces a generic mechanism so that any property type or resource loader can bubble view-side metadata up to the parent's view. The benefit applies uniformly to all selection variants (single & multi for `snippet`, `page`, `article`) and to any property resolver that emits view data on a `ResolvableResource` (e.g. `link`, smart content, or custom resolvers).

##### 1. New `ResourceLoaderContentViewInterface`

ResourceLoaders can now contribute per-resource view and content metadata via `resolveContentView(mixed $source): ContentView`. `PageResourceLoader`, `ArticleResourceLoader`, `SnippetResourceLoader`, `ExampleResourceLoader` (test bundle) and `CachedResourceLoader` (delegates) implement it.

The returned ContentView's `view` payload (e.g. `uuid`, `template`, `webspaceKey`, `parent`) is merged into the parent view at the position where the resource was referenced. The `content` payload (e.g. `authored`, `lastModified`) is merged into the parent content. Custom resource loaders can opt in by implementing the interface.

##### 2. `viewEnhancements` flow in `ResolvableResourceReplacer`

The replacer now walks the content tree tracking the path as `list<int|string>` and emits a `viewEnhancements` map alongside the replaced content. `ContentResolver` then merges those enhancements back into the view via `PropertyAccessor`. This works for any `ResolvableResource` regardless of which property resolver produced it:

- single-resource hits flat-merge into `view.<field>` (e.g. a `link` field's `{provider, href, title}` payload now reaches the view as expected)
- multi-selection items become a flat numeric list at `view.<field>` (matches the Sulu 2.6 shape, eliminating the old `ids`/`types`-mixed-into-numeric-array bug)
- multi-selection resolvers that need to coexist with resolver-level view metadata can opt into wrapping by passing a non-empty `view: [...]` and `itemsPropertyName: 'items'` (or any key); items then live under that key alongside the resolver-level data

`ResolvableResource` gains `$itemsPropertyName` to opt into the wrapped behavior.

##### 3. Selection resolvers simplified

`SnippetSelectionPropertyResolver`, `PageSelectionPropertyResolver`, `ArticleSelectionPropertyResolver` (and their single variants) no longer build view arrays manually. They pass `view: []` and let the ResourceLoader contribute the per-resource view metadata.

##### 4. Internal path representation unified

`ResolvableResourceReplacer`, `ContentResolver`, and `ContentViewDataNormalizer` all use `list<int|string>` for content-tree paths internally, converting to PropertyAccessor's bracket-string only at the API boundary. This replaces several fragile string operations (`substr_replace`, `strpos`, `substr_count('][')`, regex stripping) with plain array primitives.

#### Why?

Previously, property resolvers that emit a `ResolvableResource` had no way to surface the resolved value's view-side metadata back into the parent's view. Each resolver had to construct view arrays manually (e.g. `view: ['ids' => $ids, ...$params]`) without access to the loaded entity, and view payloads on nested resolvables (link metadata, sub-blocks, …) had nowhere to land.

That manifested as several concrete reported issues:

- **Single selections lost their inner view.** For example, `single_snippet_selection`'s view was stuck at `{id, types}` — templates reading `view.<snippetField>.<nestedKey>` (e.g. link metadata, sub-blocks) saw nothing. The same applied to `single_page_selection` and `single_article_selection`.
- **Multi-selections mixed metadata with items.** `snippet_selection`, `page_selection`, and `article_selection` returned views like `{ids, types, ...params, 0, 1, …}`, so `{% for x in view.<field> %}` yielded unexpected entries.
- **Nested link metadata was unreachable.** A `link` property nested inside a snippet/page/article had its title and provider flattened away on the data side and never bubbled up on the view side, despite `LinkPropertyResolver` already producing the right view payload.

The new architecture gives any property resolver and any resource loader a uniform way to contribute to the resolved view, makes single/multi variants behave symmetrically, and restores the flat-list shape that Sulu 2.6 emitted for multi selections so existing template logic ports cleanly.

#### BC breaks

PHP API: none. All concrete services touched are `@internal` (or `@final` in the case of `ContentResolver`); the `ContentResolverInterface` public contract is unchanged.

Twig template view shape: yes — multi-selection view changes from `{ids, types, 0, 1, ...}` to a flat numeric list `[v0, v1, ...]`; single-selection view exposes additional resolved-entity metadata. Migration paths are documented in `UPGRADE-3.x.md`.

#### Example Usage

Implement `ResourceLoaderContentViewInterface` on a custom loader to contribute view/content metadata:

```php
use Sulu\Content\Application\ContentResolver\Value\ContentView;
use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderContentViewInterface;

class CustomResourceLoader implements ResourceLoaderContentViewInterface
{
    public function resolveContentView(mixed $source): ContentView
    {
        return ContentView::create(
            ['authored' => $source->getAuthored()?->format('c')],
            ['uuid' => $source->getUuid(), 'template' => $source->getTemplateKey()],
        );
    }

    // ... load() and getKey() as before
}
```

For multi-selection-style resolvers, items default to a flat numeric list. If you also need to expose resolver-level metadata alongside the items, pass a non-empty `view` and an `itemsPropertyName`:

```php
ContentView::createResolvablesWithReferences(
    ids: $ids,
    resourceLoaderKey: 'page',
    resourceKey: 'pages',
    view: ['presentAs' => 'grid'],   // resolver-level metadata
    itemsPropertyName: 'items',      // items will live under view.<field>.items
);
```

#### To Do

- Create a documentation PR
