### PR TITLE
Fix issue with lowest CI not longer working with swiftmailer

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -247,6 +247,7 @@ jobs:
             - name: Install additional lowest dependencies
               if: ${{ matrix.dependency-versions == 'lowest' }}
               run: |
+                  composer config "audit.block-insecure" false
                   composer require symfony/swiftmailer-bundle --no-interaction --no-update
 
             - name: Set composer stability

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## 2.6.22
+
+There might be issues updating a project which still requires `Swiftmailer`.
+As announced with `2.5.0` (2022-07-13) Sulu recommends replace `Swiftmailer`
+with the `symfony/mailer` package. Check the upgrade guide [of 2.5.0 below](#replace-swiftmailer-with-symfony-mailer)
+to remove `Swiftmailer` from your project if still installed.
+
 ## 2.6.21
 
 The type of the `apiKey` in the `se_users` table has been changed to `string`.
@@ -1017,8 +1024,12 @@ framework:
         dsn: '%env(MAILER_DSN)%'
 ```
 
-It should also be considered to remove the **SwiftMailer** and **SwiftMailerBundle**
-from your application and replace it with [**Symfony Mailer**](https://symfony.com/doc/6.1/mailer.html).
+It should also be considered to remove the **SwiftMailer** and **SwiftMailerBundle**:
+from your application and replace it with [**Symfony Mailer**](https://symfony.com/doc/6.4/mailer.html).
+
+```bash
+composer remove symfony/swiftmailer-bundle
+```
 
 ## 2.4.19
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix issue with lowest CI not longer working with swiftmailer.

#### Why?

```
composer config "audit.block-insecure" true
composer require symfony/swiftmailer-bundle --no-interaction --no-update
composer update --prefer-lowest
```

Currently always fails even witht --prefer-lowest there is currently no compatible version to test against swiftmailer compatibility. To still test against it we need disable block-insecure" for the lowest CI.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires league/flysystem-aws-s3-v3 ^1.0.1 -> satisfiable by league/flysystem-aws-s3-v3[1.0.1, ..., 1.0.30].
    - Root composer.json requires superbalist/flysystem-google-storage ^7.1 -> satisfiable by superbalist/flysystem-google-storage[7.1.0, 7.2.0, 7.2.1, 7.2.2].
    - Root composer.json requires symfony/swiftmailer-bundle ^3.5 -> satisfiable by symfony/swiftmailer-bundle[v3.5.0, ..., v3.5.4].
    - google/auth v1.50.0 requires psr/log ^3.0 -> satisfiable by psr/log[3.0.0, 3.0.1, 3.0.2].
    - symfony/http-kernel[v5.4.20, ..., v5.4.51] require psr/log ^1|^2 -> satisfiable by psr/log[1.0.0, ..., 1.1.4, 2.0.0].
    - symfony/swiftmailer-bundle[v3.5.0, ..., v3.5.4] require symfony/http-kernel ^4.4|^5.0 -> satisfiable by symfony/http-kernel[v5.4.20, ..., v5.4.51].
    - Conclusion: install google/auth v1.50.0 (conflict analysis result)
    - You can only install one version of a package, so only one of these can be installed: psr/log[1.0.0, ..., 1.1.4, 2.0.0, 3.0.0, 3.0.1, 3.0.2].

Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires league/flysystem-aws-s3-v3 ^1.0.1 -> satisfiable by league/flysystem-aws-s3-v3[1.0.1, ..., 1.0.30].
    - Root composer.json requires superbalist/flysystem-google-storage ^7.1 -> satisfiable by superbalist/flysystem-google-storage[7.1.0, 7.2.0, 7.2.1, 7.2.2].
    - Root composer.json requires symfony/swiftmailer-bundle ^3.5 -> satisfiable by symfony/swiftmailer-bundle[v3.5.0, ..., v3.5.4].
    - google/auth v1.50.0 requires psr/log ^3.0 -> satisfiable by psr/log[3.0.0, 3.0.1, 3.0.2].
    - symfony/http-kernel[v5.4.20, ..., v5.4.51] require psr/log ^1|^2 -> satisfiable by psr/log[1.0.0, ..., 1.1.4, 2.0.0].
    - symfony/swiftmailer-bundle[v3.5.0, ..., v3.5.4] require symfony/http-kernel ^4.4|^5.0 -> satisfiable by symfony/http-kernel[v5.4.20, ..., v5.4.51].
    - Conclusion: install google/auth v1.50.0 (conflict analysis result)
    - You can only install one version of a package, so only one of these can be installed: psr/log[1.0.0, ..., 1.1.4, 2.0.0, 3.0.0, 3.0.1, 3.0.2].
```