### PR TITLE
Add missing return type to  RemoveArticleTranslationMessageHandler and RemoveSnippetTranslationMessageHandler

### DIFF
--- a/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/RemoveArticleTranslationMessageHandler.php
@@ -32,7 +32,7 @@ final class RemoveArticleTranslationMessageHandler
     ) {
     }
 
-    public function __invoke(RemoveArticleTranslationMessage $message): void
+    public function __invoke(RemoveArticleTranslationMessage $message): ArticleInterface
     {
         $article = $this->articleRepository->getOneBy($message->getIdentifier());
         $locale = $message->getLocale();
@@ -64,6 +64,8 @@ final class RemoveArticleTranslationMessageHandler
             $article,
             $locale
         ));
+
+        return $article;
     }
 
     private function handleGhostLocaleRemoval(

--- a/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/RemoveSnippetTranslationMessageHandler.php
@@ -32,7 +32,7 @@ final class RemoveSnippetTranslationMessageHandler
     ) {
     }
 
-    public function __invoke(RemoveSnippetTranslationMessage $message): void
+    public function __invoke(RemoveSnippetTranslationMessage $message): SnippetInterface
     {
         $snippet = $this->snippetRepository->getOneBy($message->getIdentifier());
         $locale = $message->getLocale();
@@ -64,6 +64,8 @@ final class RemoveSnippetTranslationMessageHandler
             $snippet,
             $locale
         ));
+
+        return $snippet;
     }
 
     private function handleGhostLocaleRemoval(


### PR DESCRIPTION

| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/8626
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add return type snippet and article to translation removal.

#### Why?

See https://github.com/sulu/sulu/pull/8626