### PR TITLE
Improve list performance with additional indices

### DIFF
--- a/packages/content/src/Infrastructure/Doctrine/MetadataLoader.php
+++ b/packages/content/src/Infrastructure/Doctrine/MetadataLoader.php
@@ -52,7 +52,7 @@ final class MetadataLoader
         /** @var ClassMetadata<object> $metadata */
         $metadata = $event->getClassMetadata();
         $reflection = $metadata->getReflectionClass();
-        $tableName = $metadata->getTableName();
+        $resourceForeignKeyColumn = null;
 
         if ($reflection->implementsInterface(DimensionContentInterface::class)) {
             $this->addField($metadata, 'stage', 'string', ['length' => 15, 'nullable' => false]);
@@ -65,6 +65,14 @@ final class MetadataLoader
             $this->addIndex($metadata, 'locale', ['locale']);
             $this->addIndex($metadata, 'stage', ['stage']);
             $this->addIndex($metadata, 'version', ['version']);
+            $this->addIndex($metadata, 'stage_version_locale', ['stage', 'version', 'locale']);
+
+            $resourceForeignKeyColumn = $this->getResourceForeignKeyColumn($metadata);
+            if (null !== $resourceForeignKeyColumn) {
+                $this->addIndex($metadata, 'resource_lookup', [
+                    $resourceForeignKeyColumn, 'stage', 'version', 'locale', 'ghostLocale',
+                ]);
+            }
         }
 
         if ($reflection->implementsInterface(ShadowInterface::class)) {
@@ -77,6 +85,12 @@ final class MetadataLoader
             $this->addField($metadata, 'templateData', 'json', ['nullable' => false, 'options' => ['jsonb' => true]]);
 
             $this->addIndex($metadata, 'template_key', ['templateKey']);
+
+            if (null !== $resourceForeignKeyColumn) {
+                $this->addIndex($metadata, 'resource_template_lookup', [
+                    $resourceForeignKeyColumn, 'stage', 'version', 'locale', 'templateKey',
+                ]);
+            }
         }
 
         if ($reflection->implementsInterface(SeoInterface::class)) {
@@ -243,6 +257,23 @@ final class MetadataLoader
         $tableName = $metadata->getTableName();
 
         $builder->addIndex($fields, 'idx_' . $tableName . '_' . $name);
+    }
+
+    /**
+     * @param ClassMetadata<object> $metadata
+     */
+    private function getResourceForeignKeyColumn(ClassMetadata $metadata): ?string
+    {
+        foreach ($metadata->getAssociationMappings() as $mapping) {
+            if (isset($mapping['inversedBy']) && 'dimensionContents' === $mapping['inversedBy']) {
+                $joinColumns = $mapping['joinColumns'] ?? []; // @phpstan-ignore-line
+                $columnName = $joinColumns[0]['name'] ?? null; // @phpstan-ignore-line
+
+                return \is_string($columnName) ? $columnName : null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/packages/content/tests/Unit/Content/Infrastructure/Doctrine/MetadataLoaderTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Doctrine/MetadataLoaderTest.php
@@ -105,6 +105,10 @@ class MetadataLoaderTest extends TestCase
             }))->shouldBeCalledTimes($exist ? 0 : 1);
         }
 
+        if (\in_array(DimensionContentInterface::class, $interfaces, true)) {
+            $classMetadata->getAssociationMappings()->willReturn([]);
+        }
+
         $configuration = $this->prophesize(Configuration::class);
         $configuration->getNamingStrategy()->willReturn(new UnderscoreNamingStrategy());
         $entityManager = $this->prophesize(EntityManager::class);


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #8643
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Added composite index on `stage`, `version`, `locale` for dimension content entities
  - Added `resource_lookup` index on the resource foreign key + `stage`, `version`, `locale`, `ghostLocale` columns
  - Added `resource_template_lookup` index for entities implementing `TemplateInterface`, covering the resource foreign key + `stage`, `version`, `locale`, `templateKey` columns
  - Introduced a `getResourceForeignKeyColumn` helper that dynamically resolves the resource foreign key column from the `dimensionContents` association mapping

  #### Why?

  Queries on dimension content tables frequently filter by resource, stage, version, and locale. Without proper composite indices, these lookups result in full table scans or suboptimal index usage, degrading
  performance as content grows. The new indices cover the most common query patterns for content resolution and template-based lookups.