### PR TITLE
Improve phpcr cleanup command

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -17,6 +17,7 @@ use PHPCR\SessionInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
@@ -38,6 +39,7 @@ class PHPCRCleanupCommand extends Command
     private OutputInterface $logger;
 
     public function __construct(
+        private SessionInterface $liveSession,
         private SessionInterface $session,
         private WebspaceManagerInterface $webspaceManager,
         private ServicesResetter $servicesResetter,
@@ -140,6 +142,7 @@ class PHPCRCleanupCommand extends Command
         $queryManager = $this->session->getWorkspace()->getQueryManager();
         $rows = $queryManager->createQuery($sql2, 'JCR-SQL2')->execute();
 
+        /** @var string[] $uuids */
         $uuids = \array_map(static fn ($row) => $row->getValue('jcr:uuid'), \iterator_to_array($rows->getRows()));
         unset($rows);
 
@@ -204,82 +207,39 @@ class PHPCRCleanupCommand extends Command
                     continue;
                 }
 
-                if (0 !== $status) {
-                    $stderr = $process->getErrorOutput();
-                    if ('' !== $stderr) {
-                        $errorMessages[] = $stderr;
-                    }
-
-                    // Try to parse output for detailed per-node counts before falling back
-                    $subCommandOutput = $process->getOutput();
-                    \preg_match('/Nodes processed: (\d+)/', $subCommandOutput, $matches);
-                    $batchProcessed = (int) ($matches[1] ?? 0);
-                    \preg_match('/Nodes ignored: (\d+)/', $subCommandOutput, $matches);
-                    $batchIgnored = (int) ($matches[1] ?? 0);
-                    \preg_match('/Nodes errored: (\d+)/', $subCommandOutput, $matches);
-                    $batchErrored = (int) ($matches[1] ?? 0);
-
-                    $parsedTotal = $batchProcessed + $batchIgnored + $batchErrored;
-
-                    if ($parsedTotal > 0) {
-                        $stats['nodes'] += $parsedTotal;
-                        $stats['ignoredNodes'] += $batchIgnored;
-                        $stats['erroredNodes'] += $batchErrored;
-
-                        \preg_match('/Documents: (\d+)/', $subCommandOutput, $matches);
-                        $stats['documents'] += (int) ($matches[1] ?? 0);
-                        \preg_match('/Removed properties: (\d+)/', $subCommandOutput, $matches);
-                        $stats['removedProperties'] += (int) ($matches[1] ?? 0);
-                        \preg_match('/Total properties: (\d+)/', $subCommandOutput, $matches);
-                        $stats['properties'] += (int) ($matches[1] ?? 0);
-                        \preg_match('/Removed stale locale properties: (\d+)/', $subCommandOutput, $matches);
-                        $stats['removedStaleProperties'] += (int) ($matches[1] ?? 0);
-                    } else {
-                        $stats['nodes'] += $batchNodeCount;
-                        $stats['erroredNodes'] += $batchNodeCount;
-                    }
-
-                    $this->logger->writeln(\sprintf(
-                        "# Error processing batch of %d nodes\n\n%s\n",
-                        $batchNodeCount,
-                        $stderr,
-                    ));
-
-                    $this->updateProgressBar($progressBar, $stats, $parsedTotal > 0 ? $parsedTotal : $batchNodeCount);
-
-                    continue;
-                }
-
                 $subCommandOutput = $process->getOutput();
+                $batchStats = $this->parseSubprocessOutput($subCommandOutput);
+                $parsedTotal = $batchStats['nodesProcessed'] + $batchStats['nodesIgnored'] + $batchStats['nodesErrored'];
 
-                \preg_match('/Nodes processed: (\d+)/', $subCommandOutput, $matches);
-                $batchProcessed = (int) ($matches[1] ?? 0);
-                \preg_match('/Nodes ignored: (\d+)/', $subCommandOutput, $matches);
-                $batchIgnored = (int) ($matches[1] ?? 0);
-                \preg_match('/Nodes errored: (\d+)/', $subCommandOutput, $matches);
-                $batchErrored = (int) ($matches[1] ?? 0);
-
-                $stats['nodes'] += $batchProcessed + $batchIgnored + $batchErrored;
-                $stats['ignoredNodes'] += $batchIgnored;
-                $stats['erroredNodes'] += $batchErrored;
-
-                \preg_match('/Documents: (\d+)/', $subCommandOutput, $matches);
-                $stats['documents'] += (int) ($matches[1] ?? 0);
-                \preg_match('/Removed properties: (\d+)/', $subCommandOutput, $matches);
-                $stats['removedProperties'] += (int) ($matches[1] ?? 0);
-                \preg_match('/Total properties: (\d+)/', $subCommandOutput, $matches);
-                $stats['properties'] += (int) ($matches[1] ?? 0);
-                \preg_match('/Removed stale locale properties: (\d+)/', $subCommandOutput, $matches);
-                $stats['removedStaleProperties'] += (int) ($matches[1] ?? 0);
+                if ($parsedTotal > 0) {
+                    $stats['nodes'] += $parsedTotal;
+                    $stats['ignoredNodes'] += $batchStats['nodesIgnored'];
+                    $stats['erroredNodes'] += $batchStats['nodesErrored'];
+                    $stats['documents'] += $batchStats['documents'];
+                    $stats['removedProperties'] += $batchStats['removedProperties'];
+                    $stats['properties'] += $batchStats['properties'];
+                    $stats['removedStaleProperties'] += $batchStats['removedStaleProperties'];
+                } else {
+                    $stats['nodes'] += $batchNodeCount;
+                    $stats['erroredNodes'] += $batchNodeCount;
+                }
 
                 $stderr = $process->getErrorOutput();
                 if ('' !== $stderr) {
                     $errorMessages[] = $stderr;
                 }
 
-                $this->logger->writeln($subCommandOutput);
+                if (0 !== $status) {
+                    $this->logger->writeln(\sprintf(
+                        "# Error processing batch of %d nodes\n\n%s\n",
+                        $batchNodeCount,
+                        $stderr,
+                    ));
+                } else {
+                    $this->logger->writeln($subCommandOutput);
+                }
 
-                $this->updateProgressBar($progressBar, $stats, $batchProcessed + $batchIgnored + $batchErrored);
+                $this->updateProgressBar($progressBar, $stats, $parsedTotal > 0 ? $parsedTotal : $batchNodeCount);
             }
 
             $this->servicesResetter->reset();
@@ -288,44 +248,52 @@ class PHPCRCleanupCommand extends Command
         $progressBar->finish();
 
         $staleRoutes = $this->getStaleRouteLocales();
-        $routesModified = false;
         if ([] !== $staleRoutes) {
             $io->section('Stale route locales detected');
 
+            $routesModified = false;
             foreach ($staleRoutes as $webspaceKey => $staleLocales) {
                 foreach ($staleLocales as $staleLocale) {
                     $routePath = \sprintf('/cmf/%s/routes/%s', $webspaceKey, $staleLocale);
                     $io->writeln(\sprintf('  Stale route tree: %s', $routePath));
 
                     if (!$dryRun) {
-                        if ($this->session->nodeExists($routePath)) {
-                            $this->session->getNode($routePath)->remove();
-                            $routesModified = true;
+                        foreach ([$this->session, $this->liveSession] as $phpcrSession) {
+                            if ($phpcrSession->nodeExists($routePath)) {
+                                $phpcrSession->getNode($routePath)->remove();
+                                $routesModified = true;
+                            }
                         }
                     }
                 }
             }
-        }
 
-        if (!$dryRun && $routesModified) {
-            $this->session->save();
+            if (!$dryRun && $routesModified) {
+                $this->session->save();
+                $this->liveSession->save();
+            }
         }
 
         if ([] !== $orphanedKeys) {
             $io->section('Removing orphaned webspace trees');
 
+            $orphanedModified = false;
             foreach ($orphanedKeys as $orphanedKey) {
                 $webspacePath = \sprintf('/cmf/%s', $orphanedKey);
-                if ($this->session->nodeExists($webspacePath)) {
-                    $io->writeln(\sprintf('  Removing orphaned webspace tree: %s', $webspacePath));
-                    if (!$dryRun) {
-                        $this->session->getNode($webspacePath)->remove();
+                foreach ([$this->session, $this->liveSession] as $phpcrSession) {
+                    if ($phpcrSession->nodeExists($webspacePath)) {
+                        $io->writeln(\sprintf('  Removing orphaned webspace tree: %s', $webspacePath));
+                        if (!$dryRun) {
+                            $phpcrSession->getNode($webspacePath)->remove();
+                            $orphanedModified = true;
+                        }
                     }
                 }
             }
 
-            if (!$dryRun) {
+            if (!$dryRun && $orphanedModified) {
                 $this->session->save();
+                $this->liveSession->save();
             }
         }
 
@@ -366,6 +334,31 @@ class PHPCRCleanupCommand extends Command
         $process->setTimeout(\max(120, \count($uuids) * 10));
 
         return $process;
+    }
+
+    /**
+     * @return array{nodesProcessed: int, nodesIgnored: int, nodesErrored: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int}
+     */
+    private function parseSubprocessOutput(string $output): array
+    {
+        if (\preg_match('/PHPCR_CLEANUP_STATS:(.+)$/m', $output, $matches)) {
+            $data = \json_decode($matches[1], true);
+            if (\is_array($data)) {
+                /** @var array{nodesProcessed: int, nodesIgnored: int, nodesErrored: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int} $data */
+
+                return $data;
+            }
+        }
+
+        return [
+            'nodesProcessed' => 0,
+            'nodesIgnored' => 0,
+            'nodesErrored' => 0,
+            'documents' => 0,
+            'properties' => 0,
+            'removedProperties' => 0,
+            'removedStaleProperties' => 0,
+        ];
     }
 
     /**
@@ -436,9 +429,9 @@ class PHPCRCleanupCommand extends Command
     }
 
     /**
-     * @param array<int, mixed> $stats
+     * @param array<string, int> $stats
      */
-    private function updateProgressBar(\Symfony\Component\Console\Helper\ProgressBar $progressBar, array $stats, int $advance): void
+    private function updateProgressBar(ProgressBar $progressBar, array $stats, int $advance): void
     {
         $progressBar->setMessage((string) $stats['nodes'], 'nodes');
         $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -37,6 +37,7 @@ use Webmozart\Assert\Assert;
 class PHPCRCleanupCommand extends Command
 {
     private OutputInterface $logger;
+    private string|false $phpBinary = false;
 
     public function __construct(
         private SessionInterface $liveSession,
@@ -117,14 +118,6 @@ class PHPCRCleanupCommand extends Command
         $io->newLine();
         $io->newLine();
 
-        $wheres = [];
-        foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
-            $wheres[] = \sprintf('(ISDESCENDANTNODE(page, "/cmf/%1$s/contents") OR ISSAMENODE(page, "/cmf/%1$s/contents"))', $webspace->getKey());
-        }
-
-        $wheres[] = 'page.[jcr:path] LIKE "/cmf/snippets/%/%"';
-        $wheres[] = 'page.[jcr:path] LIKE "/cmf/articles/%/%/%"';
-
         $orphanedKeys = $this->getOrphanedWebspaceKeys();
 
         if ([] !== $orphanedKeys) {
@@ -133,6 +126,44 @@ class PHPCRCleanupCommand extends Command
                 \implode(', ', $orphanedKeys),
             ));
         }
+
+        $uuids = $this->collectNodeUuids();
+        $batchSize = (int) $input->getOption('batch-size');
+        $parallelism = (int) $input->getOption('processes');
+        Assert::greaterThan($batchSize, 0, 'Batch size must be greater than 0');
+        Assert::greaterThan($parallelism, 0, 'Number of processes must be greater than 0');
+        /** @var positive-int $batchSize */
+        /** @var positive-int $parallelism */
+        $cleanupResult = $this->runBatchedCleanup($uuids, $dryRun, $debug, $batchSize, $parallelism, $io);
+        $stats = $cleanupResult['stats'];
+        $errorMessages = $cleanupResult['errorMessages'];
+
+        $this->removeStaleRouteTrees($this->getStaleRouteLocales(), $dryRun, $io);
+        $this->removeOrphanedWebspaceTrees($orphanedKeys, $dryRun, $io);
+
+        $io->success('Cleanup process finished');
+
+        $this->printErrors($errorMessages, $io, $output->isVerbose());
+
+        if ($stats['ignoredNodes'] > 0) {
+            $io->note(\sprintf('%d nodes were ignored (no matching structure metadata or locales).', $stats['ignoredNodes']));
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function collectNodeUuids(): array
+    {
+        $wheres = [];
+        foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
+            $wheres[] = \sprintf('(ISDESCENDANTNODE(page, "/cmf/%1$s/contents") OR ISSAMENODE(page, "/cmf/%1$s/contents"))', $webspace->getKey());
+        }
+
+        $wheres[] = 'page.[jcr:path] LIKE "/cmf/snippets/%/%"';
+        $wheres[] = 'page.[jcr:path] LIKE "/cmf/articles/%/%/%"';
 
         $sql2 = \sprintf(
             'SELECT [jcr:uuid] FROM [nt:unstructured] AS page WHERE %s',
@@ -143,65 +174,74 @@ class PHPCRCleanupCommand extends Command
         $rows = $queryManager->createQuery($sql2, 'JCR-SQL2')->execute();
 
         /** @var string[] $uuids */
-        $uuids = \array_map(static fn ($row) => $row->getValue('jcr:uuid'), \iterator_to_array($rows->getRows()));
+        $uuids = [];
+        foreach ($rows->getRows() as $row) {
+            $uuids[] = $row->getValue('jcr:uuid');
+        }
         unset($rows);
 
-        $stats = [
-            'nodes' => 0,
-            'ignoredNodes' => 0,
-            'erroredNodes' => 0,
-            'documents' => 0,
-            'properties' => 0,
-            'removedProperties' => 0,
-            'removedStaleProperties' => 0,
-        ];
+        return $uuids;
+    }
 
-        $errorMessages = [];
-
+    /**
+     * @param string[] $uuids
+     * @param positive-int $batchSize
+     * @param positive-int $parallelism
+     *
+     * @return array{
+     *     stats: array{nodes: int, ignoredNodes: int, erroredNodes: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int},
+     *     errorMessages: string[]
+     * }
+     */
+    private function runBatchedCleanup(
+        array $uuids,
+        bool $dryRun,
+        bool $debug,
+        int $batchSize,
+        int $parallelism,
+        SymfonyStyle $io,
+    ): array {
         $io->section('Running cleanup process ...');
 
-        $batchSize = (int) $input->getOption('batch-size');
-        $parallelism = (int) $input->getOption('processes');
-        Assert::greaterThan($batchSize, 0, 'Batch size must be greater than 0');
-        Assert::greaterThan($parallelism, 0, 'Number of processes must be greater than 0');
-
+        $stats = $this->createInitialStats();
+        $errorMessages = [];
         $batches = \array_chunk($uuids, $batchSize);
-        $io->writeln(\sprintf('Processing %d nodes in %d batches (%d per batch, %d parallel)', \count($uuids), \count($batches), $batchSize, $parallelism));
+
+        $io->writeln(\sprintf(
+            'Processing %d nodes in %d batches (%d per batch, %d parallel)',
+            \count($uuids),
+            \count($batches),
+            $batchSize,
+            $parallelism,
+        ));
         $io->newLine();
 
-        $progressBar = $io->createProgressBar(\count($uuids));
-        $progressBar->setFormat("Nodes: %nodes%\nIgnored: %ignoredNodes%\nErrored: %erroredNodes%\nDocuments: %documents%\nProperties: %properties%\nRemoved properties: %removedProperties%\nRemoved stale locale properties: %removedStaleProperties%\n\n%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%\n\n");
-
-        $progressBar->setMessage((string) $stats['nodes'], 'nodes');
-        $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
-        $progressBar->setMessage((string) $stats['erroredNodes'], 'erroredNodes');
-        $progressBar->setMessage((string) $stats['documents'], 'documents');
-        $progressBar->setMessage((string) $stats['properties'], 'properties');
-        $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
-        $progressBar->setMessage((string) $stats['removedStaleProperties'], 'removedStaleProperties');
-
-        $progressBar->start();
-
+        $progressBar = $this->createCleanupProgressBar($io, \count($uuids), $stats);
         $parallelGroups = \array_chunk($batches, $parallelism);
 
         foreach ($parallelGroups as $group) {
-            $processes = [];
+            /** @var array<int, array{process: Process, batchNodeCount: int}> $batchProcesses */
+            $batchProcesses = [];
 
-            foreach ($group as $index => $batchUuids) {
-                $processes[$index] = $this->createProcess($batchUuids, $dryRun, $debug);
-                $processes[$index]->start();
+            foreach ($group as $batchUuids) {
+                $process = $this->createProcess($batchUuids, $dryRun, $debug);
+                $process->start();
+
+                $batchProcesses[] = [
+                    'process' => $process,
+                    'batchNodeCount' => \count($batchUuids),
+                ];
             }
 
-            foreach ($processes as $index => $process) {
-                $batchUuids = $group[$index];
-                $batchNodeCount = \count($batchUuids);
-
+            foreach ($batchProcesses as $batchProcess) {
+                /** @var Process $process */
+                $process = $batchProcess['process'];
+                $batchNodeCount = $batchProcess['batchNodeCount'];
                 $status = $process->wait();
 
                 if (PHPCRCleanupSingleNodeCommand::IGNORED === $status) {
                     $stats['nodes'] += $batchNodeCount;
                     $stats['ignoredNodes'] += $batchNodeCount;
-
                     $this->updateProgressBar($progressBar, $stats, $batchNodeCount);
 
                     continue;
@@ -209,20 +249,9 @@ class PHPCRCleanupCommand extends Command
 
                 $subCommandOutput = $process->getOutput();
                 $batchStats = $this->parseSubprocessOutput($subCommandOutput);
-                $parsedTotal = $batchStats['nodesProcessed'] + $batchStats['nodesIgnored'] + $batchStats['nodesErrored'];
-
-                if ($parsedTotal > 0) {
-                    $stats['nodes'] += $parsedTotal;
-                    $stats['ignoredNodes'] += $batchStats['nodesIgnored'];
-                    $stats['erroredNodes'] += $batchStats['nodesErrored'];
-                    $stats['documents'] += $batchStats['documents'];
-                    $stats['removedProperties'] += $batchStats['removedProperties'];
-                    $stats['properties'] += $batchStats['properties'];
-                    $stats['removedStaleProperties'] += $batchStats['removedStaleProperties'];
-                } else {
-                    $stats['nodes'] += $batchNodeCount;
-                    $stats['erroredNodes'] += $batchNodeCount;
-                }
+                $batchStatsResult = $this->applyBatchStats($stats, $batchStats, $batchNodeCount);
+                $stats = $batchStatsResult['stats'];
+                $progressAdvance = $batchStatsResult['advance'];
 
                 $stderr = $process->getErrorOutput();
                 if ('' !== $stderr) {
@@ -239,7 +268,7 @@ class PHPCRCleanupCommand extends Command
                     $this->logger->writeln($subCommandOutput);
                 }
 
-                $this->updateProgressBar($progressBar, $stats, $parsedTotal > 0 ? $parsedTotal : $batchNodeCount);
+                $this->updateProgressBar($progressBar, $stats, $progressAdvance);
             }
 
             $this->servicesResetter->reset();
@@ -247,65 +276,149 @@ class PHPCRCleanupCommand extends Command
 
         $progressBar->finish();
 
-        $staleRoutes = $this->getStaleRouteLocales();
-        if ([] !== $staleRoutes) {
-            $io->section('Stale route locales detected');
+        return [
+            'stats' => $stats,
+            'errorMessages' => $errorMessages,
+        ];
+    }
 
-            $routesModified = false;
-            foreach ($staleRoutes as $webspaceKey => $staleLocales) {
-                foreach ($staleLocales as $staleLocale) {
-                    $routePath = \sprintf('/cmf/%s/routes/%s', $webspaceKey, $staleLocale);
-                    $io->writeln(\sprintf('  Stale route tree: %s', $routePath));
+    /**
+     * @param array<string, int> $stats
+     */
+    private function createCleanupProgressBar(SymfonyStyle $io, int $totalNodes, array $stats): ProgressBar
+    {
+        $progressBar = $io->createProgressBar($totalNodes);
+        $progressBar->setFormat("Nodes: %nodes%\nIgnored: %ignoredNodes%\nErrored: %erroredNodes%\nDocuments: %documents%\nProperties: %properties%\nRemoved properties: %removedProperties%\nRemoved stale locale properties: %removedStaleProperties%\n\n%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%\n\n");
 
-                    if (!$dryRun) {
-                        foreach ([$this->session, $this->liveSession] as $phpcrSession) {
-                            if ($phpcrSession->nodeExists($routePath)) {
-                                $phpcrSession->getNode($routePath)->remove();
-                                $routesModified = true;
-                            }
-                        }
+        $progressBar->setMessage((string) $stats['nodes'], 'nodes');
+        $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
+        $progressBar->setMessage((string) $stats['erroredNodes'], 'erroredNodes');
+        $progressBar->setMessage((string) $stats['documents'], 'documents');
+        $progressBar->setMessage((string) $stats['properties'], 'properties');
+        $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
+        $progressBar->setMessage((string) $stats['removedStaleProperties'], 'removedStaleProperties');
+        $progressBar->start();
+
+        return $progressBar;
+    }
+
+    /**
+     * @return array{nodes: int, ignoredNodes: int, erroredNodes: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int}
+     */
+    private function createInitialStats(): array
+    {
+        return [
+            'nodes' => 0,
+            'ignoredNodes' => 0,
+            'erroredNodes' => 0,
+            'documents' => 0,
+            'properties' => 0,
+            'removedProperties' => 0,
+            'removedStaleProperties' => 0,
+        ];
+    }
+
+    /**
+     * @param array{nodes: int, ignoredNodes: int, erroredNodes: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int} $stats
+     * @param array{nodesProcessed: int, nodesIgnored: int, nodesErrored: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int} $batchStats
+     *
+     * @return array{
+     *     stats: array{nodes: int, ignoredNodes: int, erroredNodes: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int},
+     *     advance: int
+     * }
+     */
+    private function applyBatchStats(array $stats, array $batchStats, int $batchNodeCount): array
+    {
+        $parsedTotal = $batchStats['nodesProcessed'] + $batchStats['nodesIgnored'] + $batchStats['nodesErrored'];
+        if ($parsedTotal > 0) {
+            $stats['nodes'] += $parsedTotal;
+            $stats['ignoredNodes'] += $batchStats['nodesIgnored'];
+            $stats['erroredNodes'] += $batchStats['nodesErrored'];
+            $stats['documents'] += $batchStats['documents'];
+            $stats['removedProperties'] += $batchStats['removedProperties'];
+            $stats['properties'] += $batchStats['properties'];
+            $stats['removedStaleProperties'] += $batchStats['removedStaleProperties'];
+
+            return [
+                'stats' => $stats,
+                'advance' => $parsedTotal,
+            ];
+        }
+
+        $stats['nodes'] += $batchNodeCount;
+        $stats['erroredNodes'] += $batchNodeCount;
+
+        return [
+            'stats' => $stats,
+            'advance' => $batchNodeCount,
+        ];
+    }
+
+    /**
+     * @param array<string, string[]> $staleRoutes
+     */
+    private function removeStaleRouteTrees(array $staleRoutes, bool $dryRun, SymfonyStyle $io): void
+    {
+        if ([] === $staleRoutes) {
+            return;
+        }
+
+        $io->section('Stale route locales detected');
+
+        $routesModified = false;
+        foreach ($staleRoutes as $webspaceKey => $staleLocales) {
+            foreach ($staleLocales as $staleLocale) {
+                $routePath = \sprintf('/cmf/%s/routes/%s', $webspaceKey, $staleLocale);
+                $io->writeln(\sprintf('  Stale route tree: %s', $routePath));
+
+                if ($dryRun) {
+                    continue;
+                }
+
+                foreach ($this->getPhpcrSessions() as $phpcrSession) {
+                    if ($phpcrSession->nodeExists($routePath)) {
+                        $phpcrSession->getNode($routePath)->remove();
+                        $routesModified = true;
                     }
                 }
             }
-
-            if (!$dryRun && $routesModified) {
-                $this->session->save();
-                $this->liveSession->save();
-            }
         }
 
-        if ([] !== $orphanedKeys) {
-            $io->section('Removing orphaned webspace trees');
+        if (!$dryRun && $routesModified) {
+            $this->savePhpcrSessions();
+        }
+    }
 
-            $orphanedModified = false;
-            foreach ($orphanedKeys as $orphanedKey) {
-                $webspacePath = \sprintf('/cmf/%s', $orphanedKey);
-                foreach ([$this->session, $this->liveSession] as $phpcrSession) {
-                    if ($phpcrSession->nodeExists($webspacePath)) {
-                        $io->writeln(\sprintf('  Removing orphaned webspace tree: %s', $webspacePath));
-                        if (!$dryRun) {
-                            $phpcrSession->getNode($webspacePath)->remove();
-                            $orphanedModified = true;
-                        }
-                    }
+    /**
+     * @param string[] $orphanedKeys
+     */
+    private function removeOrphanedWebspaceTrees(array $orphanedKeys, bool $dryRun, SymfonyStyle $io): void
+    {
+        if ([] === $orphanedKeys) {
+            return;
+        }
+
+        $io->section('Removing orphaned webspace trees');
+
+        $orphanedModified = false;
+        foreach ($orphanedKeys as $orphanedKey) {
+            $webspacePath = \sprintf('/cmf/%s', $orphanedKey);
+            foreach ($this->getPhpcrSessions() as $phpcrSession) {
+                if (!$phpcrSession->nodeExists($webspacePath)) {
+                    continue;
+                }
+
+                $io->writeln(\sprintf('  Removing orphaned webspace tree: %s', $webspacePath));
+                if (!$dryRun) {
+                    $phpcrSession->getNode($webspacePath)->remove();
+                    $orphanedModified = true;
                 }
             }
-
-            if (!$dryRun && $orphanedModified) {
-                $this->session->save();
-                $this->liveSession->save();
-            }
         }
 
-        $io->success('Cleanup process finished');
-
-        $this->printErrors($errorMessages, $io, $output->isVerbose());
-
-        if ($stats['ignoredNodes'] > 0) {
-            $io->note(\sprintf('%d nodes were ignored (no matching structure metadata or locales).', $stats['ignoredNodes']));
+        if (!$dryRun && $orphanedModified) {
+            $this->savePhpcrSessions();
         }
-
-        return self::SUCCESS;
     }
 
     /**
@@ -313,14 +426,15 @@ class PHPCRCleanupCommand extends Command
      */
     protected function createProcess(array $uuids, bool $dryRun, bool $debug): Process
     {
-        $executableFinder = new PhpExecutableFinder();
-        $php = $executableFinder->find(false);
-
-        if (false === $php) {
-            throw new \RuntimeException('Could not find PHP executable.');
+        if (false === $this->phpBinary) {
+            $php = (new PhpExecutableFinder())->find(false);
+            if (false === $php) {
+                throw new \RuntimeException('Could not find PHP executable.');
+            }
+            $this->phpBinary = $php;
         }
 
-        $args = [$php, $_SERVER['argv'][0], PHPCRCleanupSingleNodeCommand::getDefaultName()];
+        $args = [$this->phpBinary, $_SERVER['argv'][0], PHPCRCleanupSingleNodeCommand::getDefaultName()];
         $args = \array_merge($args, $uuids);
 
         if ($dryRun) {
@@ -350,15 +464,7 @@ class PHPCRCleanupCommand extends Command
             }
         }
 
-        return [
-            'nodesProcessed' => 0,
-            'nodesIgnored' => 0,
-            'nodesErrored' => 0,
-            'documents' => 0,
-            'properties' => 0,
-            'removedProperties' => 0,
-            'removedStaleProperties' => 0,
-        ];
+        return PHPCRCleanupSingleNodeCommand::createEmptyBatchStats();
     }
 
     /**
@@ -368,7 +474,7 @@ class PHPCRCleanupCommand extends Command
      */
     public function getOrphanedWebspaceKeys(): array
     {
-        if (!$this->session->nodeExists('/cmf')) {
+        if (!$this->session->nodeExists('/cmf') && !$this->liveSession->nodeExists('/cmf')) {
             return [];
         }
 
@@ -378,17 +484,41 @@ class PHPCRCleanupCommand extends Command
         }
 
         $reservedKeys = ['snippets', 'articles'];
+        $orphanedKeys = [];
+        foreach ($this->getPhpcrSessions() as $session) {
+            foreach ($this->getOrphanedWebspaceKeysForSession($session, $configuredKeys, $reservedKeys) as $key) {
+                $orphanedKeys[$key] = true;
+            }
+        }
+
+        return \array_keys($orphanedKeys);
+    }
+
+    /**
+     * @param string[] $configuredKeys
+     * @param string[] $reservedKeys
+     *
+     * @return string[]
+     */
+    private function getOrphanedWebspaceKeysForSession(
+        SessionInterface $session,
+        array $configuredKeys,
+        array $reservedKeys,
+    ): array {
+        if (!$session->nodeExists('/cmf')) {
+            return [];
+        }
 
         $orphanedKeys = [];
-        $cmfNode = $this->session->getNode('/cmf');
+        $cmfNode = $session->getNode('/cmf');
         foreach ($cmfNode->getNodes() as $childNode) {
             $name = $childNode->getName();
             if (\in_array($name, $configuredKeys, true) || \in_array($name, $reservedKeys, true)) {
                 continue;
             }
 
-            // Only treat as orphaned webspace if it has a 'contents' child node (webspace structure)
-            if (!$childNode->hasNode('contents')) {
+            // Only treat as orphaned webspace if it has a webspace-like structure.
+            if (!$childNode->hasNode('contents') && !$childNode->hasNode('routes')) {
                 continue;
             }
 
@@ -406,16 +536,54 @@ class PHPCRCleanupCommand extends Command
     public function getStaleRouteLocales(): array
     {
         $localesByWebspace = $this->webspaceManager->getAllLocalesByWebspaces();
+        $staleRoutesByWebspace = [];
+        foreach ($this->getPhpcrSessions() as $session) {
+            foreach ($this->getStaleRouteLocalesForSession($session, $localesByWebspace) as $webspaceKey => $staleLocales) {
+                foreach ($staleLocales as $staleLocale) {
+                    $staleRoutesByWebspace[$webspaceKey][$staleLocale] = true;
+                }
+            }
+        }
+
+        $staleRoutes = [];
+        foreach ($staleRoutesByWebspace as $webspaceKey => $staleLocalesMap) {
+            $staleRoutes[$webspaceKey] = \array_keys($staleLocalesMap);
+        }
+
+        return $staleRoutes;
+    }
+
+    /**
+     * @return SessionInterface[]
+     */
+    private function getPhpcrSessions(): array
+    {
+        return [$this->session, $this->liveSession];
+    }
+
+    private function savePhpcrSessions(): void
+    {
+        $this->session->save();
+        $this->liveSession->save();
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $localesByWebspace
+     *
+     * @return array<string, string[]>
+     */
+    private function getStaleRouteLocalesForSession(SessionInterface $session, array $localesByWebspace): array
+    {
         $staleRoutes = [];
 
         foreach ($localesByWebspace as $webspaceKey => $locales) {
             $routesPath = \sprintf('/cmf/%s/routes', $webspaceKey);
 
-            if (!$this->session->nodeExists($routesPath)) {
+            if (!$session->nodeExists($routesPath)) {
                 continue;
             }
 
-            $routesNode = $this->session->getNode($routesPath);
+            $routesNode = $session->getNode($routesPath);
             $configuredLocales = \array_keys($locales);
 
             foreach ($routesNode->getNodes() as $localeNode) {

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -205,12 +205,38 @@ class PHPCRCleanupCommand extends Command
                 }
 
                 if (0 !== $status) {
-                    $stats['nodes'] += $batchNodeCount;
-                    $stats['erroredNodes'] += $batchNodeCount;
-
                     $stderr = $process->getErrorOutput();
                     if ('' !== $stderr) {
                         $errorMessages[] = $stderr;
+                    }
+
+                    // Try to parse output for detailed per-node counts before falling back
+                    $subCommandOutput = $process->getOutput();
+                    \preg_match('/Nodes processed: (\d+)/', $subCommandOutput, $matches);
+                    $batchProcessed = (int) ($matches[1] ?? 0);
+                    \preg_match('/Nodes ignored: (\d+)/', $subCommandOutput, $matches);
+                    $batchIgnored = (int) ($matches[1] ?? 0);
+                    \preg_match('/Nodes errored: (\d+)/', $subCommandOutput, $matches);
+                    $batchErrored = (int) ($matches[1] ?? 0);
+
+                    $parsedTotal = $batchProcessed + $batchIgnored + $batchErrored;
+
+                    if ($parsedTotal > 0) {
+                        $stats['nodes'] += $parsedTotal;
+                        $stats['ignoredNodes'] += $batchIgnored;
+                        $stats['erroredNodes'] += $batchErrored;
+
+                        \preg_match('/Documents: (\d+)/', $subCommandOutput, $matches);
+                        $stats['documents'] += (int) ($matches[1] ?? 0);
+                        \preg_match('/Removed properties: (\d+)/', $subCommandOutput, $matches);
+                        $stats['removedProperties'] += (int) ($matches[1] ?? 0);
+                        \preg_match('/Total properties: (\d+)/', $subCommandOutput, $matches);
+                        $stats['properties'] += (int) ($matches[1] ?? 0);
+                        \preg_match('/Removed stale locale properties: (\d+)/', $subCommandOutput, $matches);
+                        $stats['removedStaleProperties'] += (int) ($matches[1] ?? 0);
+                    } else {
+                        $stats['nodes'] += $batchNodeCount;
+                        $stats['erroredNodes'] += $batchNodeCount;
                     }
 
                     $this->logger->writeln(\sprintf(
@@ -219,7 +245,7 @@ class PHPCRCleanupCommand extends Command
                         $stderr,
                     ));
 
-                    $this->updateProgressBar($progressBar, $stats, $batchNodeCount);
+                    $this->updateProgressBar($progressBar, $stats, $parsedTotal > 0 ? $parsedTotal : $batchNodeCount);
 
                     continue;
                 }
@@ -322,6 +348,10 @@ class PHPCRCleanupCommand extends Command
         $executableFinder = new PhpExecutableFinder();
         $php = $executableFinder->find(false);
 
+        if (false === $php) {
+            throw new \RuntimeException('Could not find PHP executable.');
+        }
+
         $args = [$php, $_SERVER['argv'][0], PHPCRCleanupSingleNodeCommand::getDefaultName()];
         $args = \array_merge($args, $uuids);
 
@@ -345,6 +375,10 @@ class PHPCRCleanupCommand extends Command
      */
     public function getOrphanedWebspaceKeys(): array
     {
+        if (!$this->session->nodeExists('/cmf')) {
+            return [];
+        }
+
         $configuredKeys = [];
         foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
             $configuredKeys[] = $webspace->getKey();
@@ -356,9 +390,16 @@ class PHPCRCleanupCommand extends Command
         $cmfNode = $this->session->getNode('/cmf');
         foreach ($cmfNode->getNodes() as $childNode) {
             $name = $childNode->getName();
-            if (!\in_array($name, $configuredKeys, true) && !\in_array($name, $reservedKeys, true)) {
-                $orphanedKeys[] = $name;
+            if (\in_array($name, $configuredKeys, true) || \in_array($name, $reservedKeys, true)) {
+                continue;
             }
+
+            // Only treat as orphaned webspace if it has a 'contents' child node (webspace structure)
+            if (!$childNode->hasNode('contents')) {
+                continue;
+            }
+
+            $orphanedKeys[] = $name;
         }
 
         return $orphanedKeys;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -55,6 +55,7 @@ class PHPCRCleanupCommand extends Command
         $this->addOption('debug', null, InputOption::VALUE_NONE, 'Write debug information to a file.');
         $this->addOption('debug-file', null, InputOption::VALUE_REQUIRED, 'Write debug information to a file.', $defaultDebugFile);
         $this->addOption('processes', 'p', InputOption::VALUE_REQUIRED, 'Number of parallel processes.', 5);
+        $this->addOption('batch-size', 'b', InputOption::VALUE_REQUIRED, 'Number of nodes per subprocess.', 50);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -122,6 +123,15 @@ class PHPCRCleanupCommand extends Command
         $wheres[] = 'page.[jcr:path] LIKE "/cmf/snippets/%/%"';
         $wheres[] = 'page.[jcr:path] LIKE "/cmf/articles/%/%/%"';
 
+        $orphanedKeys = $this->getOrphanedWebspaceKeys();
+
+        if ([] !== $orphanedKeys) {
+            $io->warning(\sprintf(
+                'Found orphaned webspaces in PHPCR: [%s]. Their trees will be removed after cleanup.',
+                \implode(', ', $orphanedKeys),
+            ));
+        }
+
         $sql2 = \sprintf(
             'SELECT [jcr:uuid] FROM [nt:unstructured] AS page WHERE %s',
             \implode(' OR ', $wheres),
@@ -140,14 +150,24 @@ class PHPCRCleanupCommand extends Command
             'documents' => 0,
             'properties' => 0,
             'removedProperties' => 0,
+            'removedStaleProperties' => 0,
         ];
 
-        $ignoredUuids = [];
-        $erroredUuids = [];
+        $errorMessages = [];
 
         $io->section('Running cleanup process ...');
+
+        $batchSize = (int) $input->getOption('batch-size');
+        $parallelism = (int) $input->getOption('processes');
+        Assert::greaterThan($batchSize, 0, 'Batch size must be greater than 0');
+        Assert::greaterThan($parallelism, 0, 'Number of processes must be greater than 0');
+
+        $batches = \array_chunk($uuids, $batchSize);
+        $io->writeln(\sprintf('Processing %d nodes in %d batches (%d per batch, %d parallel)', \count($uuids), \count($batches), $batchSize, $parallelism));
+        $io->newLine();
+
         $progressBar = $io->createProgressBar(\count($uuids));
-        $progressBar->setFormat("Nodes: %nodes%\nIgnored: %ignoredNodes%\nErrored: %erroredNodes%\nDocuments: %documents%\nProperties: %properties%\nRemoved properties: %removedProperties%\n\n%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%\n\n");
+        $progressBar->setFormat("Nodes: %nodes%\nIgnored: %ignoredNodes%\nErrored: %erroredNodes%\nDocuments: %documents%\nProperties: %properties%\nRemoved properties: %removedProperties%\nRemoved stale locale properties: %removedStaleProperties%\n\n%current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%\n\n");
 
         $progressBar->setMessage((string) $stats['nodes'], 'nodes');
         $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
@@ -155,114 +175,256 @@ class PHPCRCleanupCommand extends Command
         $progressBar->setMessage((string) $stats['documents'], 'documents');
         $progressBar->setMessage((string) $stats['properties'], 'properties');
         $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
+        $progressBar->setMessage((string) $stats['removedStaleProperties'], 'removedStaleProperties');
 
         $progressBar->start();
 
-        $chunkSize = (int) $input->getOption('processes');
-        Assert::greaterThan($chunkSize, 0, 'Chunk size must be greater than 0');
+        $parallelGroups = \array_chunk($batches, $parallelism);
 
-        $chunks = \array_chunk($uuids, $chunkSize);
-        foreach ($chunks as $chunk) {
+        foreach ($parallelGroups as $group) {
             $processes = [];
 
-            /** @var string $uuid */
-            foreach ($chunk as $uuid) {
-                $processes[$uuid] = $this->createProcess($uuid, $dryRun, $debug);
-                $processes[$uuid]->start();
+            foreach ($group as $index => $batchUuids) {
+                $processes[$index] = $this->createProcess($batchUuids, $dryRun, $debug);
+                $processes[$index]->start();
             }
 
-            foreach ($processes as $uuid => $process) {
-                ++$stats['nodes'];
+            foreach ($processes as $index => $process) {
+                $batchUuids = $group[$index];
+                $batchNodeCount = \count($batchUuids);
+
                 $status = $process->wait();
+
                 if (PHPCRCleanupSingleNodeCommand::IGNORED === $status) {
-                    ++$stats['ignoredNodes'];
-                    $ignoredUuids[] = $uuid;
+                    $stats['nodes'] += $batchNodeCount;
+                    $stats['ignoredNodes'] += $batchNodeCount;
+
+                    $this->updateProgressBar($progressBar, $stats, $batchNodeCount);
 
                     continue;
                 }
+
                 if (0 !== $status) {
-                    ++$stats['erroredNodes'];
-                    $erroredUuids[$uuid] = $process->getErrorOutput();
+                    $stats['nodes'] += $batchNodeCount;
+                    $stats['erroredNodes'] += $batchNodeCount;
+
+                    $stderr = $process->getErrorOutput();
+                    if ('' !== $stderr) {
+                        $errorMessages[] = $stderr;
+                    }
+
                     $this->logger->writeln(\sprintf(
-                        "# Error processing node '%s'\n\n%s\n",
-                        $uuid,
-                        $process->getErrorOutput(),
+                        "# Error processing batch of %d nodes\n\n%s\n",
+                        $batchNodeCount,
+                        $stderr,
                     ));
+
+                    $this->updateProgressBar($progressBar, $stats, $batchNodeCount);
 
                     continue;
                 }
 
                 $subCommandOutput = $process->getOutput();
+
+                \preg_match('/Nodes processed: (\d+)/', $subCommandOutput, $matches);
+                $batchProcessed = (int) ($matches[1] ?? 0);
+                \preg_match('/Nodes ignored: (\d+)/', $subCommandOutput, $matches);
+                $batchIgnored = (int) ($matches[1] ?? 0);
+                \preg_match('/Nodes errored: (\d+)/', $subCommandOutput, $matches);
+                $batchErrored = (int) ($matches[1] ?? 0);
+
+                $stats['nodes'] += $batchProcessed + $batchIgnored + $batchErrored;
+                $stats['ignoredNodes'] += $batchIgnored;
+                $stats['erroredNodes'] += $batchErrored;
+
                 \preg_match('/Documents: (\d+)/', $subCommandOutput, $matches);
                 $stats['documents'] += (int) ($matches[1] ?? 0);
                 \preg_match('/Removed properties: (\d+)/', $subCommandOutput, $matches);
                 $stats['removedProperties'] += (int) ($matches[1] ?? 0);
                 \preg_match('/Total properties: (\d+)/', $subCommandOutput, $matches);
                 $stats['properties'] += (int) ($matches[1] ?? 0);
+                \preg_match('/Removed stale locale properties: (\d+)/', $subCommandOutput, $matches);
+                $stats['removedStaleProperties'] += (int) ($matches[1] ?? 0);
+
+                $stderr = $process->getErrorOutput();
+                if ('' !== $stderr) {
+                    $errorMessages[] = $stderr;
+                }
 
                 $this->logger->writeln($subCommandOutput);
 
-                $progressBar->setMessage((string) $stats['nodes'], 'nodes');
-                $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
-                $progressBar->setMessage((string) $stats['erroredNodes'], 'erroredNodes');
-                $progressBar->setMessage((string) $stats['documents'], 'documents');
-                $progressBar->setMessage((string) $stats['properties'], 'properties');
-                $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
-                $progressBar->advance();
+                $this->updateProgressBar($progressBar, $stats, $batchProcessed + $batchIgnored + $batchErrored);
             }
 
             $this->servicesResetter->reset();
         }
 
         $progressBar->finish();
+
+        $staleRoutes = $this->getStaleRouteLocales();
+        $routesModified = false;
+        if ([] !== $staleRoutes) {
+            $io->section('Stale route locales detected');
+
+            foreach ($staleRoutes as $webspaceKey => $staleLocales) {
+                foreach ($staleLocales as $staleLocale) {
+                    $routePath = \sprintf('/cmf/%s/routes/%s', $webspaceKey, $staleLocale);
+                    $io->writeln(\sprintf('  Stale route tree: %s', $routePath));
+
+                    if (!$dryRun) {
+                        if ($this->session->nodeExists($routePath)) {
+                            $this->session->getNode($routePath)->remove();
+                            $routesModified = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!$dryRun && $routesModified) {
+            $this->session->save();
+        }
+
+        if ([] !== $orphanedKeys) {
+            $io->section('Removing orphaned webspace trees');
+
+            foreach ($orphanedKeys as $orphanedKey) {
+                $webspacePath = \sprintf('/cmf/%s', $orphanedKey);
+                if ($this->session->nodeExists($webspacePath)) {
+                    $io->writeln(\sprintf('  Removing orphaned webspace tree: %s', $webspacePath));
+                    if (!$dryRun) {
+                        $this->session->getNode($webspacePath)->remove();
+                    }
+                }
+            }
+
+            if (!$dryRun) {
+                $this->session->save();
+            }
+        }
+
         $io->success('Cleanup process finished');
 
-        $this->printErroredNodes($erroredUuids, $io, $output->isVerbose());
+        $this->printErrors($errorMessages, $io, $output->isVerbose());
 
-        if (0 < \count($ignoredUuids)) {
-            $io->section('Following nodes are ignored');
-            $io->listing($ignoredUuids);
+        if ($stats['ignoredNodes'] > 0) {
+            $io->note(\sprintf('%d nodes were ignored (no matching structure metadata or locales).', $stats['ignoredNodes']));
         }
 
         return self::SUCCESS;
     }
 
-    protected function createProcess(string $uuid, bool $dryRun, bool $debug): Process
+    /**
+     * @param string[] $uuids
+     */
+    protected function createProcess(array $uuids, bool $dryRun, bool $debug): Process
     {
         $executableFinder = new PhpExecutableFinder();
         $php = $executableFinder->find(false);
 
-        $process = new Process(\array_filter([
-            $php,
-            $_SERVER['argv'][0],
-            PHPCRCleanupSingleNodeCommand::getDefaultName(),
-            $uuid,
-            $dryRun ? '--dry-run' : null,
-            $debug ? '--debug' : null,
-        ]));
+        $args = [$php, $_SERVER['argv'][0], PHPCRCleanupSingleNodeCommand::getDefaultName()];
+        $args = \array_merge($args, $uuids);
 
-        $process->setTimeout(120);
+        if ($dryRun) {
+            $args[] = '--dry-run';
+        }
+        if ($debug) {
+            $args[] = '--debug';
+        }
+
+        $process = new Process($args);
+        $process->setTimeout(\max(120, \count($uuids) * 10));
 
         return $process;
     }
 
     /**
-     * @param array<string, string> $errors
+     * Finds webspace keys that exist in PHPCR but are not in webspace configuration.
+     *
+     * @return string[]
      */
-    private function printErroredNodes(array $errors, SymfonyStyle $io, bool $verbose): void
+    public function getOrphanedWebspaceKeys(): array
     {
-        if ([] === $errors) {
+        $configuredKeys = [];
+        foreach ($this->webspaceManager->getWebspaceCollection()->getWebspaces() as $webspace) {
+            $configuredKeys[] = $webspace->getKey();
+        }
+
+        $reservedKeys = ['snippets', 'articles'];
+
+        $orphanedKeys = [];
+        $cmfNode = $this->session->getNode('/cmf');
+        foreach ($cmfNode->getNodes() as $childNode) {
+            $name = $childNode->getName();
+            if (!\in_array($name, $configuredKeys, true) && !\in_array($name, $reservedKeys, true)) {
+                $orphanedKeys[] = $name;
+            }
+        }
+
+        return $orphanedKeys;
+    }
+
+    /**
+     * Finds route locale directories in PHPCR that are not in webspace configuration.
+     *
+     * @return array<string, string[]> Webspace key => array of stale locale strings
+     */
+    public function getStaleRouteLocales(): array
+    {
+        $localesByWebspace = $this->webspaceManager->getAllLocalesByWebspaces();
+        $staleRoutes = [];
+
+        foreach ($localesByWebspace as $webspaceKey => $locales) {
+            $routesPath = \sprintf('/cmf/%s/routes', $webspaceKey);
+
+            if (!$this->session->nodeExists($routesPath)) {
+                continue;
+            }
+
+            $routesNode = $this->session->getNode($routesPath);
+            $configuredLocales = \array_keys($locales);
+
+            foreach ($routesNode->getNodes() as $localeNode) {
+                if (!\in_array($localeNode->getName(), $configuredLocales, true)) {
+                    $staleRoutes[$webspaceKey][] = $localeNode->getName();
+                }
+            }
+        }
+
+        return $staleRoutes;
+    }
+
+    /**
+     * @param array<int, mixed> $stats
+     */
+    private function updateProgressBar(\Symfony\Component\Console\Helper\ProgressBar $progressBar, array $stats, int $advance): void
+    {
+        $progressBar->setMessage((string) $stats['nodes'], 'nodes');
+        $progressBar->setMessage((string) $stats['ignoredNodes'], 'ignoredNodes');
+        $progressBar->setMessage((string) $stats['erroredNodes'], 'erroredNodes');
+        $progressBar->setMessage((string) $stats['documents'], 'documents');
+        $progressBar->setMessage((string) $stats['properties'], 'properties');
+        $progressBar->setMessage((string) $stats['removedProperties'], 'removedProperties');
+        $progressBar->setMessage((string) $stats['removedStaleProperties'], 'removedStaleProperties');
+        $progressBar->advance($advance);
+    }
+
+    /**
+     * @param string[] $errorMessages
+     */
+    private function printErrors(array $errorMessages, SymfonyStyle $io, bool $verbose): void
+    {
+        if ([] === $errorMessages) {
             return;
         }
 
-        $io->section('Following nodes are errored');
+        $io->section('Errors encountered during cleanup');
         if ($verbose) {
-            foreach ($errors as $uuid => $errorMessage) {
-                $io->error($uuid);
+            foreach ($errorMessages as $errorMessage) {
                 $io->writeln($errorMessage);
             }
         } else {
-            $io->listing(\array_keys($errors));
+            $io->warning(\sprintf('%d batch(es) reported errors.', \count($errorMessages)));
             $io->note('To get more info about the errors rerun the command with the -v flag');
         }
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -173,10 +173,11 @@ class PHPCRCleanupCommand extends Command
         $queryManager = $this->session->getWorkspace()->getQueryManager();
         $rows = $queryManager->createQuery($sql2, 'JCR-SQL2')->execute();
 
-        /** @var string[] $uuids */
         $uuids = [];
         foreach ($rows->getRows() as $row) {
-            $uuids[] = $row->getValue('jcr:uuid');
+            $uuid = $row->getValue('jcr:uuid');
+            Assert::string($uuid);
+            $uuids[] = $uuid;
         }
         unset($rows);
 
@@ -254,11 +255,11 @@ class PHPCRCleanupCommand extends Command
                 $progressAdvance = $batchStatsResult['advance'];
 
                 $stderr = $process->getErrorOutput();
-                if ('' !== $stderr) {
-                    $errorMessages[] = $stderr;
-                }
 
                 if (0 !== $status) {
+                    if ('' !== $stderr) {
+                        $errorMessages[] = $stderr;
+                    }
                     $this->logger->writeln(\sprintf(
                         "# Error processing batch of %d nodes\n\n%s\n",
                         $batchNodeCount,
@@ -458,9 +459,10 @@ class PHPCRCleanupCommand extends Command
         if (\preg_match('/PHPCR_CLEANUP_STATS:(.+)$/m', $output, $matches)) {
             $data = \json_decode($matches[1], true);
             if (\is_array($data)) {
-                /** @var array{nodesProcessed: int, nodesIgnored: int, nodesErrored: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int} $data */
+                /** @var array{nodesProcessed: int, nodesIgnored: int, nodesErrored: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int} $merged */
+                $merged = \array_merge(PHPCRCleanupSingleNodeCommand::createEmptyBatchStats(), $data);
 
-                return $data;
+                return $merged;
             }
         }
 
@@ -584,10 +586,10 @@ class PHPCRCleanupCommand extends Command
             }
 
             $routesNode = $session->getNode($routesPath);
-            $configuredLocales = \array_keys($locales);
+            $configuredLocalesMap = \array_flip(\array_keys($locales));
 
             foreach ($routesNode->getNodes() as $localeNode) {
-                if (!\in_array($localeNode->getName(), $configuredLocales, true)) {
+                if (!isset($configuredLocalesMap[$localeNode->getName()])) {
                     $staleRoutes[$webspaceKey][] = $localeNode->getName();
                 }
             }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -19,6 +19,7 @@ use PHPCR\SessionInterface;
 use Sulu\Bundle\HttpCacheBundle\EventSubscriber\InvalidationSubscriber;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
 use Sulu\Component\Content\Document\Subscriber\PHPCR\CleanupNode;
+use Sulu\Component\Content\Document\Subscriber\ShadowLocaleSubscriber;
 use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
@@ -65,6 +66,11 @@ class PHPCRCleanupSingleNodeCommand extends Command
      * @var array<string, string>
      */
     private array $aliasMapping = [];
+
+    /**
+     * @var array<string, array<string, mixed>>|null
+     */
+    private ?array $cachedLocalesByWebspaces = null;
 
     /**
      * @var array<string, OptionsResolver>
@@ -114,15 +120,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
         $dryRun = $input->getOption('dry-run');
         $uuids = $input->getArgument('node');
 
-        $totalStats = [
-            'nodesProcessed' => 0,
-            'nodesIgnored' => 0,
-            'nodesErrored' => 0,
-            'documents' => 0,
-            'properties' => 0,
-            'removedProperties' => 0,
-            'removedStaleProperties' => 0,
-        ];
+        $totalStats = self::createEmptyBatchStats();
 
         foreach ($uuids as $uuid) {
             try {
@@ -135,10 +133,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
                 }
 
                 ++$totalStats['nodesProcessed'];
-                $totalStats['documents'] += $nodeStats['documents'];
-                $totalStats['properties'] += $nodeStats['properties'];
-                $totalStats['removedProperties'] += $nodeStats['removedProperties'];
-                $totalStats['removedStaleProperties'] += $nodeStats['removedStaleProperties'];
+                $totalStats = $this->mergeNodeStatsIntoTotal($totalStats, $nodeStats);
             } catch (\Exception $e) {
                 ++$totalStats['nodesErrored'];
                 \fwrite(\STDERR, (string) $e);
@@ -173,6 +168,38 @@ class PHPCRCleanupSingleNodeCommand extends Command
     }
 
     /**
+     * @return array{nodesProcessed: int, nodesIgnored: int, nodesErrored: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int}
+     */
+    public static function createEmptyBatchStats(): array
+    {
+        return [
+            'nodesProcessed' => 0,
+            'nodesIgnored' => 0,
+            'nodesErrored' => 0,
+            'documents' => 0,
+            'properties' => 0,
+            'removedProperties' => 0,
+            'removedStaleProperties' => 0,
+        ];
+    }
+
+    /**
+     * @param array{nodesProcessed: int, nodesIgnored: int, nodesErrored: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int} $totalStats
+     * @param array{documents: int, properties: int, removedProperties: int, removedStaleProperties: int} $nodeStats
+     *
+     * @return array{nodesProcessed: int, nodesIgnored: int, nodesErrored: int, documents: int, properties: int, removedProperties: int, removedStaleProperties: int}
+     */
+    private function mergeNodeStatsIntoTotal(array $totalStats, array $nodeStats): array
+    {
+        $totalStats['documents'] += $nodeStats['documents'];
+        $totalStats['properties'] += $nodeStats['properties'];
+        $totalStats['removedProperties'] += $nodeStats['removedProperties'];
+        $totalStats['removedStaleProperties'] += $nodeStats['removedStaleProperties'];
+
+        return $totalStats;
+    }
+
+    /**
      * @return array{documents: int, properties: int, removedProperties: int, removedStaleProperties: int}|null
      */
     private function processNode(string $uuid, bool $dryRun): ?array
@@ -201,47 +228,33 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
         $defaultSessionModified = false;
         $liveSessionModified = false;
+        $liveNode = $this->getLiveNodeByPathOrNull($node->getPath());
 
-        if ([] !== $staleLocales) {
-            $this->logger->writeln(\sprintf(
-                "# Removing stale locales [%s] from node \"%s\"\n",
-                \implode(', ', $staleLocales),
-                $node->getPath(),
-            ));
+        $staleLocaleCleanupResult = $this->applyStaleLocaleCleanup(
+            $node,
+            $liveNode,
+            $staleLocales,
+            $dryRun,
+            $stats,
+        );
+        $stats = $staleLocaleCleanupResult['stats'];
+        $defaultSessionModified = $staleLocaleCleanupResult['defaultSessionModified'];
+        $liveSessionModified = $staleLocaleCleanupResult['liveSessionModified'];
 
-            $stats['removedStaleProperties'] += $this->removeStaleLocaleProperties($node, $staleLocales, $dryRun);
-            $defaultSessionModified = true;
-
-            try {
-                $liveNode = $this->liveSession->getNode($node->getPath());
-                $stats['removedStaleProperties'] += $this->removeStaleLocaleProperties($liveNode, $staleLocales, $dryRun);
-                $liveSessionModified = true;
-            } catch (PathNotFoundException $e) {
-                // Node doesn't exist in live session
-            }
-        }
-
-        $cleanedShadows = $this->cleanInvalidShadowReferences($node, $activeLocales, $dryRun);
-        if ($cleanedShadows > 0) {
-            $defaultSessionModified = true;
-
-            try {
-                $liveNode = $this->liveSession->getNode($node->getPath());
-                $this->cleanInvalidShadowReferences($liveNode, $activeLocales, $dryRun);
-                $liveSessionModified = true;
-            } catch (PathNotFoundException $e) {
-                // Node doesn't exist in live session
-            }
-        }
+        $shadowCleanupResult = $this->applyInvalidShadowCleanup(
+            $node,
+            $liveNode,
+            $validLocales,
+            $dryRun,
+            $defaultSessionModified,
+            $liveSessionModified,
+        );
+        $defaultSessionModified = $shadowCleanupResult['defaultSessionModified'];
+        $liveSessionModified = $shadowCleanupResult['liveSessionModified'];
 
         // Only save now if there are no active locales to process (the per-locale loop saves after each locale)
         if (!$dryRun && [] === $activeLocales) {
-            if ($defaultSessionModified) {
-                $this->session->save();
-            }
-            if ($liveSessionModified) {
-                $this->liveSession->save();
-            }
+            $this->saveModifiedSessions($defaultSessionModified, $liveSessionModified);
         }
 
         foreach ($activeLocales as $locale) {
@@ -279,6 +292,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
             if (!$dryRun) {
                 $this->session->save();
+                $defaultSessionModified = false;
             }
 
             if ($wasPublished) {
@@ -297,13 +311,114 @@ class PHPCRCleanupSingleNodeCommand extends Command
             }
         }
 
-        // Ensure pre-loop live session changes (stale locale/shadow cleanup) are persisted
-        // even when no locale was published during the loop
-        if (!$dryRun && $liveSessionModified) {
-            $this->liveSession->save();
+        if (!$dryRun) {
+            $this->saveModifiedSessions($defaultSessionModified, $liveSessionModified);
         }
 
         return $stats;
+    }
+
+    /**
+     * @param string[] $staleLocales
+     * @param array{documents: int, properties: int, removedProperties: int, removedStaleProperties: int} $stats
+     *
+     * @return array{
+     *     stats: array{documents: int, properties: int, removedProperties: int, removedStaleProperties: int},
+     *     defaultSessionModified: bool,
+     *     liveSessionModified: bool
+     * }
+     */
+    private function applyStaleLocaleCleanup(
+        NodeInterface $node,
+        ?NodeInterface $liveNode,
+        array $staleLocales,
+        bool $dryRun,
+        array $stats,
+    ): array {
+        if ([] === $staleLocales) {
+            return [
+                'stats' => $stats,
+                'defaultSessionModified' => false,
+                'liveSessionModified' => false,
+            ];
+        }
+
+        $this->logger->writeln(\sprintf(
+            "# Removing stale locales [%s] from node \"%s\"\n",
+            \implode(', ', $staleLocales),
+            $node->getPath(),
+        ));
+
+        $removedProperties = $this->removeStaleLocaleProperties($node, $staleLocales, $dryRun);
+        $stats['removedStaleProperties'] += $removedProperties;
+        $defaultSessionModified = $removedProperties > 0;
+        $liveSessionModified = false;
+
+        if (null !== $liveNode) {
+            $removedLiveProperties = $this->removeStaleLocaleProperties($liveNode, $staleLocales, $dryRun);
+            $stats['removedStaleProperties'] += $removedLiveProperties;
+            $liveSessionModified = $removedLiveProperties > 0;
+        }
+
+        return [
+            'stats' => $stats,
+            'defaultSessionModified' => $defaultSessionModified,
+            'liveSessionModified' => $liveSessionModified,
+        ];
+    }
+
+    /**
+     * @param string[] $validLocales
+     *
+     * @return array{defaultSessionModified: bool, liveSessionModified: bool}
+     */
+    private function applyInvalidShadowCleanup(
+        NodeInterface $node,
+        ?NodeInterface $liveNode,
+        array $validLocales,
+        bool $dryRun,
+        bool $defaultSessionModified,
+        bool $liveSessionModified,
+    ): array {
+        $cleanedShadows = $this->cleanInvalidShadowReferences($node, $validLocales, $dryRun);
+        if (0 === $cleanedShadows) {
+            return [
+                'defaultSessionModified' => $defaultSessionModified,
+                'liveSessionModified' => $liveSessionModified,
+            ];
+        }
+
+        $defaultSessionModified = true;
+
+        if (null !== $liveNode) {
+            $cleanedLiveShadows = $this->cleanInvalidShadowReferences($liveNode, $validLocales, $dryRun);
+            $liveSessionModified = $liveSessionModified || $cleanedLiveShadows > 0;
+        }
+
+        return [
+            'defaultSessionModified' => $defaultSessionModified,
+            'liveSessionModified' => $liveSessionModified,
+        ];
+    }
+
+    private function getLiveNodeByPathOrNull(string $path): ?NodeInterface
+    {
+        try {
+            return $this->liveSession->getNode($path);
+        } catch (PathNotFoundException) {
+            return null;
+        }
+    }
+
+    private function saveModifiedSessions(bool $defaultSessionModified, bool $liveSessionModified): void
+    {
+        if ($defaultSessionModified) {
+            $this->session->save();
+        }
+
+        if ($liveSessionModified) {
+            $this->liveSession->save();
+        }
     }
 
     private function persist(object $document, CleanupNode $cleanupNode, string $locale): void
@@ -387,8 +502,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
      */
     public function getValidLocales(NodeInterface $node): array
     {
-        $path = $node->getPath();
-        $segments = \explode('/', \trim($path, '/'));
+        $segments = \explode('/', \trim($node->getPath(), '/'));
 
         if (\count($segments) < 2) {
             return [];
@@ -400,13 +514,9 @@ class PHPCRCleanupSingleNodeCommand extends Command
             return $this->webspaceManager->getAllLocales();
         }
 
-        $localesByWebspace = $this->webspaceManager->getAllLocalesByWebspaces();
+        $this->cachedLocalesByWebspaces ??= $this->webspaceManager->getAllLocalesByWebspaces();
 
-        if (!isset($localesByWebspace[$key])) {
-            return [];
-        }
-
-        return \array_keys($localesByWebspace[$key]);
+        return \array_keys($this->cachedLocalesByWebspaces[$key] ?? []);
     }
 
     /**
@@ -423,19 +533,32 @@ class PHPCRCleanupSingleNodeCommand extends Command
         }
 
         $removedCount = 0;
+        $staleLocalesMap = \array_flip($staleLocales);
+        $localizedPrefix = $this->languagePrefix . ':';
+        $localizedPrefixLength = \strlen($localizedPrefix);
 
         foreach ($node->getProperties() as $property) {
-            foreach ($staleLocales as $staleLocale) {
-                if (\str_starts_with($property->getName(), $this->languagePrefix . ':' . $staleLocale . '-')) {
-                    ++$removedCount;
-                    $this->logger->writeln(\sprintf('  Removing stale property: %s', $property->getName()));
+            $propertyName = $property->getName();
 
-                    if (!$dryRun) {
-                        $property->remove();
-                    }
+            if (!\str_starts_with($propertyName, $localizedPrefix)) {
+                continue;
+            }
 
-                    break;
-                }
+            $dashPosition = \strpos($propertyName, '-', $localizedPrefixLength);
+            if (false === $dashPosition) {
+                continue;
+            }
+
+            $locale = \substr($propertyName, $localizedPrefixLength, $dashPosition - $localizedPrefixLength);
+            if (!isset($staleLocalesMap[$locale])) {
+                continue;
+            }
+
+            ++$removedCount;
+            $this->logger->writeln(\sprintf('  Removing stale property: %s', $propertyName));
+
+            if (!$dryRun) {
+                $property->remove();
             }
         }
 
@@ -454,19 +577,21 @@ class PHPCRCleanupSingleNodeCommand extends Command
         $cleaned = 0;
 
         foreach ($validLocales as $locale) {
-            $shadowOnKey = $this->languagePrefix . ':' . $locale . '-shadow-on';
-            $shadowBaseKey = $this->languagePrefix . ':' . $locale . '-shadow-base';
+            $shadowOnKey = $this->languagePrefix . ':' . $locale . '-' . ShadowLocaleSubscriber::SHADOW_ENABLED_FIELD;
+            $shadowBaseKey = $this->languagePrefix . ':' . $locale . '-' . ShadowLocaleSubscriber::SHADOW_LOCALE_FIELD;
 
             if (!$node->hasProperty($shadowOnKey) || !$node->hasProperty($shadowBaseKey)) {
                 continue;
             }
 
-            $shadowOn = $node->getProperty($shadowOnKey)->getValue();
+            $shadowOnProperty = $node->getProperty($shadowOnKey);
+            $shadowOn = $shadowOnProperty->getValue();
             if (!$shadowOn) {
                 continue;
             }
 
-            $shadowBase = $node->getProperty($shadowBaseKey)->getValue();
+            $shadowBaseProperty = $node->getProperty($shadowBaseKey);
+            $shadowBase = $shadowBaseProperty->getValue();
             if (!\is_string($shadowBase)) {
                 continue;
             }
@@ -484,8 +609,8 @@ class PHPCRCleanupSingleNodeCommand extends Command
             ++$cleaned;
 
             if (!$dryRun) {
-                $node->getProperty($shadowOnKey)->setValue(null);
-                $node->getProperty($shadowBaseKey)->setValue(null);
+                $shadowOnProperty->setValue(null);
+                $shadowBaseProperty->setValue(null);
             }
         }
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -159,12 +159,14 @@ class PHPCRCleanupSingleNodeCommand extends Command
             'Total properties: ' . $totalStats['properties'],
         ]);
 
-        if ($totalStats['nodesProcessed'] > 0) {
-            return self::SUCCESS;
-        }
+        $output->writeln('PHPCR_CLEANUP_STATS:' . \json_encode($totalStats, \JSON_THROW_ON_ERROR));
 
         if ($totalStats['nodesErrored'] > 0) {
             return self::FAILURE;
+        }
+
+        if ($totalStats['nodesProcessed'] > 0) {
+            return self::SUCCESS;
         }
 
         return self::IGNORED;
@@ -268,6 +270,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
             $this->documentManager->clear();
 
+            /** @var string[] $writtenProperties */
             $writtenProperties = $defaultCleanupNode->getWrittenPropertyKeys();
             foreach ($this->cleanupNode($node, $locale, $writtenProperties, $dryRun) as $result) {
                 ++$stats['properties'];
@@ -280,6 +283,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
             if ($wasPublished) {
                 $liveNode = $this->liveSession->getNode($node->getPath());
+                /** @var string[] $writtenProperties */
                 $writtenProperties = $liveCleanupNode->getWrittenPropertyKeys();
                 foreach ($this->cleanupNode($liveNode, $locale, $writtenProperties, $dryRun) as $result) {
                     ++$stats['properties'];
@@ -319,6 +323,9 @@ class PHPCRCleanupSingleNodeCommand extends Command
         $this->documentManagerEventDispatcher->dispatch($event, Events::PUBLISH);
     }
 
+    /**
+     * @param string[] $writtenProperties
+     */
     private function cleanupNode(NodeInterface $node, string $locale, array $writtenProperties, bool $dryRun): \Generator
     {
         $this->logger->writeln(\sprintf("# Cleaning up node \"%s\" for locale \"%s\" in workspace \"%s\"\n", $node->getPath(), $locale, $node->getSession()->getWorkspace()->getName()));
@@ -460,6 +467,10 @@ class PHPCRCleanupSingleNodeCommand extends Command
             }
 
             $shadowBase = $node->getProperty($shadowBaseKey)->getValue();
+            if (!\is_string($shadowBase)) {
+                continue;
+            }
+
             if (\in_array($shadowBase, $validLocales, true)) {
                 continue;
             }
@@ -481,6 +492,9 @@ class PHPCRCleanupSingleNodeCommand extends Command
         return $cleaned;
     }
 
+    /**
+     * @return string[]
+     */
     private function getLocales(NodeInterface $node): array
     {
         $locales = [];

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -134,7 +134,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
                 ++$totalStats['nodesProcessed'];
                 $totalStats = $this->mergeNodeStatsIntoTotal($totalStats, $nodeStats);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 ++$totalStats['nodesErrored'];
                 \fwrite(\STDERR, (string) $e);
                 $this->session->refresh(false);
@@ -575,6 +575,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
     public function cleanInvalidShadowReferences(NodeInterface $node, array $validLocales, bool $dryRun): int
     {
         $cleaned = 0;
+        $validLocalesMap = \array_flip($validLocales);
 
         foreach ($validLocales as $locale) {
             $shadowOnKey = $this->languagePrefix . ':' . $locale . '-' . ShadowLocaleSubscriber::SHADOW_ENABLED_FIELD;
@@ -596,7 +597,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
                 continue;
             }
 
-            if (\in_array($shadowBase, $validLocales, true)) {
+            if (isset($validLocalesMap[$shadowBase])) {
                 continue;
             }
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -288,8 +288,15 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
                 if (!$dryRun) {
                     $this->liveSession->save();
+                    $liveSessionModified = false;
                 }
             }
+        }
+
+        // Ensure pre-loop live session changes (stale locale/shadow cleanup) are persisted
+        // even when no locale was published during the loop
+        if (!$dryRun && $liveSessionModified) {
+            $this->liveSession->save();
         }
 
         return $stats;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\DocumentManagerBundle\Command;
 
 use PHPCR\NodeInterface;
+use PHPCR\PathNotFoundException;
 use PHPCR\SessionInterface;
 use Sulu\Bundle\HttpCacheBundle\EventSubscriber\InvalidationSubscriber;
 use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
@@ -25,6 +26,7 @@ use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\Event;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -40,7 +42,7 @@ use Webmozart\Assert\Assert;
 /**
  * @internal
  */
-#[AsCommand(name: 'sulu:document:phpcr-cleanup-single-node', description: 'Cleanup a single PHPCR node and remove unused properties.')]
+#[AsCommand(name: 'sulu:document:phpcr-cleanup-single-node', description: 'Cleanup PHPCR node(s) and remove unused properties.')]
 class PHPCRCleanupSingleNodeCommand extends Command
 {
     public const IGNORED = 101;
@@ -82,6 +84,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
         private EventDispatcherInterface $documentManagerEventDispatcher,
         private DocumentManagerInterface $documentManager,
         array $mapping,
+        private WebspaceManagerInterface $webspaceManager,
     ) {
         parent::__construct();
 
@@ -95,7 +98,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
 
     protected function configure(): void
     {
-        $this->addArgument('node', InputArgument::REQUIRED, 'Node identifier to cleanup.');
+        $this->addArgument('node', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Node identifier(s) to cleanup.');
         $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Do not make any changes to the repository.');
         $this->addOption('debug', null, InputOption::VALUE_NONE, 'Write debug information to a file.');
     }
@@ -108,28 +111,138 @@ class PHPCRCleanupSingleNodeCommand extends Command
         }
 
         $io = new SymfonyStyle($input, $output);
-
         $dryRun = $input->getOption('dry-run');
-        $uuid = $input->getArgument('node');
+        $uuids = $input->getArgument('node');
 
+        $totalStats = [
+            'nodesProcessed' => 0,
+            'nodesIgnored' => 0,
+            'nodesErrored' => 0,
+            'documents' => 0,
+            'properties' => 0,
+            'removedProperties' => 0,
+            'removedStaleProperties' => 0,
+        ];
+
+        foreach ($uuids as $uuid) {
+            try {
+                $nodeStats = $this->processNode($uuid, $dryRun);
+
+                if (null === $nodeStats) {
+                    ++$totalStats['nodesIgnored'];
+
+                    continue;
+                }
+
+                ++$totalStats['nodesProcessed'];
+                $totalStats['documents'] += $nodeStats['documents'];
+                $totalStats['properties'] += $nodeStats['properties'];
+                $totalStats['removedProperties'] += $nodeStats['removedProperties'];
+                $totalStats['removedStaleProperties'] += $nodeStats['removedStaleProperties'];
+            } catch (\Exception $e) {
+                ++$totalStats['nodesErrored'];
+                \fwrite(\STDERR, (string) $e);
+                $this->session->refresh(false);
+                $this->liveSession->refresh(false);
+            }
+
+            $this->documentManager->clear();
+        }
+
+        $io->listing([
+            'Nodes processed: ' . $totalStats['nodesProcessed'],
+            'Nodes ignored: ' . $totalStats['nodesIgnored'],
+            'Nodes errored: ' . $totalStats['nodesErrored'],
+            'Documents: ' . $totalStats['documents'],
+            'Removed stale locale properties: ' . $totalStats['removedStaleProperties'],
+            'Removed properties: ' . $totalStats['removedProperties'],
+            'Total properties: ' . $totalStats['properties'],
+        ]);
+
+        if ($totalStats['nodesProcessed'] > 0) {
+            return self::SUCCESS;
+        }
+
+        if ($totalStats['nodesErrored'] > 0) {
+            return self::FAILURE;
+        }
+
+        return self::IGNORED;
+    }
+
+    /**
+     * @return array{documents: int, properties: int, removedProperties: int, removedStaleProperties: int}|null
+     */
+    private function processNode(string $uuid, bool $dryRun): ?array
+    {
         $stats = [
             'documents' => 0,
             'properties' => 0,
             'removedProperties' => 0,
+            'removedStaleProperties' => 0,
         ];
 
         $node = $this->session->getNodeByIdentifier($uuid);
         $alias = $this->getAliasForNode($node);
         if (null === $alias || !$this->structureMetaDataFactory->hasStructuresFor($alias)) {
-            return self::IGNORED;
+            return null;
         }
 
-        $locales = $this->getLocales($node);
-        if (0 === \count($locales)) {
-            return self::IGNORED;
+        $nodeLocales = $this->getLocales($node);
+        if (0 === \count($nodeLocales)) {
+            return null;
         }
 
-        foreach ($locales as $locale) {
+        $validLocales = $this->getValidLocales($node);
+        $staleLocales = \array_diff($nodeLocales, $validLocales);
+        $activeLocales = \array_intersect($nodeLocales, $validLocales);
+
+        $defaultSessionModified = false;
+        $liveSessionModified = false;
+
+        if ([] !== $staleLocales) {
+            $this->logger->writeln(\sprintf(
+                "# Removing stale locales [%s] from node \"%s\"\n",
+                \implode(', ', $staleLocales),
+                $node->getPath(),
+            ));
+
+            $stats['removedStaleProperties'] += $this->removeStaleLocaleProperties($node, $staleLocales, $dryRun);
+            $defaultSessionModified = true;
+
+            try {
+                $liveNode = $this->liveSession->getNode($node->getPath());
+                $stats['removedStaleProperties'] += $this->removeStaleLocaleProperties($liveNode, $staleLocales, $dryRun);
+                $liveSessionModified = true;
+            } catch (PathNotFoundException $e) {
+                // Node doesn't exist in live session
+            }
+        }
+
+        $cleanedShadows = $this->cleanInvalidShadowReferences($node, $activeLocales, $dryRun);
+        if ($cleanedShadows > 0) {
+            $defaultSessionModified = true;
+
+            try {
+                $liveNode = $this->liveSession->getNode($node->getPath());
+                $this->cleanInvalidShadowReferences($liveNode, $activeLocales, $dryRun);
+                $liveSessionModified = true;
+            } catch (PathNotFoundException $e) {
+                // Node doesn't exist in live session
+            }
+        }
+
+        // Only save now if there are no active locales to process (the per-locale loop saves after each locale)
+        if (!$dryRun && [] === $activeLocales) {
+            if ($defaultSessionModified) {
+                $this->session->save();
+            }
+            if ($liveSessionModified) {
+                $this->liveSession->save();
+            }
+        }
+
+        foreach ($activeLocales as $locale) {
             ++$stats['documents'];
 
             $document = $this->documentManager->find($uuid, $locale);
@@ -139,26 +252,21 @@ class PHPCRCleanupSingleNodeCommand extends Command
                 $workflowStage = $document->getWorkflowStage();
             }
 
-            try {
-                Assert::isInstanceOf($document, UuidBehavior::class);
+            Assert::isInstanceOf($document, UuidBehavior::class);
 
-                $node = $this->session->getNodeByIdentifier($document->getUuid());
-                $defaultCleanupNode = new CleanupNode(clone $node);
-                $this->persist($document, $defaultCleanupNode, $locale);
+            $node = $this->session->getNodeByIdentifier($document->getUuid());
+            $defaultCleanupNode = new CleanupNode(clone $node);
+            $this->persist($document, $defaultCleanupNode, $locale);
 
-                $wasPublished = WorkflowStage::PUBLISHED === $workflowStage;
-                if ($wasPublished) {
-                    $liveNode = $this->liveSession->getNodeByIdentifier($document->getUuid());
-                    $liveCleanupNode = new CleanupNode(clone $liveNode);
-                    $this->publish($document, $liveCleanupNode, $locale);
-                }
-
-                $this->documentManager->clear();
-            } catch (\Exception $e) {
-                \fwrite(\STDERR, (string) $e);
-
-                return self::INVALID;
+            $wasPublished = WorkflowStage::PUBLISHED === $workflowStage;
+            $liveCleanupNode = null;
+            if ($wasPublished) {
+                $liveNode = $this->liveSession->getNodeByIdentifier($document->getUuid());
+                $liveCleanupNode = new CleanupNode(clone $liveNode);
+                $this->publish($document, $liveCleanupNode, $locale);
             }
+
+            $this->documentManager->clear();
 
             $writtenProperties = $defaultCleanupNode->getWrittenPropertyKeys();
             foreach ($this->cleanupNode($node, $locale, $writtenProperties, $dryRun) as $result) {
@@ -184,18 +292,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
             }
         }
 
-        $io->success(\sprintf(
-            'Cleaned up node "%s"',
-            $node->getPath(),
-        ));
-
-        $io->listing([
-            'Documents: ' . $stats['documents'],
-            'Removed properties: ' . $stats['removedProperties'],
-            'Total properties: ' . $stats['properties'],
-        ]);
-
-        return self::SUCCESS;
+        return $stats;
     }
 
     private function persist(object $document, CleanupNode $cleanupNode, string $locale): void
@@ -267,6 +364,114 @@ class PHPCRCleanupSingleNodeCommand extends Command
         $this->optionsResolvers[$eventName] = $resolver;
 
         return $resolver;
+    }
+
+    /**
+     * Determines which locales are valid for a given node based on webspace configuration.
+     *
+     * @return string[]
+     */
+    public function getValidLocales(NodeInterface $node): array
+    {
+        $path = $node->getPath();
+        $segments = \explode('/', \trim($path, '/'));
+
+        if (\count($segments) < 2) {
+            return [];
+        }
+
+        $key = $segments[1]; // segment after 'cmf': webspace key, 'snippets', or 'articles'
+
+        if ('snippets' === $key || 'articles' === $key) {
+            return $this->webspaceManager->getAllLocales();
+        }
+
+        $localesByWebspace = $this->webspaceManager->getAllLocalesByWebspaces();
+
+        if (!isset($localesByWebspace[$key])) {
+            return [];
+        }
+
+        return \array_keys($localesByWebspace[$key]);
+    }
+
+    /**
+     * Removes all localized properties for the given stale locales from a node.
+     *
+     * @param string[] $staleLocales
+     *
+     * @return int Number of properties removed (or that would be removed in dry-run)
+     */
+    public function removeStaleLocaleProperties(NodeInterface $node, array $staleLocales, bool $dryRun): int
+    {
+        if ([] === $staleLocales) {
+            return 0;
+        }
+
+        $removedCount = 0;
+
+        foreach ($node->getProperties() as $property) {
+            foreach ($staleLocales as $staleLocale) {
+                if (\str_starts_with($property->getName(), $this->languagePrefix . ':' . $staleLocale . '-')) {
+                    ++$removedCount;
+                    $this->logger->writeln(\sprintf('  Removing stale property: %s', $property->getName()));
+
+                    if (!$dryRun) {
+                        $property->remove();
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return $removedCount;
+    }
+
+    /**
+     * Resets shadow locale properties where the shadow base locale no longer exists.
+     *
+     * @param string[] $validLocales
+     *
+     * @return int Number of shadow references cleaned
+     */
+    public function cleanInvalidShadowReferences(NodeInterface $node, array $validLocales, bool $dryRun): int
+    {
+        $cleaned = 0;
+
+        foreach ($validLocales as $locale) {
+            $shadowOnKey = $this->languagePrefix . ':' . $locale . '-shadow-on';
+            $shadowBaseKey = $this->languagePrefix . ':' . $locale . '-shadow-base';
+
+            if (!$node->hasProperty($shadowOnKey) || !$node->hasProperty($shadowBaseKey)) {
+                continue;
+            }
+
+            $shadowOn = $node->getProperty($shadowOnKey)->getValue();
+            if (!$shadowOn) {
+                continue;
+            }
+
+            $shadowBase = $node->getProperty($shadowBaseKey)->getValue();
+            if (\in_array($shadowBase, $validLocales, true)) {
+                continue;
+            }
+
+            $this->logger->writeln(\sprintf(
+                '  Resetting invalid shadow reference: %s shadows %s (locale no longer exists)',
+                $locale,
+                $shadowBase,
+            ));
+
+            ++$cleaned;
+
+            if (!$dryRun) {
+                $node->getProperty($shadowOnKey)->setValue(null);
+                $node->getProperty($shadowBaseKey)->setValue(null);
+            }
+        }
+
+        return $cleaned;
     }
 
     private function getLocales(NodeInterface $node): array

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -23,6 +23,7 @@
         </service>
 
         <service id="sulu_document_manager.command.phpcr_cleanup" class="Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupCommand">
+            <argument type="service" id="doctrine_phpcr.live_session" />
             <argument type="service" id="doctrine_phpcr.default_session" />
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument type="service" id="services_resetter" />

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -39,6 +39,7 @@
             <argument type="service" id="sulu_document_manager.event_dispatcher" />
             <argument type="service" id="sulu_document_manager.document_manager" />
             <argument>%sulu_document_manager.mapping%</argument>
+            <argument type="service" id="sulu_core.webspace.webspace_manager" />
 
             <tag name="console.command" />
         </service>

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandExecutionTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandExecutionTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Command;
+
+use PHPCR\Query\QueryInterface;
+use PHPCR\Query\QueryManagerInterface;
+use PHPCR\Query\QueryResultInterface;
+use PHPCR\Query\RowInterface;
+use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupCommand;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use Symfony\Component\Process\Process;
+
+class PHPCRCleanupCommandExecutionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy<SessionInterface> */
+    private ObjectProphecy $liveSession;
+
+    /** @var ObjectProphecy<SessionInterface> */
+    private ObjectProphecy $session;
+
+    /** @var ObjectProphecy<WebspaceManagerInterface> */
+    private ObjectProphecy $webspaceManager;
+
+    /** @var ObjectProphecy<ServicesResetter> */
+    private ObjectProphecy $servicesResetter;
+
+    protected function setUp(): void
+    {
+        $this->liveSession = $this->prophesize(SessionInterface::class);
+        $this->session = $this->prophesize(SessionInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->servicesResetter = $this->prophesize(ServicesResetter::class);
+    }
+
+    public function testExecuteReturnsSuccessWhenSomeBatchesError(): void
+    {
+        $webspaceCollection = new WebspaceCollection();
+        $webspaceCollection->setWebspaces([]);
+        $this->webspaceManager->getWebspaceCollection()->willReturn($webspaceCollection);
+        $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([]);
+
+        $this->configureQueryResult(['uuid-1']);
+        $this->session->nodeExists('/cmf')->willReturn(false);
+        $this->liveSession->nodeExists('/cmf')->willReturn(false);
+
+        $process = $this->prophesize(Process::class);
+        $process->start()->shouldBeCalledOnce();
+        $process->wait()->willReturn(1);
+        $process->getOutput()->willReturn(
+            'PHPCR_CLEANUP_STATS:{"nodesProcessed":0,"nodesIgnored":0,"nodesErrored":1,"documents":0,"properties":0,"removedProperties":0,"removedStaleProperties":0}'
+        );
+        $process->getErrorOutput()->willReturn('node parsing failed');
+
+        $this->servicesResetter->reset()->shouldBeCalledOnce();
+
+        $command = $this->createCommandWithProcess($process->reveal());
+
+        $tester = new CommandTester($command);
+        $result = $tester->execute([
+            '--dry-run' => true,
+            '--processes' => 1,
+            '--batch-size' => 1,
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $result);
+    }
+
+    /**
+     * @param string[] $uuids
+     */
+    private function configureQueryResult(array $uuids): void
+    {
+        $workspace = $this->prophesize(WorkspaceInterface::class);
+        $queryManager = $this->prophesize(QueryManagerInterface::class);
+        $query = $this->prophesize(QueryInterface::class);
+        $queryResult = $this->prophesize(QueryResultInterface::class);
+
+        $rows = [];
+        foreach ($uuids as $uuid) {
+            $row = $this->prophesize(RowInterface::class);
+            $row->getValue('jcr:uuid')->willReturn($uuid);
+            $rows[] = $row->reveal();
+        }
+
+        $this->session->getWorkspace()->willReturn($workspace->reveal());
+        $workspace->getQueryManager()->willReturn($queryManager->reveal());
+        $queryManager->createQuery(Argument::type('string'), 'JCR-SQL2')->willReturn($query->reveal());
+        $query->execute()->willReturn($queryResult->reveal());
+        $queryResult->getRows()->willReturn(new \ArrayIterator($rows));
+    }
+
+    private function createCommandWithProcess(Process $process): PHPCRCleanupCommand
+    {
+        return new class(
+            $this->liveSession->reveal(),
+            $this->session->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->servicesResetter->reveal(),
+            '/tmp/test-project',
+            $process,
+        ) extends PHPCRCleanupCommand {
+            public function __construct(
+                SessionInterface $liveSession,
+                SessionInterface $session,
+                WebspaceManagerInterface $webspaceManager,
+                ServicesResetter $servicesResetter,
+                string $projectDirectory,
+                private Process $process,
+            ) {
+                parent::__construct($liveSession, $session, $webspaceManager, $servicesResetter, $projectDirectory);
+            }
+
+            /**
+             * @param string[] $uuids
+             */
+            protected function createProcess(array $uuids, bool $dryRun, bool $debug): Process
+            {
+                return $this->process;
+            }
+        };
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandTest.php
@@ -55,14 +55,10 @@ class PHPCRCleanupCommandTest extends TestCase
 
     public function testGetOrphanedWebspaceKeys(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
-
-        $collection = new WebspaceCollection();
-        $collection->setWebspaces(['sulu_io' => $webspace]);
-        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
+        $this->configureSuluIoWebspaceCollection();
 
         $this->session->nodeExists('/cmf')->willReturn(true);
+        $this->liveSession->nodeExists('/cmf')->willReturn(false);
         $cmfNode = $this->prophesize(NodeInterface::class);
         $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
 
@@ -91,16 +87,65 @@ class PHPCRCleanupCommandTest extends TestCase
         $this->assertSame(['old_webspace'], $result);
     }
 
-    public function testGetOrphanedWebspaceKeysNoneOrphaned(): void
+    public function testGetOrphanedWebspaceKeysIncludesLiveOnlyOrphans(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
+        $this->configureSuluIoWebspaceCollection();
 
-        $collection = new WebspaceCollection();
-        $collection->setWebspaces(['sulu_io' => $webspace]);
-        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
+        $this->session->nodeExists('/cmf')->willReturn(false);
+        $this->liveSession->nodeExists('/cmf')->willReturn(true);
+        $cmfNode = $this->prophesize(NodeInterface::class);
+        $this->liveSession->getNode('/cmf')->willReturn($cmfNode->reveal());
+
+        $suluIoNode = $this->prophesize(NodeInterface::class);
+        $suluIoNode->getName()->willReturn('sulu_io');
+
+        $removedNode = $this->prophesize(NodeInterface::class);
+        $removedNode->getName()->willReturn('old_webspace');
+        $removedNode->hasNode('contents')->willReturn(true);
+
+        $cmfNode->getNodes()->willReturn([
+            $suluIoNode->reveal(),
+            $removedNode->reveal(),
+        ]);
+
+        $result = $this->command->getOrphanedWebspaceKeys();
+
+        $this->assertSame(['old_webspace'], $result);
+    }
+
+    public function testGetOrphanedWebspaceKeysDetectsRoutesOnlyTree(): void
+    {
+        $this->configureSuluIoWebspaceCollection();
 
         $this->session->nodeExists('/cmf')->willReturn(true);
+        $this->liveSession->nodeExists('/cmf')->willReturn(false);
+        $cmfNode = $this->prophesize(NodeInterface::class);
+        $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
+
+        $suluIoNode = $this->prophesize(NodeInterface::class);
+        $suluIoNode->getName()->willReturn('sulu_io');
+
+        $removedNode = $this->prophesize(NodeInterface::class);
+        $removedNode->getName()->willReturn('old_webspace');
+        $removedNode->hasNode('contents')->willReturn(false);
+        $removedNode->hasNode('routes')->willReturn(true);
+
+        $cmfNode->getNodes()->willReturn([
+            $suluIoNode->reveal(),
+            $removedNode->reveal(),
+        ]);
+
+        $result = $this->command->getOrphanedWebspaceKeys();
+
+        $this->assertSame(['old_webspace'], $result);
+    }
+
+    public function testGetOrphanedWebspaceKeysNoneOrphaned(): void
+    {
+        $this->configureSuluIoWebspaceCollection();
+
+        $this->session->nodeExists('/cmf')->willReturn(true);
+        $this->liveSession->nodeExists('/cmf')->willReturn(false);
         $cmfNode = $this->prophesize(NodeInterface::class);
         $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
 
@@ -122,24 +167,21 @@ class PHPCRCleanupCommandTest extends TestCase
 
     public function testGetOrphanedWebspaceKeysSkipsNonWebspaceNodes(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
-
-        $collection = new WebspaceCollection();
-        $collection->setWebspaces(['sulu_io' => $webspace]);
-        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
+        $this->configureSuluIoWebspaceCollection();
 
         $this->session->nodeExists('/cmf')->willReturn(true);
+        $this->liveSession->nodeExists('/cmf')->willReturn(false);
         $cmfNode = $this->prophesize(NodeInterface::class);
         $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
 
         $suluIoNode = $this->prophesize(NodeInterface::class);
         $suluIoNode->getName()->willReturn('sulu_io');
 
-        // Unknown node without 'contents' child should NOT be treated as orphaned webspace
+        // Unknown node without 'contents' or 'routes' child should NOT be treated as orphaned webspace
         $customNode = $this->prophesize(NodeInterface::class);
         $customNode->getName()->willReturn('custom_data');
         $customNode->hasNode('contents')->willReturn(false);
+        $customNode->hasNode('routes')->willReturn(false);
 
         $cmfNode->getNodes()->willReturn([
             $suluIoNode->reveal(),
@@ -154,6 +196,7 @@ class PHPCRCleanupCommandTest extends TestCase
     public function testGetOrphanedWebspaceKeysNoCmfNode(): void
     {
         $this->session->nodeExists('/cmf')->willReturn(false);
+        $this->liveSession->nodeExists('/cmf')->willReturn(false);
 
         $result = $this->command->getOrphanedWebspaceKeys();
 
@@ -162,21 +205,16 @@ class PHPCRCleanupCommandTest extends TestCase
 
     public function testGetStaleRouteLocales(): void
     {
-        $webspace = new Webspace();
-        $webspace->setKey('sulu_io');
         $deLocalization = new Localization('de');
         $enLocalization = new Localization('en');
-        $webspace->setLocalizations([$deLocalization, $enLocalization]);
-
-        $collection = new WebspaceCollection();
-        $collection->setWebspaces(['sulu_io' => $webspace]);
-        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
+        $this->configureSuluIoWebspaceCollection([$deLocalization, $enLocalization]);
         $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([
             'sulu_io' => ['de' => $deLocalization, 'en' => $enLocalization],
         ]);
 
         $routesNode = $this->prophesize(NodeInterface::class);
         $this->session->nodeExists('/cmf/sulu_io/routes')->willReturn(true);
+        $this->liveSession->nodeExists('/cmf/sulu_io/routes')->willReturn(false);
         $this->session->getNode('/cmf/sulu_io/routes')->willReturn($routesNode->reveal());
 
         $deNode = $this->prophesize(NodeInterface::class);
@@ -197,5 +235,52 @@ class PHPCRCleanupCommandTest extends TestCase
         $result = $this->command->getStaleRouteLocales();
 
         $this->assertSame(['sulu_io' => ['fr']], $result);
+    }
+
+    public function testGetStaleRouteLocalesIncludesLiveOnlyRoutes(): void
+    {
+        $deLocalization = new Localization('de');
+        $enLocalization = new Localization('en');
+        $this->configureSuluIoWebspaceCollection([$deLocalization, $enLocalization]);
+        $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([
+            'sulu_io' => ['de' => $deLocalization, 'en' => $enLocalization],
+        ]);
+
+        $this->session->nodeExists('/cmf/sulu_io/routes')->willReturn(false);
+        $this->liveSession->nodeExists('/cmf/sulu_io/routes')->willReturn(true);
+
+        $routesNode = $this->prophesize(NodeInterface::class);
+        $this->liveSession->getNode('/cmf/sulu_io/routes')->willReturn($routesNode->reveal());
+
+        $deNode = $this->prophesize(NodeInterface::class);
+        $deNode->getName()->willReturn('de');
+
+        $frNode = $this->prophesize(NodeInterface::class);
+        $frNode->getName()->willReturn('fr');
+
+        $routesNode->getNodes()->willReturn([
+            $deNode->reveal(),
+            $frNode->reveal(),
+        ]);
+
+        $result = $this->command->getStaleRouteLocales();
+
+        $this->assertSame(['sulu_io' => ['fr']], $result);
+    }
+
+    /**
+     * @param Localization[] $localizations
+     */
+    private function configureSuluIoWebspaceCollection(array $localizations = []): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        if ([] !== $localizations) {
+            $webspace->setLocalizations($localizations);
+        }
+
+        $collection = new WebspaceCollection();
+        $collection->setWebspaces(['sulu_io' => $webspace]);
+        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Command;
+
+use PHPCR\NodeInterface;
+use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupCommand;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+
+class PHPCRCleanupCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $session;
+    private $webspaceManager;
+    private PHPCRCleanupCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->session = $this->prophesize(SessionInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $servicesResetter = $this->prophesize(ServicesResetter::class);
+
+        $this->command = new PHPCRCleanupCommand(
+            $this->session->reveal(),
+            $this->webspaceManager->reveal(),
+            $servicesResetter->reveal(),
+            '/tmp/test-project',
+        );
+    }
+
+    public function testGetOrphanedWebspaceKeys(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+
+        $collection = new WebspaceCollection();
+        $collection->setWebspaces(['sulu_io' => $webspace]);
+        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
+
+        $cmfNode = $this->prophesize(NodeInterface::class);
+        $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
+
+        $suluIoNode = $this->prophesize(NodeInterface::class);
+        $suluIoNode->getName()->willReturn('sulu_io');
+
+        $removedNode = $this->prophesize(NodeInterface::class);
+        $removedNode->getName()->willReturn('old_webspace');
+
+        $snippetsNode = $this->prophesize(NodeInterface::class);
+        $snippetsNode->getName()->willReturn('snippets');
+
+        $articlesNode = $this->prophesize(NodeInterface::class);
+        $articlesNode->getName()->willReturn('articles');
+
+        $cmfNode->getNodes()->willReturn([
+            $suluIoNode->reveal(),
+            $removedNode->reveal(),
+            $snippetsNode->reveal(),
+            $articlesNode->reveal(),
+        ]);
+
+        $result = $this->command->getOrphanedWebspaceKeys();
+
+        $this->assertSame(['old_webspace'], $result);
+    }
+
+    public function testGetOrphanedWebspaceKeysNoneOrphaned(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+
+        $collection = new WebspaceCollection();
+        $collection->setWebspaces(['sulu_io' => $webspace]);
+        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
+
+        $cmfNode = $this->prophesize(NodeInterface::class);
+        $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
+
+        $suluIoNode = $this->prophesize(NodeInterface::class);
+        $suluIoNode->getName()->willReturn('sulu_io');
+
+        $snippetsNode = $this->prophesize(NodeInterface::class);
+        $snippetsNode->getName()->willReturn('snippets');
+
+        $cmfNode->getNodes()->willReturn([
+            $suluIoNode->reveal(),
+            $snippetsNode->reveal(),
+        ]);
+
+        $result = $this->command->getOrphanedWebspaceKeys();
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetStaleRouteLocales(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        $deLocalization = new Localization('de');
+        $enLocalization = new Localization('en');
+        $webspace->setLocalizations([$deLocalization, $enLocalization]);
+
+        $collection = new WebspaceCollection();
+        $collection->setWebspaces([$webspace]);
+        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
+        $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([
+            'sulu_io' => ['de' => $deLocalization, 'en' => $enLocalization],
+        ]);
+
+        $routesNode = $this->prophesize(NodeInterface::class);
+        $this->session->nodeExists('/cmf/sulu_io/routes')->willReturn(true);
+        $this->session->getNode('/cmf/sulu_io/routes')->willReturn($routesNode->reveal());
+
+        $deNode = $this->prophesize(NodeInterface::class);
+        $deNode->getName()->willReturn('de');
+
+        $enNode = $this->prophesize(NodeInterface::class);
+        $enNode->getName()->willReturn('en');
+
+        $frNode = $this->prophesize(NodeInterface::class);
+        $frNode->getName()->willReturn('fr');
+
+        $routesNode->getNodes()->willReturn([
+            $deNode->reveal(),
+            $enNode->reveal(),
+            $frNode->reveal(),
+        ]);
+
+        $result = $this->command->getStaleRouteLocales();
+
+        $this->assertSame(['sulu_io' => ['fr']], $result);
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandTest.php
@@ -55,6 +55,7 @@ class PHPCRCleanupCommandTest extends TestCase
         $collection->setWebspaces(['sulu_io' => $webspace]);
         $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
 
+        $this->session->nodeExists('/cmf')->willReturn(true);
         $cmfNode = $this->prophesize(NodeInterface::class);
         $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
 
@@ -63,6 +64,7 @@ class PHPCRCleanupCommandTest extends TestCase
 
         $removedNode = $this->prophesize(NodeInterface::class);
         $removedNode->getName()->willReturn('old_webspace');
+        $removedNode->hasNode('contents')->willReturn(true);
 
         $snippetsNode = $this->prophesize(NodeInterface::class);
         $snippetsNode->getName()->willReturn('snippets');
@@ -91,6 +93,7 @@ class PHPCRCleanupCommandTest extends TestCase
         $collection->setWebspaces(['sulu_io' => $webspace]);
         $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
 
+        $this->session->nodeExists('/cmf')->willReturn(true);
         $cmfNode = $this->prophesize(NodeInterface::class);
         $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
 
@@ -104,6 +107,46 @@ class PHPCRCleanupCommandTest extends TestCase
             $suluIoNode->reveal(),
             $snippetsNode->reveal(),
         ]);
+
+        $result = $this->command->getOrphanedWebspaceKeys();
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetOrphanedWebspaceKeysSkipsNonWebspaceNodes(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+
+        $collection = new WebspaceCollection();
+        $collection->setWebspaces(['sulu_io' => $webspace]);
+        $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
+
+        $this->session->nodeExists('/cmf')->willReturn(true);
+        $cmfNode = $this->prophesize(NodeInterface::class);
+        $this->session->getNode('/cmf')->willReturn($cmfNode->reveal());
+
+        $suluIoNode = $this->prophesize(NodeInterface::class);
+        $suluIoNode->getName()->willReturn('sulu_io');
+
+        // Unknown node without 'contents' child should NOT be treated as orphaned webspace
+        $customNode = $this->prophesize(NodeInterface::class);
+        $customNode->getName()->willReturn('custom_data');
+        $customNode->hasNode('contents')->willReturn(false);
+
+        $cmfNode->getNodes()->willReturn([
+            $suluIoNode->reveal(),
+            $customNode->reveal(),
+        ]);
+
+        $result = $this->command->getOrphanedWebspaceKeys();
+
+        $this->assertSame([], $result);
+    }
+
+    public function testGetOrphanedWebspaceKeysNoCmfNode(): void
+    {
+        $this->session->nodeExists('/cmf')->willReturn(false);
 
         $result = $this->command->getOrphanedWebspaceKeys();
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupCommandTest.php
@@ -17,6 +17,7 @@ use PHPCR\NodeInterface;
 use PHPCR\SessionInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupCommand;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceCollection;
@@ -28,17 +29,23 @@ class PHPCRCleanupCommandTest extends TestCase
 {
     use ProphecyTrait;
 
-    private $session;
-    private $webspaceManager;
+    /** @var ObjectProphecy<SessionInterface> */
+    private ObjectProphecy $liveSession;
+    /** @var ObjectProphecy<SessionInterface> */
+    private ObjectProphecy $session;
+    /** @var ObjectProphecy<WebspaceManagerInterface> */
+    private ObjectProphecy $webspaceManager;
     private PHPCRCleanupCommand $command;
 
     protected function setUp(): void
     {
+        $this->liveSession = $this->prophesize(SessionInterface::class);
         $this->session = $this->prophesize(SessionInterface::class);
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
         $servicesResetter = $this->prophesize(ServicesResetter::class);
 
         $this->command = new PHPCRCleanupCommand(
+            $this->liveSession->reveal(),
             $this->session->reveal(),
             $this->webspaceManager->reveal(),
             $servicesResetter->reveal(),
@@ -162,7 +169,7 @@ class PHPCRCleanupCommandTest extends TestCase
         $webspace->setLocalizations([$deLocalization, $enLocalization]);
 
         $collection = new WebspaceCollection();
-        $collection->setWebspaces([$webspace]);
+        $collection->setWebspaces(['sulu_io' => $webspace]);
         $this->webspaceManager->getWebspaceCollection()->willReturn($collection);
         $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([
             'sulu_io' => ['de' => $deLocalization, 'en' => $enLocalization],

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
@@ -14,17 +14,23 @@ declare(strict_types=1);
 namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Command;
 
 use PHPCR\NodeInterface;
+use PHPCR\NodeType\NodeTypeInterface;
 use PHPCR\PropertyInterface;
 use PHPCR\SessionInterface;
+use PHPCR\WorkspaceInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupSingleNodeCommand;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\DocumentManager\NamespaceRegistry;
 use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class PHPCRCleanupSingleNodeCommandTest extends TestCase
@@ -55,7 +61,12 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
         $this->namespaceRegistry = $this->prophesize(NamespaceRegistry::class);
         $this->namespaceRegistry->getPrefix('system_localized')->willReturn('i18n');
         $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->eventDispatcher->dispatch(Argument::type('object'), Argument::type('string'))
+            ->will(function(array $arguments) {
+                return $arguments[0];
+            });
         $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $this->documentManager->clear()->willReturn(null);
         $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
 
         $this->command = new PHPCRCleanupSingleNodeCommand(
@@ -181,6 +192,28 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
         $this->assertSame(0, $count);
     }
 
+    public function testRemoveStaleLocalePropertiesReadsPropertyNameOncePerProperty(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        $nonStaleProperty = $this->prophesize(PropertyInterface::class);
+        $nonStaleProperty->getName()->willReturn('i18n:de-template')->shouldBeCalledOnce();
+        $nonStaleProperty->remove()->shouldNotBeCalled();
+
+        $staleProperty = $this->prophesize(PropertyInterface::class);
+        $staleProperty->getName()->willReturn('i18n:fr-template')->shouldBeCalledOnce();
+        $staleProperty->remove()->shouldBeCalledOnce();
+
+        $node->getProperties()->willReturn([
+            $nonStaleProperty->reveal(),
+            $staleProperty->reveal(),
+        ]);
+
+        $count = $this->command->removeStaleLocaleProperties($node->reveal(), ['fr', 'it'], false);
+
+        $this->assertSame(1, $count);
+    }
+
     public function testCleanInvalidShadowReferences(): void
     {
         $node = $this->prophesize(NodeInterface::class);
@@ -232,5 +265,71 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
         $result = $this->command->cleanInvalidShadowReferences($node->reveal(), ['en', 'de'], false);
 
         $this->assertSame(0, $result);
+    }
+
+    public function testExecuteUsesConfiguredLocalesForShadowValidation(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/cmf/sulu_io/contents/page-1');
+
+        $nodeType = $this->prophesize(NodeTypeInterface::class);
+        $nodeType->getName()->willReturn('sulu:page');
+        $node->getMixinNodeTypes()->willReturn([$nodeType->reveal()]);
+
+        $templateProperty = $this->prophesize(PropertyInterface::class);
+        $templateProperty->getName()->willReturn('i18n:en-template');
+        $node->getProperties()->willReturn([$templateProperty->reveal()]);
+
+        $this->session->getNodeByIdentifier('uuid-1')->willReturn($node->reveal());
+
+        $workspace = $this->prophesize(WorkspaceInterface::class);
+        $workspace->getName()->willReturn('default');
+        $this->session->getWorkspace()->willReturn($workspace->reveal());
+        $node->getSession()->willReturn($this->session->reveal());
+
+        $this->structureMetadataFactory->hasStructuresFor('page')->willReturn(true);
+        $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([
+            'sulu_io' => ['en' => new Localization('en'), 'de' => new Localization('de')],
+        ]);
+
+        $document = new class() implements UuidBehavior {
+            public function getUuid()
+            {
+                return 'uuid-1';
+            }
+        };
+        $this->documentManager->find('uuid-1', 'en')->willReturn($document);
+
+        $command = new class(
+            $this->liveSession->reveal(),
+            $this->session->reveal(),
+            $this->structureMetadataFactory->reveal(),
+            $this->namespaceRegistry->reveal(),
+            $this->eventDispatcher->reveal(),
+            $this->documentManager->reveal(),
+            [['phpcr_type' => 'sulu:page', 'alias' => 'page']],
+            $this->webspaceManager->reveal(),
+        ) extends PHPCRCleanupSingleNodeCommand {
+            /** @var string[][] */
+            public array $shadowValidationLocales = [];
+
+            /**
+             * @param string[] $validLocales
+             */
+            public function cleanInvalidShadowReferences(NodeInterface $node, array $validLocales, bool $dryRun): int
+            {
+                $this->shadowValidationLocales[] = $validLocales;
+
+                return 0;
+            }
+        };
+
+        $result = $command->run(new ArrayInput([
+            'node' => ['uuid-1'],
+            '--dry-run' => true,
+        ]), new BufferedOutput());
+
+        $this->assertSame(0, $result);
+        $this->assertSame([['en', 'de']], $command->shadowValidationLocales);
     }
 }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\DocumentManagerBundle\Tests\Unit\Command;
+
+use PHPCR\NodeInterface;
+use PHPCR\PropertyInterface;
+use PHPCR\SessionInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupSingleNodeCommand;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\DocumentManager\DocumentManagerInterface;
+use Sulu\Component\DocumentManager\NamespaceRegistry;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class PHPCRCleanupSingleNodeCommandTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private $liveSession;
+    private $session;
+    private $structureMetadataFactory;
+    private $namespaceRegistry;
+    private $eventDispatcher;
+    private $documentManager;
+    private $webspaceManager;
+    private PHPCRCleanupSingleNodeCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->liveSession = $this->prophesize(SessionInterface::class);
+        $this->session = $this->prophesize(SessionInterface::class);
+        $this->structureMetadataFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->namespaceRegistry = $this->prophesize(NamespaceRegistry::class);
+        $this->namespaceRegistry->getPrefix('system_localized')->willReturn('i18n');
+        $this->eventDispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $this->documentManager = $this->prophesize(DocumentManagerInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+
+        $this->command = new PHPCRCleanupSingleNodeCommand(
+            $this->liveSession->reveal(),
+            $this->session->reveal(),
+            $this->structureMetadataFactory->reveal(),
+            $this->namespaceRegistry->reveal(),
+            $this->eventDispatcher->reveal(),
+            $this->documentManager->reveal(),
+            [['phpcr_type' => 'sulu:page', 'alias' => 'page']],
+            $this->webspaceManager->reveal(),
+        );
+    }
+
+    public function testGetValidLocalesForPageNode(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/cmf/sulu_io/contents/page-1');
+
+        $deLocalization = new Localization('de');
+        $enLocalization = new Localization('en');
+
+        $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([
+            'sulu_io' => ['de' => $deLocalization, 'en' => $enLocalization],
+        ]);
+
+        $result = $this->command->getValidLocales($node->reveal());
+
+        $this->assertEqualsCanonicalizing(['de', 'en'], $result);
+    }
+
+    public function testGetValidLocalesForSnippetNode(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/cmf/snippets/hotel/snippet-1');
+
+        $this->webspaceManager->getAllLocales()->willReturn(['de', 'en', 'fr']);
+
+        $result = $this->command->getValidLocales($node->reveal());
+
+        $this->assertEqualsCanonicalizing(['de', 'en', 'fr'], $result);
+    }
+
+    public function testGetValidLocalesForArticleNode(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/cmf/articles/default/some-uuid/article-1');
+
+        $this->webspaceManager->getAllLocales()->willReturn(['de', 'en']);
+
+        $result = $this->command->getValidLocales($node->reveal());
+
+        $this->assertEqualsCanonicalizing(['de', 'en'], $result);
+    }
+
+    public function testGetValidLocalesForRemovedWebspace(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getPath()->willReturn('/cmf/removed_webspace/contents/page-1');
+
+        $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([
+            'sulu_io' => ['de' => new Localization('de')],
+        ]);
+
+        $result = $this->command->getValidLocales($node->reveal());
+
+        $this->assertSame([], $result);
+    }
+
+    public function testRemoveStaleLocaleProperties(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        $staleProperty1 = $this->prophesize(PropertyInterface::class);
+        $staleProperty1->getName()->willReturn('i18n:fr-template');
+        $staleProperty1->remove()->shouldBeCalledOnce();
+
+        $staleProperty2 = $this->prophesize(PropertyInterface::class);
+        $staleProperty2->getName()->willReturn('i18n:fr-title');
+        $staleProperty2->remove()->shouldBeCalledOnce();
+
+        $validProperty = $this->prophesize(PropertyInterface::class);
+        $validProperty->getName()->willReturn('i18n:de-template');
+        $validProperty->remove()->shouldNotBeCalled();
+
+        $unlocalizedProperty = $this->prophesize(PropertyInterface::class);
+        $unlocalizedProperty->getName()->willReturn('sulu:order');
+        $unlocalizedProperty->remove()->shouldNotBeCalled();
+
+        $node->getProperties()->willReturn([
+            $staleProperty1->reveal(),
+            $staleProperty2->reveal(),
+            $validProperty->reveal(),
+            $unlocalizedProperty->reveal(),
+        ]);
+
+        $count = $this->command->removeStaleLocaleProperties($node->reveal(), ['fr'], false);
+
+        $this->assertSame(2, $count);
+    }
+
+    public function testRemoveStaleLocalePropertiesDryRun(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        $staleProperty = $this->prophesize(PropertyInterface::class);
+        $staleProperty->getName()->willReturn('i18n:fr-template');
+        $staleProperty->remove()->shouldNotBeCalled();
+
+        $node->getProperties()->willReturn([$staleProperty->reveal()]);
+
+        $count = $this->command->removeStaleLocaleProperties($node->reveal(), ['fr'], true);
+
+        $this->assertSame(1, $count);
+    }
+
+    public function testRemoveStaleLocalePropertiesNoStaleLocales(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        $count = $this->command->removeStaleLocaleProperties($node->reveal(), [], false);
+
+        $this->assertSame(0, $count);
+    }
+
+    public function testCleanInvalidShadowReferences(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        // i18n:en-shadow-on = true, i18n:en-shadow-base = "fr" (fr no longer exists)
+        $shadowOnProp = $this->prophesize(PropertyInterface::class);
+        $shadowOnProp->getName()->willReturn('i18n:en-shadow-on');
+        $node->hasProperty('i18n:en-shadow-on')->willReturn(true);
+        $node->getProperty('i18n:en-shadow-on')->willReturn($shadowOnProp->reveal());
+        $shadowOnProp->getValue()->willReturn(true);
+        $shadowOnProp->setValue(null)->shouldBeCalledOnce();
+
+        $shadowBaseProp = $this->prophesize(PropertyInterface::class);
+        $shadowBaseProp->getName()->willReturn('i18n:en-shadow-base');
+        $node->hasProperty('i18n:en-shadow-base')->willReturn(true);
+        $node->getProperty('i18n:en-shadow-base')->willReturn($shadowBaseProp->reveal());
+        $shadowBaseProp->getValue()->willReturn('fr');
+        $shadowBaseProp->setValue(null)->shouldBeCalledOnce();
+
+        // de locale has no shadow properties
+        $node->hasProperty('i18n:de-shadow-on')->willReturn(false);
+
+        $result = $this->command->cleanInvalidShadowReferences($node->reveal(), ['en', 'de'], false);
+
+        $this->assertSame(1, $result);
+    }
+
+    public function testCleanInvalidShadowReferencesValidShadow(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        $shadowOnProp = $this->prophesize(PropertyInterface::class);
+        $shadowOnProp->getName()->willReturn('i18n:en-shadow-on');
+        $node->hasProperty('i18n:en-shadow-on')->willReturn(true);
+        $node->getProperty('i18n:en-shadow-on')->willReturn($shadowOnProp->reveal());
+        $shadowOnProp->getValue()->willReturn(true);
+        $shadowOnProp->setValue(null)->shouldNotBeCalled();
+
+        $shadowBaseProp = $this->prophesize(PropertyInterface::class);
+        $shadowBaseProp->getName()->willReturn('i18n:en-shadow-base');
+        $node->hasProperty('i18n:en-shadow-base')->willReturn(true);
+        $node->getProperty('i18n:en-shadow-base')->willReturn($shadowBaseProp->reveal());
+        $shadowBaseProp->getValue()->willReturn('de');
+        $shadowBaseProp->setValue(null)->shouldNotBeCalled();
+
+        // de locale has no shadow properties
+        $node->hasProperty('i18n:de-shadow-on')->willReturn(false);
+
+        $result = $this->command->cleanInvalidShadowReferences($node->reveal(), ['en', 'de'], false);
+
+        $this->assertSame(0, $result);
+    }
+}

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
@@ -18,6 +18,7 @@ use PHPCR\PropertyInterface;
 use PHPCR\SessionInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupSingleNodeCommand;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
@@ -30,13 +31,20 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
 {
     use ProphecyTrait;
 
-    private $liveSession;
-    private $session;
-    private $structureMetadataFactory;
-    private $namespaceRegistry;
-    private $eventDispatcher;
-    private $documentManager;
-    private $webspaceManager;
+    /** @var ObjectProphecy<SessionInterface> */
+    private ObjectProphecy $liveSession;
+    /** @var ObjectProphecy<SessionInterface> */
+    private ObjectProphecy $session;
+    /** @var ObjectProphecy<StructureMetadataFactoryInterface> */
+    private ObjectProphecy $structureMetadataFactory;
+    /** @var ObjectProphecy<NamespaceRegistry> */
+    private ObjectProphecy $namespaceRegistry;
+    /** @var ObjectProphecy<EventDispatcherInterface> */
+    private ObjectProphecy $eventDispatcher;
+    /** @var ObjectProphecy<DocumentManagerInterface> */
+    private ObjectProphecy $documentManager;
+    /** @var ObjectProphecy<WebspaceManagerInterface> */
+    private ObjectProphecy $webspaceManager;
     private PHPCRCleanupSingleNodeCommand $command;
 
     protected function setUp(): void


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - **Batch processing**: The single-node subprocess now accepts multiple UUIDs, reducing process spawn overhead. A new `--batch-size` option (default 50) controls how many nodes each subprocess handles.
  - **Stale locale cleanup**: Detects locales on PHPCR nodes that no longer exist in the webspace configuration and removes their localized properties from both default and live sessions.
  - **Invalid shadow reference cleanup**: Resets shadow-on/shadow-base properties when the shadow base locale no longer exists in the webspace.
  - **Orphaned webspace tree removal**: Detects and removes entire `/cmf/<key>` trees for webspaces that are no longer configured.
  - **Stale route locale removal**: Removes route locale directories (e.g. `/cmf/<webspace>/routes/<locale>`) that are no longer in the webspace configuration.
  - **Unit tests**: Added `PHPCRCleanupCommandTest` and `PHPCRCleanupSingleNodeCommandTest` covering the new detection and cleanup methods.

  #### Why?

  The PHPCR cleanup command previously spawned one subprocess per node, which is very slow on large repositories. Batching nodes into subprocesses significantly reduces overhead. Additionally, when webspaces or
  locales are removed from configuration, their PHPCR data was left behind — stale locale properties, orphaned webspace trees, invalid shadow references, and unused route directories would accumulate over time,
  causing confusion and wasted storage.