### PR TITLE
Fix media bundle tests after backmerge 2.6 to 3.0 with autofocus

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/collection_details.json
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/snapshots/collection_details.json
@@ -7,6 +7,11 @@
             "type": "text_line",
             "colSpan": 12,
             "options": {
+                "autofocus": {
+                    "name": "autofocus",
+                    "type": "string",
+                    "value": true
+                },
                 "headline": {
                     "name": "headline",
                     "type": "string",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/8639
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix media bundle tests after backmerge 2.6 to 3.0 with autofocus.

#### Why?

Some metadata tests exists on 3.0 which didn't exist on 2.6 and so we need update them.