### PR TITLE
Allow massive/build-bundle 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "jackalope/jackalope": "^1.4.5 || ^2.0",
         "jms/serializer": "^3.16",
         "jms/serializer-bundle": "^4.0.1 || ^5.0",
-        "massive/build-bundle": "^0.5.7 || ^0.6",
+        "massive/build-bundle": "^0.5.7 || ^0.6 || ^1.0",
         "massive/search-bundle": "^2.8.2",
         "matomo/device-detector": "^3.9 || ^4.0.1 || ^5.0 || ^6.0",
         "nyholm/psr7": "^1.3",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Allow massive/build-bundle 1.0.

#### Why?

We support latest version of massive build as there where no changes between 0.6 and 1.0. We want to use most stable versions.