### PR TITLE
Fixing return type of ListRestHelper

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6559,18 +6559,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getId\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getId\(\) should return array but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getKey\(\) should return string but returns mixed\.$#'
 			identifier: return.type
 			count: 1
@@ -6694,12 +6682,6 @@ parameters:
 			message: '#^Strict comparison using \=\=\= between null and Sulu\\Bundle\\CategoryBundle\\Entity\\CategoryTranslationInterface will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 6
-			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between null and array will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25849,19 +25849,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
 
 		-
-			message: '#^Parameter \#4 \$search of method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManagerInterface\:\:getTree\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
-
-		-
 			message: '#^Parameter \#5 \$depth of method Sulu\\Bundle\\MediaBundle\\Collection\\Manager\\CollectionManagerInterface\:\:getTree\(\) expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
-
-		-
-			message: '#^Parameter \#5 \$page of class Sulu\\Component\\Rest\\ListBuilder\\ListRepresentation constructor expects int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -48499,12 +48487,6 @@ parameters:
 			path: src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
 
 		-
-			message: '#^Cannot cast mixed to int\.$#'
-			identifier: cast.int
-			count: 1
-			path: src/Sulu/Bundle/SearchBundle/Controller/SearchController.php
-
-		-
 			message: '#^Parameter \#1 \$query of method Massive\\Bundle\\SearchBundle\\Search\\SearchManagerInterface\:\:createSearch\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -54424,24 +54406,6 @@ parameters:
 			message: '#^Parameter \#2 \$string of function explode expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
-
-		-
-			message: '#^Parameter \#3 \$search of method Sulu\\Bundle\\SnippetBundle\\Snippet\\SnippetRepository\:\:getSnippetsAmount\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
-
-		-
-			message: '#^Parameter \#5 \$page of class Sulu\\Component\\Rest\\ListBuilder\\ListRepresentation constructor expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
-
-		-
-			message: '#^Parameter \#5 \$search of method Sulu\\Bundle\\SnippetBundle\\Snippet\\SnippetRepository\:\:getSnippets\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Sulu/Bundle/SnippetBundle/Controller/SnippetController.php
 
 		-
@@ -83719,12 +83683,6 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getExcludedIds\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
-
-		-
 			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getFields\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -83743,19 +83701,7 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getIds\(\) should return array but returns array\<int\<0, max\>, string\>\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getLimit\(\) should return int but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getLimit\(\) should return int\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -83767,8 +83713,8 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getPage\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getPage\(\) should return int but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
@@ -83779,8 +83725,8 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getSearchPattern\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getSearchPattern\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
@@ -83803,12 +83749,6 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelperInterface\:\:getExcludedIds\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
-
-		-
 			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelperInterface\:\:getFields\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -83821,26 +83761,8 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelperInterface\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelperInterface\:\:getPage\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
-
-		-
 			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelperInterface\:\:getSearchFields\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelperInterface\:\:getSearchPattern\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
 
@@ -85130,18 +85052,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$key of function array_key_exists expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: '#^Parameter \#1 \$page of method Sulu\\Component\\Rest\\ListBuilder\\ListBuilderInterface\:\:setCurrentPage\(\) expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: '#^Parameter \#1 \$search of method Sulu\\Component\\Rest\\ListBuilder\\ListBuilderInterface\:\:search\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Rest/RestHelper.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6529,18 +6529,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getChanged\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getCreated\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Api/Category.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Api\\Category\:\:getDefaultLocale\(\) should return string but returns mixed\.$#'
 			identifier: return.type
 			count: 1
@@ -25365,7 +25353,7 @@ parameters:
 		-
 			message: '#^Cannot access offset string on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
+			count: 4
 			path: src/Sulu/Bundle/MediaBundle/Content/Types/ImageMapContentType.php
 
 		-
@@ -36085,12 +36073,6 @@ parameters:
 			path: src/Sulu/Bundle/PageBundle/Controller/VersionController.php
 
 		-
-			message: '#^Parameter \#5 \$page of class Sulu\\Component\\Rest\\ListBuilder\\ListRepresentation constructor expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/PageBundle/Controller/VersionController.php
-
-		-
 			message: '#^Strict comparison using \!\=\= between false and string will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
 			count: 1
@@ -43881,13 +43863,13 @@ parameters:
 		-
 			message: '#^Offset ''changed'' might not exist on Sulu\\Component\\Content\\Repository\\Content\|null\.$#'
 			identifier: offsetAccess.notFound
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
 
 		-
 			message: '#^Offset ''created'' might not exist on Sulu\\Component\\Content\\Repository\\Content\|null\.$#'
 			identifier: offsetAccess.notFound
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/PageBundle/Tests/Functional/Repository/ContentRepositoryTest.php
 
 		-
@@ -58717,12 +58699,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
 
 		-
-			message: '#^Parameter \#2 \$alias of method Sulu\\Bundle\\WebsiteBundle\\Controller\\SitemapController\:\:sitemapPaginatedAction\(\) expects string, int\<min, \-1\>\|int\<1, max\>\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/SitemapController.php
-
-		-
 			message: '#^Parameter \#2 \$values of method Symfony\\Component\\HttpFoundation\\ResponseHeaderBag\:\:set\(\) expects array\<string\>\|string\|null, int given\.$#'
 			identifier: argument.type
 			count: 1
@@ -63339,7 +63315,7 @@ parameters:
 		-
 			message: '#^Cannot access offset string on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 2
 			path: src/Sulu/Component/Content/Compat/Block/BlockProperty.php
 
 		-
@@ -84751,21 +84727,9 @@ parameters:
 			path: src/Sulu/Component/Rest/Listing/ListRepository.php
 
 		-
-			message: '#^Parameter \#1 \$value of function count expects array\|Countable, array\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Rest/Listing/ListRepository.php
-
-		-
 			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Component/Rest/Listing/ListRepository.php
-
-		-
-			message: '#^Parameter \#2 \$intersectArray of method Sulu\\Component\\Rest\\Listing\\ListRepository\:\:getFieldsWitTypes\(\) expects array\<string\>\|null, array\|null given\.$#'
-			identifier: argument.type
-			count: 2
 			path: src/Sulu/Component/Rest/Listing/ListRepository.php
 
 		-
@@ -84783,12 +84747,6 @@ parameters:
 		-
 			message: '#^Parameter \#3 \$justCount \(bool\) of method Sulu\\Component\\Rest\\Listing\\ListRepository\:\:find\(\) should be compatible with parameter \$lockVersion \(int\|null\) of method Doctrine\\ORM\\EntityRepository\<object\>\:\:find\(\)$#'
 			identifier: method.childParameterType
-			count: 1
-			path: src/Sulu/Component/Rest/Listing/ListRepository.php
-
-		-
-			message: '#^Parameter \#4 \$fields of class Sulu\\Component\\Rest\\Listing\\ListQueryBuilder constructor expects array\<string\>, array\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Rest/Listing/ListRepository.php
 
@@ -84871,18 +84829,6 @@ parameters:
 			path: src/Sulu/Component/Rest/Listing/ListRestHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\Listing\\ListRestHelper\:\:getAllFields\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/Listing/ListRestHelper.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\Listing\\ListRestHelper\:\:getFields\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Rest/Listing/ListRestHelper.php
-
-		-
 			message: '#^Method Sulu\\Component\\Rest\\Listing\\ListRestHelper\:\:getLimit\(\) should return int but returns mixed\.$#'
 			identifier: return.type
 			count: 1
@@ -84897,12 +84843,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Component\\Rest\\Listing\\ListRestHelper\:\:getPage\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Rest/Listing/ListRestHelper.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\Listing\\ListRestHelper\:\:getSearchFields\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Rest/Listing/ListRestHelper.php
 
@@ -90679,12 +90619,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
-
-		-
 			message: '#^Method Sulu\\Component\\Webspace\\Tests\\Unit\\Analyzer\\Attributes\\AdminRequestProcessorTest\:\:provideData\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -90719,18 +90653,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/ParameterRequestProcessorTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/PortalInformationRequestProcessorTest.php
 
 		-
 			message: '#^Cannot access offset ''format'' on mixed\.$#'
@@ -90947,12 +90869,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/UrlRequestProcessorTest.php
-
-		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
-			identifier: method.alreadyNarrowedType
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/WebsiteRequestProcessorTest.php
 
 		-
 			message: '#^Cannot call method getUrl\(\) on mixed\.$#'

--- a/src/Sulu/Bundle/CategoryBundle/Api/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Api/Category.php
@@ -250,26 +250,28 @@ class Category extends ApiEntityWrapper
     /**
      * Returns the created date for the category.
      *
-     * @return string
+     * @return \DateTimeInterface
      */
     #[VirtualProperty]
     #[SerializedName('created')]
     #[Groups(['fullCategory'])]
     public function getCreated()
     {
+        /** @var \DateTimeInterface */
         return $this->entity->getCreated();
     }
 
     /**
      * Returns the created date for the category.
      *
-     * @return string
+     * @return \DateTimeInterface
      */
     #[VirtualProperty]
     #[SerializedName('changed')]
     #[Groups(['fullCategory'])]
     public function getChanged()
     {
+        /** @var \DateTimeInterface */
         return $this->entity->getChanged();
     }
 

--- a/src/Sulu/Bundle/CategoryBundle/Api/Category.php
+++ b/src/Sulu/Bundle/CategoryBundle/Api/Category.php
@@ -19,7 +19,6 @@ use Sulu\Bundle\CategoryBundle\Entity\CategoryMetaInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryTranslationInterface;
 use Sulu\Bundle\CoreBundle\Entity\ApiEntityWrapper;
 use Sulu\Bundle\MediaBundle\Api\Media;
-use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
 use Sulu\Component\Security\Authentication\UserInterface;
 
 class Category extends ApiEntityWrapper
@@ -33,13 +32,14 @@ class Category extends ApiEntityWrapper
     /**
      * Returns the id of the category.
      *
-     * @return array
+     * @return int
      */
     #[VirtualProperty]
     #[SerializedName('id')]
     #[Groups(['fullCategory', 'partialCategory'])]
     public function getId()
     {
+        /** @var int */
         return $this->entity->getId();
     }
 
@@ -312,7 +312,10 @@ class Category extends ApiEntityWrapper
         $translationEntity->setTranslation($translation->getTranslation());
         $translationEntity->setLocale($translation->getLocale());
 
-        if (null === $this->getId() && null === $this->getDefaultLocale()) {
+        /** @var int|null $id */
+        $id = $this->getId();
+
+        if (null === $id && null === $this->getDefaultLocale()) {
             // new entity and new translation
             // save first locale as default
             $this->entity->setDefaultLocale($translationEntity->getLocale());

--- a/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Collection/Manager/CollectionManagerInterface.php
@@ -84,7 +84,7 @@ interface CollectionManagerInterface
      * @param string $locale the locale which the collection should be return
      * @param int $offset
      * @param int|null $limit
-     * @param string $search
+     * @param string|null $search
      * @param int $depth maximum depth for query
      * @param array $sortBy
      * @param bool $systemCollections Whether or not system collectino should be included in the result

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -209,7 +209,7 @@ class CollectionController extends AbstractRestController implements ClassResour
                     $this->getRequestParameter($request, 'locale', true),
                     $offset,
                     $limit,
-                    $search,
+                    (string) $search,
                     $depth,
                     null !== $sortBy ? [$sortBy => $sortOrder] : [],
                     $this->securityChecker->hasPermission('sulu.media.system_collections', 'view'),

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -209,7 +209,7 @@ class CollectionController extends AbstractRestController implements ClassResour
                     $this->getRequestParameter($request, 'locale', true),
                     $offset,
                     $limit,
-                    (string) $search,
+                    $search,
                     $depth,
                     null !== $sortBy ? [$sortBy => $sortOrder] : [],
                     $this->securityChecker->hasPermission('sulu.media.system_collections', 'view'),

--- a/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/AbstractListBuilder.php
@@ -35,7 +35,7 @@ abstract class AbstractListBuilder implements ListBuilderInterface
     /**
      * The value for which the searchfields will be searched.
      *
-     * @var string
+     * @var string|null
      */
     protected $search;
 

--- a/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
@@ -102,7 +102,7 @@ interface ListBuilderInterface
     /**
      * Sets the search value for the search fields.
      *
-     * @param string $search
+     * @param string|null $search
      *
      * @return ListBuilderInterface
      */

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -52,12 +52,6 @@ class ListRestHelper implements ListRestHelperInterface
         return $request;
     }
 
-    /**
-     * Returns an array of ids to which the response should be restricted.
-     * If null is returned, entities in the response should not be restricted by their id.
-     *
-     * @return array
-     */
     public function getIds()
     {
         $idsString = $this->getRequest()->get('ids');
@@ -65,11 +59,6 @@ class ListRestHelper implements ListRestHelperInterface
         return (null !== $idsString) ? \array_filter(\explode(',', $idsString)) : null;
     }
 
-    /**
-     * Returns an array of ids which should be excluded from the response.
-     *
-     * @return array
-     */
     public function getExcludedIds()
     {
         $excludedIdsString = $this->getRequest()->get('excludedIds');
@@ -100,7 +89,7 @@ class ListRestHelper implements ListRestHelperInterface
     /**
      * Returns the maximum number of elements in a single response.
      *
-     * @return int
+     * @return int|null
      */
     public function getLimit()
     {

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
@@ -20,14 +20,14 @@ interface ListRestHelperInterface
      * Returns an array of ids to which the response should be restricted.
      * If null is returned, entities in the response should not be restricted by their id.
      *
-     * @return array
+     * @return array<string>|null
      */
     public function getIds();
 
     /**
      * Returns an array of ids which should be excluded from the response.
      *
-     * @return array
+     * @return array<string>
      */
     public function getExcludedIds();
 
@@ -48,7 +48,7 @@ interface ListRestHelperInterface
     /**
      * Returns the maximum number of elements in a single response.
      *
-     * @return int
+     * @return int|null
      */
     public function getLimit();
 
@@ -62,6 +62,8 @@ interface ListRestHelperInterface
 
     /**
      * returns the current page.
+     *
+     * @return int
      */
     public function getPage();
 
@@ -75,6 +77,8 @@ interface ListRestHelperInterface
 
     /**
      * Returns the pattern of the search.
+     *
+     * @return string|null
      */
     public function getSearchPattern();
 

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -43,7 +43,7 @@ class ListRepository extends EntityRepository
         $searchFields = $this->helper->getSearchFields();
 
         // if search string is set, but search fields are not, take all fields into account
-        if (!\is_null($searchPattern) && '' != $searchPattern && (\is_null($searchFields) || 0 == \count($searchFields))) {
+        if (!\is_null($searchPattern) && '' != $searchPattern && [] === $searchFields) {
             $searchFields = $this->getEntityManager()->getClassMetadata($this->getEntityName())->getFieldNames();
         }
 
@@ -86,7 +86,7 @@ class ListRepository extends EntityRepository
             }
         }
         if (null != $searchPattern && '' != $searchPattern) {
-            if (\count($searchFields ?? []) > 0) {
+            if ([] !== $searchFields) {
                 if (\count($textFields) > 0) {
                     $query->setParameter('search', '%' . $searchPattern . '%');
                 }

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -58,7 +58,7 @@ class ListRepository extends EntityRepository
             $this->getClassMetadata()->getAssociationNames(),
             $this->getClassMetadata()->getFieldNames(),
             $this->getEntityName(),
-            $this->helper->getFields(),
+            $this->helper->getFields() ?? [],
             $this->helper->getSorting(),
             $where,
             $textFields,
@@ -86,7 +86,7 @@ class ListRepository extends EntityRepository
             }
         }
         if (null != $searchPattern && '' != $searchPattern) {
-            if (\count($searchFields) > 0) {
+            if (\count($searchFields ?? []) > 0) {
                 if (\count($textFields) > 0) {
                     $query->setParameter('search', '%' . $searchPattern . '%');
                 }

--- a/src/Sulu/Component/Rest/Listing/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/Listing/ListRestHelper.php
@@ -190,7 +190,7 @@ class ListRestHelper
     /**
      * Returns an array with all the fields the search pattern should be executed on.
      *
-     * @return array<string>|null
+     * @return array<string>
      */
     public function getSearchFields()
     {

--- a/src/Sulu/Component/Rest/Listing/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/Listing/ListRestHelper.php
@@ -159,7 +159,7 @@ class ListRestHelper
      *
      * @param string $entityName
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getAllFields($entityName)
     {
@@ -170,7 +170,7 @@ class ListRestHelper
      * Returns an array with all the fields, which should be contained in the response.
      * If null is returned every field should be contained.
      *
-     * @return array|null
+     * @return array<string>|null
      */
     public function getFields()
     {
@@ -190,7 +190,7 @@ class ListRestHelper
     /**
      * Returns an array with all the fields the search pattern should be executed on.
      *
-     * @return array|null
+     * @return array<string>|null
      */
     public function getSearchFields()
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no (only types)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7608
| Related issues/PRs | https://github.com/sulu/sulu/pull/8642
| License | MIT
| Documentation PR | -

#### What's in this PR?
* Correcting the documentation of the ListRestHelper that limit can be null or int.
* Moving the documentation to the interface
* Fixing some downstream type issues.

#### Why?

Wrong types makes it hard to see errors in plugins and projects that use Sulu as phpstan relies on the incorrect docs.

phpstan baseline is smaller.