### PR TITLE
Rename Filename in MediaBundle

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Api/Media.php
+++ b/src/Sulu/Bundle/MediaBundle/Api/Media.php
@@ -343,6 +343,36 @@ class Media extends ApiWrapper
     }
 
     /**
+     * @param string|null $seoFilename
+     *
+     * @return $this
+     */
+    public function setSeoFilename($seoFilename)
+    {
+        $this->getMeta(true)->setSeoFilename($seoFilename);
+
+        return $this;
+    }
+
+    /**
+     * Returns SEO filename for media.
+     *
+     * @return string|null
+     *
+     * @throws FileVersionNotFoundException
+     */
+    #[VirtualProperty]
+    #[SerializedName('seoFilename')]
+    public function getSeoFilename()
+    {
+        if (!$this->getLocalizedMeta()) {
+            return null;
+        }
+
+        return $this->getLocalizedMeta()->getSeoFilename();
+    }
+
+    /**
      * @param int $version
      *
      * @return $this

--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMeta.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMeta.php
@@ -23,6 +23,8 @@ class FileVersionMeta
 
     private ?string $credits = null;
 
+    private ?string $seoFilename = null;
+
     private string $locale;
 
     private FileVersion $fileVersion;
@@ -78,6 +80,35 @@ class FileVersionMeta
     public function getCredits(): ?string
     {
         return $this->credits;
+    }
+
+    public function setSeoFilename(?string $seoFilename): static
+    {
+        $this->seoFilename = $seoFilename;
+
+        return $this;
+    }
+
+    public function getSeoFilename(): ?string
+    {
+        return $this->seoFilename;
+    }
+
+    /**
+     * Returns the SEO filename if set, otherwise falls back to the FileVersion name.
+     */
+    public function getEffectiveFilename(): string
+    {
+        if (null !== $this->seoFilename && '' !== $this->seoFilename) {
+            // Preserve the original file extension
+            $fileVersionName = $this->fileVersion->getName();
+            $extension = \pathinfo($fileVersionName, \PATHINFO_EXTENSION);
+            $seoBasename = \pathinfo($this->seoFilename, \PATHINFO_FILENAME);
+
+            return $seoBasename . '.' . $extension;
+        }
+
+        return $this->fileVersion->getName();
     }
 
     public function setLocale(string $locale): static

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManager.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Media\Exception\FormatNotFoundException;
@@ -98,9 +99,25 @@ class FormatManager implements FormatManagerInterface
                 throw new ImageProxyMediaNotFoundException(\sprintf('Requested FileVersion "%s" for media with id "%s" was not found.', $version, $id));
             }
 
+            // Check if filename matches either the original name or any SEO filename
             $requestedFileVersionImageFormatName = $this->replaceExtension($requestedFileVersion->getName(), $imageFormat);
+            $fileNameMatches = ($requestedFileVersionImageFormatName === $fileName);
 
-            if ($requestedFileVersionImageFormatName !== $fileName) {
+            // Also check against SEO filenames from all locales
+            if (!$fileNameMatches) {
+                foreach ($requestedFileVersion->getMeta() as $meta) {
+                    $seoFilename = $meta->getSeoFilename();
+                    if (null !== $seoFilename && '' !== $seoFilename) {
+                        $seoFileNameWithExtension = $this->replaceExtension($seoFilename, $imageFormat);
+                        if ($seoFileNameWithExtension === $fileName) {
+                            $fileNameMatches = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!$fileNameMatches) {
                 throw new ImageProxyMediaNotFoundException(\sprintf('FileVersion "%s" for media with id "%s" was not found.', $requestedFileVersion->getVersion(), $id));
             }
 
@@ -144,7 +161,7 @@ class FormatManager implements FormatManagerInterface
                 $this->formatCache->save(
                     $responseContent,
                     $media->getId(),
-                    $this->replaceExtension($fileVersion->getName(), $imageFormat),
+                    $this->replaceExtension($fileName, $imageFormat),
                     $formatKey
                 );
             }
@@ -192,6 +209,40 @@ class FormatManager implements FormatManagerInterface
         }
 
         return $formats;
+    }
+
+    /**
+     * Get formats using SEO filename from FileVersionMeta for a specific locale.
+     *
+     * @param int $id
+     * @param FileVersion $fileVersion
+     * @param string $locale
+     *
+     * @return array
+     */
+    public function getFormatsWithSeoFilename($id, FileVersion $fileVersion, string $locale)
+    {
+        $fileName = $fileVersion->getName();
+
+        // Try to find SEO filename for the given locale
+        foreach ($fileVersion->getMeta() as $meta) {
+            if ($meta->getLocale() === $locale) {
+                $seoFilename = $meta->getSeoFilename();
+                if (null !== $seoFilename && '' !== $seoFilename) {
+                    // Use the effective filename which preserves the original extension
+                    $fileName = $meta->getEffectiveFilename();
+                }
+                break;
+            }
+        }
+
+        return $this->getFormats(
+            $id,
+            $fileName,
+            $fileVersion->getVersion(),
+            $fileVersion->getSubVersion(),
+            $fileVersion->getMimeType()
+        );
     }
 
     public function purge($idMedia, $fileName, $mimeType)

--- a/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/FormatManager/FormatManagerInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Media\FormatManager;
 
+use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -47,6 +48,17 @@ interface FormatManagerInterface
      * @return array
      */
     public function getFormats($id, $fileName, $version, $subVersion, $mimeType);
+
+    /**
+     * Get formats using SEO filename from FileVersionMeta for a specific locale.
+     *
+     * @param int $id
+     * @param FileVersion $fileVersion
+     * @param string $locale
+     *
+     * @return array
+     */
+    public function getFormatsWithSeoFilename($id, FileVersion $fileVersion, string $locale);
 
     /**
      * Returns a definition of a format with a given key.

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/doctrine/FileVersionMeta.orm.xml
@@ -17,6 +17,7 @@
         <field name="description" type="text" column="description" nullable="true"/>
         <field name="copyright" type="text" column="copyright" nullable="true"/>
         <field name="credits" type="text" column="credits" nullable="true"/>
+        <field name="seoFilename" type="string" column="seoFilename" length="191" nullable="true"/>
         <field name="locale" type="string" column="locale" length="15"/>
 
         <many-to-one field="fileVersion" target-entity="Sulu\Bundle\MediaBundle\Entity\FileVersion" inversed-by="meta">

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/forms/media_details.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/forms/media_details.xml
@@ -28,6 +28,15 @@
                     </meta>
                 </property>
 
+                <property name="seoFilename" type="text_line">
+                    <meta>
+                        <title>sulu_media.seo_filename</title>
+                    </meta>
+                    <params>
+                        <param name="soft" value="true"/>
+                    </params>
+                </property>
+
                 <section name="license">
                     <meta>
                         <title>sulu_media.license</title>


### PR DESCRIPTION
| Q | A
| --- | ---
| New feature? | yes

#### What's in this PR?

Adds the possibility to set a locale file name in MediaBundle and overwrites the filename for output. This would be very helpful for defining SEO file names in Sulu.

#### Why?

It's annoying to upload a new file just to change the file name. Furthermore, the file name is not locale specific.