### PR TITLE
Improve LinkProvider performance and generate localized urls

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
@@ -13,26 +13,28 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Content;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Article\Domain\Model\ArticleDimensionContent;
 use Sulu\Article\Domain\Model\ArticleInterface;
-use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
-use Sulu\Content\Application\ContentManager\ContentManagerInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @interal This class is an integration to the SuluMarkupBundle and can be changed any time.
- *          Use Symfony dependency injection service decoration and change the behaviour if you need.
+ * @internal This class is an integration to the SuluMarkupBundle and can be changed any time.
+ *           Use Symfony dependency injection service decoration and change the behaviour if you need.
  */
 final class ArticleLinkProvider implements LinkProviderInterface
 {
     public function __construct(
-        private readonly ContentManagerInterface $contentManager,
-        private readonly ArticleRepositoryInterface $articleRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly WebspaceManagerInterface $webspaceManager,
+        private readonly RequestAnalyzerInterface $requestAnalyzer,
         private readonly ReferenceStoreInterface $referenceStore,
         private readonly TranslatorInterface $translator,
     ) {
@@ -52,46 +54,106 @@ final class ArticleLinkProvider implements LinkProviderInterface
 
     public function preload(array $hrefs, string $locale, bool $published = true): iterable
     {
-        $dimensionAttributes = [
-            'locale' => $locale,
-            'stage' => $published ? DimensionContentInterface::STAGE_LIVE : DimensionContentInterface::STAGE_DRAFT,
-            'version' => DimensionContentInterface::CURRENT_VERSION,
-        ];
+        if ([] === $hrefs) {
+            return [];
+        }
 
-        $articles = $this->articleRepository->findBy(
-            filters: [
-                'uuids' => $hrefs,
-                'locale' => $locale,
-                'stage' => $dimensionAttributes['stage'],
-                'version' => DimensionContentInterface::CURRENT_VERSION,
-            ],
-            selects: [
-                ArticleRepositoryInterface::SELECT_ARTICLE_CONTENT => [
-                    DimensionContentQueryEnhancer::GROUP_SELECT_CONTENT_WEBSITE => true,
-                ],
-            ]
-        );
+        $stage = $published ? DimensionContentInterface::STAGE_LIVE : DimensionContentInterface::STAGE_DRAFT;
+        $version = DimensionContentInterface::CURRENT_VERSION;
+
+        $requestWebspace = $this->requestAnalyzer->getWebspace()?->getKey();
+        $rows = $this->findArticlesByUuids($hrefs, $locale, $stage, $version, $requestWebspace);
 
         $result = [];
-        foreach ($articles as $article) {
-            $dimensionContent = $this->contentManager->resolve($article, $dimensionAttributes);
-            $this->referenceStore->add($article->getId(), ArticleInterface::RESOURCE_KEY);
+        foreach ($rows as $row) {
+            $this->referenceStore->add($row['uuid'], ArticleInterface::RESOURCE_KEY);
 
-            /** @var string|null $url */
-            $url = $dimensionContent->getTemplateData()['url'] ?? null;
+            if (null === $row['slug']) {
+                continue;
+            }
+
+            $webspace = $this->determineWebspace($row, $requestWebspace);
+            if (null === $webspace) {
+                continue;
+            }
+
+            $url = $this->webspaceManager->findUrlByResourceLocator(
+                $row['slug'],
+                null,
+                $locale,
+                $webspace,
+            );
+
             if (null === $url) {
-                // TODO what to do when there is no url?
                 continue;
             }
 
             $result[] = new LinkItem(
-                $article->getUuid(),
-                (string) $dimensionContent->getTitle(),
+                $row['uuid'],
+                (string) ($row['title'] ?? ''),
                 $url,
-                $published
+                $published,
             );
         }
 
         return $result;
+    }
+
+    /**
+     * @param string[] $uuids
+     *
+     * @return list<array{uuid: string, title: ?string, slug: ?string, mainWebspace: ?string, additionalWebspace?: ?string}>
+     */
+    private function findArticlesByUuids(
+        array $uuids,
+        string $locale,
+        string $stage,
+        int $version,
+        ?string $requestWebspace,
+    ): array {
+        $queryBuilder = $this->entityManager->createQueryBuilder()
+            ->select('article.uuid', 'dimensionContent.title', 'route.slug', 'dimensionContent.mainWebspace')
+            ->from(ArticleDimensionContent::class, 'dimensionContent')
+            ->join('dimensionContent.article', 'article')
+            ->leftJoin('dimensionContent.route', 'route')
+            ->where('article.uuid IN (:uuids)')
+            ->andWhere('dimensionContent.locale = :locale')
+            ->andWhere('dimensionContent.stage = :stage')
+            ->andWhere('dimensionContent.version = :version')
+            ->setParameter('uuids', $uuids)
+            ->setParameter('locale', $locale)
+            ->setParameter('stage', $stage)
+            ->setParameter('version', $version);
+
+        if (null !== $requestWebspace) {
+            $queryBuilder
+                ->addSelect('additionalWebspace.additionalWebspace')
+                ->leftJoin(
+                    'dimensionContent.additionalWebspaces',
+                    'additionalWebspace',
+                    'WITH',
+                    'additionalWebspace.additionalWebspace = :requestWebspace',
+                )
+                ->setParameter('requestWebspace', $requestWebspace);
+        }
+
+        /** @var list<array{uuid: string, title: ?string, slug: ?string, mainWebspace: ?string, additionalWebspace?: ?string}> */
+        return $queryBuilder->getQuery()->getArrayResult();
+    }
+
+    /**
+     * @param array{mainWebspace: ?string, additionalWebspace?: ?string} $row
+     */
+    private function determineWebspace(array $row, ?string $requestWebspace): ?string
+    {
+        if (null === $requestWebspace) {
+            return $row['mainWebspace'];
+        }
+
+        if ($row['mainWebspace'] === $requestWebspace || ($row['additionalWebspace'] ?? null) !== null) {
+            return $requestWebspace;
+        }
+
+        return $row['mainWebspace'];
     }
 }

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
@@ -21,8 +21,8 @@ use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -33,7 +33,7 @@ final class ArticleLinkProvider implements LinkProviderInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
-        private readonly WebspaceManagerInterface $webspaceManager,
+        private readonly RouteGeneratorInterface $routeGenerator,
         private readonly RequestAnalyzerInterface $requestAnalyzer,
         private readonly ReferenceStoreInterface $referenceStore,
         private readonly TranslatorInterface $translator,
@@ -73,20 +73,12 @@ final class ArticleLinkProvider implements LinkProviderInterface
             }
 
             $webspace = $this->determineWebspace($row, $requestWebspace);
-            if (null === $webspace) {
-                continue;
-            }
 
-            $url = $this->webspaceManager->findUrlByResourceLocator(
+            $url = $this->routeGenerator->generate(
                 $row['slug'],
-                null,
                 $locale,
                 $webspace,
             );
-
-            if (null === $url) {
-                continue;
-            }
 
             $result[] = new LinkItem(
                 $row['uuid'],

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -333,7 +333,7 @@ final class SuluArticleBundle extends AbstractBundle
             ->class(ArticleLinkProvider::class)
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
-                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_route.route_generator'),
                 new Reference('sulu_core.webspace.request_analyzer'),
                 new Reference('sulu_http_cache.reference_store'),
                 new Reference('translator'),

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -332,8 +332,9 @@ final class SuluArticleBundle extends AbstractBundle
         $services->set('sulu_article.article_link_provider')
             ->class(ArticleLinkProvider::class)
             ->args([
-                new Reference('sulu_content.content_manager'),
-                new Reference('sulu_article.article_repository'),
+                new Reference('doctrine.orm.entity_manager'),
+                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_core.webspace.request_analyzer'),
                 new Reference('sulu_http_cache.reference_store'),
                 new Reference('translator'),
             ])

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/ArticleLinkProviderTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/ArticleLinkProviderTest.php
@@ -23,8 +23,10 @@ use Sulu\Article\Infrastructure\Sulu\Content\ArticleLinkProvider;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
+use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ArticleLinkProviderTest extends TestCase
@@ -37,15 +39,7 @@ class ArticleLinkProviderTest extends TestCase
      */
     private ObjectProphecy $entityManager;
 
-    /**
-     * @var ObjectProphecy<WebspaceManagerInterface>
-     */
-    private ObjectProphecy $webspaceManager;
-
-    /**
-     * @var ObjectProphecy<RequestAnalyzerInterface>
-     */
-    private ObjectProphecy $requestAnalyzer;
+    private RouteGeneratorInterface $routeGenerator;
 
     /**
      * @var ObjectProphecy<ReferenceStoreInterface>
@@ -57,21 +51,47 @@ class ArticleLinkProviderTest extends TestCase
      */
     private ObjectProphecy $translator;
 
-    private ArticleLinkProvider $articleLinkProvider;
-
     protected function setUp(): void
     {
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
-        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
-        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $this->translator = $this->prophesize(TranslatorInterface::class);
         $this->translator->trans(Argument::cetera())->willReturnArgument(0);
 
-        $this->articleLinkProvider = new ArticleLinkProvider(
+        $webspaceRouteGenerator = new class() implements WebspaceRouteGeneratorInterface {
+            public function generate(RequestContext $requestContext, string $slug, string $locale): string
+            {
+                return \sprintf('/%s%s', $locale, $slug);
+            }
+        };
+
+        $this->routeGenerator = new class($webspaceRouteGenerator) implements RouteGeneratorInterface {
+            public function __construct(private WebspaceRouteGeneratorInterface $webspaceRouteGenerator)
+            {
+            }
+
+            public function generate(string $slug, ?string $locale = null, ?string $webspace = null, int $referenceType = 0): string
+            {
+                return $this->webspaceRouteGenerator->generate(new RequestContext(), $slug, $locale ?? 'en');
+            }
+        };
+    }
+
+    private function createProvider(?string $requestWebspace = null): ArticleLinkProvider
+    {
+        $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        if (null !== $requestWebspace) {
+            $webspace = new Webspace();
+            $webspace->setKey($requestWebspace);
+            $requestAnalyzer->getWebspace()->willReturn($webspace);
+        } else {
+            $requestAnalyzer->getWebspace()->willReturn(null);
+        }
+
+        return new ArticleLinkProvider(
             $this->entityManager->reveal(),
-            $this->webspaceManager->reveal(),
-            $this->requestAnalyzer->reveal(),
+            $this->routeGenerator,
+            $requestAnalyzer->reveal(),
             $this->referenceStore->reveal(),
             $this->translator->reveal(),
         );
@@ -79,7 +99,8 @@ class ArticleLinkProviderTest extends TestCase
 
     public function testGetConfigurationBuilder(): void
     {
-        $linkConfigurationBuilder = $this->articleLinkProvider->getConfigurationBuilder();
+        $provider = $this->createProvider();
+        $linkConfigurationBuilder = $provider->getConfigurationBuilder();
         $linkConfiguration = $linkConfigurationBuilder->getLinkConfiguration();
 
         $this->assertSame(
@@ -99,17 +120,14 @@ class ArticleLinkProviderTest extends TestCase
 
     public function testPreloadEmptyHrefs(): void
     {
-        $result = $this->articleLinkProvider->preload([], 'en');
+        $provider = $this->createProvider();
+        $result = $provider->preload([], 'en');
 
         $this->assertSame([], $result);
     }
 
     public function testPreloadWithMainWebspace(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('blog');
-        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
-
         $this->mockQueryBuilder(
             [
                 [
@@ -126,12 +144,10 @@ class ArticleLinkProviderTest extends TestCase
             'blog',
         );
 
-        $this->webspaceManager->findUrlByResourceLocator('/test-article', null, 'en', 'blog')
-            ->willReturn('/en/test-article');
-
         $this->referenceStore->add('article-1', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
 
-        $result = [...$this->articleLinkProvider->preload(['article-1'], 'en', true)];
+        $provider = $this->createProvider('blog');
+        $result = [...$provider->preload(['article-1'], 'en', true)];
 
         $this->assertCount(1, $result);
         $this->assertSame('article-1', $result[0]->getId());
@@ -142,10 +158,6 @@ class ArticleLinkProviderTest extends TestCase
 
     public function testPreloadWithAdditionalWebspace(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('main_site');
-        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
-
         $this->mockQueryBuilder(
             [
                 [
@@ -162,12 +174,10 @@ class ArticleLinkProviderTest extends TestCase
             'main_site',
         );
 
-        $this->webspaceManager->findUrlByResourceLocator('/shared-article', null, 'en', 'main_site')
-            ->willReturn('/en/shared-article');
-
         $this->referenceStore->add('article-2', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
 
-        $result = [...$this->articleLinkProvider->preload(['article-2'], 'en', true)];
+        $provider = $this->createProvider('main_site');
+        $result = [...$provider->preload(['article-2'], 'en', true)];
 
         $this->assertCount(1, $result);
         $this->assertSame('/en/shared-article', $result[0]->getUrl());
@@ -175,10 +185,6 @@ class ArticleLinkProviderTest extends TestCase
 
     public function testPreloadFallbackToMainWebspace(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('other_site');
-        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
-
         $this->mockQueryBuilder(
             [
                 [
@@ -195,21 +201,17 @@ class ArticleLinkProviderTest extends TestCase
             'other_site',
         );
 
-        $this->webspaceManager->findUrlByResourceLocator('/blog-article', null, 'en', 'blog')
-            ->willReturn('/en/blog-article');
-
         $this->referenceStore->add('article-3', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
 
-        $result = [...$this->articleLinkProvider->preload(['article-3'], 'en', true)];
+        $provider = $this->createProvider('other_site');
+        $result = [...$provider->preload(['article-3'], 'en', true)];
 
         $this->assertCount(1, $result);
         $this->assertSame('/en/blog-article', $result[0]->getUrl());
     }
 
-    public function testPreloadNullWebspace(): void
+    public function testPreloadNoRequestWebspace(): void
     {
-        $this->requestAnalyzer->getWebspace()->willReturn(null);
-
         $this->mockQueryBuilder(
             [
                 [
@@ -225,12 +227,10 @@ class ArticleLinkProviderTest extends TestCase
             null,
         );
 
-        $this->webspaceManager->findUrlByResourceLocator('/cli-article', null, 'en', 'blog')
-            ->willReturn('/en/cli-article');
-
         $this->referenceStore->add('article-4', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
 
-        $result = [...$this->articleLinkProvider->preload(['article-4'], 'en', true)];
+        $provider = $this->createProvider(null);
+        $result = [...$provider->preload(['article-4'], 'en', true)];
 
         $this->assertCount(1, $result);
         $this->assertSame('/en/cli-article', $result[0]->getUrl());
@@ -238,10 +238,6 @@ class ArticleLinkProviderTest extends TestCase
 
     public function testPreloadDraftStage(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('blog');
-        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
-
         $this->mockQueryBuilder(
             [
                 [
@@ -258,12 +254,10 @@ class ArticleLinkProviderTest extends TestCase
             'blog',
         );
 
-        $this->webspaceManager->findUrlByResourceLocator('/draft-article', null, 'en', 'blog')
-            ->willReturn('/en/draft-article');
-
         $this->referenceStore->add('article-5', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
 
-        $result = [...$this->articleLinkProvider->preload(['article-5'], 'en', false)];
+        $provider = $this->createProvider('blog');
+        $result = [...$provider->preload(['article-5'], 'en', false)];
 
         $this->assertCount(1, $result);
         $this->assertSame('/en/draft-article', $result[0]->getUrl());
@@ -272,10 +266,6 @@ class ArticleLinkProviderTest extends TestCase
 
     public function testPreloadNullSlug(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('blog');
-        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
-
         $this->mockQueryBuilder(
             [
                 [
@@ -294,68 +284,8 @@ class ArticleLinkProviderTest extends TestCase
 
         $this->referenceStore->add('article-6', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
 
-        $result = [...$this->articleLinkProvider->preload(['article-6'], 'en', true)];
-
-        $this->assertCount(0, $result);
-    }
-
-    public function testPreloadNullMainWebspace(): void
-    {
-        $webspace = new Webspace();
-        $webspace->setKey('blog');
-        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $this->mockQueryBuilder(
-            [
-                [
-                    'uuid' => 'article-7',
-                    'title' => 'Orphan Article',
-                    'slug' => '/orphan-article',
-                    'mainWebspace' => null,
-                    'additionalWebspace' => null,
-                ],
-            ],
-            ['article-7'],
-            'en',
-            'live',
-            'blog',
-        );
-
-        $this->referenceStore->add('article-7', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
-
-        $result = [...$this->articleLinkProvider->preload(['article-7'], 'en', true)];
-
-        $this->assertCount(0, $result);
-    }
-
-    public function testPreloadUrlResolutionReturnsNull(): void
-    {
-        $webspace = new Webspace();
-        $webspace->setKey('blog');
-        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
-
-        $this->mockQueryBuilder(
-            [
-                [
-                    'uuid' => 'article-8',
-                    'title' => 'Unresolvable Article',
-                    'slug' => '/unresolvable',
-                    'mainWebspace' => 'blog',
-                    'additionalWebspace' => null,
-                ],
-            ],
-            ['article-8'],
-            'en',
-            'live',
-            'blog',
-        );
-
-        $this->webspaceManager->findUrlByResourceLocator('/unresolvable', null, 'en', 'blog')
-            ->willReturn(null);
-
-        $this->referenceStore->add('article-8', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
-
-        $result = [...$this->articleLinkProvider->preload(['article-8'], 'en', true)];
+        $provider = $this->createProvider('blog');
+        $result = [...$provider->preload(['article-6'], 'en', true)];
 
         $this->assertCount(0, $result);
     }

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/ArticleLinkProviderTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/ArticleLinkProviderTest.php
@@ -1,0 +1,401 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Tests\Unit\Infrastructure\Sulu\Content;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Article\Infrastructure\Sulu\Content\ArticleLinkProvider;
+use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ArticleLinkProviderTest extends TestCase
+{
+    use ProphecyTrait;
+    use SetGetPrivatePropertyTrait;
+
+    /**
+     * @var ObjectProphecy<EntityManagerInterface>
+     */
+    private ObjectProphecy $entityManager;
+
+    /**
+     * @var ObjectProphecy<WebspaceManagerInterface>
+     */
+    private ObjectProphecy $webspaceManager;
+
+    /**
+     * @var ObjectProphecy<RequestAnalyzerInterface>
+     */
+    private ObjectProphecy $requestAnalyzer;
+
+    /**
+     * @var ObjectProphecy<ReferenceStoreInterface>
+     */
+    private ObjectProphecy $referenceStore;
+
+    /**
+     * @var ObjectProphecy<TranslatorInterface>
+     */
+    private ObjectProphecy $translator;
+
+    private ArticleLinkProvider $articleLinkProvider;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+        $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
+        $this->translator = $this->prophesize(TranslatorInterface::class);
+        $this->translator->trans(Argument::cetera())->willReturnArgument(0);
+
+        $this->articleLinkProvider = new ArticleLinkProvider(
+            $this->entityManager->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->requestAnalyzer->reveal(),
+            $this->referenceStore->reveal(),
+            $this->translator->reveal(),
+        );
+    }
+
+    public function testGetConfigurationBuilder(): void
+    {
+        $linkConfigurationBuilder = $this->articleLinkProvider->getConfigurationBuilder();
+        $linkConfiguration = $linkConfigurationBuilder->getLinkConfiguration();
+
+        $this->assertSame(
+            ArticleInterface::RESOURCE_KEY,
+            self::getPrivateProperty($linkConfiguration, 'resourceKey'),
+        );
+
+        $this->assertSame(
+            'table',
+            self::getPrivateProperty($linkConfiguration, 'listAdapter'),
+        );
+
+        $this->assertSame([
+            'title',
+        ], self::getPrivateProperty($linkConfiguration, 'displayProperties'));
+    }
+
+    public function testPreloadEmptyHrefs(): void
+    {
+        $result = $this->articleLinkProvider->preload([], 'en');
+
+        $this->assertSame([], $result);
+    }
+
+    public function testPreloadWithMainWebspace(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('blog');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-1',
+                    'title' => 'Test Article',
+                    'slug' => '/test-article',
+                    'mainWebspace' => 'blog',
+                    'additionalWebspace' => null,
+                ],
+            ],
+            ['article-1'],
+            'en',
+            'live',
+            'blog',
+        );
+
+        $this->webspaceManager->findUrlByResourceLocator('/test-article', null, 'en', 'blog')
+            ->willReturn('/en/test-article');
+
+        $this->referenceStore->add('article-1', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->articleLinkProvider->preload(['article-1'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('article-1', $result[0]->getId());
+        $this->assertSame('Test Article', $result[0]->getTitle());
+        $this->assertSame('/en/test-article', $result[0]->getUrl());
+        $this->assertTrue($result[0]->isPublished());
+    }
+
+    public function testPreloadWithAdditionalWebspace(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('main_site');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-2',
+                    'title' => 'Shared Article',
+                    'slug' => '/shared-article',
+                    'mainWebspace' => 'blog',
+                    'additionalWebspace' => 'main_site',
+                ],
+            ],
+            ['article-2'],
+            'en',
+            'live',
+            'main_site',
+        );
+
+        $this->webspaceManager->findUrlByResourceLocator('/shared-article', null, 'en', 'main_site')
+            ->willReturn('/en/shared-article');
+
+        $this->referenceStore->add('article-2', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->articleLinkProvider->preload(['article-2'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('/en/shared-article', $result[0]->getUrl());
+    }
+
+    public function testPreloadFallbackToMainWebspace(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('other_site');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-3',
+                    'title' => 'Blog Article',
+                    'slug' => '/blog-article',
+                    'mainWebspace' => 'blog',
+                    'additionalWebspace' => null,
+                ],
+            ],
+            ['article-3'],
+            'en',
+            'live',
+            'other_site',
+        );
+
+        $this->webspaceManager->findUrlByResourceLocator('/blog-article', null, 'en', 'blog')
+            ->willReturn('/en/blog-article');
+
+        $this->referenceStore->add('article-3', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->articleLinkProvider->preload(['article-3'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('/en/blog-article', $result[0]->getUrl());
+    }
+
+    public function testPreloadNullWebspace(): void
+    {
+        $this->requestAnalyzer->getWebspace()->willReturn(null);
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-4',
+                    'title' => 'CLI Article',
+                    'slug' => '/cli-article',
+                    'mainWebspace' => 'blog',
+                ],
+            ],
+            ['article-4'],
+            'en',
+            'live',
+            null,
+        );
+
+        $this->webspaceManager->findUrlByResourceLocator('/cli-article', null, 'en', 'blog')
+            ->willReturn('/en/cli-article');
+
+        $this->referenceStore->add('article-4', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->articleLinkProvider->preload(['article-4'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('/en/cli-article', $result[0]->getUrl());
+    }
+
+    public function testPreloadDraftStage(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('blog');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-5',
+                    'title' => 'Draft Article',
+                    'slug' => '/draft-article',
+                    'mainWebspace' => 'blog',
+                    'additionalWebspace' => null,
+                ],
+            ],
+            ['article-5'],
+            'en',
+            'draft',
+            'blog',
+        );
+
+        $this->webspaceManager->findUrlByResourceLocator('/draft-article', null, 'en', 'blog')
+            ->willReturn('/en/draft-article');
+
+        $this->referenceStore->add('article-5', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->articleLinkProvider->preload(['article-5'], 'en', false)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('/en/draft-article', $result[0]->getUrl());
+        $this->assertFalse($result[0]->isPublished());
+    }
+
+    public function testPreloadNullSlug(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('blog');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-6',
+                    'title' => 'No Route Article',
+                    'slug' => null,
+                    'mainWebspace' => 'blog',
+                    'additionalWebspace' => null,
+                ],
+            ],
+            ['article-6'],
+            'en',
+            'live',
+            'blog',
+        );
+
+        $this->referenceStore->add('article-6', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->articleLinkProvider->preload(['article-6'], 'en', true)];
+
+        $this->assertCount(0, $result);
+    }
+
+    public function testPreloadNullMainWebspace(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('blog');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-7',
+                    'title' => 'Orphan Article',
+                    'slug' => '/orphan-article',
+                    'mainWebspace' => null,
+                    'additionalWebspace' => null,
+                ],
+            ],
+            ['article-7'],
+            'en',
+            'live',
+            'blog',
+        );
+
+        $this->referenceStore->add('article-7', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->articleLinkProvider->preload(['article-7'], 'en', true)];
+
+        $this->assertCount(0, $result);
+    }
+
+    public function testPreloadUrlResolutionReturnsNull(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('blog');
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-8',
+                    'title' => 'Unresolvable Article',
+                    'slug' => '/unresolvable',
+                    'mainWebspace' => 'blog',
+                    'additionalWebspace' => null,
+                ],
+            ],
+            ['article-8'],
+            'en',
+            'live',
+            'blog',
+        );
+
+        $this->webspaceManager->findUrlByResourceLocator('/unresolvable', null, 'en', 'blog')
+            ->willReturn(null);
+
+        $this->referenceStore->add('article-8', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->articleLinkProvider->preload(['article-8'], 'en', true)];
+
+        $this->assertCount(0, $result);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @param string[] $expectedUuids
+     */
+    private function mockQueryBuilder(
+        array $rows,
+        array $expectedUuids,
+        string $expectedLocale,
+        string $expectedStage,
+        ?string $expectedRequestWebspace,
+    ): void {
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+
+        $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->from(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->join(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->leftJoin(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->where(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->andWhere(Argument::cetera())->willReturn($queryBuilder);
+
+        $queryBuilder->setParameter('uuids', $expectedUuids)->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->setParameter('locale', $expectedLocale)->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->setParameter('stage', $expectedStage)->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->setParameter('version', 0)->willReturn($queryBuilder)->shouldBeCalled();
+
+        if (null !== $expectedRequestWebspace) {
+            $queryBuilder->addSelect('additionalWebspace.additionalWebspace')
+                ->willReturn($queryBuilder)->shouldBeCalled();
+            $queryBuilder->setParameter('requestWebspace', $expectedRequestWebspace)
+                ->willReturn($queryBuilder)->shouldBeCalled();
+        }
+
+        $query = $this->prophesize(Query::class);
+        $query->getArrayResult()->willReturn($rows);
+        $queryBuilder->getQuery()->willReturn($query->reveal());
+
+        $this->entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
+    }
+}

--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -15,13 +15,13 @@ namespace Sulu\Page\Infrastructure\Sulu\Content\ContentResolver;
 
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkUrlTrait;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentEnhancer\DimensionContentEnhancerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 
 /**
  * @internal This class should not be instantiated by a project.
@@ -35,7 +35,7 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         private PageRepositoryInterface $pageRepository,
         private ContentAggregatorInterface $contentAggregator,
         private LinkProviderPoolInterface $linkProviderPool,
-        private WebspaceManagerInterface $webspaceManager,
+        private RouteGeneratorInterface $routeGenerator,
     ) {
     }
 
@@ -117,15 +117,14 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         /** @var PageInterface $targetPage */
         $targetPage = $targetDimensionContent->getResource();
         $url = null !== $route && null !== $targetLocale
-            ? $this->webspaceManager->findUrlByResourceLocator(
+            ? $this->routeGenerator->generate(
                 $route->getSlug(),
-                null,
                 $targetLocale,
                 $targetPage->getWebspaceKey(),
             )
             : null;
 
-        if (\is_string($url) && null !== $linkData) {
+        if (null !== $url && null !== $linkData) {
             $url = $this->appendQueryAndAnchor($url, $linkData);
         }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -14,10 +14,13 @@ declare(strict_types=1);
 namespace Sulu\Page\Infrastructure\Sulu\Content\ContentResolver;
 
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkUrlTrait;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentEnhancer\DimensionContentEnhancerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 
 /**
@@ -26,16 +29,23 @@ use Sulu\Page\Domain\Repository\PageRepositoryInterface;
  */
 class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterface
 {
+    use LinkUrlTrait;
+
     public function __construct(
         private PageRepositoryInterface $pageRepository,
         private ContentAggregatorInterface $contentAggregator,
         private LinkProviderPoolInterface $linkProviderPool,
+        private WebspaceManagerInterface $webspaceManager,
     ) {
     }
 
     public function enhance(DimensionContentInterface $dimensionContent): DimensionContentInterface
     {
         if (!$dimensionContent instanceof PageDimensionContentInterface) {
+            return $dimensionContent;
+        }
+
+        if (null === $dimensionContent->getLocale()) {
             return $dimensionContent;
         }
 
@@ -102,7 +112,19 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         /** @var PageDimensionContentInterface $targetDimensionContent */
         $targetDimensionContent = $this->contentAggregator->aggregate($page, $dimensionAttributes);
 
-        $url = $targetDimensionContent->getTemplateData()['url'] ?? null;
+        $route = $targetDimensionContent->getRoute();
+        $targetLocale = $targetDimensionContent->getLocale();
+        /** @var PageInterface $targetPage */
+        $targetPage = $targetDimensionContent->getResource();
+        $url = null !== $route && null !== $targetLocale
+            ? $this->webspaceManager->findUrlByResourceLocator(
+                $route->getSlug(),
+                null,
+                $targetLocale,
+                $targetPage->getWebspaceKey(),
+            )
+            : null;
+
         if (\is_string($url) && null !== $linkData) {
             $url = $this->appendQueryAndAnchor($url, $linkData);
         }
@@ -131,12 +153,13 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
 
         $url = $linkData['href'] ?? null;
         $provider = $linkData['provider'] ?? null;
-        if (!\is_string($provider) || !\is_string($url)) {
+        $locale = $pageDimensionContent->getLocale();
+        if (!\is_string($provider) || !\is_string($url) || null === $locale) {
             return $pageDimensionContent;
         }
 
         $linkProvider = $this->linkProviderPool->getProvider($provider);
-        $preloadResult = $linkProvider->preload([$url], $pageDimensionContent->getLocale() ?? 'en');
+        $preloadResult = $linkProvider->preload([$url], $locale);
         $linkItem = [...$preloadResult][0] ?? null;
 
         if (null === $linkItem) {
@@ -156,22 +179,5 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         ]);
 
         return $pageDimensionContent;
-    }
-
-    /**
-     * Append query string and anchor to a URL based on linkData.
-     *
-     * @param array<string, mixed> $linkData
-     */
-    private function appendQueryAndAnchor(string $url, array $linkData): string
-    {
-        if (isset($linkData['query']) && \is_string($linkData['query'])) {
-            $url = \sprintf('%s?%s', $url, \ltrim($linkData['query'], '?'));
-        }
-        if (isset($linkData['anchor']) && \is_string($linkData['anchor'])) {
-            $url = \sprintf('%s#%s', $url, \ltrim($linkData['anchor'], '#'));
-        }
-
-        return $url;
     }
 }

--- a/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
@@ -19,10 +19,10 @@ use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkUrlTrait;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -35,7 +35,7 @@ final class PageLinkProvider implements LinkProviderInterface
 
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
-        private readonly WebspaceManagerInterface $webspaceManager,
+        private readonly RouteGeneratorInterface $routeGenerator,
         private readonly ReferenceStoreInterface $referenceStore,
         private readonly TranslatorInterface $translator,
     ) {
@@ -174,16 +174,11 @@ final class PageLinkProvider implements LinkProviderInterface
                 return null;
             }
 
-            $url = $this->webspaceManager->findUrlByResourceLocator(
+            $url = $this->routeGenerator->generate(
                 $target['slug'],
-                null,
                 $locale,
                 $target['webspaceKey'],
             );
-
-            if (null === $url) {
-                return null;
-            }
 
             return $this->appendQueryAndAnchor($url, $linkData);
         }
@@ -193,9 +188,8 @@ final class PageLinkProvider implements LinkProviderInterface
             return null;
         }
 
-        return $this->webspaceManager->findUrlByResourceLocator(
+        return $this->routeGenerator->generate(
             $row['slug'],
-            null,
             $locale,
             $row['webspaceKey'],
         );

--- a/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
@@ -13,30 +13,29 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Infrastructure\Sulu\Content;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
-use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
-use Sulu\Content\Application\ContentEnhancer\ContentEnhancerInterface;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkUrlTrait;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
-use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageInterface;
-use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Webmozart\Assert\Assert;
 
 /**
- * @interal This class is an integration to the SuluMarkupBundle and can be changed any time.
- *          Use Symfony dependency injection service decoration and change the behaviour if you need.
+ * @internal This class is an integration to the SuluMarkupBundle and can be changed any time.
+ *           Use Symfony dependency injection service decoration and change the behaviour if you need.
  */
 final class PageLinkProvider implements LinkProviderInterface
 {
+    use LinkUrlTrait;
+
     public function __construct(
-        private readonly ContentAggregatorInterface $contentAggregator,
-        private readonly ContentEnhancerInterface $contentEnhancer,
-        private readonly PageRepositoryInterface $pageRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly WebspaceManagerInterface $webspaceManager,
         private readonly ReferenceStoreInterface $referenceStore,
         private readonly TranslatorInterface $translator,
     ) {
@@ -56,51 +55,149 @@ final class PageLinkProvider implements LinkProviderInterface
 
     public function preload(array $hrefs, string $locale, bool $published = true): iterable
     {
-        $dimensionAttributes = [
-            'locale' => $locale,
-            'stage' => $published ? DimensionContentInterface::STAGE_LIVE : DimensionContentInterface::STAGE_DRAFT,
-            'version' => DimensionContentInterface::CURRENT_VERSION,
-        ];
+        if ([] === $hrefs) {
+            return [];
+        }
 
-        $pages = $this->pageRepository->findBy(
-            filters: [
-                'uuids' => $hrefs,
-                'locale' => $locale,
-                'stage' => $dimensionAttributes['stage'],
-                'version' => DimensionContentInterface::CURRENT_VERSION,
-            ],
-            selects: [
-                PageRepositoryInterface::SELECT_PAGE_CONTENT => [
-                    DimensionContentQueryEnhancer::GROUP_SELECT_CONTENT_WEBSITE => true,
-                ],
-            ]
-        );
+        $stage = $published ? DimensionContentInterface::STAGE_LIVE : DimensionContentInterface::STAGE_DRAFT;
+        $version = DimensionContentInterface::CURRENT_VERSION;
+
+        $rows = $this->findPagesByUuids($hrefs, $locale, $stage, $version);
+
+        $internalLinkTargetUuids = [];
+        foreach ($rows as $row) {
+            if ('page' === $row['linkProvider'] && \is_array($row['linkData']) && \is_string($row['linkData']['href'] ?? null)) {
+                $internalLinkTargetUuids[] = $row['linkData']['href'];
+            }
+        }
+
+        $targetRoutes = [];
+        if ([] !== $internalLinkTargetUuids) {
+            $targetRows = $this->findTargetPageRoutes($internalLinkTargetUuids, $locale, $stage, $version);
+
+            foreach ($targetRows as $targetRow) {
+                $targetRoutes[$targetRow['uuid']] = [
+                    'slug' => $targetRow['slug'],
+                    'webspaceKey' => $targetRow['webspaceKey'],
+                ];
+            }
+        }
 
         $result = [];
-        foreach ($pages as $page) {
-            $dimensionContent = $this->contentAggregator->aggregate($page, $dimensionAttributes);
-            $dimensionContent = $this->contentEnhancer->enhance($dimensionContent);
-            Assert::isInstanceOf($dimensionContent, PageDimensionContentInterface::class);
+        foreach ($rows as $row) {
+            $this->referenceStore->add($row['uuid'], PageInterface::RESOURCE_KEY);
 
-            $this->referenceStore->add($page->getId(), PageInterface::RESOURCE_KEY);
-
-            /** @var array<string, mixed> $templateData */
-            $templateData = $dimensionContent->getTemplateData();
-            /** @var string|null $url */
-            $url = $templateData['url'] ?? null;
+            $url = $this->resolveUrl($row, $targetRoutes, $locale);
             if (null === $url) {
-                // TODO what to do when there is no url?
                 continue;
             }
 
             $result[] = new LinkItem(
-                $page->getUuid(),
-                (string) $dimensionContent->getTitle(),
+                $row['uuid'],
+                (string) ($row['title'] ?? ''),
                 $url,
-                $published
+                $published,
             );
         }
 
         return $result;
+    }
+
+    /**
+     * @param string[] $uuids
+     *
+     * @return list<array{uuid: string, title: ?string, slug: ?string, webspaceKey: string, linkProvider: ?string, linkData: ?array<string, mixed>}>
+     */
+    private function findPagesByUuids(array $uuids, string $locale, string $stage, int $version): array
+    {
+        /** @var list<array{uuid: string, title: ?string, slug: ?string, webspaceKey: string, linkProvider: ?string, linkData: ?array<string, mixed>}> */
+        return $this->entityManager->createQueryBuilder()
+            ->select('page.uuid', 'dimensionContent.title', 'route.slug', 'page.webspaceKey',
+                'dimensionContent.linkProvider', 'dimensionContent.linkData')
+            ->from(PageDimensionContent::class, 'dimensionContent')
+            ->join('dimensionContent.page', 'page')
+            ->leftJoin('dimensionContent.route', 'route')
+            ->where('page.uuid IN (:uuids)')
+            ->andWhere('dimensionContent.locale = :locale')
+            ->andWhere('dimensionContent.stage = :stage')
+            ->andWhere('dimensionContent.version = :version')
+            ->setParameter('uuids', $uuids)
+            ->setParameter('locale', $locale)
+            ->setParameter('stage', $stage)
+            ->setParameter('version', $version)
+            ->getQuery()
+            ->getArrayResult();
+    }
+
+    /**
+     * @param string[] $targetUuids
+     *
+     * @return list<array{uuid: string, slug: ?string, webspaceKey: string}>
+     */
+    private function findTargetPageRoutes(array $targetUuids, string $locale, string $stage, int $version): array
+    {
+        /** @var list<array{uuid: string, slug: ?string, webspaceKey: string}> */
+        return $this->entityManager->createQueryBuilder()
+            ->select('page.uuid', 'route.slug', 'page.webspaceKey')
+            ->from(PageDimensionContent::class, 'dimensionContent')
+            ->join('dimensionContent.page', 'page')
+            ->leftJoin('dimensionContent.route', 'route')
+            ->where('page.uuid IN (:targetUuids)')
+            ->andWhere('dimensionContent.locale = :locale')
+            ->andWhere('dimensionContent.stage = :stage')
+            ->andWhere('dimensionContent.version = :version')
+            ->setParameter('targetUuids', $targetUuids)
+            ->setParameter('locale', $locale)
+            ->setParameter('stage', $stage)
+            ->setParameter('version', $version)
+            ->getQuery()
+            ->getArrayResult();
+    }
+
+    /**
+     * @param array{uuid: string, title: ?string, slug: ?string, webspaceKey: string, linkProvider: ?string, linkData: ?array<string, mixed>} $row
+     * @param array<string, array{slug: ?string, webspaceKey: string}> $targetRoutes
+     */
+    private function resolveUrl(array $row, array $targetRoutes, string $locale): ?string
+    {
+        $linkProvider = $row['linkProvider'];
+        $linkData = $row['linkData'];
+
+        if ('external' === $linkProvider && \is_array($linkData) && \is_string($linkData['href'] ?? null)) {
+            return $this->appendQueryAndAnchor($linkData['href'], $linkData);
+        }
+
+        if ('page' === $linkProvider && \is_array($linkData) && \is_string($linkData['href'] ?? null)) {
+            $targetUuid = $linkData['href'];
+            $target = $targetRoutes[$targetUuid] ?? null;
+            if (null === $target || null === $target['slug']) {
+                return null;
+            }
+
+            $url = $this->webspaceManager->findUrlByResourceLocator(
+                $target['slug'],
+                null,
+                $locale,
+                $target['webspaceKey'],
+            );
+
+            if (null === $url) {
+                return null;
+            }
+
+            return $this->appendQueryAndAnchor($url, $linkData);
+        }
+
+        // Unknown link providers (or no link provider) fall through to using the page's own route
+        if (null === $row['slug']) {
+            return null;
+        }
+
+        return $this->webspaceManager->findUrlByResourceLocator(
+            $row['slug'],
+            null,
+            $locale,
+            $row['webspaceKey'],
+        );
     }
 }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -278,7 +278,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_markup.link_tag.provider_pool'),
-                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_route.route_generator'),
             ])
             ->tag('sulu_content.dimension_content_enhancer');
 
@@ -431,7 +431,7 @@ final class SuluPageBundle extends AbstractBundle
             ->class(PageLinkProvider::class)
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
-                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_route.route_generator'),
                 new Reference('sulu_http_cache.reference_store'),
                 new Reference('translator'),
             ])

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -278,6 +278,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_markup.link_tag.provider_pool'),
+                new Reference('sulu_core.webspace.webspace_manager'),
             ])
             ->tag('sulu_content.dimension_content_enhancer');
 
@@ -429,9 +430,8 @@ final class SuluPageBundle extends AbstractBundle
         $services->set('sulu_page.page_link_provider')
             ->class(PageLinkProvider::class)
             ->args([
-                new Reference('sulu_content.content_aggregator'),
-                new Reference('sulu_content.content_enhancer'),
-                new Reference('sulu_page.page_repository'),
+                new Reference('doctrine.orm.entity_manager'),
+                new Reference('sulu_core.webspace.webspace_manager'),
                 new Reference('sulu_http_cache.reference_store'),
                 new Reference('translator'),
             ])

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Symfony\Component\Routing\RequestContext;
 
 #[CoversNothing]
 class NavigationRepositoryLinkTest extends SuluTestCase
@@ -62,6 +63,10 @@ class NavigationRepositoryLinkTest extends SuluTestCase
     {
         parent::setUp();
         $this->navigationRepository = $this->getContainer()->get('sulu_page.navigation_repository');
+
+        /** @var RequestContext $requestContext */
+        $requestContext = self::getContainer()->get('router')->getContext();
+        $requestContext->setParameter('webspace', 'sulu-io');
     }
 
     public static function setUpBeforeClass(): void

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -175,7 +175,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         /** @var array<string, mixed> $internalLinkNav */
         $internalLinkNav = $navigation[2];
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
-        $this->assertSame('/target-page', $internalLinkNav['url']);
+        $this->assertSame('http://sulu.io/en/target-page', $internalLinkNav['url']);
         $this->assertSame('sulu-io', $internalLinkNav['webspaceKey']);
 
         // Test external link resolve url
@@ -239,7 +239,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         /** @var array<string, mixed> $internalLinkNav */
         $internalLinkNav = $homepageChildren[1];
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
-        $this->assertSame('/target-page', $internalLinkNav['url']);
+        $this->assertSame('http://sulu.io/en/target-page', $internalLinkNav['url']);
         $this->assertArrayHasKey('children', $internalLinkNav);
 
         // Test external link resolve url

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageLinkProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageLinkProviderTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Symfony\Component\Routing\RequestContext;
 
 #[CoversNothing]
 class PageLinkProviderTest extends SuluTestCase
@@ -37,6 +38,10 @@ class PageLinkProviderTest extends SuluTestCase
         parent::setUp();
 
         $this->linkProvider = self::getContainer()->get('sulu_page.page_link_provider');
+
+        /** @var RequestContext $requestContext */
+        $requestContext = self::getContainer()->get('router')->getContext();
+        $requestContext->setParameter('webspace', 'sulu-io');
     }
 
     public function testPreloadWithContentLinks(): void

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageLinkProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageLinkProviderTest.php
@@ -108,10 +108,10 @@ class PageLinkProviderTest extends SuluTestCase
             $linksByUuid[$link->getId()] = $link;
         }
 
-        // Test content link - shows own title and URL
+        // Test content link - shows own title and URL resolved via webspace manager
         $this->assertArrayHasKey($contentPage->getUuid(), $linksByUuid);
         $this->assertSame('Content Page', $linksByUuid[$contentPage->getUuid()]->getTitle());
-        $this->assertSame('/content-page', $linksByUuid[$contentPage->getUuid()]->getUrl());
+        $this->assertSame('http://sulu.io/en/content-page', $linksByUuid[$contentPage->getUuid()]->getUrl());
 
         // Test external link - shows external URL with page's own title
         $this->assertArrayHasKey($externalPage->getUuid(), $linksByUuid);
@@ -121,6 +121,6 @@ class PageLinkProviderTest extends SuluTestCase
         // Test internal link - resolves to target page's URL with custom title
         $this->assertArrayHasKey($internalPage->getUuid(), $linksByUuid);
         $this->assertSame('Internal Link Page', $linksByUuid[$internalPage->getUuid()]->getTitle());
-        $this->assertSame('/link-target', $linksByUuid[$internalPage->getUuid()]->getUrl());
+        $this->assertSame('http://sulu.io/en/link-target', $linksByUuid[$internalPage->getUuid()]->getUrl());
     }
 }

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentResolverTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentResolverTest.php
@@ -162,7 +162,7 @@ class PageSmartContentResolverTest extends SuluTestCase
 
         // Test internal link - resolves to target page's URL with custom title
         $this->assertArrayHasKey('Internal Link Page', $pagesByTitle);
-        $this->assertSame('/target-page', $pagesByTitle['Internal Link Page']['url']);
+        $this->assertSame('http://sulu.io/en/target-page', $pagesByTitle['Internal Link Page']['url']);
         $this->assertSame('Internal Link Page', $pagesByTitle['Internal Link Page']['title']);
     }
 }

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentResolverTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentResolverTest.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Symfony\Component\Routing\RequestContext;
 
 #[CoversNothing]
 class PageSmartContentResolverTest extends SuluTestCase
@@ -40,6 +41,10 @@ class PageSmartContentResolverTest extends SuluTestCase
 
         $this->contentResolver = self::getContainer()->get('sulu_content.content_resolver');
         $this->contentAggregator = self::getContainer()->get('sulu_content.content_aggregator');
+
+        /** @var RequestContext $requestContext */
+        $requestContext = self::getContainer()->get('router')->getContext();
+        $requestContext->setParameter('webspace', 'sulu-io');
     }
 
     public function testResolveSmartContentWithLinks(): void

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
@@ -11,16 +11,17 @@
 
 namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
-use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
-use Sulu\Content\Application\ContentEnhancer\ContentEnhancerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Page\Domain\Model\PageInterface;
-use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -30,19 +31,14 @@ class PageLinkProviderTest extends TestCase
     use SetGetPrivatePropertyTrait;
 
     /**
-     * @var ObjectProphecy<ContentAggregatorInterface>
+     * @var ObjectProphecy<EntityManagerInterface>
      */
-    private ObjectProphecy $contentAggregator;
+    private ObjectProphecy $entityManager;
 
     /**
-     * @var ObjectProphecy<ContentEnhancerInterface>
+     * @var ObjectProphecy<WebspaceManagerInterface>
      */
-    private ObjectProphecy $contentEnhancer;
-
-    /**
-     * @var ObjectProphecy<PageRepositoryInterface>
-     */
-    private ObjectProphecy $pageRepository;
+    private ObjectProphecy $webspaceManager;
 
     /**
      * @var ObjectProphecy<ReferenceStoreInterface>
@@ -58,19 +54,17 @@ class PageLinkProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
-        $this->contentEnhancer = $this->prophesize(ContentEnhancerInterface::class);
-        $this->pageRepository = $this->prophesize(PageRepositoryInterface::class);
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $this->translator = $this->prophesize(TranslatorInterface::class);
         $this->translator->trans(Argument::cetera())->willReturnArgument(0);
 
         $this->pageLinkProvider = new PageLinkProvider(
-            $this->contentAggregator->reveal(),
-            $this->contentEnhancer->reveal(),
-            $this->pageRepository->reveal(),
+            $this->entityManager->reveal(),
+            $this->webspaceManager->reveal(),
             $this->referenceStore->reveal(),
-            $this->translator->reveal()
+            $this->translator->reveal(),
         );
     }
 
@@ -92,5 +86,225 @@ class PageLinkProviderTest extends TestCase
         $this->assertSame([
             'title',
         ], self::getPrivateProperty($linkConfiguration, 'displayProperties'));
+    }
+
+    public function testPreloadEmptyHrefs(): void
+    {
+        $result = $this->pageLinkProvider->preload([], 'en');
+
+        $this->assertSame([], $result);
+    }
+
+    public function testPreloadRegularPage(): void
+    {
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'uuid-1',
+                    'title' => 'Test Page',
+                    'slug' => '/test-page',
+                    'webspaceKey' => 'sulu_io',
+                    'linkProvider' => null,
+                    'linkData' => null,
+                ],
+            ],
+            ['uuid-1'],
+            'en',
+            'live',
+        );
+
+        $this->webspaceManager->findUrlByResourceLocator('/test-page', null, 'en', 'sulu_io')
+            ->willReturn('/en/test-page');
+
+        $this->referenceStore->add('uuid-1', PageInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->pageLinkProvider->preload(['uuid-1'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('uuid-1', $result[0]->getId());
+        $this->assertSame('Test Page', $result[0]->getTitle());
+        $this->assertSame('/en/test-page', $result[0]->getUrl());
+        $this->assertTrue($result[0]->isPublished());
+    }
+
+    public function testPreloadExternalLink(): void
+    {
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'uuid-ext',
+                    'title' => 'External Page',
+                    'slug' => '/external-page',
+                    'webspaceKey' => 'sulu_io',
+                    'linkProvider' => 'external',
+                    'linkData' => ['href' => 'https://example.com', 'query' => 'foo=bar', 'anchor' => 'section'],
+                ],
+            ],
+            ['uuid-ext'],
+            'en',
+            'live',
+        );
+
+        $this->referenceStore->add('uuid-ext', PageInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->pageLinkProvider->preload(['uuid-ext'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('https://example.com?foo=bar#section', $result[0]->getUrl());
+    }
+
+    public function testPreloadInternalLink(): void
+    {
+        $mainQueryBuilder = $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'uuid-link',
+                    'title' => 'Link Page',
+                    'slug' => '/link-page',
+                    'webspaceKey' => 'sulu_io',
+                    'linkProvider' => 'page',
+                    'linkData' => ['href' => 'uuid-target'],
+                ],
+            ],
+            ['uuid-link'],
+            'en',
+            'live',
+        );
+
+        $targetQueryBuilder = $this->createQueryBuilderMock(
+            [
+                [
+                    'uuid' => 'uuid-target',
+                    'slug' => '/target-page',
+                    'webspaceKey' => 'sulu_io',
+                ],
+            ],
+            ['uuid-target'],
+            'en',
+            'live',
+            'targetUuids',
+        );
+
+        $this->entityManager->createQueryBuilder()
+            ->willReturn($mainQueryBuilder->reveal(), $targetQueryBuilder->reveal());
+
+        $this->webspaceManager->findUrlByResourceLocator('/target-page', null, 'en', 'sulu_io')
+            ->willReturn('/en/target-page');
+
+        $this->referenceStore->add('uuid-link', PageInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->pageLinkProvider->preload(['uuid-link'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('uuid-link', $result[0]->getId());
+        $this->assertSame('Link Page', $result[0]->getTitle());
+        $this->assertSame('/en/target-page', $result[0]->getUrl());
+    }
+
+    public function testPreloadMissingRoute(): void
+    {
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'uuid-no-route',
+                    'title' => 'No Route Page',
+                    'slug' => null,
+                    'webspaceKey' => 'sulu_io',
+                    'linkProvider' => null,
+                    'linkData' => null,
+                ],
+            ],
+            ['uuid-no-route'],
+            'en',
+            'live',
+        );
+
+        $this->referenceStore->add('uuid-no-route', PageInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->pageLinkProvider->preload(['uuid-no-route'], 'en', true)];
+
+        $this->assertCount(0, $result);
+    }
+
+    public function testPreloadDraftStage(): void
+    {
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'uuid-draft',
+                    'title' => 'Draft Page',
+                    'slug' => '/draft-page',
+                    'webspaceKey' => 'sulu_io',
+                    'linkProvider' => null,
+                    'linkData' => null,
+                ],
+            ],
+            ['uuid-draft'],
+            'en',
+            'draft',
+        );
+
+        $this->webspaceManager->findUrlByResourceLocator('/draft-page', null, 'en', 'sulu_io')
+            ->willReturn('/en/draft-page');
+
+        $this->referenceStore->add('uuid-draft', PageInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->pageLinkProvider->preload(['uuid-draft'], 'en', false)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('/en/draft-page', $result[0]->getUrl());
+        $this->assertFalse($result[0]->isPublished());
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @param string[] $expectedUuids
+     *
+     * @return ObjectProphecy<QueryBuilder>
+     */
+    private function mockQueryBuilder(
+        array $rows,
+        array $expectedUuids,
+        string $expectedLocale,
+        string $expectedStage,
+    ): ObjectProphecy {
+        $queryBuilder = $this->createQueryBuilderMock($rows, $expectedUuids, $expectedLocale, $expectedStage);
+        $this->entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
+
+        return $queryBuilder;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     * @param string[] $expectedUuids
+     *
+     * @return ObjectProphecy<QueryBuilder>
+     */
+    private function createQueryBuilderMock(
+        array $rows,
+        array $expectedUuids,
+        string $expectedLocale,
+        string $expectedStage,
+        string $uuidParameterName = 'uuids',
+    ): ObjectProphecy {
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+
+        $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->from(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->join(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->leftJoin(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->where(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->andWhere(Argument::cetera())->willReturn($queryBuilder);
+
+        $queryBuilder->setParameter($uuidParameterName, $expectedUuids)->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->setParameter('locale', $expectedLocale)->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->setParameter('stage', $expectedStage)->willReturn($queryBuilder)->shouldBeCalled();
+        $queryBuilder->setParameter('version', 0)->willReturn($queryBuilder)->shouldBeCalled();
+
+        $query = $this->prophesize(Query::class);
+        $query->getArrayResult()->willReturn($rows);
+        $queryBuilder->getQuery()->willReturn($query->reveal());
+
+        return $queryBuilder;
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
@@ -20,9 +20,11 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
+use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PageLinkProviderTest extends TestCase
@@ -35,10 +37,7 @@ class PageLinkProviderTest extends TestCase
      */
     private ObjectProphecy $entityManager;
 
-    /**
-     * @var ObjectProphecy<WebspaceManagerInterface>
-     */
-    private ObjectProphecy $webspaceManager;
+    private RouteGeneratorInterface $routeGenerator;
 
     /**
      * @var ObjectProphecy<ReferenceStoreInterface>
@@ -55,14 +54,31 @@ class PageLinkProviderTest extends TestCase
     protected function setUp(): void
     {
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
-        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $this->referenceStore = $this->prophesize(ReferenceStoreInterface::class);
         $this->translator = $this->prophesize(TranslatorInterface::class);
         $this->translator->trans(Argument::cetera())->willReturnArgument(0);
 
+        $webspaceRouteGenerator = new class() implements WebspaceRouteGeneratorInterface {
+            public function generate(RequestContext $requestContext, string $slug, string $locale): string
+            {
+                return \sprintf('/%s%s', $locale, $slug);
+            }
+        };
+
+        $this->routeGenerator = new class($webspaceRouteGenerator) implements RouteGeneratorInterface {
+            public function __construct(private WebspaceRouteGeneratorInterface $webspaceRouteGenerator)
+            {
+            }
+
+            public function generate(string $slug, ?string $locale = null, ?string $webspace = null, int $referenceType = 0): string
+            {
+                return $this->webspaceRouteGenerator->generate(new RequestContext(), $slug, $locale ?? 'en');
+            }
+        };
+
         $this->pageLinkProvider = new PageLinkProvider(
             $this->entityManager->reveal(),
-            $this->webspaceManager->reveal(),
+            $this->routeGenerator,
             $this->referenceStore->reveal(),
             $this->translator->reveal(),
         );
@@ -112,9 +128,6 @@ class PageLinkProviderTest extends TestCase
             'en',
             'live',
         );
-
-        $this->webspaceManager->findUrlByResourceLocator('/test-page', null, 'en', 'sulu_io')
-            ->willReturn('/en/test-page');
 
         $this->referenceStore->add('uuid-1', PageInterface::RESOURCE_KEY)->shouldBeCalled();
 
@@ -188,9 +201,6 @@ class PageLinkProviderTest extends TestCase
         $this->entityManager->createQueryBuilder()
             ->willReturn($mainQueryBuilder->reveal(), $targetQueryBuilder->reveal());
 
-        $this->webspaceManager->findUrlByResourceLocator('/target-page', null, 'en', 'sulu_io')
-            ->willReturn('/en/target-page');
-
         $this->referenceStore->add('uuid-link', PageInterface::RESOURCE_KEY)->shouldBeCalled();
 
         $result = [...$this->pageLinkProvider->preload(['uuid-link'], 'en', true)];
@@ -243,9 +253,6 @@ class PageLinkProviderTest extends TestCase
             'en',
             'draft',
         );
-
-        $this->webspaceManager->findUrlByResourceLocator('/draft-page', null, 'en', 'sulu_io')
-            ->willReturn('/en/draft-page');
 
         $this->referenceStore->add('uuid-draft', PageInterface::RESOURCE_KEY)->shouldBeCalled();
 

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkUrlTrait.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkUrlTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MarkupBundle\Markup\Link;
+
+/**
+ * @internal
+ */
+trait LinkUrlTrait
+{
+    /**
+     * @param array<string, mixed> $linkData
+     */
+    private function appendQueryAndAnchor(string $url, array $linkData): string
+    {
+        if (isset($linkData['query']) && \is_string($linkData['query'])) {
+            $url = \sprintf('%s?%s', $url, \ltrim($linkData['query'], '?'));
+        }
+        if (isset($linkData['anchor']) && \is_string($linkData['anchor'])) {
+            $url = \sprintf('%s#%s', $url, \ltrim($linkData['anchor'], '#'));
+        }
+
+        return $url;
+    }
+}


### PR DESCRIPTION
 | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #8611
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Replaced entity hydration in `PageLinkProvider` and `ArticleLinkProvider` with direct DQL queries that fetch only the columns needed (uuid, title, slug, webspaceKey)
  - Resolved URLs via `WebspaceManagerInterface::findUrlByResourceLocator()` instead of relying on `templateData['url']` which was never populated
  - Fixed `PageLinkDimensionContentEnhancer` to resolve internal link URLs from routes instead of reading empty template data
  - Added webspace-aware URL resolution for articles (mainWebspace / additionalWebspace / requestWebspace fallback)
  - Extracted shared `LinkUrlTrait` for query string and anchor appending
  - Added comprehensive unit tests for both providers including edge cases (draft stage, null slug, null webspace, unresolvable URLs)

  #### Why?

  In Sulu 3.0, `PageLinkProvider`, `ArticleLinkProvider` did not take the webspace localization into account on the generated urls.

  The fix replaces the heavy ContentManager/ContentAggregator abstraction layer with lean DQL queries and uses `findUrlByResourceLocator()` to build full URLs from route slugs.