### PR TITLE
Fix publishedState state in ArticleController cgetAction

### DIFF
--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -91,12 +91,12 @@ final class ArticleController implements SecuredControllerInterface
         /** @var DoctrineListBuilder $listBuilder */
         $listBuilder = $this->listBuilderFactory->create(ArticleInterface::class);
         $listBuilder->setIdField($fieldDescriptors['id']); // TODO should be uuid field descriptor
+        $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
         $listBuilder->addSelectField($fieldDescriptors['locale']);
         $listBuilder->addSelectField($fieldDescriptors['ghostLocale']);
         $listBuilder->addSelectField($fieldDescriptors['published']);
         $listBuilder->addSelectField($fieldDescriptors['publishedState']);
         $listBuilder->setParameter('locale', $request->query->get('locale'));
-        $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
         if (0 !== \count($templates)) {
             $dimensionContentTemplateKey = $fieldDescriptors['dimensionContentTemplateKey'];
             $ghostDimensionContentTemplateKey = $fieldDescriptors['ghostDimensionContentTemplateKey'];

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -117,6 +117,15 @@ class ArticleControllerTest extends SuluTestCase
     }
 
     #[Depends('testPostPublish')]
+    public function testGetListPublished(): void
+    {
+        $this->client->request('GET', '/admin/api/articles?locale=en');
+        $response = $this->client->getResponse();
+
+        $this->assertResponseSnapshot('article_cget_published.json', $response, 200);
+    }
+
+    #[Depends('testPostPublish')]
     public function testVersionListAfterPublish(string $id): string
     {
         $this->client->request('GET', '/admin/api/articles/' . $id . '/versions?page=1&locale=en&fields=title,version,changer,id');

--- a/packages/article/tests/Functional/Integration/responses/article_cget_published.json
+++ b/packages/article/tests/Functional/Integration/responses/article_cget_published.json
@@ -2,7 +2,7 @@
     "_embedded": {
         "articles": [
             {
-                "author": "@string@",
+                "author": null,
                 "authored": "@datetime@",
                 "changed": "@datetime@",
                 "changer": "@string@",
@@ -11,9 +11,9 @@
                 "ghostLocale": null,
                 "id": "@string@",
                 "locale": "@string@",
-                "published": null,
-                "publishedState": false,
-                "title": "Test Article 2"
+                "published": "@datetime@",
+                "publishedState": true,
+                "title": "Test Article"
             }
         ]
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Change listBuilder order in ArticleController, because otherwise the initializeListBuilder function will overwrite all addSelectField calls.

#### Why?

Because the article_selection always shows `unpublished` publishedState.