### PR TITLE
Fix smart content provider (Page webspace permissions, article webspace filter)

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -48,6 +48,7 @@ use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
  *       audienceTargeting?: bool,
  *       targetGroupId?: int,
  *       segmentKey?: string,
+ *       webspaceKey?: string,
  *   }
  * @phpstan-type ArticleSmartContentCountFilters array{
  *        categories: int[],
@@ -69,6 +70,7 @@ use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
  *        audienceTargeting?: bool,
  *        targetGroupId?: int,
  *        segmentKey?: string,
+ *        webspaceKey?: string,
  *    }
  */
 readonly class ArticleSmartContentProvider implements SmartContentProviderInterface
@@ -247,7 +249,8 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      *         offset?: int,
      *         includeSubFolders: bool,
      *         excludeDuplicates: bool,
-     *         audienceTargeting?: bool
+     *         audienceTargeting?: bool,
+     *         webspaceKey?: string
      *     }
      */
     protected function mapFilters(array $filters): array
@@ -283,6 +286,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      *     websiteCategoryOperator: 'AND'|'OR',
      *     websiteTags: string[],
      *     websiteTagOperator: 'AND'|'OR',
+     *     webspaceKey?: string,
      *  } $filters
      */
     protected function addInternalFilters(QueryBuilder $queryBuilder, array $filters, string $alias): void
@@ -311,6 +315,13 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
                 $websiteTagNames,
                 $filters['websiteTagOperator'],
             );
+        }
+
+        $webspaceKey = $filters['webspaceKey'] ?? null;
+        if (null !== $webspaceKey) {
+            $queryBuilder->leftJoin('filterDimensionContent.additionalWebspaces', 'additionalWebspace');
+            $queryBuilder->andWhere('filterDimensionContent.mainWebspace = :webspaceKey OR additionalWebspace.additionalWebspace = :webspaceKey');
+            $queryBuilder->setParameter('webspaceKey', $webspaceKey);
         }
     }
 

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Article\Tests\Functional\Infrastructure\Sulu\Content;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Sulu\Article\Application\Message\ApplyWorkflowTransitionArticleMessage;
 use Sulu\Article\Application\Message\CreateArticleMessage;
+use Sulu\Article\Application\Message\ModifyArticleMessage;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
@@ -41,6 +42,8 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
  *     excerptTags?: string[],
  *     author?: int|null,
  *     authored?: string|null,
+ *     mainWebspace?: string,
+ *     additionalWebspace?: string[],
  * }
  *
  * @phpstan-import-type SmartContentBaseFilters from SmartContentProviderInterface
@@ -128,12 +131,35 @@ class ArticleSmartContentProviderTest extends SuluTestCase
             'template' => 'blog',
         ]);
 
+        self::modifyArticle(
+            self::$articles['tech2']->getUuid(),
+            [
+                'title' => 'Cloud Computing',
+                'excerptCategories' => [self::$categories['tech']->getId(), self::$categories['business']->getId()],
+                'excerptTags' => [self::$tags['cloud']],
+                'authored' => '2023-02-20T14:30:00+00:00',
+                'template' => 'blog',
+                'mainWebspaceKey' => 'blog',
+            ],
+        );
+
         self::$articles['sports1'] = self::createArticle([
             'title' => 'Football Season',
             'excerptCategories' => [self::$categories['sports']->getId()],
             'excerptTags' => [self::$tags['football']],
             'authored' => '2023-03-10T09:15:00+00:00',
         ]);
+
+        self::modifyArticle(
+            self::$articles['sports1']->getUuid(),
+            [
+                'title' => 'Football Season',
+                'excerptCategories' => [self::$categories['sports']->getId()],
+                'excerptTags' => [self::$tags['football']],
+                'authored' => '2023-03-10T09:15:00+00:00',
+                'additionalWebspace' => ['blog'],
+            ],
+        );
 
         self::$articles['sports2'] = self::createArticle([
             'title' => 'Tennis Championship',
@@ -704,6 +730,45 @@ class ArticleSmartContentProviderTest extends SuluTestCase
     }
 
     /**
+     * @param ArticleData $data
+     */
+    private static function modifyArticle(
+        string $identifier,
+        array $data,
+    ): ArticleInterface {
+        $data = \array_merge([
+            'title' => 'Example Article',
+            'url' => '/example-article-' . \uniqid(),
+            'template' => 'article',
+            'locale' => 'en',
+            'mainWebspace' => 'blog',
+            'customizeWebspaceSettings' => true,
+            'additionalWebspaces' => [],
+        ], $data);
+
+        $messageBus = self::getContainer()->get('sulu_message_bus');
+
+        $envelope = $messageBus->dispatch(new Envelope(new ModifyArticleMessage(identifier: ['uuid' => $identifier], data: $data), [new EnableFlushStamp()]));
+        /** @var HandledStamp[] $handledStamps */
+        $handledStamps = $envelope->all(HandledStamp::class);
+
+        /** @var ArticleInterface $article */
+        $article = $handledStamps[0]->getResult();
+        $messageBus->dispatch(
+            new Envelope(
+                new ApplyWorkflowTransitionArticleMessage(
+                    identifier: ['uuid' => $article->getUuid()],
+                    locale: $data['locale'],
+                    transitionName: WorkflowInterface::WORKFLOW_TRANSITION_PUBLISH,
+                ),
+                [new EnableFlushStamp()],
+            ),
+        );
+
+        return $article;
+    }
+
+    /**
      * @param string[] $groups
      * @param string[] $articleKeys
      */
@@ -735,6 +800,20 @@ class ArticleSmartContentProviderTest extends SuluTestCase
             }
             $this->assertContains($article->getUuid(), $resultIds, "Article '$key' should be in the default group");
         }
+    }
+
+    public function testFindFlatByWebspace(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy([...$this->getDefaultFilters(), ...['locale' => 'en', 'webspaceKey' => 'blog']], []);
+        $this->assertCount(2, $result);
+
+        $resultIds = \array_map(
+            fn ($article) => $article['id'],
+            $result,
+        );
+
+        $this->assertContains(self::$articles['tech2']->getUuid(), $resultIds);
+        $this->assertContains(self::$articles['sports1']->getUuid(), $resultIds);
     }
 
     /**

--- a/packages/page/src/Infrastructure/Sulu/Content/Visitor/WebspaceSmartContentFiltersVisitor.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/Visitor/WebspaceSmartContentFiltersVisitor.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * @internal This class should not be instantiated by a project.
  *           Create your own smart content filters visitor to change its behaviour.
  */
-class PageSmartContentFiltersVisitor implements SmartContentFiltersVisitorInterface
+class WebspaceSmartContentFiltersVisitor implements SmartContentFiltersVisitorInterface
 {
     public function __construct(
         private RequestAnalyzerInterface $requestAnalyzer,

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -63,8 +63,8 @@ use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageSelectionProperty
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\PageTreeRoutePropertyResolver;
 use Sulu\Page\Infrastructure\Sulu\Content\PropertyResolver\SinglePageSelectionPropertyResolver;
 use Sulu\Page\Infrastructure\Sulu\Content\ResourceLoader\PageResourceLoader;
-use Sulu\Page\Infrastructure\Sulu\Content\Visitor\PageSmartContentFiltersVisitor;
 use Sulu\Page\Infrastructure\Sulu\Content\Visitor\SegmentSmartContentFiltersVisitor;
+use Sulu\Page\Infrastructure\Sulu\Content\Visitor\WebspaceSmartContentFiltersVisitor;
 use Sulu\Page\Infrastructure\Sulu\HttpCache\EventSubscriber\PageCacheInvalidationSubscriber;
 use Sulu\Page\Infrastructure\Sulu\Reference\PageReferenceRefresher;
 use Sulu\Page\Infrastructure\Sulu\Route\PageWebspaceRouteGenerator;
@@ -456,8 +456,8 @@ final class SuluPageBundle extends AbstractBundle
             ])
             ->tag('sulu_content.smart_content_provider', ['type' => PageInterface::RESOURCE_KEY]);
 
-        $services->set('sulu_page.page_smart_content_filters_visitor_webspace')
-            ->class(PageSmartContentFiltersVisitor::class)
+        $services->set('sulu_page.webspace_smart_content_filters_visitor_webspace')
+            ->class(WebspaceSmartContentFiltersVisitor::class)
             ->args([
                 new Reference('sulu_core.webspace.request_analyzer'),
                 new Reference('request_stack'),

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -397,6 +397,8 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_core.doctrine_rest_helper'),
                 new Reference('sulu_security.access_control_manager'),
                 new Reference('security.token_storage'),
+                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_security.security_checker'),
             ])
             ->tag('sulu.context', ['context' => 'admin']);
 

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -24,7 +24,11 @@ use Sulu\Component\Rest\RestHelperInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Component\Security\Authorization\AccessControl\SecuredObjectControllerInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\SecuredControllerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentManager\ContentManagerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\WorkflowInterface;
@@ -43,6 +47,7 @@ use Sulu\Page\Domain\Exception\PageNotFoundException;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -71,6 +76,8 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         private RestHelperInterface $restHelper,
         private AccessControlManagerInterface $accessControlManager,
         private TokenStorageInterface $tokenStorage,
+        private WebspaceManagerInterface $webspaceManager,
+        private SecurityCheckerInterface $securityChecker,
     ) {
         // TODO controller should not need more then Repository, MessageBus, Serializer
     }
@@ -150,7 +157,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
                 $listRepresentation->toArray(),
                 'json',
                 ['sulu_admin' => true, 'sulu_admin_page' => true, 'sulu_admin_page_list' => true],
-            )
+            ),
         );
     }
 
@@ -179,7 +186,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
 
             return new JsonResponse(
                 $exception->toArray(),
-                404
+                404,
             );
         }
 
@@ -314,7 +321,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
             /** @var PageInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('restore' === $action) {
-            $version = \intval($request->query->get('version'));
+            $version = (int) $request->query->get('version');
             if (!$version) {
                 throw new \InvalidArgumentException('The "version" query parameter is required for restoring a version.');
             }
@@ -369,6 +376,18 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         foreach ($parameters as $key => $value) {
             $listBuilder->setParameter($key, $value);
         }
+
+        /** @var string|null $webspaceKey */
+        $webspaceKey = $filters['webspaceKey'] ?? null;
+        unset($filters['webspaceKey']);
+
+        if ($webspaceKey) {
+            $webspaces = [$this->getWebspaceKey($webspaceKey)];
+        } else {
+            $webspaces = $this->getWebspaceKeys();
+        }
+
+        $listBuilder->in($fieldDescriptors['webspaceKey'], $webspaces);
 
         foreach ($filters as $key => $value) {
             $listBuilder->where($fieldDescriptors[$key], $value); // @phpstan-ignore argument.type
@@ -481,7 +500,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
 
             $allPermissions = $this->accessControlManager->getPermissions(
                 Page::class,
-                $rowId
+                $rowId,
             );
             $row['_hasPermissions'] = !empty($allPermissions);
 
@@ -494,7 +513,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
                         null,
                         \sprintf('sulu.webspaces.%s', $webspaceKey),
                         $allPermissions,
-                        $user
+                        $user,
                     );
                     $row['_permissions'] = $permissions;
                 } else {
@@ -570,5 +589,39 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         $id = $request->get('id');
 
         return \is_string($id) ? $id : '';
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getWebspaceKeys(): array
+    {
+        $webspaceKeys = [];
+
+        foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
+            if ($this->securityChecker->hasPermission(
+                PageAdmin::getPageSecurityContext($webspace->getKey()),
+                PermissionTypes::VIEW,
+            )) {
+                $webspaceKeys[] = $webspace->getKey();
+            }
+        }
+
+        return $webspaceKeys;
+    }
+
+    private function getWebspaceKey(string $webspaceKey): ?string
+    {
+        /** @var Webspace $webspace */
+        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
+
+        if ($this->securityChecker->hasPermission(
+            PageAdmin::getPageSecurityContext($webspace->getKey()),
+            PermissionTypes::VIEW,
+        )) {
+            return $webspace->getKey();
+        }
+
+        return null;
     }
 }

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -321,7 +321,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
             /** @var PageInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('restore' === $action) {
-            $version = (int) $request->query->get('version');
+            $version = $request->query->getInt('version');
             if (!$version) {
                 throw new \InvalidArgumentException('The "version" query parameter is required for restoring a version.');
             }

--- a/packages/page/tests/Functional/Integration/PageControllerPermissionsTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerPermissionsTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\SecurityBundle\Entity\Permission;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\SecurityBundle\Entity\UserRole;
+use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Application\Message\CreatePageMessage;
+use Sulu\Page\Application\MessageHandler\CreatePageMessageHandler;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Tests\Traits\CreatePageWithPermissionsTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * The integration test should have no impact on the coverage so we set it to coversNothing.
+ */
+#[CoversNothing]
+class PageControllerPermissionsTest extends SuluTestCase
+{
+    use AssertSnapshotTrait;
+    use CreatePageWithPermissionsTrait;
+
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+    }
+
+    private function createHomepage(string $uuid, string $webspaceKey): PageInterface
+    {
+        $homepage = new Page($uuid);
+        $homepage->setLft(0);
+        $homepage->setRgt(1);
+        $homepage->setDepth(0);
+        $homepage->setWebspaceKey($webspaceKey);
+        self::getEntityManager()->persist($homepage);
+        self::getEntityManager()->flush();
+
+        return $homepage;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function createPage(
+        string $parentId,
+        array $data = [],
+        string $webspaceKey = 'sulu-io',
+    ): PageInterface {
+        $data = \array_merge(
+            [
+                'title' => 'Test Page',
+                'locale' => 'en',
+                'url' => '/test-page-' . \uniqid(),
+                'template' => 'default',
+            ],
+            $data,
+        );
+        $message = new CreatePageMessage($webspaceKey, $parentId, $data);
+
+        /** @var CreatePageMessageHandler $messageHandler */
+        $messageHandler = self::getContainer()->get('sulu_page.create_page_handler');
+        $page = $messageHandler->__invoke($message);
+        self::getEntityManager()->flush();
+
+        return $page;
+    }
+
+    public function testCgetActionWithoutWebspacePermissionsReturnsEmpty(): void
+    {
+        self::purgeDatabase();
+
+        $entityManager = self::getEntityManager();
+
+        $role = new Role();
+        $role->setName('Limited Role');
+        $role->setSystem('Sulu');
+        $entityManager->persist($role);
+
+        $permission = new Permission();
+        $permission->setRole($role);
+        $permission->setPermissions(127);
+        $permission->setContext('sulu.webspaces.sulu-io');
+        $entityManager->persist($permission);
+
+        $contact = new Contact();
+        $contact->setFirstName('Limited');
+        $contact->setLastName('User');
+        $entityManager->persist($contact);
+
+        $user = new User();
+        $user->setUsername('limiteduser');
+        $user->setSalt('');
+        $user->setLocale('en');
+        $user->setEmail('limiteduser@test.com');
+        $user->setContact($contact);
+
+        $passwordHasherFactory = self::getContainer()->get('security.password_hasher_factory');
+        $hasher = $passwordHasherFactory->getPasswordHasher($user);
+        $user->setPassword($hasher->hash('test'));
+
+        $entityManager->persist($user);
+
+        // Link user to role
+        $userRole = new UserRole();
+        $userRole->setRole($role);
+        $userRole->setUser($user);
+        $userRole->setLocale((string) \json_encode(['en']));
+        $user->addUserRole($userRole);
+        $entityManager->persist($userRole);
+
+        $entityManager->flush();
+        $entityManager->clear();
+
+        self::ensureKernelShutdown();
+
+        $homepage = $this->createHomepage('sulu-io-test-permissions-uuid', 'sulu-io');
+        $this->createPage($homepage->getId(), [
+            'title' => 'Sulu-io Page',
+            'template' => 'default',
+            'url' => '/sulu-io-test-no-permission',
+        ]);
+        $this->createPage($homepage->getId(), [
+            'title' => 'Sulu-io Page 2',
+            'template' => 'default',
+            'url' => '/sulu-io-test-no-permission2',
+        ]);
+        $homepage2 = $this->createHomepage('blog-test-permissions-uuid', 'blog');
+        $this->createPage(
+            $homepage2->getId(),
+            [
+                'title' => 'Blog Page',
+                'template' => 'default',
+                'url' => '/blog-test-no-permission',
+            ],
+            'blog',
+        );
+
+        self::ensureKernelShutdown();
+
+        $limitedClient = $this->createAuthenticatedClient(
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'PHP_AUTH_USER' => 'limiteduser',
+                'PHP_AUTH_PW' => 'test',
+            ],
+        );
+
+        $limitedClient->request(
+            'GET',
+            '/admin/api/pages?locale=en',
+        );
+
+        $response = $limitedClient->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{_embedded?: array{pages?: list<array<string, mixed>>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pagesSuluIo = $content['_embedded']['pages'] ?? [];
+
+        $this->assertNotEmpty($pagesSuluIo, 'User with sulu-io permission should see sulu-io pages');
+        $this->assertCount(1, $pagesSuluIo);
+
+        $limitedClient->request(
+            'GET',
+            '/admin/api/pages?locale=en&webspace=blog',
+        );
+
+        $response = $limitedClient->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{_embedded?: array{pages?: list<array<string, mixed>>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pagesBlog = $content['_embedded']['pages'] ?? [];
+
+        $this->assertEmpty($pagesBlog, 'User without blog permission should not see blog pages');
+    }
+}

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/Visitor/WebspaceSmartContentFiltersVisitorTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/Visitor/WebspaceSmartContentFiltersVisitorTest.php
@@ -18,11 +18,11 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Webspace;
-use Sulu\Page\Infrastructure\Sulu\Content\Visitor\PageSmartContentFiltersVisitor;
+use Sulu\Page\Infrastructure\Sulu\Content\Visitor\WebspaceSmartContentFiltersVisitor;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class PageSmartContentFiltersVisitorTest extends TestCase
+class WebspaceSmartContentFiltersVisitorTest extends TestCase
 {
     use ProphecyTrait;
 
@@ -34,14 +34,14 @@ class PageSmartContentFiltersVisitorTest extends TestCase
      * @var ObjectProphecy<RequestStack>
      */
     private ObjectProphecy $requestStack;
-    private PageSmartContentFiltersVisitor $visitor;
+    private WebspaceSmartContentFiltersVisitor $visitor;
 
     protected function setUp(): void
     {
         $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         $this->requestStack = $this->prophesize(RequestStack::class);
 
-        $this->visitor = new PageSmartContentFiltersVisitor(
+        $this->visitor = new WebspaceSmartContentFiltersVisitor(
             $this->requestAnalyzer->reveal(),
             $this->requestStack->reveal()
         );

--- a/src/Sulu/Bundle/AdminBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/SmartContentItemController.php
@@ -113,6 +113,7 @@ class SmartContentItemController extends AbstractRestController
             'maxPerPage' => ($params['max_per_page'] ?? null) ? $params['max_per_page']->getValue() : null,
             'includeSubFolders' => isset($filters['includeSubFolders']) && ('true' === $filters['includeSubFolders'] || true === $filters['includeSubFolders']),
             'excludeDuplicates' => isset($params['exclude_duplicates']) && ('true' === $params['exclude_duplicates']->getValue() || true === $params['exclude_duplicates']->getValue()),
+            'webspaceKey' => $filters['webspace'] ?? null,
         ];
 
         // Transform page/maxPerPage to offset for provider compatibility

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/SmartContentProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/SmartContentProviderInterface.php
@@ -33,6 +33,7 @@ use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfigurationInte
  *      offset: int,
  *      includeSubFolders: bool,
  *      excludeDuplicates: bool,
+ *      webspaceKey?: string|null,
  *  }
  * @phpstan-type SmartContentCountBaseFilters array{
  *       categories: int[],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Check for webspace permissions in the page smart_content provider.
Only load articles with the current webspace as mainWebspace or additionalWebspace in the smart_content provider.

#### Why?

To avoid permission issues and have the same logic as in 2.6.x.

