### PR TITLE
Fix crop images issue

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/ImageRectangleSelection.js
@@ -23,6 +23,16 @@ class ImageRectangleSelection extends React.Component<Props> {
     image: Image;
     @observable imageLoaded = false;
 
+    normalizeNaturalSelection(data: SelectionData): SelectionData {
+        const {naturalHeight, naturalWidth} = this.image;
+        const width = Math.min(Math.max(data.width, 0), naturalWidth);
+        const height = Math.min(Math.max(data.height, 0), naturalHeight);
+        const left = Math.min(Math.max(data.left, 0), naturalWidth - width);
+        const top = Math.min(Math.max(data.top, 0), naturalHeight - height);
+
+        return {height, left, top, width};
+    }
+
     naturalHorizontalToScaled = (h: number) => {
         return Math.max(h * this.scaledImageWidth / this.image.naturalWidth, 0);
     };
@@ -37,21 +47,32 @@ class ImageRectangleSelection extends React.Component<Props> {
     };
 
     naturalDataToScaled(data: SelectionData): SelectionData {
+        const normalizedData = this.normalizeNaturalSelection(data);
+        const left = this.naturalHorizontalToScaled(normalizedData.left);
+        const top = this.naturalVerticalToScaled(normalizedData.top);
+        const right = this.naturalHorizontalToScaled(normalizedData.left + normalizedData.width);
+        const bottom = this.naturalVerticalToScaled(normalizedData.top + normalizedData.height);
+
         return {
-            width: this.naturalHorizontalToScaled(data.width),
-            height: this.naturalVerticalToScaled(data.height),
-            left: this.naturalHorizontalToScaled(data.left),
-            top: this.naturalVerticalToScaled(data.top),
+            width: right - left,
+            height: bottom - top,
+            left,
+            top,
         };
     }
 
     scaledDataToNatural(data: SelectionData): SelectionData {
-        return {
-            width: this.scaledHorizontalToNatural(data.width),
-            height: this.scaledVerticalToNatural(data.height),
-            left: this.scaledHorizontalToNatural(data.left),
-            top: this.scaledVerticalToNatural(data.top),
-        };
+        const left = this.scaledHorizontalToNatural(data.left);
+        const top = this.scaledVerticalToNatural(data.top);
+        const right = this.scaledHorizontalToNatural(data.left + data.width);
+        const bottom = this.scaledVerticalToNatural(data.top + data.height);
+
+        return this.normalizeNaturalSelection({
+            width: right - left,
+            height: bottom - top,
+            left,
+            top,
+        });
     }
 
     constructor(props: Props) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/ImageRectangleSelection.test.js
@@ -164,6 +164,39 @@ test('The component should not scale the value to exceed the natural image width
     expect(changeSpy).toBeCalledWith({width: 4896, height: 1769.1056910569105, top: 0, left: 0});
 });
 
+test('The component should keep converted bottom edge inside natural image bounds', () => {
+    const changeSpy = jest.fn();
+
+    const view = mount(
+        <ImageRectangleSelection
+            containerHeight={200}
+            containerWidth={200}
+            image="//:0"
+            onChange={changeSpy}
+            value={undefined}
+        />
+    );
+
+    const onImageLoad = view.instance().image.onload;
+    view.instance().image = {
+        naturalWidth: 253,
+        naturalHeight: 200,
+    };
+    onImageLoad();
+    view.update();
+
+    // Simulate a measured selection where the bottom edge is slightly below the actual scaled image.
+    view.find('RectangleSelectionComponent').prop('onChange')({width: 200, height: 100, top: 59, left: 0});
+
+    expect(changeSpy).toBeCalledWith(expect.objectContaining({
+        left: 0,
+        width: 253,
+    }));
+
+    const convertedSelection = changeSpy.mock.calls[changeSpy.mock.calls.length - 1][0];
+    expect(convertedSelection.top + convertedSelection.height).toBeLessThanOrEqual(200);
+});
+
 test.each([
     [300, 600, 360, 640, 100, 200],
     [200, 200, 400, 480, 50, 50],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/__snapshots__/ImageRectangleSelection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ImageRectangleSelection/tests/__snapshots__/ImageRectangleSelection.test.js.snap
@@ -64,7 +64,7 @@ exports[`The component should render with initial selection 1`] = `
   <div
     class="rectangle hasBackdrop"
     role="button"
-    style="left: 100px; top: 66.66666666666667px; width: 500px; height: 266.6666666666667px;"
+    style="left: 100px; top: 66.66666666666667px; width: 500px; height: 266.66666666666663px;"
   >
     <div
       class="backdrop"

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/ImagineImageConverter.php
@@ -295,12 +295,16 @@ class ImagineImageConverter implements ImageConverterInterface
     private function getCropParameters(ImageInterface $image, $formatOptions, array $format)
     {
         if (isset($formatOptions)) {
-            $parameters = [
+            $parameters = $this->normalizeCropParameters($image, [
                 'x' => $formatOptions->getCropX(),
                 'y' => $formatOptions->getCropY(),
                 'width' => $formatOptions->getCropWidth(),
                 'height' => $formatOptions->getCropHeight(),
-            ];
+            ]);
+
+            if (!isset($parameters)) {
+                return null;
+            }
 
             if ($this->cropper->isValid(
                 $image,
@@ -315,6 +319,40 @@ class ImagineImageConverter implements ImageConverterInterface
         }
 
         return null;
+    }
+
+    /**
+     * @param array{x: int, y: int, width: int, height: int} $parameters
+     *
+     * @return ?array{x: int, y: int, width: int, height: int}
+     */
+    private function normalizeCropParameters(ImageInterface $image, array $parameters): ?array
+    {
+        $imageWidth = $image->getSize()->getWidth();
+        $imageHeight = $image->getSize()->getHeight();
+
+        $x = \max(0, $parameters['x']);
+        $y = \max(0, $parameters['y']);
+        $width = \max(0, $parameters['width']);
+        $height = \max(0, $parameters['height']);
+
+        if ($x >= $imageWidth || $y >= $imageHeight || 0 === $width || 0 === $height) {
+            return null;
+        }
+
+        $width = \min($width, $imageWidth - $x);
+        $height = \min($height, $imageHeight - $y);
+
+        if (0 === $width || 0 === $height) {
+            return null;
+        }
+
+        return [
+            'x' => $x,
+            'y' => $y,
+            'width' => $width,
+            'height' => $height,
+        ];
     }
 
     /**

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/CropOverlay.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/CropOverlay.js
@@ -85,11 +85,16 @@ class CropOverlay extends React.Component<Props> {
             return {};
         }
 
+        const cropX = Math.max(0, Math.floor(selection.left));
+        const cropY = Math.max(0, Math.floor(selection.top));
+        const cropRight = Math.max(cropX, Math.ceil(selection.left + selection.width));
+        const cropBottom = Math.max(cropY, Math.ceil(selection.top + selection.height));
+
         return {
-            cropX: selection.left,
-            cropY: selection.top,
-            cropWidth: selection.width,
-            cropHeight: selection.height,
+            cropX,
+            cropY,
+            cropWidth: cropRight - cropX,
+            cropHeight: cropBottom - cropY,
         };
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/CropOverlay.test.js
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/CropOverlay.test.js
@@ -39,6 +39,31 @@ test('Closing the overlay should call the onClose callback', () => {
     expect(closeSpy).toBeCalledWith();
 });
 
+test('Convert selection to format options with edge-based integer coordinates', () => {
+    const cropOverlay = shallow(
+        <CropOverlay
+            id={4}
+            image="test.jpg"
+            locale="de"
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+        />
+    );
+
+    expect(cropOverlay.instance().convertSelectionToFormatOptions({
+        left: 100.6,
+        top: 74.63,
+        width: 152.4,
+        height: 125.37,
+    })).toEqual({
+        cropX: 100,
+        cropY: 74,
+        cropWidth: 153,
+        cropHeight: 126,
+    });
+});
+
 test('Reset format croppings when closing overlay', () => {
     const formats = [
         {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/ImageConverter/ImagineImageConverterTest.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Tests\Unit\Media\ImageConverter;
 
+use Imagine\Image\BoxInterface;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\ImagineInterface;
 use Imagine\Image\Palette\PaletteInterface;
@@ -20,6 +21,7 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FormatOptions;
 use Sulu\Bundle\MediaBundle\Media\Exception\ImageProxyMediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\Cropper\CropperInterface;
 use Sulu\Bundle\MediaBundle\Media\ImageConverter\Focus\FocusInterface;
@@ -135,6 +137,64 @@ class ImagineImageConverterTest extends TestCase
         $imagineImage->interlace(ImageInterface::INTERLACE_PLANE)->shouldBeCalled();
 
         $imagineImage->get('jpg', [])->willReturn('new-image-resource');
+
+        $this->focus->focus(Argument::any())->shouldNotBeCalled();
+
+        $this->assertEquals('new-image-resource', $this->imagineImageConverter->convert($fileVersion, '640x480', 'jpg'));
+    }
+
+    public function testConvertWithCropOutsideImageIsClampedToImageBounds(): void
+    {
+        $imagineImage = $this->prophesize(ImageInterface::class);
+        $palette = $this->prophesize(PaletteInterface::class);
+        $imageSize = $this->prophesize(BoxInterface::class);
+        $imageSize->getWidth()->willReturn(3264);
+        $imageSize->getHeight()->willReturn(1836);
+
+        $formatOptions = new FormatOptions();
+        $formatOptions->setFormatKey('640x480');
+        $formatOptions->setCropX(1390.2315297889866);
+        $formatOptions->setCropY(1216.6401957753455);
+        $formatOptions->setCropWidth(882.7375964718849);
+        $formatOptions->setCropHeight(629.9900771775082);
+
+        $fileVersion = new FileVersion();
+        $fileVersion->setName('test.jpg');
+        $fileVersion->setVersion(1);
+        $fileVersion->setStorageOptions(['option' => 'value']);
+        $fileVersion->setMimeType('image/jpeg');
+        $fileVersion->addFormatOptions($formatOptions);
+
+        $this->storage->load(['option' => 'value'])->willReturn('image-resource');
+        $this->mediaImageExtractor->extract('image-resource', 'image/jpeg')->willReturn('image-resource');
+        $this->imagine->read('image-resource')->willReturn($imagineImage->reveal());
+
+        $imagineImage->palette()->willReturn($palette->reveal());
+        $imagineImage->metadata()->willReturn(['']);
+        $imagineImage->getSize()->willReturn($imageSize->reveal());
+        $imagineImage->layers()->willReturn(['']);
+        $imagineImage->strip()->shouldBeCalled();
+        $imagineImage->interlace(ImageInterface::INTERLACE_PLANE)->shouldBeCalled();
+        $imagineImage->get('jpg', [])->willReturn('new-image-resource');
+
+        $this->cropper->isValid(
+            $imagineImage->reveal(),
+            1390,
+            1217,
+            883,
+            619,
+            Argument::that(
+                fn(array $format) => ['options' => []] === $format
+            )
+        )->willReturn(true)->shouldBeCalled();
+
+        $this->cropper->crop(
+            $imagineImage->reveal(),
+            1390,
+            1217,
+            883,
+            619
+        )->willReturn($imagineImage->reveal())->shouldBeCalled();
 
         $this->focus->focus(Argument::any())->shouldNotBeCalled();
 


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes https://github.com/sulu/sulu/issues/6527 
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Normalized crop selection coordinates in `ImageRectangleSelection` to clamp values
  within natural image bounds, preventing out-of-bounds crop regions
  - Fixed `naturalDataToScaled` and `scaledDataToNatural` conversions to use edge-based
  arithmetic (left+width → right, top+height → bottom) instead of converting
  width/height independently, avoiding rounding drift
  - Added `normalizeCropParameters` to `ImagineImageConverter` that clamps crop
  coordinates to image dimensions and returns `null` for invalid crops
  - Converted floating-point crop selections to integer pixel coordinates in
  `CropOverlay` using floor/ceil on edges to preserve the full selected area
  - Added unit tests for all three layers (JS component, JS overlay, PHP converter)

  #### Why?

  When cropping images, floating-point rounding errors during the scaled-to-natural
  coordinate conversion could produce crop regions that extend beyond the actual image
  boundaries. This caused Imagine to throw exceptions when attempting to crop outside
  the image dimensions. The fix normalizes coordinates at every layer: the JS selection
  component, the crop overlay, and the PHP image converter.