### PR TITLE
Add array check for multiselection to avoid errors after content type…

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/MultiSelection.js
@@ -85,6 +85,11 @@ class MultiSelection extends React.Component<Props> {
         const newIds = toJS(this.props.value);
         const loadedIds = toJS(this.selectionStore.items.map((item) => item.id));
 
+        if (!Array.isArray(newIds)) {
+            this.selectionStore.loadItems([]);
+            return;
+        }
+
         newIds.sort();
         loadedIds.sort();
         if (!equals(newIds, loadedIds)) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/stores/MultiSelectionStore/MultiSelectionStore.js
@@ -59,7 +59,7 @@ export default class MultiSelectionStore<T = string | number, U: {id: T} = Objec
     }
 
     loadItems(itemIds: ?Array<T>) {
-        if (!itemIds || itemIds.length === 0) {
+        if (!itemIds || itemIds.length === 0 || !(Array.isArray(itemIds))) {
             this.set([]);
             return;
         }


### PR DESCRIPTION
… change

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add array check for multi selection.

#### Why?

To avoid errors when the content type changed and the old data still exists. 
