### PR TITLE
Fix copy locale from detail-view

### DIFF
--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -286,15 +286,23 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         }
 
         if ('copy_locale' === $action) {
-            $message = new CopyLocalePageMessage(
-                ['uuid' => $uuid],
-                (string) $request->query->get('src'),
-                (string) $request->query->get('dest'),
-            );
+            $srcLocale = (string) ($request->query->get('src') ?: $request->query->get('locale'));
+            $destLocales = \array_filter(\array_map('trim', \explode(',', (string) $request->query->get('dest'))));
 
-            /** @see \Sulu\Page\Application\MessageHandler\CopyLocalePageMessageHandler */
-            /** @var PageInterface|null */
-            return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
+            $result = null;
+            foreach ($destLocales as $destLocale) {
+                $message = new CopyLocalePageMessage(
+                    ['uuid' => $uuid],
+                    $srcLocale,
+                    $destLocale,
+                );
+
+                /** @see \Sulu\Page\Application\MessageHandler\CopyLocalePageMessageHandler */
+                /** @var PageInterface|null */
+                $result = $this->handle(new Envelope($message, [new EnableFlushStamp()]));
+            }
+
+            return $result;
         } elseif ('move' === $action) {
             $destinationUuid = $request->query->getString('destination');
             $message = new MovePageMessage(['uuid' => $uuid], ['uuid' => $destinationUuid], $this->getLocale($request));

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -525,6 +525,20 @@ class PageControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testPostTriggerCopyLocaleWithLocaleFallbackAsSrc(string $id): void
+    {
+        $this->client->request('POST', '/admin/api/pages/' . $id . '?locale=en&action=copy_locale&dest=de');
+
+        $response = $this->client->getResponse();
+        $content = \json_decode((string) $response->getContent(), true);
+
+        $this->assertHttpStatusCode(200, $response);
+        $this->assertIsArray($content);
+        $this->assertContains('de', $content['contentLocales']);
+        $this->assertContains('en', $content['contentLocales']);
+    }
+
+    #[Depends('testPost')]
     #[Depends('testGet')]
     public function testPut(string $id): void
     {

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -534,6 +534,8 @@ class PageControllerTest extends SuluTestCase
 
         $this->assertHttpStatusCode(200, $response);
         $this->assertIsArray($content);
+        $this->assertArrayHasKey('contentLocales', $content);
+        $this->assertIsArray($content['contentLocales']);
         $this->assertContains('de', $content['contentLocales']);
         $this->assertContains('en', $content['contentLocales']);
     }


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Fixed copy locale action in the page detail-view when no explicit `src` parameter is provided
  - Added fallback to use the `locale` query parameter as source locale when `src` is absent
  - Support multiple comma-separated destination locales in the `dest` query parameter
  - Added functional test covering the `locale`-as-src fallback scenario

  #### Why?

  When triggering the `copy_locale` action from the detail-view, the `src` query parameter was not being sent, only `locale` was available. This caused the copy to fail because the handler received an empty source
   locale. The fix falls back to `locale` when `src` is absent, aligning the detail-view trigger with the list-view trigger.