### PR TITLE
Make createQueryBuilder public to have it easier composed

### DIFF
--- a/packages/article/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
+++ b/packages/article/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
@@ -51,27 +51,27 @@ final class ArticleRepository implements ArticleRepositoryInterface
     /**
      * @var EntityRepository<ArticleInterface>
      */
-    protected $entityRepository;
+    private $entityRepository;
 
     /**
      * @var EntityRepository<ArticleDimensionContentInterface>
      */
-    protected $entityDimensionContentRepository;
+    private $entityDimensionContentRepository;
 
     /**
      * @var DimensionContentQueryEnhancer
      */
-    protected $dimensionContentQueryEnhancer;
+    private $dimensionContentQueryEnhancer;
 
     /**
      * @var class-string<ArticleInterface>
      */
-    protected $articleClassName;
+    private $articleClassName;
 
     /**
      * @var class-string<ArticleDimensionContentInterface>
      */
-    protected $articleDimensionContentClassName;
+    private $articleDimensionContentClassName;
 
     public function __construct(
         EntityManagerInterface $entityManager,

--- a/packages/article/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
+++ b/packages/article/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
@@ -24,7 +24,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Webmozart\Assert\Assert;
 
-class ArticleRepository implements ArticleRepositoryInterface
+final class ArticleRepository implements ArticleRepositoryInterface
 {
     /**
      * TODO it should be possible to extend fields and groups inside the SELECTS.
@@ -214,7 +214,7 @@ class ArticleRepository implements ArticleRepositoryInterface
      *     with-article-content?: bool|array<string, mixed>,
      * }|array<string, mixed> $selects
      */
-    private function createQueryBuilder(array $filters, array $sortBy = [], array $selects = []): QueryBuilder
+    public function createQueryBuilder(array $filters, array $sortBy = [], array $selects = []): QueryBuilder
     {
         foreach ($selects as $selectGroup => $value) {
             if (!$value) {

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -273,6 +273,7 @@ final class SuluArticleBundle extends AbstractBundle
             ]);
 
         $services->alias(ArticleRepositoryInterface::class, 'sulu_article.article_repository');
+        $services->alias(ArticleRepository::class, 'sulu_article.article_repository');
 
         $services->set('sulu_article.admin_article_controller')
             ->class(ArticleController::class)

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -58,17 +58,17 @@ final class PageRepository implements PageRepositoryInterface
     /**
      * @var NestedTreeRepository<PageInterface>
      */
-    protected $entityRepository;
+    private $entityRepository;
 
     /**
      * @var EntityRepository<PageDimensionContentInterface>
      */
-    protected $entityDimensionContentRepository;
+    private $entityDimensionContentRepository;
 
     /**
      * @var DimensionContentQueryEnhancer
      */
-    protected $dimensionContentQueryEnhancer;
+    private $dimensionContentQueryEnhancer;
 
     /**
      * @var AccessControlQueryEnhancer
@@ -78,12 +78,12 @@ final class PageRepository implements PageRepositoryInterface
     /**
      * @var class-string<PageInterface>
      */
-    protected $pageClassName;
+    private $pageClassName;
 
     /**
      * @var class-string<PageDimensionContentInterface>
      */
-    protected $pageDimensionContentClassName;
+    private $pageDimensionContentClassName;
 
     public function __construct(
         EntityManagerInterface $entityManager,

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -31,7 +31,7 @@ use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Webmozart\Assert\Assert;
 
-class PageRepository implements PageRepositoryInterface
+final class PageRepository implements PageRepositoryInterface
 {
     /**
      * TODO it should be possible to extend fields and groups inside the SELECTS.
@@ -286,7 +286,7 @@ class PageRepository implements PageRepositoryInterface
      *     with-page-content?: bool|array<string, mixed>,
      * }|array<string, mixed> $selects
      */
-    private function createQueryBuilder(array $filters, array $sortBy = [], array $selects = []): QueryBuilder
+    public function createQueryBuilder(array $filters, array $sortBy = [], array $selects = []): QueryBuilder
     {
         $accessControl = $filters['accessControl'] ?? null;
         unset($filters['accessControl']);

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -370,6 +370,7 @@ final class SuluPageBundle extends AbstractBundle
             ->tag('sulu.descendant_provider');
 
         $services->alias(PageRepositoryInterface::class, 'sulu_page.page_repository');
+        $services->alias(PageRepository::class, 'sulu_page.page_repository');
 
         // Commands services
         $services->set('sulu_page.command.initialize_homepage')

--- a/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetRepository.php
+++ b/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetRepository.php
@@ -24,7 +24,7 @@ use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 use Webmozart\Assert\Assert;
 
-class SnippetRepository implements SnippetRepositoryInterface
+final class SnippetRepository implements SnippetRepositoryInterface
 {
     /**
      * TODO it should be possible to extend fields and groups inside the SELECTS.
@@ -214,7 +214,7 @@ class SnippetRepository implements SnippetRepositoryInterface
      *     with-snippet-content?: bool|array<string, mixed>,
      * }|array<string, mixed> $selects
      */
-    private function createQueryBuilder(array $filters, array $sortBy = [], array $selects = []): QueryBuilder
+    public function createQueryBuilder(array $filters, array $sortBy = [], array $selects = []): QueryBuilder
     {
         foreach ($selects as $selectGroup => $value) {
             if (!$value) {

--- a/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetRepository.php
+++ b/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetRepository.php
@@ -51,27 +51,27 @@ final class SnippetRepository implements SnippetRepositoryInterface
     /**
      * @var EntityRepository<SnippetInterface>
      */
-    protected $entityRepository;
+    private $entityRepository;
 
     /**
      * @var EntityRepository<SnippetDimensionContentInterface>
      */
-    protected $entityDimensionContentRepository;
+    private $entityDimensionContentRepository;
 
     /**
      * @var DimensionContentQueryEnhancer
      */
-    protected $dimensionContentQueryEnhancer;
+    private $dimensionContentQueryEnhancer;
 
     /**
      * @var class-string<SnippetInterface>
      */
-    protected $snippetClassName;
+    private $snippetClassName;
 
     /**
      * @var class-string<SnippetDimensionContentInterface>
      */
-    protected $snippetDimensionContentClassName;
+    private $snippetDimensionContentClassName;
 
     public function __construct(
         EntityManagerInterface $entityManager,

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -280,6 +280,7 @@ final class SuluSnippetBundle extends AbstractBundle
             ]);
 
         $services->alias(SnippetRepositoryInterface::class, 'sulu_snippet.snippet_repository');
+        $services->alias(SnippetRepository::class, 'sulu_snippet.snippet_repository');
 
         $services->set('sulu_snippet.snippet_area_repository')
             ->class(SnippetAreaRepository::class)


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Changed `createQueryBuilder` from `private` to `public` in `ArticleRepository`, `PageRepository`, and `SnippetRepository`
  - Added a concrete class alias for each repository alongside the existing interface alias

  #### Why?

  The repositories' `createQueryBuilder` methods were private, making it impossible for projects to compose custom queries by extending or decorating the repositories. By making these methods public, downstream
  projects can reuse the existing query building logic (with its filters, sorting, and select handling) as a foundation for more complex or specialized queries without duplicating the implementation. The additional
   concrete class alias enables type-hinting against e.g. `ArticleRepository` directly when access to the public `createQueryBuilder` method is needed, since the interface does not expose it.

  #### Example Usage

  ```php
  // Inject the concrete repository to access createQueryBuilder
  public function __construct(
      private ArticleRepository $articleRepository,
  ) {}

  $qb = $this->articleRepository->createQueryBuilder(...);

  // Add custom conditions
  $qb->andWhere('article.authored > :since')
     ->setParameter('since', new \DateTimeImmutable('-7 days'));

  $results = $qb->getQuery()->getResult();