### PR TITLE
Fix name of test file to be consistent to tested file

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FieldMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/FieldMetadataTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
 
-class FieldMetaDataTest extends TestCase
+class FieldMetadataTest extends TestCase
 {
     public function testAddTypeAddsToTypes(): void
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix name of test file to be consistent to tested file.

#### Why?

Make problem as there already exist a test file on 3.0 branch which name is differently.

```diff
-FieldMetaData
+FieldMetadata
```