### PR TITLE
Fix multi locale queries

### DIFF
--- a/packages/article/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
+++ b/packages/article/src/Infrastructure/Doctrine/Repository/ArticleRepository.php
@@ -98,7 +98,7 @@ final class ArticleRepository implements ArticleRepositoryInterface
 
         try {
             /** @var ArticleInterface $article */
-            $article = $queryBuilder->getQuery()->getSingleResult();
+            $article = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getSingleResult();
         } catch (NoResultException $e) {
             throw new ArticleNotFoundException($filters, 0, $e);
         }
@@ -112,7 +112,7 @@ final class ArticleRepository implements ArticleRepositoryInterface
 
         try {
             /** @var ArticleInterface $article */
-            $article = $queryBuilder->getQuery()->getSingleResult();
+            $article = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getSingleResult();
         } catch (NoResultException $e) {
             return null;
         }
@@ -144,7 +144,7 @@ final class ArticleRepository implements ArticleRepositoryInterface
         $queryBuilder = $this->createQueryBuilder($filters, $sortBy, $selects);
 
         /** @var iterable<ArticleInterface> $articles */
-        $articles = $queryBuilder->getQuery()->getResult();
+        $articles = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getResult();
 
         foreach ($articles as $article) {
             yield $article;

--- a/packages/content/src/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
+++ b/packages/content/src/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
@@ -15,6 +15,7 @@ namespace Sulu\Content\Infrastructure\Doctrine;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
@@ -66,6 +67,28 @@ class DimensionContentQueryEnhancer
             self::SELECT_ROUTE => true,
         ],
     ];
+
+    /**
+     * Creates a Query and sets HINT_REFRESH when the QueryBuilder joins
+     * dimensionContent, to force Doctrine to re-hydrate entities from query
+     * results instead of returning stale data from the identity map.
+     *
+     * Without this, loading the same content entity with different dimension
+     * attributes (e.g. first EN then DE locale) in a single request returns
+     * the first locale's dimensionContents for both queries.
+     *
+     * @return Query<mixed, mixed>
+     */
+    public function createQuery(QueryBuilder $queryBuilder): Query
+    {
+        $query = $queryBuilder->getQuery();
+
+        if (\in_array('dimensionContent', $queryBuilder->getAllAliases(), true)) {
+            $query->setHint(Query::HINT_REFRESH, true);
+        }
+
+        return $query;
+    }
 
     /**
      * TODO it should be possible to add custom filters for all contents here example when the

--- a/packages/content/tests/Application/ExampleTestBundle/Repository/ExampleRepository.php
+++ b/packages/content/tests/Application/ExampleTestBundle/Repository/ExampleRepository.php
@@ -99,7 +99,7 @@ class ExampleRepository
 
         try {
             /** @var Example $example */
-            $example = $queryBuilder->getQuery()->getSingleResult();
+            $example = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getSingleResult();
         } catch (NoResultException $e) {
             throw new ExampleNotFoundException($filters, 0, $e);
         }
@@ -126,7 +126,7 @@ class ExampleRepository
 
         try {
             /** @var Example $example */
-            $example = $queryBuilder->getQuery()->getSingleResult();
+            $example = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getSingleResult();
         } catch (NoResultException $e) {
             return null;
         }
@@ -215,7 +215,7 @@ class ExampleRepository
 
         // TODO optimize hydration with toIterable()
         /** @var iterable<Example> $examples */
-        $examples = $queryBuilder->getQuery()->getResult();
+        $examples = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getResult();
 
         foreach ($examples as $example) {
             yield $example;

--- a/packages/content/tests/Functional/Infrastructure/Doctrine/DimensionContentQueryEnhancerTest.php
+++ b/packages/content/tests/Functional/Infrastructure/Doctrine/DimensionContentQueryEnhancerTest.php
@@ -729,4 +729,49 @@ class DimensionContentQueryEnhancerTest extends SuluTestCase
             'segmentKey' => 'segment-nonexistent',
         ]));
     }
+
+    /**
+     * Verifies that loading the same entity with different locales in a single
+     * request returns correct dimension content for each locale, not stale data
+     * from the identity map.
+     */
+    public function testLoadSameEntityWithDifferentLocalesWithoutClear(): void
+    {
+        static::purgeDatabase();
+
+        $example = static::createExample();
+        static::createExampleContent($example, [
+            'locale' => 'en',
+            'stage' => 'live',
+            'templateKey' => 'default',
+            'templateData' => ['title' => 'English Title'],
+        ]);
+        static::createExampleContent($example, [
+            'locale' => 'de',
+            'stage' => 'live',
+            'templateKey' => 'example-2',
+            'templateData' => ['title' => 'German Title'],
+        ]);
+        static::getEntityManager()->flush();
+        $exampleId = $example->getId();
+        static::getEntityManager()->clear();
+
+        // First load: English
+        $enExample = $this->exampleRepository->getOneBy(
+            ['id' => $exampleId, 'locale' => 'en', 'stage' => 'live'],
+            [ExampleRepository::GROUP_SELECT_EXAMPLE_ADMIN => true]
+        );
+        $enResolved = $this->contentManager->resolve($enExample, ['locale' => 'en', 'stage' => 'live']);
+        $this->assertSame('default', $enResolved->getTemplateKey());
+        $this->assertSame('English Title', $enResolved->getTemplateData()['title']);
+
+        // Second load: German - WITHOUT clearing the entity manager.
+        $deExample = $this->exampleRepository->getOneBy(
+            ['id' => $exampleId, 'locale' => 'de', 'stage' => 'live'],
+            [ExampleRepository::GROUP_SELECT_EXAMPLE_ADMIN => true]
+        );
+        $deResolved = $this->contentManager->resolve($deExample, ['locale' => 'de', 'stage' => 'live']);
+        $this->assertSame('example-2', $deResolved->getTemplateKey());
+        $this->assertSame('German Title', $deResolved->getTemplateData()['title']);
+    }
 }

--- a/packages/content/tests/Unit/Content/Infrastructure/Doctrine/DimensionContentQueryEnhancerTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Doctrine/DimensionContentQueryEnhancerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Infrastructure\Doctrine;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
+
+class DimensionContentQueryEnhancerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testCreateQuerySetsRefreshHintWhenDimensionContentJoined(): void
+    {
+        $enhancer = new DimensionContentQueryEnhancer();
+
+        $query = $this->prophesize(Query::class);
+        $query->setHint(Query::HINT_REFRESH, true)->willReturn($query)->shouldBeCalled();
+
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->getQuery()->willReturn($query->reveal());
+        $queryBuilder->getAllAliases()->willReturn(['example', 'dimensionContent']);
+
+        $result = $enhancer->createQuery($queryBuilder->reveal());
+
+        $this->assertSame($query->reveal(), $result);
+    }
+
+    public function testCreateQueryDoesNotSetRefreshHintWithoutDimensionContentJoin(): void
+    {
+        $enhancer = new DimensionContentQueryEnhancer();
+
+        $query = $this->prophesize(Query::class);
+        $query->setHint(Query::HINT_REFRESH, true)->shouldNotBeCalled();
+
+        $queryBuilder = $this->prophesize(QueryBuilder::class);
+        $queryBuilder->getQuery()->willReturn($query->reveal());
+        $queryBuilder->getAllAliases()->willReturn(['example', 'filterDimensionContent']);
+
+        $result = $enhancer->createQuery($queryBuilder->reveal());
+
+        $this->assertSame($query->reveal(), $result);
+    }
+}

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -125,7 +125,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
         $filters = $this->buildChildrenFilters($uuid, $locale, $webspaceKey, $depth, $navigationContext);
 
         /** @var iterable<PageInterface> $pages */
-        $pages = $this->createQueryBuilder($filters)->getQuery()->getResult();
+        $pages = $this->dimensionContentQueryEnhancer->createQuery($this->createQueryBuilder($filters))->getResult();
 
         return $this->resolveAndNormalizePages($pages, $locale, $properties);
     }
@@ -151,25 +151,25 @@ final class NavigationRepository implements NavigationRepositoryInterface
         array $properties = []
     ): array {
         /** @var PageInterface|null $page */
-        $page = $this->createQueryBuilder([
+        $page = $this->dimensionContentQueryEnhancer->createQuery($this->createQueryBuilder([
             'uuid' => $uuid,
             'locale' => $locale,
             'stage' => DimensionContentInterface::STAGE_LIVE,
-        ])->getQuery()->getOneOrNullResult();
+        ]))->getOneOrNullResult();
 
         if (null === $page) {
             return [];
         }
 
         /** @var PageInterface[] $ancestors */
-        $ancestors = $this->createQueryBuilder([
+        $ancestors = $this->dimensionContentQueryEnhancer->createQuery($this->createQueryBuilder([
             'ancestorLft' => $page->getLft(),
             'ancestorRgt' => $page->getRgt(),
             'webspaceKey' => $webspaceKey,
             'locale' => $locale,
             'stage' => DimensionContentInterface::STAGE_LIVE,
             'skipAccessControl' => true,
-        ])->getQuery()->getResult();
+        ]))->getResult();
 
         /** @var PageInterface[] $pages */
         $pages = [...$ancestors, $page];
@@ -262,7 +262,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
      */
     private function findBy(array $filters = []): \Generator
     {
-        $query = $this->createQueryBuilder($filters)->getQuery();
+        $query = $this->dimensionContentQueryEnhancer->createQuery($this->createQueryBuilder($filters));
 
         /** @var PageInterface $page */
         foreach ($query->getResult() as $page) { // @phpstan-ignore-line foreach.nonIterable
@@ -288,7 +288,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
     {
         $queryBuilder = $this->createQueryBuilder($filters);
 
-        $query = $queryBuilder->getQuery();
+        $query = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder);
         // Hint is necessary for the TreeObjectHydrator to work
         // https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/tree.md#building-trees-from-your-entities
         $query->setHint(Query::HINT_INCLUDE_META_COLUMNS, true);

--- a/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/PageRepository.php
@@ -115,7 +115,7 @@ final class PageRepository implements PageRepositoryInterface
 
         try {
             /** @var PageInterface $page */
-            $page = $queryBuilder->getQuery()->getSingleResult();
+            $page = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getSingleResult();
         } catch (NoResultException $e) {
             throw new PageNotFoundException($filters, 0, $e);
         }
@@ -129,7 +129,7 @@ final class PageRepository implements PageRepositoryInterface
 
         try {
             /** @var PageInterface $page */
-            $page = $queryBuilder->getQuery()->getSingleResult();
+            $page = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getSingleResult();
         } catch (NoResultException $e) {
             return null;
         }
@@ -161,7 +161,7 @@ final class PageRepository implements PageRepositoryInterface
         $queryBuilder = $this->createQueryBuilder($filters, $sortBy, $selects);
 
         /** @var iterable<PageInterface> $pages */
-        $pages = $queryBuilder->getQuery()->getResult();
+        $pages = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getResult();
 
         foreach ($pages as $page) {
             yield $page;
@@ -206,7 +206,7 @@ final class PageRepository implements PageRepositoryInterface
     {
         $queryBuilder = $this->createQueryBuilder($filters, $sortBy, $selects);
 
-        $query = $queryBuilder->getQuery();
+        $query = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder);
         // Hint is necessary for the TreeObjectHydrator to work
         // https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/tree.md#building-trees-from-your-entities
         $query->setHint(Query::HINT_INCLUDE_META_COLUMNS, true);

--- a/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -140,7 +140,7 @@ class NavigationRepositoryTest extends TestCase
         $queryBuilder->andWhere('page.depth <= :depth')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('depth', 1)->willReturn($queryBuilder->reveal());
         $queryBuilder->addOrderBy('page.lft', 'asc')->willReturn($queryBuilder->reveal());
-        $queryBuilder->getQuery()->willReturn($query->reveal());
+        $this->dimensionContentQueryEnhancer->createQuery($queryBuilder->reveal())->willReturn($query->reveal());
 
         $expectedFilters = [
             'locale' => 'en',
@@ -220,7 +220,7 @@ class NavigationRepositoryTest extends TestCase
         $queryBuilder->andWhere('page.depth <= :depth')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('depth', 2)->willReturn($queryBuilder->reveal());
         $queryBuilder->addOrderBy('page.lft', 'asc')->willReturn($queryBuilder->reveal());
-        $queryBuilder->getQuery()->willReturn($query->reveal());
+        $this->dimensionContentQueryEnhancer->createQuery($queryBuilder->reveal())->willReturn($query->reveal());
 
         $expectedFilters = [
             'locale' => 'de',
@@ -301,7 +301,7 @@ class NavigationRepositoryTest extends TestCase
         $queryBuilder->andWhere('page.depth <= :depth')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('depth', 3)->willReturn($queryBuilder->reveal());
         $queryBuilder->addOrderBy('page.lft', 'asc')->willReturn($queryBuilder->reveal());
-        $queryBuilder->getQuery()->willReturn($query->reveal());
+        $this->dimensionContentQueryEnhancer->createQuery($queryBuilder->reveal())->willReturn($query->reveal());
 
         $expectedFilters = [
             'locale' => 'en',
@@ -382,7 +382,7 @@ class NavigationRepositoryTest extends TestCase
         $queryBuilder->andWhere('page.depth <= :depth')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('depth', 2)->willReturn($queryBuilder->reveal());
         $queryBuilder->addOrderBy('page.lft', 'asc')->willReturn($queryBuilder->reveal());
-        $queryBuilder->getQuery()->willReturn($query->reveal());
+        $this->dimensionContentQueryEnhancer->createQuery($queryBuilder->reveal())->willReturn($query->reveal());
 
         $expectedFilters = [
             'locale' => 'en',
@@ -468,7 +468,7 @@ class NavigationRepositoryTest extends TestCase
         $queryBuilder->andWhere('page.depth <= :depth')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('depth', 1)->willReturn($queryBuilder->reveal());
         $queryBuilder->addOrderBy('page.lft', 'asc')->willReturn($queryBuilder->reveal());
-        $queryBuilder->getQuery()->willReturn($query->reveal());
+        $this->dimensionContentQueryEnhancer->createQuery($queryBuilder->reveal())->willReturn($query->reveal());
 
         $expectedFilters = [
             'locale' => 'en',

--- a/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetRepository.php
+++ b/packages/snippet/src/Infrastructure/Doctrine/Repository/SnippetRepository.php
@@ -98,7 +98,7 @@ final class SnippetRepository implements SnippetRepositoryInterface
 
         try {
             /** @var SnippetInterface $snippet */
-            $snippet = $queryBuilder->getQuery()->getSingleResult();
+            $snippet = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getSingleResult();
         } catch (NoResultException $e) {
             throw new SnippetNotFoundException($filters, 0, $e);
         }
@@ -112,7 +112,7 @@ final class SnippetRepository implements SnippetRepositoryInterface
 
         try {
             /** @var SnippetInterface $snippet */
-            $snippet = $queryBuilder->getQuery()->getSingleResult();
+            $snippet = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getSingleResult();
         } catch (NoResultException $e) {
             return null;
         }
@@ -144,7 +144,7 @@ final class SnippetRepository implements SnippetRepositoryInterface
         $queryBuilder = $this->createQueryBuilder($filters, $sortBy, $selects);
 
         /** @var iterable<SnippetInterface> $snippets */
-        $snippets = $queryBuilder->getQuery()->getResult();
+        $snippets = $this->dimensionContentQueryEnhancer->createQuery($queryBuilder)->getResult();
 
         foreach ($snippets as $snippet) {
             yield $snippet;


### PR DESCRIPTION
 | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #8623
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Added `createQuery()` method to `DimensionContentQueryEnhancer` that conditionally sets `Query::HINT_REFRESH` when the QueryBuilder joins `dimensionContent`
  - Updated all content repositories (Article, Page, Snippet, Navigation) to use `createQuery()` instead of `$queryBuilder->getQuery()`
  - Added unit tests for conditional hint behavior and a functional regression test loading the same entity with different locales

  #### Why?

  When the same content entity is loaded multiple times with different dimension attributes (e.g. first EN then DE locale) in a single request, Doctrine's identity map returns the cached entity from the first
  query. This means the `dimensionContents` collection stays stale — the second query returns EN dimension content instead of DE. Setting `HINT_REFRESH` forces Doctrine to re-hydrate entities from query results,
  ensuring each locale query returns the correct dimension content.

  #### To Do

  - [ ] Create a documentation PR
  - [ ] Add breaking changes to UPGRADE.md