### PR TITLE
Add check for invalid http_cache true configuration

### DIFF
--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheCompilerPass.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheCompilerPass.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\HttpCacheBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SuluHttpCacheCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if ($container->hasDefinition('http_cache') && $container->getDefinition('http_cache')->isPublic()) {
+            throw new \InvalidArgumentException('Enabling the Symfony Http Cache is not compatible with Sulu! Cache is handled in index.php!');
+        }
+    }
+}

--- a/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheCompilerPass.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/DependencyInjection/SuluHttpCacheCompilerPass.php
@@ -14,6 +14,9 @@ namespace Sulu\Bundle\HttpCacheBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @internal no backwards compatibility promise is given for this class it can be removed at any time
+ */
 class SuluHttpCacheCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void

--- a/src/Sulu/Bundle/HttpCacheBundle/SuluHttpCacheBundle.php
+++ b/src/Sulu/Bundle/HttpCacheBundle/SuluHttpCacheBundle.php
@@ -11,8 +11,15 @@
 
 namespace Sulu\Bundle\HttpCacheBundle;
 
+use Sulu\Bundle\HttpCacheBundle\DependencyInjection\SuluHttpCacheCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SuluHttpCacheBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+        $container->addCompilerPass(new SuluHttpCacheCompilerPass());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8640
| Related issues/PRs | #8640
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adds a Compiler Pass that checks if the framework.http_cache is set to true.

#### Why?

#8640 

#### Example Usage

```yaml
# framework.yaml
framework:
	http_cache: true
```
With `http_cache: true` the Compiler Pass will throw an exception depending on if the service is public as it always exists: https://github.com/symfony/symfony/blob/0fcf3560679ef39e85d7b196ba3d2e14513d43c6/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L934-L936