### PR TITLE
Add AccessControl to NavigationRepository

### DIFF
--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -68,6 +68,10 @@ class NavigationRepository implements NavigationRepositoryInterface
         private ?Security $security = null,
         private ?array $permissions = null,
     ) {
+        if (null === $webspaceManager || null === $accessControlQueryEnhancer || null === $permissions) {
+            @trigger_deprecation('sulu/sulu', '3.0', 'Not passing the "$webspaceManager", "$accessControlQueryEnhancer" and "$permissions" arguments to "%s" is deprecated and they will be required in a future version.', __METHOD__);
+        }
+
         $repository = $entityManager->getRepository(PageInterface::class);
         Assert::isInstanceOf($repository, NestedTreeRepository::class);
 
@@ -238,13 +242,13 @@ class NavigationRepository implements NavigationRepositoryInterface
      */
     private function fetchNestedSetValues(string $uuid, array $fields): ?array
     {
-        $qb = $this->entityRepository->createQueryBuilder('page');
-        $qb->select(...\array_map(fn ($f) => "page.{$f}", $fields))
+        $queryBuilder = $this->entityRepository->createQueryBuilder('page');
+        $queryBuilder->select(...\array_map(fn ($f) => "page.{$f}", $fields))
             ->where('page.uuid = :uuid')
             ->setParameter('uuid', $uuid);
 
         /** @var array<string, int|string>|null $result */
-        $result = $qb->getQuery()->getOneOrNullResult();
+        $result = $queryBuilder->getQuery()->getOneOrNullResult();
 
         return $result;
     }
@@ -537,7 +541,7 @@ class NavigationRepository implements NavigationRepositoryInterface
         if ($permission) {
             $this->accessControlQueryEnhancer->enhance(
                 $queryBuilder,
-                $user instanceof UserInterface ? $user : null,
+                $user,
                 $permission,
                 Page::class,
                 $alias,

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -17,13 +17,19 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
+use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
 use Webmozart\Assert\Assert;
 
 class NavigationRepository implements NavigationRepositoryInterface
@@ -48,12 +54,19 @@ class NavigationRepository implements NavigationRepositoryInterface
      */
     protected string $pageDimensionContentClassName;
 
+    /**
+     * @param array<string, int>|null $permissions
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
         private DimensionContentQueryEnhancer $dimensionContentQueryEnhancer,
         private ContentAggregatorInterface $contentAggregator,
         private ContentResolverInterface $contentResolver,
         private bool $audienceTargetingEnabled = false,
+        private ?WebspaceManagerInterface $webspaceManager = null,
+        private ?AccessControlQueryEnhancer $accessControlQueryEnhancer = null,
+        private ?Security $security = null,
+        private ?array $permissions = null,
     ) {
         $repository = $entityManager->getRepository(PageInterface::class);
         Assert::isInstanceOf($repository, NestedTreeRepository::class);
@@ -158,6 +171,7 @@ class NavigationRepository implements NavigationRepositoryInterface
             'webspaceKey' => $webspaceKey,
             'locale' => $locale,
             'stage' => DimensionContentInterface::STAGE_LIVE,
+            'skipAccessControl' => true,
         ])->getQuery()->getResult();
 
         /** @var PageInterface[] $pages */
@@ -353,6 +367,7 @@ class NavigationRepository implements NavigationRepositoryInterface
      *     ancestorRgt?: int,
      *     childrenOf?: string,
      *     childrenDepth?: int,
+     *     skipAccessControl?: bool,
      * } $filters
      */
     private function createQueryBuilder(array $filters): QueryBuilder
@@ -493,7 +508,42 @@ class NavigationRepository implements NavigationRepositoryInterface
 
         $queryBuilder->addOrderBy('page.lft', 'asc');
 
+        $skipAccessControl = $filters['skipAccessControl'] ?? false;
+        $webspaceKey = $filters['webspaceKey'] ?? null;
+        if (null !== $webspaceKey && !$skipAccessControl) {
+            $this->enhanceQueryBuilderWithAccessControl($queryBuilder, $webspaceKey, 'page');
+        }
+
         return $queryBuilder;
+    }
+
+    private function enhanceQueryBuilderWithAccessControl(
+        QueryBuilder $queryBuilder,
+        string $webspaceKey,
+        string $alias
+    ): void {
+        if (!$this->webspaceManager || !$this->accessControlQueryEnhancer) {
+            return;
+        }
+
+        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+        /** @var UserInterface|null $user */
+        $user = $webspace && $webspace->hasWebsiteSecurity() && $this->security ? $this->security->getUser() : null;
+        /** @var int|null $permission */
+        $permission = $webspace && $webspace->hasWebsiteSecurity() && $this->permissions
+            ? $this->permissions[PermissionTypes::VIEW]
+            : null;
+
+        if ($permission) {
+            $this->accessControlQueryEnhancer->enhance(
+                $queryBuilder,
+                $user instanceof UserInterface ? $user : null,
+                $permission,
+                Page::class,
+                $alias,
+                'uuid'
+            );
+        }
     }
 
     private function leftJoinDimensionContent(QueryBuilder $queryBuilder): void

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -32,52 +32,45 @@ use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Webmozart\Assert\Assert;
 
-class NavigationRepository implements NavigationRepositoryInterface
+/**
+ * @internal
+ */
+final class NavigationRepository implements NavigationRepositoryInterface
 {
     /**
      * @var NestedTreeRepository<PageInterface>
      */
-    protected NestedTreeRepository $entityRepository;
+    private NestedTreeRepository $entityRepository;
 
     /**
      * @var EntityRepository<PageDimensionContentInterface>
      */
-    protected EntityRepository $entityDimensionContentRepository;
-
-    /**
-     * @var class-string<PageInterface>
-     */
-    protected string $pageClassName;
+    private EntityRepository $entityDimensionContentRepository;
 
     /**
      * @var class-string<PageDimensionContentInterface>
      */
-    protected string $pageDimensionContentClassName;
+    private string $pageDimensionContentClassName;
 
     /**
-     * @param array<string, int>|null $permissions
+     * @param array<string, int> $permissions
      */
     public function __construct(
         EntityManagerInterface $entityManager,
         private DimensionContentQueryEnhancer $dimensionContentQueryEnhancer,
         private ContentAggregatorInterface $contentAggregator,
         private ContentResolverInterface $contentResolver,
+        private WebspaceManagerInterface $webspaceManager,
+        private AccessControlQueryEnhancer $accessControlQueryEnhancer,
+        private ?Security $security,
+        private array $permissions,
         private bool $audienceTargetingEnabled = false,
-        private ?WebspaceManagerInterface $webspaceManager = null,
-        private ?AccessControlQueryEnhancer $accessControlQueryEnhancer = null,
-        private ?Security $security = null,
-        private ?array $permissions = null,
     ) {
-        if (null === $webspaceManager || null === $accessControlQueryEnhancer || null === $permissions) {
-            @trigger_deprecation('sulu/sulu', '3.0', 'Not passing the "$webspaceManager", "$accessControlQueryEnhancer" and "$permissions" arguments to "%s" is deprecated and they will be required in a future version.', __METHOD__);
-        }
-
         $repository = $entityManager->getRepository(PageInterface::class);
         Assert::isInstanceOf($repository, NestedTreeRepository::class);
 
         $this->entityRepository = $repository;
         $this->entityDimensionContentRepository = $entityManager->getRepository(PageDimensionContentInterface::class);
-        $this->pageClassName = $this->entityRepository->getClassName();
         $this->pageDimensionContentClassName = $this->entityDimensionContentRepository->getClassName();
     }
 
@@ -334,7 +327,7 @@ class NavigationRepository implements NavigationRepositoryInterface
      *
      * @return array<string, mixed>
      */
-    protected function resolvePageContent(PageInterface $page, string $locale, array $properties): array
+    private function resolvePageContent(PageInterface $page, string $locale, array $properties): array
     {
         $pageDimensionContent = $this->contentAggregator->aggregate($page, [
             'locale' => $locale,
@@ -526,15 +519,18 @@ class NavigationRepository implements NavigationRepositoryInterface
         string $webspaceKey,
         string $alias
     ): void {
-        if (!$this->webspaceManager || !$this->accessControlQueryEnhancer) {
-            return;
-        }
-
         $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
-        /** @var UserInterface|null $user */
-        $user = $webspace && $webspace->hasWebsiteSecurity() && $this->security ? $this->security->getUser() : null;
+        $user = null;
+
+        if ($webspace && $webspace->hasWebsiteSecurity()) {
+            $user = $this->security?->getUser();
+
+            if (!$user instanceof UserInterface) {
+                $user = null;
+            }
+        }
         /** @var int|null $permission */
-        $permission = $webspace && $webspace->hasWebsiteSecurity() && $this->permissions
+        $permission = $webspace && $webspace->hasWebsiteSecurity()
             ? $this->permissions[PermissionTypes::VIEW]
             : null;
 

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -477,11 +477,11 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_content.dimension_content_query_enhancer'),
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_content.content_resolver'),
-                expr("container.hasParameter('sulu_audience_targeting.enabled')"),
                 new Reference('sulu_core.webspace.webspace_manager'),
                 new Reference('sulu_security.access_control_query_enhancer'),
                 new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
                 param('sulu_security.permissions'),
+                expr("container.hasParameter('sulu_audience_targeting.enabled')"),
             ]);
 
         $services->alias(NavigationRepository::class, 'sulu_page.navigation_repository');

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -478,6 +478,10 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_content.content_resolver'),
                 expr("container.hasParameter('sulu_audience_targeting.enabled')"),
+                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_security.access_control_query_enhancer'),
+                new Reference('security.helper', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+                param('sulu_security.permissions'),
             ]);
 
         $services->alias(NavigationRepository::class, 'sulu_page.navigation_repository');

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryPermissionTest.php
@@ -1,0 +1,354 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Doctrine\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
+
+class NavigationRepositoryPermissionTest extends SuluTestCase
+{
+    use CreatePageTrait;
+    use CreatePageWithPermissionsTrait;
+
+    private EntityManagerInterface $entityManager;
+    private NavigationRepositoryInterface $navigationRepository;
+    private Role $anonymousRole;
+    private Page $homepageNonSecure;
+    private Page $homepageSecure;
+
+    /**
+     * @return array<string, string>
+     */
+    private function getDefaultProperties(): array
+    {
+        return [
+            'uuid' => 'object.resource.id',
+            'title' => 'title',
+            'url' => 'url',
+            'webspaceKey' => 'object.resource.webspaceKey',
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->entityManager = $this->getEntityManager();
+        $this->navigationRepository = $this->getContainer()->get('sulu_page.navigation_repository');
+        $this->anonymousRole = $this->createAnonymousRoleWithWebspacePermissions('sulu-test-secure');
+
+        $this->homepageNonSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ], 'sulu-io');
+
+        $this->homepageSecure = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ], 'sulu-test-secure');
+    }
+
+    public function testNavigationFlatWithoutWebspaceSecurityShowsAllPages(): void
+    {
+        $page1 = $this->createSimplePage('sulu-io', 'en', 'Page 1');
+        $page2 = $this->createSimplePage('sulu-io', 'en', 'Page 2');
+        $page3 = $this->createSimplePage('sulu-io', 'en', 'Page 3');
+
+        $this->denyAccessToPage($page2, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationFlat(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            1,
+            $this->getDefaultProperties()
+        );
+
+        $this->assertCount(4, $result);
+        $uuids = \array_column($result, 'uuid');
+        $this->assertContains($page1->getUuid(), $uuids);
+        $this->assertContains($page2->getUuid(), $uuids);
+        $this->assertContains($page3->getUuid(), $uuids);
+    }
+
+    public function testNavigationFlatWithWebspaceSecurityFiltersDeniedPages(): void
+    {
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+        $deniedPage1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 1');
+        $deniedPage2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page 2');
+
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage1, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage2, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationFlat(
+            'main',
+            'en',
+            'sulu-test-secure',
+            null,
+            1,
+            $this->getDefaultProperties()
+        );
+
+        $uuids = \array_column($result, 'uuid');
+        $this->assertContains($allowedPage->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage1->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage2->getUuid(), $uuids);
+    }
+
+    public function testNavigationTreeWithWebspaceSecurityFiltersDeniedPages(): void
+    {
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+        $deniedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page');
+
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationTreeByUuid(
+            $this->homepageSecure->getUuid(),
+            'en',
+            'sulu-test-secure',
+            1,
+            'main',
+            $this->getDefaultProperties()
+        );
+
+        $uuids = \array_column($result, 'uuid');
+        $this->assertContains($allowedPage->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage->getUuid(), $uuids);
+    }
+
+    public function testNavigationFlatByUuidWithWebspaceSecurityFiltersDeniedPages(): void
+    {
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+        $deniedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page');
+
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationFlatByUuid(
+            $this->homepageSecure->getUuid(),
+            'en',
+            'sulu-test-secure',
+            1,
+            'main',
+            $this->getDefaultProperties()
+        );
+
+        $uuids = \array_column($result, 'uuid');
+        $this->assertContains($allowedPage->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage->getUuid(), $uuids);
+    }
+
+    public function testNavigationTreeByUuidWithWebspaceSecurityFiltersDeniedPages(): void
+    {
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+        $deniedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page');
+
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->denyAccessToPage($deniedPage, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationTreeByUuid(
+            $this->homepageSecure->getUuid(),
+            'en',
+            'sulu-test-secure',
+            1,
+            'main',
+            $this->getDefaultProperties()
+        );
+
+        $uuids = \array_column($result, 'uuid');
+        $this->assertContains($allowedPage->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage->getUuid(), $uuids);
+    }
+
+    public function testNavigationTreeWithMixedPermissions(): void
+    {
+        $allowed1 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 1');
+        $allowed2 = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed 2');
+        $denied1 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 1');
+        $denied2 = $this->createSimplePage('sulu-test-secure', 'en', 'Denied 2');
+
+        $this->grantViewAccessToPage($allowed1, $this->anonymousRole);
+        $this->grantViewAccessToPage($allowed2, $this->anonymousRole);
+        $this->denyAccessToPage($denied1, $this->anonymousRole);
+        $this->denyAccessToPage($denied2, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationTreeByUuid(
+            $this->homepageSecure->getUuid(),
+            'en',
+            'sulu-test-secure',
+            1,
+            'main',
+            $this->getDefaultProperties()
+        );
+
+        $uuids = \array_column($result, 'uuid');
+        $this->assertContains($allowed1->getUuid(), $uuids);
+        $this->assertContains($allowed2->getUuid(), $uuids);
+        $this->assertNotContains($denied1->getUuid(), $uuids);
+        $this->assertNotContains($denied2->getUuid(), $uuids);
+    }
+
+    public function testNavigationTreeWithWebspaceSecurityFiltersTreeChildren(): void
+    {
+        $parentPage = $this->createSimplePage('sulu-test-secure', 'en', 'Parent Page');
+
+        $allowedChild = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Allowed Child',
+                    'url' => '/parent-page/allowed-child',
+                    'navigationContexts' => ['main'],
+                    'parentId' => $parentPage->getUuid(),
+                ],
+            ],
+        ], 'sulu-test-secure');
+
+        $deniedChild = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Denied Child',
+                    'url' => '/parent-page/denied-child',
+                    'navigationContexts' => ['main'],
+                    'parentId' => $parentPage->getUuid(),
+                ],
+            ],
+        ], 'sulu-test-secure');
+
+        $this->grantViewAccessToPage($parentPage, $this->anonymousRole);
+        $this->grantViewAccessToPage($allowedChild, $this->anonymousRole);
+        $this->denyAccessToPage($deniedChild, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationTreeByUuid(
+            $this->homepageSecure->getUuid(),
+            'en',
+            'sulu-test-secure',
+            2,
+            'main',
+            $this->getDefaultProperties()
+        );
+
+        $parentInResult = null;
+        foreach ($result as $item) {
+            if ($item['uuid'] === $parentPage->getUuid()) {
+                $parentInResult = $item;
+                break;
+            }
+        }
+
+        $this->assertNotNull($parentInResult, 'Parent page should be in navigation');
+        $this->assertIsArray($parentInResult['children']);
+
+        $childUuids = \array_column($parentInResult['children'], 'uuid');
+        $this->assertContains($allowedChild->getUuid(), $childUuids);
+        $this->assertNotContains($deniedChild->getUuid(), $childUuids);
+    }
+
+    public function testNavigationWithPageWithoutAccessControlEntryUsesWebspacePermissions(): void
+    {
+        $pageWithoutAcl = $this->createSimplePage('sulu-test-secure', 'en', 'Page Without ACL');
+
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationFlat(
+            'main',
+            'en',
+            'sulu-test-secure',
+            null,
+            1,
+            $this->getDefaultProperties()
+        );
+
+        $uuids = \array_column($result, 'uuid');
+        $this->assertContains($pageWithoutAcl->getUuid(), $uuids);
+    }
+
+    public function testBreadcrumbShowsAllAncestorsRegardlessOfPermissions(): void
+    {
+        $parentPage = $this->createSimplePage('sulu-test-secure', 'en', 'Parent Page');
+
+        $childPage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Child Page',
+                    'url' => '/parent-page/child-page',
+                    'navigationContexts' => ['main'],
+                    'parentId' => $parentPage->getUuid(),
+                ],
+            ],
+        ], 'sulu-test-secure');
+
+        $this->denyAccessToPage($parentPage, $this->anonymousRole);
+        $this->grantViewAccessToPage($childPage, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getBreadcrumb(
+            $childPage->getUuid(),
+            'en',
+            'sulu-test-secure',
+            $this->getDefaultProperties()
+        );
+
+        $this->assertGreaterThanOrEqual(2, \count($result));
+        $uuids = \array_column($result, 'uuid');
+        $this->assertContains($parentPage->getUuid(), $uuids);
+        $this->assertContains($childPage->getUuid(), $uuids);
+    }
+
+    private function createSimplePage(string $webspaceKey, string $locale, string $title, string $template = 'default'): Page
+    {
+        $url = '/' . \strtolower(\str_replace(' ', '-', $title));
+        $homepage = 'sulu-io' === $webspaceKey ? $this->homepageNonSecure : $this->homepageSecure;
+
+        return $this->createPage([
+            $locale => [
+                'live' => [
+                    'template' => $template,
+                    'title' => $title,
+                    'url' => $url,
+                    'parentId' => $homepage->getUuid(),
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ], $webspaceKey);
+    }
+}

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryPermissionTest.php
@@ -52,6 +52,9 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         $this->navigationRepository = $this->getContainer()->get('sulu_page.navigation_repository');
         $this->anonymousRole = $this->createAnonymousRoleWithWebspacePermissions('sulu-test-secure');
 
+        $systemStore = $this->getContainer()->get('sulu_security.system_store');
+        $systemStore->setSystem('sulu-test-secure');
+
         $this->homepageNonSecure = $this->createPage([
             'en' => [
                 'live' => [
@@ -121,6 +124,7 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         );
 
         $uuids = \array_column($result, 'uuid');
+        $this->assertCount(2, $result);
         $this->assertContains($allowedPage->getUuid(), $uuids);
         $this->assertNotContains($deniedPage1->getUuid(), $uuids);
         $this->assertNotContains($deniedPage2->getUuid(), $uuids);
@@ -135,16 +139,17 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         $this->denyAccessToPage($deniedPage, $this->anonymousRole);
         $this->entityManager->clear();
 
-        $result = $this->navigationRepository->getNavigationTreeByUuid(
-            $this->homepageSecure->getUuid(),
+        $result = $this->navigationRepository->getNavigationTree(
+            'main',
             'en',
             'sulu-test-secure',
-            1,
-            'main',
+            null,
+            2,
             $this->getDefaultProperties()
         );
 
-        $uuids = \array_column($result, 'uuid');
+        $uuids = $this->collectTreeUuids($result);
+        $this->assertCount(2, $uuids);
         $this->assertContains($allowedPage->getUuid(), $uuids);
         $this->assertNotContains($deniedPage->getUuid(), $uuids);
     }
@@ -168,6 +173,7 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         );
 
         $uuids = \array_column($result, 'uuid');
+        $this->assertCount(1, $result);
         $this->assertContains($allowedPage->getUuid(), $uuids);
         $this->assertNotContains($deniedPage->getUuid(), $uuids);
     }
@@ -191,6 +197,7 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         );
 
         $uuids = \array_column($result, 'uuid');
+        $this->assertCount(1, $result);
         $this->assertContains($allowedPage->getUuid(), $uuids);
         $this->assertNotContains($deniedPage->getUuid(), $uuids);
     }
@@ -218,6 +225,7 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         );
 
         $uuids = \array_column($result, 'uuid');
+        $this->assertCount(2, $result);
         $this->assertContains($allowed1->getUuid(), $uuids);
         $this->assertContains($allowed2->getUuid(), $uuids);
         $this->assertNotContains($denied1->getUuid(), $uuids);
@@ -278,6 +286,7 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         $this->assertIsArray($parentInResult['children']);
 
         $childUuids = \array_column($parentInResult['children'], 'uuid');
+        $this->assertCount(1, $childUuids);
         $this->assertContains($allowedChild->getUuid(), $childUuids);
         $this->assertNotContains($deniedChild->getUuid(), $childUuids);
     }
@@ -285,7 +294,8 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
     public function testNavigationWithPageWithoutAccessControlEntryUsesWebspacePermissions(): void
     {
         $pageWithoutAcl = $this->createSimplePage('sulu-test-secure', 'en', 'Page Without ACL');
-
+        $deniedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Page');
+        $this->denyAccessToPage($deniedPage, $this->anonymousRole);
         $this->entityManager->clear();
 
         $result = $this->navigationRepository->getNavigationFlat(
@@ -298,7 +308,9 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         );
 
         $uuids = \array_column($result, 'uuid');
+        $this->assertCount(2, $result);
         $this->assertContains($pageWithoutAcl->getUuid(), $uuids);
+        $this->assertNotContains($deniedPage->getUuid(), $uuids);
     }
 
     public function testBreadcrumbShowsAllAncestorsRegardlessOfPermissions(): void
@@ -321,6 +333,18 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         $this->grantViewAccessToPage($childPage, $this->anonymousRole);
         $this->entityManager->clear();
 
+        $navResult = $this->navigationRepository->getNavigationFlat(
+            'main',
+            'en',
+            'sulu-test-secure',
+            null,
+            2,
+            $this->getDefaultProperties()
+        );
+
+        $navUuids = \array_column($navResult, 'uuid');
+        $this->assertNotContains($parentPage->getUuid(), $navUuids, 'Denied parent should be filtered from regular navigation');
+
         $result = $this->navigationRepository->getBreadcrumb(
             $childPage->getUuid(),
             'en',
@@ -332,6 +356,66 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         $uuids = \array_column($result, 'uuid');
         $this->assertContains($parentPage->getUuid(), $uuids);
         $this->assertContains($childPage->getUuid(), $uuids);
+    }
+
+    public function testNavigationTreeWithDeniedParentStillShowsAllowedChildren(): void
+    {
+        $deniedParent = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Parent');
+
+        $childOfDenied = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Child of Denied',
+                    'url' => '/denied-parent/child-of-denied',
+                    'navigationContexts' => ['main'],
+                    'parentId' => $deniedParent->getUuid(),
+                ],
+            ],
+        ], 'sulu-test-secure');
+
+        $allowedPage = $this->createSimplePage('sulu-test-secure', 'en', 'Allowed Page');
+
+        $this->denyAccessToPage($deniedParent, $this->anonymousRole);
+        $this->grantViewAccessToPage($childOfDenied, $this->anonymousRole);
+        $this->grantViewAccessToPage($allowedPage, $this->anonymousRole);
+        $this->entityManager->clear();
+
+        $result = $this->navigationRepository->getNavigationTree(
+            'main',
+            'en',
+            'sulu-test-secure',
+            null,
+            2,
+            $this->getDefaultProperties()
+        );
+
+        $uuids = $this->collectTreeUuids($result);
+        $this->assertContains($allowedPage->getUuid(), $uuids);
+        $this->assertNotContains($deniedParent->getUuid(), $uuids);
+        $this->assertContains($childOfDenied->getUuid(), $uuids);
+    }
+
+    /**
+     * @param array<array<string, mixed>> $items
+     *
+     * @return string[]
+     */
+    private function collectTreeUuids(array $items): array
+    {
+        $uuids = [];
+        foreach ($items as $item) {
+            if (isset($item['uuid']) && \is_string($item['uuid'])) {
+                $uuids[] = $item['uuid'];
+            }
+            if (!empty($item['children']) && \is_array($item['children'])) {
+                /** @var array<array<string, mixed>> $children */
+                $children = $item['children'];
+                $uuids = \array_merge($uuids, $this->collectTreeUuids($children));
+            }
+        }
+
+        return $uuids;
     }
 
     private function createSimplePage(string $webspaceKey, string $locale, string $title, string $template = 'default'): Page

--- a/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -22,6 +22,9 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancer;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
@@ -29,6 +32,7 @@ use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Doctrine\Repository\NavigationRepository;
+use Symfony\Bundle\SecurityBundle\Security;
 
 class NavigationRepositoryTest extends TestCase
 {
@@ -47,6 +51,12 @@ class NavigationRepositoryTest extends TestCase
     private ObjectProphecy $contentAggregator;
     /** @var ObjectProphecy<ContentResolverInterface> */
     private ObjectProphecy $contentResolver;
+    /** @var ObjectProphecy<WebspaceManagerInterface> */
+    private ObjectProphecy $webspaceManager;
+    /** @var ObjectProphecy<AccessControlQueryEnhancer> */
+    private ObjectProphecy $accessControlQueryEnhancer;
+    /** @var ObjectProphecy<Security> */
+    private ObjectProphecy $security;
 
     /**
      * @return array<string, string>
@@ -91,6 +101,9 @@ class NavigationRepositoryTest extends TestCase
         $this->dimensionContentQueryEnhancer = $this->prophesize(DimensionContentQueryEnhancer::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
         $this->contentResolver = $this->prophesize(ContentResolverInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->accessControlQueryEnhancer = $this->prophesize(AccessControlQueryEnhancer::class);
+        $this->security = $this->prophesize(Security::class);
 
         $this->entityManager->getRepository(PageInterface::class)->willReturn($this->nestedTreeRepository->reveal());
         $this->entityManager->getRepository(PageDimensionContentInterface::class)->willReturn($this->dimensionContentRepository->reveal());
@@ -103,6 +116,10 @@ class NavigationRepositoryTest extends TestCase
             $this->dimensionContentQueryEnhancer->reveal(),
             $this->contentAggregator->reveal(),
             $this->contentResolver->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->accessControlQueryEnhancer->reveal(),
+            $this->security->reveal(),
+            [PermissionTypes::VIEW => 64],
             false
         );
     }


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | yes <!-- if yes add them to the UPGRADE.md file -->
  | Fixed tickets | fixes #8565
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Added ACL query filtering to `NavigationRepository` so that pages denied to the anonymous role (or current user) are excluded from website navigation, matching the behavior already present in `PageRepository`
  - Introduced `AccessControlQueryEnhancer` integration in `NavigationRepository::createQueryBuilder()`, respecting webspace security configuration
  - Breadcrumb queries skip access control (`skipAccessControl: true`) so ancestors always appear regardless of permissions
  - Added deprecation warning when `$webspaceManager`, `$accessControlQueryEnhancer`, or `$permissions` constructor arguments are not provided
  - Added comprehensive permission tests covering flat/tree navigation, mixed permissions, children filtering, breadcrumb behavior, and pages without explicit ACL entries

  #### Why?

  When a webspace has `permission-check="true"` enabled, pages with denied permissions still appeared in website navigation menus. The `NavigationRepository` was not applying any ACL filtering, even though
  `PageRepository` already does. This PR adds the.       missing ACL integration to `NavigationRepository` so permission checks are consistently applied across all page listing mechanisms.