### PR TITLE
Hide empty overlay when no ai application present

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -455,13 +455,13 @@ initializer.addUpdateConfigHook('sulu_ai', (config: Object, initialized: boolean
         return;
     }
 
-    const div = document.createElement('div');
-    div.id = 'su-ai-application';
-    document.body?.appendChild(div);
-
     if (!config['writing_assistant']?.enabled && !config['translation']?.enabled && !config['feedback']?.enabled) {
         return;
     }
+
+    const div = document.createElement('div');
+    div.id = 'su-ai-application';
+    document.body?.appendChild(div);
 
     render(<AiApplication
         feedback={config['feedback']}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This PR hides an empty overlay div, when neither writing_aisstant, nor translation or feedback for sulu ai are configured active for the current user.

#### Why?

Some of our users are not allowed to use any of the sulu ai features, so we disabled them for those users. But with the current implementation, there is a tiny empty div displayed, when for users with enough permissions a small ai-feature trigger is displayed.
