### PR TITLE
Add FormMetadataProvider InMemory cache

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
@@ -16,10 +16,10 @@ namespace Sulu\Article\Infrastructure\Sulu\Search\Visitor;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 
 /**
  * @internal if you need to override this service, create a new service based on the WebsiteArticleReindexProviderEnhancerInterface
@@ -41,7 +41,7 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
     ];
 
     public function __construct(
-        private FormMetadataProvider $formMetadataProvider,
+        private MetadataProviderInterface $formMetadataProvider,
     ) {
     }
 
@@ -90,7 +90,7 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
     private function getTemplateFormMetadata(string $templateKey, string $locale): ?FormMetadata
     {
         /** @var TypedFormMetadata $formMetadata */
-        $formMetadata = $this->formMetadataProvider->getMetadata('article', $locale);
+        $formMetadata = $this->formMetadataProvider->getMetadata('article', $locale, []);
         /** @var array<string, FormMetadata> $forms */
         $forms = $formMetadata->getForms();
 

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
@@ -22,16 +22,16 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Article\Infrastructure\Sulu\Search\Visitor\WebsiteArticleReindexContentEnhancer;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 
 class WebsiteArticleReindexContentEnhancerTest extends TestCase
 {
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy<FormMetadataProvider>
+     * @var ObjectProphecy<MetadataProviderInterface>
      */
     private ObjectProphecy $formMetadataProvider;
 
@@ -39,7 +39,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formMetadataProvider = $this->prophesize(FormMetadataProvider::class);
+        $this->formMetadataProvider = $this->prophesize(MetadataProviderInterface::class);
         $this->enhancer = new WebsiteArticleReindexContentEnhancer($this->formMetadataProvider->reveal());
     }
 
@@ -120,7 +120,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -154,7 +154,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -206,7 +206,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -241,7 +241,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -425,7 +425,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -455,7 +455,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -485,7 +485,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -520,7 +520,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -552,7 +552,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -587,7 +587,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -618,7 +618,7 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('article', 'en')
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
@@ -16,10 +16,10 @@ namespace Sulu\Page\Infrastructure\Sulu\Search\Visitor;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 
 /**
  * @internal if you need to override this service, create a new service based on the WebsitePageReindexProviderEnhancerInterface
@@ -41,7 +41,7 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
     ];
 
     public function __construct(
-        private FormMetadataProvider $formMetadataProvider,
+        private MetadataProviderInterface $formMetadataProvider,
     ) {
     }
 
@@ -90,7 +90,7 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
     private function getTemplateFormMetadata(string $templateKey, string $locale): ?FormMetadata
     {
         /** @var TypedFormMetadata $formMetadata */
-        $formMetadata = $this->formMetadataProvider->getMetadata('page', $locale);
+        $formMetadata = $this->formMetadataProvider->getMetadata('page', $locale, []);
         /** @var array<string, FormMetadata> $forms */
         $forms = $formMetadata->getForms();
 

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
@@ -21,9 +21,9 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
-use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TagMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\WebsitePageReindexContentEnhancer;
 
 class WebsitePageReindexContentEnhancerTest extends TestCase
@@ -31,7 +31,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
     use ProphecyTrait;
 
     /**
-     * @var ObjectProphecy<FormMetadataProvider>
+     * @var ObjectProphecy<MetadataProviderInterface>
      */
     private ObjectProphecy $formMetadataProvider;
 
@@ -39,7 +39,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->formMetadataProvider = $this->prophesize(FormMetadataProvider::class);
+        $this->formMetadataProvider = $this->prophesize(MetadataProviderInterface::class);
         $this->enhancer = new WebsitePageReindexContentEnhancer($this->formMetadataProvider->reveal());
     }
 
@@ -120,7 +120,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -154,7 +154,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -206,7 +206,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -241,7 +241,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -425,7 +425,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -455,7 +455,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -485,7 +485,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -520,7 +520,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -552,7 +552,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -587,7 +587,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 
@@ -618,7 +618,7 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $typedFormMetadata = new TypedFormMetadata();
         $typedFormMetadata->addForm('default', $formMetadata);
 
-        $this->formMetadataProvider->getMetadata('page', 'en')
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
             ->willReturn($typedFormMetadata)
             ->shouldBeCalledOnce();
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/CachedFormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/CachedFormMetadataProvider.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * @internal this class should not be extended or initialized by any application outside of sulu
  */
-class CachedFormMetadataProvider implements MetadataProviderInterface, ResetInterface
+final class CachedFormMetadataProvider implements MetadataProviderInterface, ResetInterface
 {
     /**
      * @var array<string, MetadataInterface>
@@ -30,23 +30,17 @@ class CachedFormMetadataProvider implements MetadataProviderInterface, ResetInte
     ) {
     }
 
-    public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
+    public function getMetadata(...$args): MetadataInterface // @phpstan-ignore missingType.parameter
     {
-        $cacheKey = $this->buildCacheKey([
-            'key' => $key,
-            'locale' => $locale,
-            'metadataOptions' => $metadataOptions,
-        ]);
+        $cacheKey = $this->buildCacheKey($args);
 
         if (isset($this->cache[$cacheKey])) {
             return $this->cache[$cacheKey];
         }
 
-        $metadata = $this->inner->getMetadata($key, $locale, $metadataOptions);
+        $metadata = $this->inner->getMetadata(...$args); // @phpstan-ignore argument.type
 
-        if ($metadata->isCacheable()) {
-            $this->cache[$cacheKey] = $metadata;
-        }
+        $this->cache[$cacheKey] = $metadata;
 
         return $metadata;
     }
@@ -57,7 +51,7 @@ class CachedFormMetadataProvider implements MetadataProviderInterface, ResetInte
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param array<int|string, mixed> $input
      */
     private function buildCacheKey(array $input): string
     {
@@ -67,7 +61,6 @@ class CachedFormMetadataProvider implements MetadataProviderInterface, ResetInte
     private function normalizeValue(mixed $value): string
     {
         if (\is_array($value)) {
-            \ksort($value);
             $parts = [];
             foreach ($value as $k => $v) {
                 $parts[] = $k . ':' . $this->normalizeValue($v);
@@ -80,9 +73,7 @@ class CachedFormMetadataProvider implements MetadataProviderInterface, ResetInte
             return \spl_object_hash($value);
         }
 
-        if (!\is_scalar($value) && null !== $value) {
-            return '';
-        }
+        \assert(\is_scalar($value) || null === $value, 'Expected a scalar value here got: ' . \get_debug_type($value));
 
         return (string) $value;
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/CachedFormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/CachedFormMetadataProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata;
+
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @internal this class should not be extended or initialized by any application outside of sulu
+ */
+class CachedFormMetadataProvider implements MetadataProviderInterface, ResetInterface
+{
+    /**
+     * @var array<string, MetadataInterface>
+     */
+    private array $cache = [];
+
+    public function __construct(
+        private MetadataProviderInterface $inner,
+    ) {
+    }
+
+    public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
+    {
+        $cacheKey = $this->buildCacheKey([
+            'key' => $key,
+            'locale' => $locale,
+            'metadataOptions' => $metadataOptions,
+        ]);
+
+        if (isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
+
+        $metadata = $this->inner->getMetadata($key, $locale, $metadataOptions);
+
+        if ($metadata->isCacheable()) {
+            $this->cache[$cacheKey] = $metadata;
+        }
+
+        return $metadata;
+    }
+
+    public function reset(): void
+    {
+        $this->cache = [];
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function buildCacheKey(array $input): string
+    {
+        return \hash('xxh128', $this->normalizeValue($input));
+    }
+
+    private function normalizeValue(mixed $value): string
+    {
+        if (\is_array($value)) {
+            \ksort($value);
+            $parts = [];
+            foreach ($value as $k => $v) {
+                $parts[] = $k . ':' . $this->normalizeValue($v);
+            }
+
+            return \implode(',', $parts);
+        }
+
+        if (\is_object($value)) {
+            return \spl_object_hash($value);
+        }
+
+        if (!\is_scalar($value) && null !== $value) {
+            return '';
+        }
+
+        return (string) $value;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -22,11 +22,6 @@ use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 class FormMetadataProvider implements MetadataProviderInterface
 {
     /**
-     * @var array<string, MetadataInterface>
-     */
-    private array $cache = [];
-
-    /**
      * @param iterable<FormMetadataLoaderInterface> $formMetadataLoaders
      * @param iterable<FormMetadataVisitorInterface> $formMetadataVisitors
      * @param iterable<TypedFormMetadataVisitorInterface> $typedFormMetadataVisitors
@@ -41,12 +36,6 @@ class FormMetadataProvider implements MetadataProviderInterface
 
     public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
     {
-        $cacheKey = $key . '.' . $locale . '.' . \serialize($metadataOptions);
-
-        if (isset($this->cache[$cacheKey])) {
-            return $this->cache[$cacheKey];
-        }
-
         $formMetadata = null;
         foreach ($this->formMetadataLoaders as $metadataLoader) {
             $formMetadata = $metadataLoader->getMetadata($key, $locale, $metadataOptions);
@@ -78,6 +67,6 @@ class FormMetadataProvider implements MetadataProviderInterface
             }
         }
 
-        return $this->cache[$cacheKey] = $formMetadata;
+        return $formMetadata;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/FormMetadataProvider.php
@@ -22,6 +22,11 @@ use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 class FormMetadataProvider implements MetadataProviderInterface
 {
     /**
+     * @var array<string, MetadataInterface>
+     */
+    private array $cache = [];
+
+    /**
      * @param iterable<FormMetadataLoaderInterface> $formMetadataLoaders
      * @param iterable<FormMetadataVisitorInterface> $formMetadataVisitors
      * @param iterable<TypedFormMetadataVisitorInterface> $typedFormMetadataVisitors
@@ -36,6 +41,12 @@ class FormMetadataProvider implements MetadataProviderInterface
 
     public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
     {
+        $cacheKey = $key . '.' . $locale . '.' . \serialize($metadataOptions);
+
+        if (isset($this->cache[$cacheKey])) {
+            return $this->cache[$cacheKey];
+        }
+
         $formMetadata = null;
         foreach ($this->formMetadataLoaders as $metadataLoader) {
             $formMetadata = $metadataLoader->getMetadata($key, $locale, $metadataOptions);
@@ -67,6 +78,6 @@ class FormMetadataProvider implements MetadataProviderInterface
             }
         }
 
-        return $formMetadata;
+        return $this->cache[$cacheKey] = $formMetadata;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -52,22 +52,24 @@
         </service>
 
         <service
-            id="sulu_admin.form_metadata_provider.inner"
+            id="sulu_admin.form_metadata_provider"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider"
         >
             <argument type="tagged_iterator" tag="sulu_admin.form_metadata_loader"/>
             <argument type="tagged_iterator" tag="sulu_admin.form_metadata_visitor"/>
             <argument type="tagged_iterator" tag="sulu_admin.typed_form_metadata_visitor"/>
             <argument>%sulu_core.fallback_locale%</argument>
+
+            <tag name="sulu_admin.metadata_provider" type="form"/>
         </service>
 
         <service
-            id="sulu_admin.form_metadata_provider"
+            id="sulu_admin.cached_form_metadata_provider"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\CachedFormMetadataProvider"
+            decorates="sulu_admin.form_metadata_provider"
         >
-            <argument type="service" id="sulu_admin.form_metadata_provider.inner"/>
+            <argument type="service" id=".inner"/>
 
-            <tag name="sulu_admin.metadata_provider" type="form"/>
             <tag name="kernel.reset" method="reset"/>
         </service>
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.xml
@@ -52,15 +52,23 @@
         </service>
 
         <service
-            id="sulu_admin.form_metadata_provider"
+            id="sulu_admin.form_metadata_provider.inner"
             class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataProvider"
         >
             <argument type="tagged_iterator" tag="sulu_admin.form_metadata_loader"/>
             <argument type="tagged_iterator" tag="sulu_admin.form_metadata_visitor"/>
             <argument type="tagged_iterator" tag="sulu_admin.typed_form_metadata_visitor"/>
             <argument>%sulu_core.fallback_locale%</argument>
+        </service>
 
-            <tag name="sulu_admin.metadata_provider" type="form" />
+        <service
+            id="sulu_admin.form_metadata_provider"
+            class="Sulu\Bundle\AdminBundle\Metadata\FormMetadata\CachedFormMetadataProvider"
+        >
+            <argument type="service" id="sulu_admin.form_metadata_provider.inner"/>
+
+            <tag name="sulu_admin.metadata_provider" type="form"/>
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="sulu_admin.expression_language" class="Symfony\Component\ExpressionLanguage\ExpressionLanguage">

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/CachedFormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/CachedFormMetadataProviderTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Exception\MetadataNotFoundException;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\CachedFormMetadataProvider;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataInterface;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
+
+class CachedFormMetadataProviderTest extends TestCase
+{
+    public function testGetMetadataDelegatesToInner(): void
+    {
+        $metadata = $this->createCacheableMetadata();
+        $callCount = 0;
+        $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
+        $cached = new CachedFormMetadataProvider($inner);
+
+        $result = $cached->getMetadata('page', 'en', []);
+
+        $this->assertSame($metadata, $result);
+        $this->assertSame(1, $callCount);
+    }
+
+    public function testGetMetadataCachesCacheableResult(): void
+    {
+        $metadata = $this->createCacheableMetadata();
+        $callCount = 0;
+        $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
+        $cached = new CachedFormMetadataProvider($inner);
+
+        $result1 = $cached->getMetadata('page', 'en', []);
+        $result2 = $cached->getMetadata('page', 'en', []);
+
+        $this->assertSame($metadata, $result1);
+        $this->assertSame($metadata, $result2);
+        $this->assertSame(1, $callCount);
+    }
+
+    public function testGetMetadataDoesNotCacheNonCacheableResult(): void
+    {
+        $metadata = $this->createNonCacheableMetadata();
+        $callCount = 0;
+        $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
+        $cached = new CachedFormMetadataProvider($inner);
+
+        $cached->getMetadata('page', 'en', []);
+        $cached->getMetadata('page', 'en', []);
+
+        $this->assertSame(2, $callCount);
+    }
+
+    public function testGetMetadataWithDifferentKeyProducesSeparateCacheEntries(): void
+    {
+        $metadata1 = $this->createCacheableMetadata();
+        $metadata2 = $this->createCacheableMetadata();
+        $callCount = 0;
+        $inner = $this->createInnerProvider([
+            'page' => ['en' => $metadata1],
+            'article' => ['en' => $metadata2],
+        ], $callCount);
+        $cached = new CachedFormMetadataProvider($inner);
+
+        $result1 = $cached->getMetadata('page', 'en', []);
+        $result2 = $cached->getMetadata('article', 'en', []);
+
+        $this->assertSame($metadata1, $result1);
+        $this->assertSame($metadata2, $result2);
+        $this->assertSame(2, $callCount);
+    }
+
+    public function testGetMetadataWithDifferentLocaleProducesSeparateCacheEntries(): void
+    {
+        $metadata1 = $this->createCacheableMetadata();
+        $metadata2 = $this->createCacheableMetadata();
+        $callCount = 0;
+        $inner = $this->createInnerProvider([
+            'page' => ['en' => $metadata1, 'de' => $metadata2],
+        ], $callCount);
+        $cached = new CachedFormMetadataProvider($inner);
+
+        $result1 = $cached->getMetadata('page', 'en', []);
+        $result2 = $cached->getMetadata('page', 'de', []);
+
+        $this->assertSame($metadata1, $result1);
+        $this->assertSame($metadata2, $result2);
+        $this->assertSame(2, $callCount);
+    }
+
+    public function testGetMetadataWithReorderedOptionsHitsSameCache(): void
+    {
+        $metadata = $this->createCacheableMetadata();
+        $callCount = 0;
+        $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
+        $cached = new CachedFormMetadataProvider($inner);
+
+        $result1 = $cached->getMetadata('page', 'en', ['a' => '1', 'b' => '2']);
+        $result2 = $cached->getMetadata('page', 'en', ['b' => '2', 'a' => '1']);
+
+        $this->assertSame($metadata, $result1);
+        $this->assertSame($metadata, $result2);
+        $this->assertSame(1, $callCount);
+    }
+
+    public function testResetClearsCache(): void
+    {
+        $metadata = $this->createCacheableMetadata();
+        $callCount = 0;
+        $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
+        $cached = new CachedFormMetadataProvider($inner);
+
+        $cached->getMetadata('page', 'en', []);
+        $cached->reset();
+        $cached->getMetadata('page', 'en', []);
+
+        $this->assertSame(2, $callCount);
+    }
+
+    public function testGetMetadataForwardsException(): void
+    {
+        $callCount = 0;
+        $inner = $this->createInnerProvider([], $callCount);
+        $cached = new CachedFormMetadataProvider($inner);
+
+        $this->expectException(MetadataNotFoundException::class);
+
+        $cached->getMetadata('nonexistent', 'en', []);
+    }
+
+    /**
+     * @param array<string, array<string, MetadataInterface>> $metadataMap
+     */
+    private function createInnerProvider(array $metadataMap, int &$callCount): MetadataProviderInterface
+    {
+        return new class($metadataMap, $callCount) implements MetadataProviderInterface {
+            /**
+             * @param array<string, array<string, MetadataInterface>> $metadataMap
+             */
+            public function __construct(
+                private array $metadataMap,
+                private int &$callCount,
+            ) {
+            }
+
+            public function getMetadata(string $key, string $locale, array $metadataOptions = []): MetadataInterface
+            {
+                ++$this->callCount;
+
+                if (!isset($this->metadataMap[$key][$locale])) {
+                    throw new MetadataNotFoundException('form', $key);
+                }
+
+                return $this->metadataMap[$key][$locale];
+            }
+        };
+    }
+
+    private function createCacheableMetadata(): MetadataInterface
+    {
+        return new class() implements MetadataInterface {
+            public function isCacheable(): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    private function createNonCacheableMetadata(): MetadataInterface
+    {
+        return new class() implements MetadataInterface {
+            public function isCacheable(): bool
+            {
+                return false;
+            }
+        };
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/CachedFormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/CachedFormMetadataProviderTest.php
@@ -21,7 +21,7 @@ class CachedFormMetadataProviderTest extends TestCase
 {
     public function testGetMetadataDelegatesToInner(): void
     {
-        $metadata = $this->createCacheableMetadata();
+        $metadata = $this->createMetadata();
         $callCount = 0;
         $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
         $cached = new CachedFormMetadataProvider($inner);
@@ -32,9 +32,9 @@ class CachedFormMetadataProviderTest extends TestCase
         $this->assertSame(1, $callCount);
     }
 
-    public function testGetMetadataCachesCacheableResult(): void
+    public function testGetMetadataCachesResult(): void
     {
-        $metadata = $this->createCacheableMetadata();
+        $metadata = $this->createMetadata();
         $callCount = 0;
         $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
         $cached = new CachedFormMetadataProvider($inner);
@@ -47,23 +47,10 @@ class CachedFormMetadataProviderTest extends TestCase
         $this->assertSame(1, $callCount);
     }
 
-    public function testGetMetadataDoesNotCacheNonCacheableResult(): void
-    {
-        $metadata = $this->createNonCacheableMetadata();
-        $callCount = 0;
-        $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
-        $cached = new CachedFormMetadataProvider($inner);
-
-        $cached->getMetadata('page', 'en', []);
-        $cached->getMetadata('page', 'en', []);
-
-        $this->assertSame(2, $callCount);
-    }
-
     public function testGetMetadataWithDifferentKeyProducesSeparateCacheEntries(): void
     {
-        $metadata1 = $this->createCacheableMetadata();
-        $metadata2 = $this->createCacheableMetadata();
+        $metadata1 = $this->createMetadata();
+        $metadata2 = $this->createMetadata();
         $callCount = 0;
         $inner = $this->createInnerProvider([
             'page' => ['en' => $metadata1],
@@ -81,8 +68,8 @@ class CachedFormMetadataProviderTest extends TestCase
 
     public function testGetMetadataWithDifferentLocaleProducesSeparateCacheEntries(): void
     {
-        $metadata1 = $this->createCacheableMetadata();
-        $metadata2 = $this->createCacheableMetadata();
+        $metadata1 = $this->createMetadata();
+        $metadata2 = $this->createMetadata();
         $callCount = 0;
         $inner = $this->createInnerProvider([
             'page' => ['en' => $metadata1, 'de' => $metadata2],
@@ -97,24 +84,27 @@ class CachedFormMetadataProviderTest extends TestCase
         $this->assertSame(2, $callCount);
     }
 
-    public function testGetMetadataWithReorderedOptionsHitsSameCache(): void
+    public function testGetMetadataCachesNonCacheableResult(): void
     {
-        $metadata = $this->createCacheableMetadata();
+        $metadata = new class() implements MetadataInterface {
+            public function isCacheable(): bool
+            {
+                return false;
+            }
+        };
         $callCount = 0;
         $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
         $cached = new CachedFormMetadataProvider($inner);
 
-        $result1 = $cached->getMetadata('page', 'en', ['a' => '1', 'b' => '2']);
-        $result2 = $cached->getMetadata('page', 'en', ['b' => '2', 'a' => '1']);
+        $cached->getMetadata('page', 'en', []);
+        $cached->getMetadata('page', 'en', []);
 
-        $this->assertSame($metadata, $result1);
-        $this->assertSame($metadata, $result2);
         $this->assertSame(1, $callCount);
     }
 
     public function testResetClearsCache(): void
     {
-        $metadata = $this->createCacheableMetadata();
+        $metadata = $this->createMetadata();
         $callCount = 0;
         $inner = $this->createInnerProvider(['page' => ['en' => $metadata]], $callCount);
         $cached = new CachedFormMetadataProvider($inner);
@@ -165,22 +155,12 @@ class CachedFormMetadataProviderTest extends TestCase
         };
     }
 
-    private function createCacheableMetadata(): MetadataInterface
+    private function createMetadata(): MetadataInterface
     {
         return new class() implements MetadataInterface {
             public function isCacheable(): bool
             {
                 return true;
-            }
-        };
-    }
-
-    private function createNonCacheableMetadata(): MetadataInterface
-    {
-        return new class() implements MetadataInterface {
-            public function isCacheable(): bool
-            {
-                return false;
             }
         };
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This PR implements a very simple InMemory Cache for the FormMetadata to proof the value of it. 

If we decide to go with this approach, the implementation has to be adjusted properly with a CachedFormMetadata decorator and also implementing the ResetInterface.

#### Why?

FormMetadata are fetched multiple times and also all the visitors are executed especially in navigation requests multiple times. This could be a easy improvements.

