### PR TITLE
Allow usage with sulu/messenger 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "stof/doctrine-extensions-bundle": "^1.7",
-        "sulu/messenger": "^0.2",
+        "sulu/messenger": "^0.2 || ^1.0",
         "symfony-cmf/routing": "^3.0",
         "symfony-cmf/routing-bundle": "^3.0",
         "symfony/asset": "^6.4 || ^7.1",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow usage with sulu/messenger 1.0.

#### Why?

New stable version tagged.