### PR TITLE
Fix adapter installation command in upgrade guide

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -274,7 +274,7 @@ SEAL_DSN=loupe://%kernel.project_dir%/var/indexes
 To install the adapter use:
 
 ```bash
-composer require cmsig/search-loupe-adapter --no-scripts
+composer require cmsig/seal-loupe-adapter --no-scripts
 ```
 
 Make sure you have the `pdo_sqlite` extension installed and enabled.


### PR DESCRIPTION
Corrected the package name for the adapter installation.

| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR |

#### What's in this PR?

Fixes reference to non-existing package - fixed package name in upgrade guide

#### Why?

Unable to copy paste the command in terminal to upgrade/install the referenced/required package.
