### PR TITLE
Add html flag to structure, to strip html tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "jms/serializer": "^3.16",
         "jms/serializer-bundle": "^4.0.1 || ^5.0",
         "massive/build-bundle": "^0.5.7 || ^0.6 || ^1.0",
-        "massive/search-bundle": "^2.10@dev",
+        "massive/search-bundle": "^2.8.2",
         "matomo/device-detector": "^3.9 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.3",
         "oro/doctrine-extensions": "^1.0.8 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "jms/serializer": "^3.16",
         "jms/serializer-bundle": "^4.0.1 || ^5.0",
         "massive/build-bundle": "^0.5.7 || ^0.6 || ^1.0",
-        "massive/search-bundle": "^2.8.2",
+        "massive/search-bundle": "^2.10@dev",
         "matomo/device-detector": "^3.9 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.3",
         "oro/doctrine-extensions": "^1.0.8 || ^2.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -65935,7 +65935,7 @@ parameters:
 			path: src/Sulu/Component/Content/Compat/Structure/StructureBridge.php
 
 		-
-			message: '#^Method Sulu\\Component\\Content\\Compat\\Structure\\StructureBridge\:\:getProperties\(\) should return array\<Sulu\\Component\\Content\\Compat\\PropertyInterface\> but returns array\.$#'
+			message: '#^Method Sulu\\Component\\Content\\Compat\\Structure\\StructureBridge\:\:getProperties\(\) should return array\<Sulu\\Component\\Content\\Compat\\PropertyInterface\> but returns array\<int\|string, mixed\>\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Content/Compat/Structure/StructureBridge.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -45699,13 +45699,13 @@ parameters:
 		-
 			message: '#^Cannot call method createSearch\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 5
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
 
 		-
 			message: '#^Cannot call method execute\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 5
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
 
 		-
@@ -45735,13 +45735,13 @@ parameters:
 		-
 			message: '#^Cannot call method index\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 5
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
 
 		-
 			message: '#^Cannot call method locale\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 5
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
 
 		-

--- a/src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Structure/ExcerptStructureExtension.php
@@ -191,6 +191,7 @@ class ExcerptStructureExtension extends AbstractExtension implements ExportExten
                 'field' => $this->factory->createMetadataExpression(
                     \sprintf('object.getExtensionsData()["excerpt"]["%s"]', $property->getName())
                 ),
+                'html' => 'text_editor' === $property->getContentTypeName(),
             ];
         }
 

--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -33,6 +33,7 @@ use Sulu\Component\Content\Metadata\BlockMetadata;
 use Sulu\Component\Content\Metadata\ComponentMetadata;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\Content\Metadata\ItemMetadata;
+use Sulu\Component\Content\Metadata\PropertyMetadata;
 use Sulu\Component\Content\Metadata\StructureMetadata;
 use Sulu\Component\DocumentManager\Behavior\Mapping\TitleBehavior;
 use Sulu\Component\DocumentManager\Metadata;
@@ -160,6 +161,7 @@ EOT;
                         'field' => $this->factory->createMetadataField('title'),
                         'aggregate' => true,
                         'indexed' => false,
+                        'html' => false,
                     ]
                 );
             }
@@ -172,6 +174,7 @@ EOT;
                 [
                     'type' => 'string',
                     'field' => $this->factory->createMetadataProperty('webspaceName'),
+                    'html' => false,
                 ]
             );
         }
@@ -184,6 +187,7 @@ EOT;
                     'field' => $this->factory->createMetadataExpression(
                         'object.getWorkflowStage() == 1 ? "test" : "published"'
                     ),
+                    'html' => false,
                 ]
             );
             $indexMeta->addFieldMapping(
@@ -193,6 +197,7 @@ EOT;
                     'field' => $this->factory->createMetadataExpression(
                         'object.getPublished()'
                     ),
+                    'html' => false,
                 ]
             );
         }
@@ -205,6 +210,7 @@ EOT;
                     'field' => $this->factory->createMetadataExpression(
                         'object.getAuthored()'
                     ),
+                    'html' => false,
                 ]
             );
         }
@@ -216,6 +222,7 @@ EOT;
                 'stored' => true,
                 'indexed' => true,
                 'field' => $this->factory->createMetadataProperty('structureType'),
+                'html' => false,
             ]
         );
 
@@ -264,6 +271,12 @@ EOT;
     private function mapProperty(ItemMetadata $property, $metadata, string $prefix = '', $condition = null)
     {
         $propertyName = $prefix . $property->getName();
+        $isHtml = false;
+        $contentType = null;
+
+        if ($property instanceof PropertyMetadata) {
+            $contentType = $property->getType();
+        }
 
         if ($metadata instanceof IndexMetadata) {
             $field = $this->factory->createMetadataExpression(
@@ -273,6 +286,7 @@ EOT;
                 ),
                 $condition
             );
+            $isHtml = 'text_editor' === $contentType;
         } else {
             $field = $this->factory->createMetadataProperty(
                 '[' . $property->getName() . ']',
@@ -303,6 +317,7 @@ EOT;
                         'type' => 'complex',
                         'mapping' => $propertyMapping,
                         'field' => $field,
+                        'html' => $isHtml,
                     ]
                 );
             }
@@ -318,6 +333,7 @@ EOT;
                     'field' => $field,
                     'aggregate' => true,
                     'indexed' => false,
+                    'html' => 'text_editor' === $contentType,
                 ]
             );
         }
@@ -329,6 +345,7 @@ EOT;
                     'field' => $field,
                     'aggregate' => true,
                     'indexed' => false,
+                    'html' => $isHtml,
                 ]
             );
         }
@@ -351,6 +368,7 @@ EOT;
                             'type' => 'string',
                             'aggregate' => true,
                             'indexed' => false,
+                            'html' => 'text_editor' === $contentType,
                         ]
                     );
                     break;
@@ -363,6 +381,7 @@ EOT;
                             'type' => 'string',
                             'aggregate' => true,
                             'indexed' => false,
+                            'html' => $isHtml,
                         ]
                     );
                     break;
@@ -390,6 +409,7 @@ EOT;
                     'field' => $field,
                     'aggregate' => true,
                     'indexed' => isset($tagAttributes['index']) && 'indexed' === $tagAttributes['index'],
+                    'html' => 'text_editor' === $contentType,
                 ]
             );
         }

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/text_editor.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/text_editor.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" ?>
+
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>text_editor</key>
+
+    <view>ClientWebsiteBundle:templates:default</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <meta>
+        <title lang="de">Standard</title>
+        <title lang="en">Default</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="de">Titel</title>
+                <title lang="en">Title</title>
+            </meta>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="de">Adresse</title>
+                <title lang="en">Resourcelocator</title>
+            </meta>
+
+            <indexField />
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="article" type="text_editor">
+            <meta>
+                <title lang="de">Artikel</title>
+                <title lang="en">Article</title>
+            </meta>
+
+            <tag name="sulu.search.field" role="description" />
+        </property>
+
+        <block name="block"
+            default-type="article"
+            minOccurs="1"
+            maxOccurs="5"
+            mandatory="true"
+            >
+            <meta>
+                <title lang="de">Block</title>
+                <title lang="en">Block</title>
+            </meta>
+
+            <types>
+                <type name="article">
+                    <meta>
+                        <title lang="de">Article</title>
+                        <title lang="en">Article</title>
+                    </meta>
+
+                    <properties>
+                        <property name="title" type="text_line" mandatory="true">
+                            <meta>
+                                <title lang="de">Titel</title>
+                                <title lang="en">Title</title>
+                            </meta>
+
+                            <tag name="sulu.search.field" type="string" />
+                        </property>
+
+                        <property name="article" type="text_editor" mandatory="true">
+                            <meta>
+                                <title lang="de">Article</title>
+                                <title lang="en">Article</title>
+                            </meta>
+
+                            <tag name="sulu.search.field" type="string" />
+                        </property>
+                    </properties>
+                </type>
+            </types>
+        </block>
+    </properties>
+</template>

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
@@ -177,7 +177,7 @@ class SaveDocumentTest extends BaseTestCase
 
     public function testSaveDocumentStripTags(): void
     {
-        $version = InstalledVersions::getPrettyVersion('massive/search-bundle');
+        $version = InstalledVersions::getPrettyVersion('massive/search-bundle') ?? '2.10.0';
         if (\version_compare($version, '2.10.0', '<')) {
             $this->markTestSkipped('This feature requires atleast "massive/search-bundle" of 2.10.0.');
         }

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Search;
 
+use Composer\InstalledVersions;
 use Massive\Bundle\SearchBundle\Search\Field;
 use Massive\Bundle\SearchBundle\Search\QueryHit;
 use Massive\Bundle\SearchBundle\Search\SearchResult;
@@ -176,6 +177,11 @@ class SaveDocumentTest extends BaseTestCase
 
     public function testSaveDocumentStripTags(): void
     {
+        $version = InstalledVersions::getPrettyVersion('massive/search-bundle');
+        if (\version_compare($version, '2.10.0', '<')) {
+            $this->markTestSkipped('This feature requires atleast "massive/search-bundle" of 2.10.0.');
+        }
+
         $document = new PageDocument();
         $document->setTitle('Places');
         $document->setStructureType('text_editor');

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
@@ -11,7 +11,11 @@
 
 namespace Sulu\Bundle\PageBundle\Tests\Functional\Search;
 
+use Massive\Bundle\SearchBundle\Search\Field;
+use Massive\Bundle\SearchBundle\Search\QueryHit;
+use Massive\Bundle\SearchBundle\Search\SearchResult;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
+use Sulu\Bundle\SearchBundle\Search\Document;
 use Sulu\Component\Content\Document\WorkflowStage;
 
 class SaveDocumentTest extends BaseTestCase
@@ -167,6 +171,53 @@ class SaveDocumentTest extends BaseTestCase
         foreach ($searches as $search => $count) {
             $res = $searchManager->createSearch($search)->locale('de')->index('page_sulu_io')->execute();
             $this->assertCount($count, $res, 'Searching for: ' . $search);
+        }
+    }
+
+    public function testSaveDocumentStripTags(): void
+    {
+        $document = new PageDocument();
+        $document->setTitle('Places');
+        $document->setStructureType('text_editor');
+        $document->setResourceSegment('/places');
+        $document->setWorkflowStage(WorkflowStage::PUBLISHED);
+        $document->getStructure()->bind([
+            'title' => 'Sulu',
+            'article' => '<p>Sulu is the best</p>',
+            'block' => [
+                [
+                    'type' => 'article',
+                    'title' => 'Sulu',
+                    'article' => '<p><strong>Sulu</strong> is very cool</p>',
+                ],
+            ],
+        ], false);
+        $document->setParent($this->homeDocument);
+
+        $this->documentManager->persist($document, 'de');
+        $this->documentManager->flush();
+
+        $searchManager = $this->getSearchManager();
+
+        /** @var SearchResult $res */
+        $res = $searchManager->createSearch('Sulu')->locale('de')->index('page_sulu_io')->execute();
+
+        /** @var QueryHit $hit */
+        foreach ($res as $hit) {
+            /** @var Document $document */
+            $document = $hit->getDocument();
+            $this->assertSame('Sulu is the best', $document->getDescription());
+            $articleBlockValue = '';
+            /** @var Field[] $fields */
+            $fields = $document->getFields();
+
+            foreach ($fields as $field) {
+                if ('block_article_article' === $field->getName()) {
+                    $articleBlockValue = $field->getValue();
+                }
+            }
+
+            $this->assertSame('Sulu is very cool', $articleBlockValue, 'Article block value should be stripped of tags');
         }
     }
 }

--- a/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
+++ b/src/Sulu/Bundle/SnippetBundle/Twig/SnippetAreaTwigExtension.php
@@ -51,6 +51,7 @@ class SnippetAreaTwigExtension extends AbstractExtension
      */
     public function loadByArea($area, $webspaceKey = null, $locale = null/*, $loadExcerpt = false */)
     {
+        /** @var bool $loadExcerpt */
         $loadExcerpt = \func_num_args() > 3 ? \func_get_args()[3] : false;
         if (!$webspaceKey) {
             $webspaceKey = $this->requestAnalyzer->getWebspace()->getKey();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8606
| Related issues/PRs | https://github.com/massiveart/MassiveSearchBundle/pull/189
| License | MIT

#### What's in this PR?

Add HTML flag to search structure to strip html tags in massiveSearch.

#### Why?

To avoid search results for html tags e.g. "strong".