### PR TITLE
Add ReindexProviderEnhancer for Admin index

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\EntityRepository;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Admin\ArticleAdmin;
+use Sulu\Article\Infrastructure\Sulu\Search\Visitor\AdminArticleReindexProviderEnhancerInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
 use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
@@ -44,16 +45,15 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
      */
     private EntityRepository $dimensionContentRepository;
 
-    private GroupProviderInterface $groupProvider;
-
+    /**
+     * @param iterable<AdminArticleReindexProviderEnhancerInterface> $enhancers
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
-        GroupProviderInterface $groupProvider,
+        private readonly GroupProviderInterface $groupProvider,
+        private readonly iterable $enhancers = [],
     ) {
-        $dimensionContentRepository = $entityManager->getRepository(ArticleDimensionContentInterface::class);
-
-        $this->dimensionContentRepository = $dimensionContentRepository;
-        $this->groupProvider = $groupProvider;
+        $this->dimensionContentRepository = $entityManager->getRepository(ArticleDimensionContentInterface::class);
     }
 
     public function total(): ?int
@@ -79,7 +79,7 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
                 }
             }
 
-            yield [
+            $data = [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . ((string) $article['articleId']) . '__' . $article['locale'],
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
                 'resourceId' => (string) $article['articleId'],
@@ -92,6 +92,12 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
                 ],
                 'securityContext' => ArticleAdmin::getArticleSecurityContext($groupIdentifier ?? 'default'),
             ];
+
+            foreach ($this->enhancers as $enhancer) {
+                $data = $enhancer->enhanceDocument($article, $data);
+            }
+
+            yield $data;
         }
     }
 
@@ -145,6 +151,10 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
 
         foreach ($parameters as $parameterKey => $parameterValue) {
             $qb->setParameter($parameterKey, $parameterValue);
+        }
+
+        foreach ($this->enhancers as $enhancer) {
+            $enhancer->enhanceQuery($qb);
         }
 
         /** @var iterable<Article> */

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/AdminArticleReindexProviderEnhancerInterface.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/AdminArticleReindexProviderEnhancerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Interface for enhancers that can process and manipulate reindex data
+ * for admin article dimension content during search indexing.
+ */
+interface AdminArticleReindexProviderEnhancerInterface
+{
+    /**
+     * Enhance the query builder before executing the reindex query.
+     *
+     * @param QueryBuilder $queryBuilder The query builder to enhance
+     */
+    public function enhanceQuery(QueryBuilder $queryBuilder): void;
+
+    /**
+     * Enhance and manipulate the reindex data for an article dimension content.
+     *
+     * @param array<string, mixed> $queryResult The raw query result containing article data
+     * @param array<string, mixed> $document The document data to be indexed
+     *
+     * @return array<string, mixed>
+     */
+    public function enhanceDocument(array $queryResult, array $document): array;
+}

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -53,6 +53,7 @@ use Sulu\Article\Infrastructure\Sulu\Reference\ArticleReferenceRefresher;
 use Sulu\Article\Infrastructure\Sulu\Route\ArticleRouteDefaultsProvider;
 use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleIndexListener;
 use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleReindexProvider;
+use Sulu\Article\Infrastructure\Sulu\Search\Visitor\AdminArticleReindexProviderEnhancerInterface;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexContentEnhancer;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexExcerptEnhancer;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexProviderEnhancerInterface;
@@ -464,6 +465,7 @@ final class SuluArticleBundle extends AbstractBundle
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_admin.metadata_group_provider'),
+                tagged_iterator('sulu_article.admin_article_reindex_provider_enhancer'),
             ])
             ->tag('cmsig_seal.reindex_provider');
 
@@ -475,6 +477,9 @@ final class SuluArticleBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => ArticleWorkflowTransitionAppliedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleRemovedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleTranslationRemovedEvent::class, 'method' => 'onArticleChanged']);
+
+        $builder->registerForAutoconfiguration(AdminArticleReindexProviderEnhancerInterface::class)
+            ->addTag('sulu_article.admin_article_reindex_provider_enhancer');
 
         $builder->registerForAutoconfiguration(WebsiteArticleReindexProviderEnhancerInterface::class)
             ->addTag('sulu_article.website_article_reindex_provider_enhancer');

--- a/packages/page/src/Infrastructure/Sulu/Search/AdminPageReindexProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/AdminPageReindexProvider.php
@@ -21,6 +21,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
+use Sulu\Page\Infrastructure\Sulu\Search\Visitor\AdminPageReindexProviderEnhancerInterface;
 
 /**
  * @phpstan-type Page array{
@@ -42,12 +43,14 @@ final class AdminPageReindexProvider implements ReindexProviderInterface
      */
     private EntityRepository $dimensionContentRepository;
 
+    /**
+     * @param iterable<AdminPageReindexProviderEnhancerInterface> $enhancers
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly iterable $enhancers = [],
     ) {
-        $dimensionContentRepository = $entityManager->getRepository(PageDimensionContentInterface::class);
-
-        $this->dimensionContentRepository = $dimensionContentRepository;
+        $this->dimensionContentRepository = $entityManager->getRepository(PageDimensionContentInterface::class);
     }
 
     public function total(): ?int
@@ -62,7 +65,7 @@ final class AdminPageReindexProvider implements ReindexProviderInterface
 
         /** @var Page $page */
         foreach ($pages as $page) {
-            yield [
+            $data = [
                 'id' => PageInterface::RESOURCE_KEY . '__' . ((string) $page['pageId']) . '__' . $page['locale'],
                 'resourceKey' => PageInterface::RESOURCE_KEY,
                 'resourceId' => (string) $page['pageId'],
@@ -75,6 +78,12 @@ final class AdminPageReindexProvider implements ReindexProviderInterface
                 ],
                 'securityContext' => PageAdmin::SECURITY_CONTEXT_PREFIX . $page['webspaceKey'],
             ];
+
+            foreach ($this->enhancers as $enhancer) {
+                $data = $enhancer->enhanceDocument($page, $data);
+            }
+
+            yield $data;
         }
     }
 
@@ -129,6 +138,10 @@ final class AdminPageReindexProvider implements ReindexProviderInterface
 
         foreach ($parameters as $parameterKey => $parameterValue) {
             $qb->setParameter($parameterKey, $parameterValue);
+        }
+
+        foreach ($this->enhancers as $enhancer) {
+            $enhancer->enhanceQuery($qb);
         }
 
         /** @var iterable<Page> */

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/AdminPageReindexProviderEnhancerInterface.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/AdminPageReindexProviderEnhancerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Interface for enhancers that can process and manipulate reindex data
+ * for admin page dimension content during search indexing.
+ */
+interface AdminPageReindexProviderEnhancerInterface
+{
+    /**
+     * Enhance the query builder before executing the reindex query.
+     *
+     * @param QueryBuilder $queryBuilder The query builder to enhance
+     */
+    public function enhanceQuery(QueryBuilder $queryBuilder): void;
+
+    /**
+     * Enhance and manipulate the reindex data for a page dimension content.
+     *
+     * @param array<string, mixed> $queryResult The raw query result containing page data
+     * @param array<string, mixed> $document The document data to be indexed
+     *
+     * @return array<string, mixed>
+     */
+    public function enhanceDocument(array $queryResult, array $document): array;
+}

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -71,6 +71,7 @@ use Sulu\Page\Infrastructure\Sulu\Reference\PageReferenceRefresher;
 use Sulu\Page\Infrastructure\Sulu\Route\PageWebspaceRouteGenerator;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider;
+use Sulu\Page\Infrastructure\Sulu\Search\Visitor\AdminPageReindexProviderEnhancerInterface;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexContentEnhancer;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexExcerptEnhancer;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexProviderEnhancerInterface;
@@ -598,6 +599,7 @@ final class SuluPageBundle extends AbstractBundle
             ->class(AdminPageReindexProvider::class)
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
+                tagged_iterator('sulu_page.admin_page_reindex_provider_enhancer'),
             ])
             ->tag('cmsig_seal.reindex_provider');
 
@@ -609,6 +611,9 @@ final class SuluPageBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => PageWorkflowTransitionAppliedEvent::class, 'method' => 'onPageChanged'])
             ->tag('kernel.event_listener', ['event' => PageRemovedEvent::class, 'method' => 'onPageChanged'])
             ->tag('kernel.event_listener', ['event' => PageTranslationRemovedEvent::class, 'method' => 'onPageChanged']);
+
+        $builder->registerForAutoconfiguration(AdminPageReindexProviderEnhancerInterface::class)
+            ->addTag('sulu_page.admin_page_reindex_provider_enhancer');
 
         $builder->registerForAutoconfiguration(WebsitePageReindexProviderEnhancerInterface::class)
             ->addTag('sulu_page.website_page_reindex_provider_enhancer');

--- a/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
@@ -21,6 +21,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Admin\SnippetAdmin;
+use Sulu\Snippet\Infrastructure\Sulu\Search\Visitor\AdminSnippetReindexProviderEnhancerInterface;
 
 /**
  * @phpstan-type Snippet array{
@@ -41,12 +42,14 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
      */
     private EntityRepository $dimensionContentRepository;
 
+    /**
+     * @param iterable<AdminSnippetReindexProviderEnhancerInterface> $enhancers
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly iterable $enhancers = [],
     ) {
-        $dimensionContentRepository = $entityManager->getRepository(SnippetDimensionContentInterface::class);
-
-        $this->dimensionContentRepository = $dimensionContentRepository;
+        $this->dimensionContentRepository = $entityManager->getRepository(SnippetDimensionContentInterface::class);
     }
 
     public function total(): ?int
@@ -61,7 +64,7 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
 
         /** @var Snippet $snippet */
         foreach ($snippets as $snippet) {
-            yield [
+            $data = [
                 'id' => SnippetInterface::RESOURCE_KEY . '__' . ((string) $snippet['snippetId']) . '__' . $snippet['locale'],
                 'resourceKey' => SnippetInterface::RESOURCE_KEY,
                 'resourceId' => (string) $snippet['snippetId'],
@@ -71,6 +74,12 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
                 'locale' => $snippet['locale'],
                 'securityContext' => SnippetAdmin::SECURITY_CONTEXT,
             ];
+
+            foreach ($this->enhancers as $enhancer) {
+                $data = $enhancer->enhanceDocument($snippet, $data);
+            }
+
+            yield $data;
         }
     }
 
@@ -123,6 +132,10 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
 
         foreach ($parameters as $parameterKey => $parameterValue) {
             $qb->setParameter($parameterKey, $parameterValue);
+        }
+
+        foreach ($this->enhancers as $enhancer) {
+            $enhancer->enhanceQuery($qb);
         }
 
         /** @var iterable<Snippet> */

--- a/packages/snippet/src/Infrastructure/Sulu/Search/Visitor/AdminSnippetReindexProviderEnhancerInterface.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/Visitor/AdminSnippetReindexProviderEnhancerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Interface for enhancers that can process and manipulate reindex data
+ * for admin snippet dimension content during search indexing.
+ */
+interface AdminSnippetReindexProviderEnhancerInterface
+{
+    /**
+     * Enhance the query builder before executing the reindex query.
+     *
+     * @param QueryBuilder $queryBuilder The query builder to enhance
+     */
+    public function enhanceQuery(QueryBuilder $queryBuilder): void;
+
+    /**
+     * Enhance and manipulate the reindex data for a snippet dimension content.
+     *
+     * @param array<string, mixed> $queryResult The raw query result containing snippet data
+     * @param array<string, mixed> $document The document data to be indexed
+     *
+     * @return array<string, mixed>
+     */
+    public function enhanceDocument(array $queryResult, array $document): array;
+}

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -57,6 +57,7 @@ use Sulu\Snippet\Infrastructure\Sulu\HttpCache\EventSubscriber\SnippetCacheInval
 use Sulu\Snippet\Infrastructure\Sulu\Reference\SnippetReferenceRefresher;
 use Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetIndexListener;
 use Sulu\Snippet\Infrastructure\Sulu\Search\AdminSnippetReindexProvider;
+use Sulu\Snippet\Infrastructure\Sulu\Search\Visitor\AdminSnippetReindexProviderEnhancerInterface;
 use Sulu\Snippet\Infrastructure\Sulu\Trash\SnippetTrashItemHandler;
 use Sulu\Snippet\Infrastructure\Symfony\CompilerPass\SnippetAreaCompilerPass;
 use Sulu\Snippet\Infrastructure\Symfony\Normalizer\SnippetAreaNormalizer;
@@ -427,10 +428,14 @@ final class SuluSnippetBundle extends AbstractBundle
             ->tag('kernel.event_listener', ['event' => SnippetTranslationAddedEvent::class, 'method' => 'onSnippetChanged'])
             ->tag('kernel.event_listener', ['event' => SnippetTranslationRemovedEvent::class, 'method' => 'onSnippetChanged']);
 
+        $builder->registerForAutoconfiguration(AdminSnippetReindexProviderEnhancerInterface::class)
+            ->addTag('sulu_snippet.admin_snippet_reindex_provider_enhancer');
+
         $services->set('sulu_snippet.admin_snippet_reindex_provider')
             ->class(AdminSnippetReindexProvider::class)
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
+                tagged_iterator('sulu_snippet.admin_snippet_reindex_provider_enhancer'),
             ])
             ->tag('cmsig_seal.reindex_provider');
     }

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryReindexProvider.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/AdminCategoryReindexProvider.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\EntityRepository;
 use Sulu\Bundle\CategoryBundle\Admin\CategoryAdmin;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\Visitor\AdminCategoryReindexProviderEnhancerInterface;
 
 /**
  * @phpstan-type Category array{
@@ -40,8 +41,12 @@ final class AdminCategoryReindexProvider implements ReindexProviderInterface
      */
     private EntityRepository $categoryTranslationRepository;
 
+    /**
+     * @param iterable<AdminCategoryReindexProviderEnhancerInterface> $enhancers
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly iterable $enhancers = [],
     ) {
         $translationRepository = $entityManager->getRepository(CategoryTranslationInterface::class);
 
@@ -60,7 +65,7 @@ final class AdminCategoryReindexProvider implements ReindexProviderInterface
 
         /** @var Category $category */
         foreach ($categories as $category) {
-            yield [
+            $data = [
                 'id' => CategoryInterface::RESOURCE_KEY . '__' . ((string) $category['id']) . '__' . $category['locale'],
                 'resourceKey' => CategoryInterface::RESOURCE_KEY,
                 'resourceId' => (string) $category['id'],
@@ -70,6 +75,12 @@ final class AdminCategoryReindexProvider implements ReindexProviderInterface
                 'locale' => $category['locale'],
                 'securityContext' => CategoryAdmin::SECURITY_CONTEXT,
             ];
+
+            foreach ($this->enhancers as $enhancer) {
+                $data = $enhancer->enhanceDocument($category, $data);
+            }
+
+            yield $data;
         }
     }
 
@@ -115,6 +126,10 @@ final class AdminCategoryReindexProvider implements ReindexProviderInterface
             foreach ($parameters as $parameterKey => $parameterValue) {
                 $qb->setParameter($parameterKey, $parameterValue);
             }
+        }
+
+        foreach ($this->enhancers as $enhancer) {
+            $enhancer->enhanceQuery($qb);
         }
 
         /** @var iterable<Category> */

--- a/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/Visitor/AdminCategoryReindexProviderEnhancerInterface.php
+++ b/src/Sulu/Bundle/CategoryBundle/Infrastructure/Sulu/Search/Visitor/AdminCategoryReindexProviderEnhancerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Interface for enhancers that can process and manipulate reindex data
+ * for admin category during search indexing.
+ */
+interface AdminCategoryReindexProviderEnhancerInterface
+{
+    /**
+     * Enhance the query builder before executing the reindex query.
+     *
+     * @param QueryBuilder $queryBuilder The query builder to enhance
+     */
+    public function enhanceQuery(QueryBuilder $queryBuilder): void;
+
+    /**
+     * Enhance and manipulate the reindex data for a category.
+     *
+     * @param array<string, mixed> $queryResult The raw query result containing category data
+     * @param array<string, mixed> $document The document data to be indexed
+     *
+     * @return array<string, mixed>
+     */
+    public function enhanceDocument(array $queryResult, array $document): array;
+}

--- a/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/CategoryBundle/Resources/config/services.xml
@@ -95,6 +95,7 @@
                 class="Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\AdminCategoryReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="tagged_iterator" tag="sulu_category.admin_category_reindex_provider_enhancer"/>
             <tag name="cmsig_seal.reindex_provider"/>
         </service>
     </services>

--- a/src/Sulu/Bundle/CategoryBundle/SuluCategoryBundle.php
+++ b/src/Sulu/Bundle/CategoryBundle/SuluCategoryBundle.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\CategoryBundle;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface;
 use Sulu\Bundle\CategoryBundle\Entity\KeywordInterface;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Search\Visitor\AdminCategoryReindexProviderEnhancerInterface;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -35,5 +36,8 @@ final class SuluCategoryBundle extends Bundle
             ],
             $container
         );
+
+        $container->registerForAutoconfiguration(AdminCategoryReindexProviderEnhancerInterface::class)
+            ->addTag('sulu_category.admin_category_reindex_provider_enhancer');
     }
 }

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminAccountReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminAccountReindexProvider.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\Visitor\AdminAccountReindexProviderEnhancerInterface;
 
 /**
  * @phpstan-type Account array{
@@ -39,8 +40,12 @@ final class AdminAccountReindexProvider implements ReindexProviderInterface
      */
     private EntityRepository $accountRepository;
 
+    /**
+     * @param iterable<AdminAccountReindexProviderEnhancerInterface> $enhancers
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly iterable $enhancers = [],
     ) {
         $repository = $entityManager->getRepository(AccountInterface::class);
 
@@ -58,7 +63,7 @@ final class AdminAccountReindexProvider implements ReindexProviderInterface
 
         /** @var Account $account */
         foreach ($accounts as $account) {
-            yield [
+            $data = [
                 'id' => AccountInterface::RESOURCE_KEY . '__' . ((string) $account['id']),
                 'resourceKey' => AccountInterface::RESOURCE_KEY,
                 'resourceId' => (string) $account['id'],
@@ -68,6 +73,12 @@ final class AdminAccountReindexProvider implements ReindexProviderInterface
                 'title' => $account['name'],
                 'securityContext' => ContactAdmin::ACCOUNT_SECURITY_CONTEXT,
             ];
+
+            foreach ($this->enhancers as $enhancer) {
+                $data = $enhancer->enhanceDocument($account, $data);
+            }
+
+            yield $data;
         }
     }
 
@@ -88,6 +99,10 @@ final class AdminAccountReindexProvider implements ReindexProviderInterface
         if (0 < \count($identifiers)) {
             $qb->where('account.id IN (:ids)')
                 ->setParameter('ids', \array_map(fn ($identifier) => (int) \str_replace(AccountInterface::RESOURCE_KEY . '__', '', $identifier), $identifiers));
+        }
+
+        foreach ($this->enhancers as $enhancer) {
+            $enhancer->enhanceQuery($qb);
         }
 
         /** @var iterable<Account> */

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactReindexProvider.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/AdminContactReindexProvider.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Sulu\Bundle\ContactBundle\Admin\ContactAdmin;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\Visitor\AdminContactReindexProviderEnhancerInterface;
 
 /**
  * @phpstan-type Contact array{
@@ -40,8 +41,12 @@ final class AdminContactReindexProvider implements ReindexProviderInterface
      */
     private EntityRepository $contactRepository;
 
+    /**
+     * @param iterable<AdminContactReindexProviderEnhancerInterface> $enhancers
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly iterable $enhancers = [],
     ) {
         $repository = $entityManager->getRepository(ContactInterface::class);
 
@@ -59,7 +64,7 @@ final class AdminContactReindexProvider implements ReindexProviderInterface
 
         /** @var Contact $contact */
         foreach ($contacts as $contact) {
-            yield [
+            $data = [
                 'id' => ContactInterface::RESOURCE_KEY . '__' . ((string) $contact['id']),
                 'resourceKey' => ContactInterface::RESOURCE_KEY,
                 'resourceId' => (string) $contact['id'],
@@ -69,6 +74,12 @@ final class AdminContactReindexProvider implements ReindexProviderInterface
                 'title' => $contact['firstName'] . ' ' . $contact['lastName'],
                 'securityContext' => ContactAdmin::CONTACT_SECURITY_CONTEXT,
             ];
+
+            foreach ($this->enhancers as $enhancer) {
+                $data = $enhancer->enhanceDocument($contact, $data);
+            }
+
+            yield $data;
         }
     }
 
@@ -90,6 +101,10 @@ final class AdminContactReindexProvider implements ReindexProviderInterface
         if (0 < \count($identifiers)) {
             $qb->where('contact.id IN (:ids)')
                 ->setParameter('ids', \array_map(fn ($identifier) => (int) \str_replace(ContactInterface::RESOURCE_KEY . '__', '', $identifier), $identifiers));
+        }
+
+        foreach ($this->enhancers as $enhancer) {
+            $enhancer->enhanceQuery($qb);
         }
 
         /** @var iterable<Contact> */

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/Visitor/AdminAccountReindexProviderEnhancerInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/Visitor/AdminAccountReindexProviderEnhancerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Interface for enhancers that can process and manipulate reindex data
+ * for admin account during search indexing.
+ */
+interface AdminAccountReindexProviderEnhancerInterface
+{
+    /**
+     * Enhance the query builder before executing the reindex query.
+     *
+     * @param QueryBuilder $queryBuilder The query builder to enhance
+     */
+    public function enhanceQuery(QueryBuilder $queryBuilder): void;
+
+    /**
+     * Enhance and manipulate the reindex data for an account.
+     *
+     * @param array<string, mixed> $queryResult The raw query result containing account data
+     * @param array<string, mixed> $document The document data to be indexed
+     *
+     * @return array<string, mixed>
+     */
+    public function enhanceDocument(array $queryResult, array $document): array;
+}

--- a/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/Visitor/AdminContactReindexProviderEnhancerInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Infrastructure/Sulu/Search/Visitor/AdminContactReindexProviderEnhancerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Interface for enhancers that can process and manipulate reindex data
+ * for admin contact during search indexing.
+ */
+interface AdminContactReindexProviderEnhancerInterface
+{
+    /**
+     * Enhance the query builder before executing the reindex query.
+     *
+     * @param QueryBuilder $queryBuilder The query builder to enhance
+     */
+    public function enhanceQuery(QueryBuilder $queryBuilder): void;
+
+    /**
+     * Enhance and manipulate the reindex data for a contact.
+     *
+     * @param array<string, mixed> $queryResult The raw query result containing contact data
+     * @param array<string, mixed> $document The document data to be indexed
+     *
+     * @return array<string, mixed>
+     */
+    public function enhanceDocument(array $queryResult, array $document): array;
+}

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -225,6 +225,7 @@
                 class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AdminAccountReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="tagged_iterator" tag="sulu_contact.admin_account_reindex_provider_enhancer"/>
             <tag name="cmsig_seal.reindex_provider"/>
         </service>
 
@@ -233,6 +234,7 @@
                 class="Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\AdminContactReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="tagged_iterator" tag="sulu_contact.admin_contact_reindex_provider_enhancer"/>
             <tag name="cmsig_seal.reindex_provider"/>
         </service>
     </services>

--- a/src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
+++ b/src/Sulu/Bundle/ContactBundle/SuluContactBundle.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\ContactBundle;
 
 use Sulu\Bundle\ContactBundle\Entity\AccountInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\Visitor\AdminAccountReindexProviderEnhancerInterface;
+use Sulu\Bundle\ContactBundle\Infrastructure\Sulu\Search\Visitor\AdminContactReindexProviderEnhancerInterface;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -35,5 +37,11 @@ final class SuluContactBundle extends Bundle
             ],
             $container
         );
+
+        $container->registerForAutoconfiguration(AdminContactReindexProviderEnhancerInterface::class)
+            ->addTag('sulu_contact.admin_contact_reindex_provider_enhancer');
+
+        $container->registerForAutoconfiguration(AdminAccountReindexProviderEnhancerInterface::class)
+            ->addTag('sulu_contact.admin_account_reindex_provider_enhancer');
     }
 }

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionReindexProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminCollectionReindexProvider.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\EntityRepository;
 use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
 use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\Visitor\AdminCollectionReindexProviderEnhancerInterface;
 
 /**
  * @phpstan-type Collection array{
@@ -40,8 +41,12 @@ final class AdminCollectionReindexProvider implements ReindexProviderInterface
      */
     private EntityRepository $collectionMetaRepository;
 
+    /**
+     * @param iterable<AdminCollectionReindexProviderEnhancerInterface> $enhancers
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly iterable $enhancers = [],
     ) {
         $repository = $entityManager->getRepository(CollectionMeta::class);
 
@@ -59,7 +64,7 @@ final class AdminCollectionReindexProvider implements ReindexProviderInterface
 
         /** @var Collection $collection */
         foreach ($collections as $collection) {
-            yield [
+            $data = [
                 'id' => CollectionInterface::RESOURCE_KEY . '__' . ((string) $collection['collectionId']) . '__' . $collection['locale'],
                 'resourceKey' => CollectionInterface::RESOURCE_KEY,
                 'resourceId' => (string) $collection['collectionId'],
@@ -69,6 +74,12 @@ final class AdminCollectionReindexProvider implements ReindexProviderInterface
                 'locale' => $collection['locale'],
                 'securityContext' => MediaAdmin::SECURITY_CONTEXT,
             ];
+
+            foreach ($this->enhancers as $enhancer) {
+                $data = $enhancer->enhanceDocument($collection, $data);
+            }
+
+            yield $data;
         }
     }
 
@@ -115,6 +126,10 @@ final class AdminCollectionReindexProvider implements ReindexProviderInterface
             foreach ($parameters as $parameterKey => $parameterValue) {
                 $qb->setParameter($parameterKey, $parameterValue);
             }
+        }
+
+        foreach ($this->enhancers as $enhancer) {
+            $enhancer->enhanceQuery($qb);
         }
 
         /** @var iterable<Collection> */

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaReindexProvider.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/AdminMediaReindexProvider.php
@@ -19,6 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Sulu\Bundle\MediaBundle\Admin\MediaAdmin;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\Visitor\AdminMediaReindexProviderEnhancerInterface;
 
 /**
  * @phpstan-type Media array{
@@ -40,8 +41,12 @@ final class AdminMediaReindexProvider implements ReindexProviderInterface
      */
     private EntityRepository $mediaRepository;
 
+    /**
+     * @param iterable<AdminMediaReindexProviderEnhancerInterface> $enhancers
+     */
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly iterable $enhancers = [],
     ) {
         $repository = $entityManager->getRepository(MediaInterface::class);
 
@@ -60,7 +65,7 @@ final class AdminMediaReindexProvider implements ReindexProviderInterface
 
         /** @var Media $media */
         foreach ($medias as $media) {
-            yield [
+            $data = [
                 'id' => MediaInterface::RESOURCE_KEY . '__' . ((string) $media['id']) . '__' . $media['locale'],
                 'resourceKey' => MediaInterface::RESOURCE_KEY,
                 'resourceId' => (string) $media['id'],
@@ -71,6 +76,12 @@ final class AdminMediaReindexProvider implements ReindexProviderInterface
                 'locale' => $media['locale'],
                 'securityContext' => MediaAdmin::SECURITY_CONTEXT,
             ];
+
+            foreach ($this->enhancers as $enhancer) {
+                $data = $enhancer->enhanceDocument($media, $data);
+            }
+
+            yield $data;
         }
     }
 
@@ -121,6 +132,10 @@ final class AdminMediaReindexProvider implements ReindexProviderInterface
             foreach ($parameters as $parameterKey => $parameterValue) {
                 $qb->setParameter($parameterKey, $parameterValue);
             }
+        }
+
+        foreach ($this->enhancers as $enhancer) {
+            $enhancer->enhanceQuery($qb);
         }
 
         /** @var iterable<Media> */

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/Visitor/AdminCollectionReindexProviderEnhancerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/Visitor/AdminCollectionReindexProviderEnhancerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Interface for enhancers that can process and manipulate reindex data
+ * for admin collection during search indexing.
+ */
+interface AdminCollectionReindexProviderEnhancerInterface
+{
+    /**
+     * Enhance the query builder before executing the reindex query.
+     *
+     * @param QueryBuilder $queryBuilder The query builder to enhance
+     */
+    public function enhanceQuery(QueryBuilder $queryBuilder): void;
+
+    /**
+     * Enhance and manipulate the reindex data for a collection.
+     *
+     * @param array<string, mixed> $queryResult The raw query result containing collection data
+     * @param array<string, mixed> $document The document data to be indexed
+     *
+     * @return array<string, mixed>
+     */
+    public function enhanceDocument(array $queryResult, array $document): array;
+}

--- a/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/Visitor/AdminMediaReindexProviderEnhancerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Infrastructure/Sulu/Search/Visitor/AdminMediaReindexProviderEnhancerInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\Visitor;
+
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Interface for enhancers that can process and manipulate reindex data
+ * for admin media during search indexing.
+ */
+interface AdminMediaReindexProviderEnhancerInterface
+{
+    /**
+     * Enhance the query builder before executing the reindex query.
+     *
+     * @param QueryBuilder $queryBuilder The query builder to enhance
+     */
+    public function enhanceQuery(QueryBuilder $queryBuilder): void;
+
+    /**
+     * Enhance and manipulate the reindex data for a media.
+     *
+     * @param array<string, mixed> $queryResult The raw query result containing media data
+     * @param array<string, mixed> $document The document data to be indexed
+     *
+     * @return array<string, mixed>
+     */
+    public function enhanceDocument(array $queryResult, array $document): array;
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.xml
@@ -488,6 +488,7 @@
                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminMediaReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="tagged_iterator" tag="sulu_media.admin_media_reindex_provider_enhancer"/>
             <tag name="cmsig_seal.reindex_provider"/>
         </service>
 
@@ -496,6 +497,7 @@
                 class="Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\AdminCollectionReindexProvider"
         >
             <argument type="service" id="doctrine.orm.entity_manager"/>
+            <argument type="tagged_iterator" tag="sulu_media.admin_collection_reindex_provider_enhancer"/>
             <tag name="cmsig_seal.reindex_provider"/>
         </service>
     </services>

--- a/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
+++ b/src/Sulu/Bundle/MediaBundle/SuluMediaBundle.php
@@ -15,6 +15,8 @@ use Sulu\Bundle\MediaBundle\DependencyInjection\FlysystemCompilerPass;
 use Sulu\Bundle\MediaBundle\DependencyInjection\ImageFormatCompilerPass;
 use Sulu\Bundle\MediaBundle\Entity\CollectionInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\Visitor\AdminCollectionReindexProviderEnhancerInterface;
+use Sulu\Bundle\MediaBundle\Infrastructure\Sulu\Search\Visitor\AdminMediaReindexProviderEnhancerInterface;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -38,6 +40,12 @@ final class SuluMediaBundle extends Bundle
 
         $container->addCompilerPass(new ImageFormatCompilerPass());
         $container->addCompilerPass(new FlysystemCompilerPass());
+
+        $container->registerForAutoconfiguration(AdminMediaReindexProviderEnhancerInterface::class)
+            ->addTag('sulu_media.admin_media_reindex_provider_enhancer');
+
+        $container->registerForAutoconfiguration(AdminCollectionReindexProviderEnhancerInterface::class)
+            ->addTag('sulu_media.admin_collection_reindex_provider_enhancer');
 
         parent::build($container);
     }


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Added `ReindexProviderEnhancer` support to all admin index providers: Page, Article, Snippet, Media, Collection, Contact, Account, and Category
  - Each provider now accepts an `iterable` of enhancers implementing a typed `EnhancerInterface` specific to that resource type
  - Enhancers can modify the Doctrine query via `enhanceQuery(QueryBuilder)` and the indexed document via `enhanceDocument(array $queryResult, array $document): array`
  - Autoconfiguration is registered in each bundle's `build()` method so third-party services implementing the interface are tagged automatically

  #### Why?

  There was no way for third-party bundles or project code to extend what data gets indexed for admin search resources without overriding the entire provider class. This PR introduces an extensibility hook. The
  same pattern used internally for content types like website pages and articles to all remaining admin reindex providers.

  #### Example Usage

  ```php
  use Doctrine\ORM\QueryBuilder;
  use Sulu\Article\Infrastructure\Sulu\Search\Visitor\AdminArticleReindexProviderEnhancerInterface;

  class CustomAdminArticleReindexEnhancer implements AdminArticleReindexProviderEnhancerInterface
  {
      public function enhanceQuery(QueryBuilder $queryBuilder): void
      {
          $queryBuilder->addSelect('dimensionContent.customField');
      }

      public function enhanceDocument(array $queryResult, array $document): array
      {
          $document['customField'] = $queryResult['customField'] ?? null;

          return $document;
      }
  }

  The enhancer is automatically tagged and injected via autoconfiguration — just implement the interface.