### PR TITLE
Add case-insensitive LIKE search for PostgreSQL

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -424,7 +424,7 @@ class ContactRepository extends EntityRepository implements DataProviderReposito
             ->where(\sprintf('contact.id NOT IN (%s)', $subQueryBuilder->getDQL()));
 
         if ($search) {
-            $queryBuilder->andWhere('contact.firstName LIKE :firstNameSearch or contact.lastName LIKE :lastNameSearch');
+            $queryBuilder->andWhere('LOWER(contact.firstName) LIKE LOWER(:firstNameSearch) or LOWER(contact.lastName) LIKE LOWER(:lastNameSearch)');
             $queryBuilder->setParameter('firstNameSearch', '%' . $search . '%');
             $queryBuilder->setParameter('lastNameSearch', '%' . $search . '%');
         }

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -211,7 +211,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
                 $qb->setParameter('depth', \intval($depth));
             }
             if (null !== $search) {
-                $qb->andWhere('collectionMeta.title LIKE :search');
+                $qb->andWhere('LOWER(collectionMeta.title) LIKE LOWER(:search)');
                 $qb->setParameter('search', '%' . $search . '%');
             }
             if (null !== $offset) {
@@ -349,7 +349,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
         }
 
         if (\array_key_exists('search', $filter) && null !== $filter['search']) {
-            $queryBuilder->andWhere('collectionMeta.title LIKE :search OR defaultMeta.locale != :locale');
+            $queryBuilder->andWhere('LOWER(collectionMeta.title) LIKE LOWER(:search) OR defaultMeta.locale != :locale');
             $queryBuilder->setParameter('search', '%' . $filter['search'] . '%');
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -390,7 +390,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
                 ->innerJoin('file.fileVersions', 'fileVersion', 'WITH', 'fileVersion.version = file.version')
                 ->leftJoin('fileVersion.meta', 'fileVersionMeta');
 
-            $queryBuilder->andWhere('fileVersionMeta.title LIKE :search');
+            $queryBuilder->andWhere('LOWER(fileVersionMeta.title) LIKE LOWER(:search)');
             $queryBuilder->setParameter('search', '%' . $search . '%');
         }
 

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/AbstractDoctrineFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/AbstractDoctrineFieldDescriptor.php
@@ -22,7 +22,7 @@ abstract class AbstractDoctrineFieldDescriptor extends FieldDescriptor implement
 
     public function getSearch()
     {
-        return \sprintf('%s LIKE :search', $this->getSelect());
+        return \sprintf('LOWER(%s) LIKE LOWER(:search)', $this->getSelect());
     }
 
     public function getWhere()

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptor.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptor.php
@@ -55,7 +55,7 @@ class DoctrineCaseFieldDescriptor extends AbstractDoctrineFieldDescriptor
     public function getSearch()
     {
         return \sprintf(
-            '%s LIKE :search OR (%s is NULL AND %s LIKE :search)',
+            'LOWER(%s) LIKE LOWER(:search) OR (%s IS NULL AND LOWER(%s) LIKE LOWER(:search))',
             $this->case1->getSelect(),
             $this->case1->getSelect(),
             $this->case2->getSelect()

--- a/src/Sulu/Component/Rest/Listing/ListQueryBuilder.php
+++ b/src/Sulu/Component/Rest/Listing/ListQueryBuilder.php
@@ -377,7 +377,11 @@ class ListQueryBuilder
                         $comparator = 'LIKE';
                         $search = ':search';
                     }
-                    $searches[] = $prefixActual . '.' . $col . ' ' . $comparator . ' ' . $search;
+                    if ('LIKE' === $comparator) {
+                        $searches[] = 'LOWER(' . $prefixActual . '.' . $col . ') LIKE LOWER(' . $search . ')';
+                    } else {
+                        $searches[] = $prefixActual . '.' . $col . ' ' . $comparator . ' ' . $search;
+                    }
                 }
             }
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -602,7 +602,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->andWhere(
-            '(' . self::$translationEntityNameAlias . '.desc LIKE :search OR ' . self::$entityNameAlias . '.name LIKE :search)'
+            '(LOWER(' . self::$translationEntityNameAlias . '.desc) LIKE LOWER(:search) OR LOWER(' . self::$entityNameAlias . '.name) LIKE LOWER(:search))'
         )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('search', '%value%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
@@ -628,7 +628,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->search('val*e');
 
         $this->queryBuilder->andWhere(
-            '(' . self::$translationEntityNameAlias . '.desc LIKE :search OR ' . self::$entityNameAlias . '.name LIKE :search)'
+            '(LOWER(' . self::$translationEntityNameAlias . '.desc) LIKE LOWER(:search) OR LOWER(' . self::$entityNameAlias . '.name) LIKE LOWER(:search))'
         )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('search', '%val%e%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptorTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/FieldDescriptor/DoctrineCaseFieldDescriptorTest.php
@@ -27,7 +27,7 @@ class DoctrineCaseFieldDescriptorTest extends TestCase
                 new DoctrineDescriptor('entity2', 'field2'),
                 '(CASE WHEN entity1.field1 IS NOT NULL THEN entity1.field1 ELSE entity2.field2 END)',
                 [],
-                'entity1.field1 LIKE :search OR (entity1.field1 is NULL AND entity2.field2 LIKE :search)',
+                'LOWER(entity1.field1) LIKE LOWER(:search) OR (entity1.field1 IS NULL AND LOWER(entity2.field2) LIKE LOWER(:search))',
             ],
             [
                 'test',
@@ -35,7 +35,7 @@ class DoctrineCaseFieldDescriptorTest extends TestCase
                 new DoctrineDescriptor('test3', 'test4'),
                 '(CASE WHEN test1.test2 IS NOT NULL THEN test1.test2 ELSE test3.test4 END)',
                 [],
-                'test1.test2 LIKE :search OR (test1.test2 is NULL AND test3.test4 LIKE :search)',
+                'LOWER(test1.test2) LIKE LOWER(:search) OR (test1.test2 IS NULL AND LOWER(test3.test4) LIKE LOWER(:search))',
             ],
             [
                 'test',
@@ -57,7 +57,7 @@ class DoctrineCaseFieldDescriptorTest extends TestCase
                         'entity.relation'
                     ),
                 ],
-                'test1.test2 LIKE :search OR (test1.test2 is NULL AND test3.test4 LIKE :search)',
+                'LOWER(test1.test2) LIKE LOWER(:search) OR (test1.test2 IS NULL AND LOWER(test3.test4) LIKE LOWER(:search))',
             ],
             [
                 'test',
@@ -82,7 +82,7 @@ class DoctrineCaseFieldDescriptorTest extends TestCase
                         'entity.relation'
                     ),
                 ],
-                'test1.test2 LIKE :search OR (test1.test2 is NULL AND test3.test4 LIKE :search)',
+                'LOWER(test1.test2) LIKE LOWER(:search) OR (test1.test2 IS NULL AND LOWER(test3.test4) LIKE LOWER(:search))',
             ],
             [
                 'test',
@@ -117,7 +117,7 @@ class DoctrineCaseFieldDescriptorTest extends TestCase
                         'test10'
                     ),
                 ],
-                'test1.test2 LIKE :search OR (test1.test2 is NULL AND test3.test4 LIKE :search)',
+                'LOWER(test1.test2) LIKE LOWER(:search) OR (test1.test2 IS NULL AND LOWER(test3.test4) LIKE LOWER(:search))',
             ],
         ];
     }

--- a/src/Sulu/Component/Rest/Tests/Unit/Listing/ListQueryBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/Listing/ListQueryBuilderTest.php
@@ -98,7 +98,7 @@ class ListQueryBuilderTest extends TestCase
 
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
-        $this->assertEquals('SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE (u.field LIKE :search)', $dql);
+        $this->assertEquals('SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE (LOWER(u.field) LIKE LOWER(:search))', $dql);
     }
 
     public function testFindWithWhereAndSearch(): void
@@ -116,7 +116,7 @@ class ListQueryBuilderTest extends TestCase
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
         $this->assertEquals(
-            'SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE u.field1 = 1 AND u.field2 = 2 AND (u.field LIKE :search)',
+            'SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE u.field1 = 1 AND u.field2 = 2 AND (LOWER(u.field) LIKE LOWER(:search))',
             $dql
         );
     }
@@ -137,7 +137,7 @@ class ListQueryBuilderTest extends TestCase
         $dql = \str_replace(' ,', ',', \trim(\preg_replace('/\s+/', ' ', $builder->find())));
 
         $this->assertEquals(
-            'SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE u.field1 = 1 AND u.field2 = 2 AND (u.field1 LIKE :search OR u.field2 = :strictSearch OR u.field3 = :strictSearch)',
+            'SELECT u FROM Sulu\Bundle\CoreBundle\Entity\Example u WHERE u.field1 = 1 AND u.field2 = 2 AND (LOWER(u.field1) LIKE LOWER(:search) OR u.field2 = :strictSearch OR u.field3 = :strictSearch)',
             $dql
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Wrap LIKE queries with LOWER() on both column and search parameter to ensure case-insensitive search across all supported databases.      

Changed files:             
  - `AbstractDoctrineFieldDescriptor::getSearch()`
  - `DoctrineCaseFieldDescriptor::getSearch()`    
  - `ListQueryBuilder` - dynamic LIKE search builder
  - `ContactRepository` - firstName/lastName search
  - `MediaRepository` - media title search
  - `CollectionRepository` - collection title search

#### Why?

LIKE operator in PostgreSQL is case-sensitive by default. Searching for "Opel" won't find "opel" in admin lists. MySQL handles this implicitly via its default utf8_general_ci collation, so the issue only affects PostgreSQL users.

LOWER() LIKE LOWER() is preferred over ILIKE (PostgreSQL-specific) and COLLATE (requires schema migration). Since LIKE '%...%' already skips indexes, LOWER() has no performance impact.
