### PR TITLE
Fix single_select default_value not applied inside blocks

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -14,7 +14,7 @@ import conditionDataProviderRegistry from '../Form/registries/conditionDataProvi
 import {getDifference} from '../../utils/DifferenceCalculator';
 import blockPreviewTransformerRegistry from './registries/blockPreviewTransformerRegistry';
 import FieldRenderer from './FieldRenderer';
-import type {BlockError, FieldTypeProps, FormStoreInterface} from '../Form/types';
+import type {BlockError, ChangeContext, FieldTypeProps, FormStoreInterface} from '../Form/types';
 import type {BlockEntry} from './types';
 import type {Message} from '../../components/BlockCollection/types';
 
@@ -267,7 +267,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         this.value = value;
     };
 
-    handleBlockChange = (index: number, name: string, value: Object, context?: Object) => {
+    handleBlockChange = (index: number, name: string, value: Object, context?: ChangeContext) => {
         const {onChange} = this.props;
         const oldValues = this.value;
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -267,7 +267,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         this.value = value;
     };
 
-    handleBlockChange = (index: number, name: string, value: Object) => {
+    handleBlockChange = (index: number, name: string, value: Object, context?: Object) => {
         const {onChange} = this.props;
         const oldValues = this.value;
 
@@ -280,7 +280,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
         this.setValue(newValues);
 
-        onChange(newValues);
+        onChange(newValues, context);
     };
 
     handleBlocksChange = (value: Object) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -56,7 +56,12 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         const {types: oldTypes} = prevProps;
 
         if (!equals(toJS(prevProps.value), toJS(value))){
-            this.setValue(value);
+            // Only sync from props if no local changes were made since the last render.
+            // This prevents stale echoed values from overwriting local changes
+            // (e.g., default values applied by field components during mount).
+            if (!this.value || equals(toJS(this.value), toJS(prevProps.value))) {
+                this.setValue(value);
+            }
         }
 
         if (!types || !oldTypes) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldRenderer.js
@@ -11,7 +11,7 @@ type Props = {|
     errors?: ErrorCollection,
     formInspector: FormInspector,
     index: number,
-    onChange: (index: number, name: string, value: *) => void,
+    onChange: (index: number, name: string, value: *, context?: Object) => void,
     onFieldFinish: ?() => void,
     onSuccess: ?() => void,
     router: ?Router,
@@ -26,9 +26,9 @@ export default class FieldRenderer extends React.Component<Props> {
         showAllErrors: false,
     };
 
-    handleChange = (name: string, value: *) => {
+    handleChange = (name: string, value: *, context?: Object) => {
         const {index, onChange} = this.props;
-        onChange(index, name, value);
+        onChange(index, name, value, context);
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldRenderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldRenderer.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import Router from '../../services/Router';
 import {FormInspector, Renderer} from '../Form';
-import type {ErrorCollection} from '../Form/types';
+import type {ChangeContext, ErrorCollection} from '../Form/types';
 import type {Schema} from '../Form';
 
 type Props = {|
@@ -11,7 +11,7 @@ type Props = {|
     errors?: ErrorCollection,
     formInspector: FormInspector,
     index: number,
-    onChange: (index: number, name: string, value: *, context?: Object) => void,
+    onChange: (index: number, name: string, value: *, context?: ChangeContext) => void,
     onFieldFinish: ?() => void,
     onSuccess: ?() => void,
     router: ?Router,
@@ -26,7 +26,7 @@ export default class FieldRenderer extends React.Component<Props> {
         showAllErrors: false,
     };
 
-    handleChange = (name: string, value: *, context?: Object) => {
+    handleChange = (name: string, value: *, context?: ChangeContext) => {
         const {index, onChange} = this.props;
         onChange(index, name, value, context);
     };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -1223,11 +1223,52 @@ test ('Should set nested properties in handleBlockChange and call onChange with 
     fieldBlocks.find('FieldRenderer').prop('onChange')(0, 'options/test1', 'value1');
 
     const expectedArray1 = [{type: 'default', options: {test1: 'value1'}}];
-    expect(changeSpy).toBeCalledWith(expectedArray1);
+    expect(changeSpy).toBeCalledWith(expectedArray1, undefined);
 
     fieldBlocks.find('FieldRenderer').prop('onChange')(0, 'options/test2/test3', 'value2');
     const expectedArray2 = [{type: 'default', options: {test1: 'value1', test2: {test3: 'value2'}}}];
-    expect(changeSpy).toBeCalledWith(expectedArray2);
+    expect(changeSpy).toBeCalledWith(expectedArray2, undefined);
+});
+
+test('Should pass context through handleBlockChange to onChange', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const types = {
+        default: {
+            title: 'Default',
+            form: {
+                text: {
+                    label: 'Text',
+                    type: 'text_line',
+                },
+            },
+        },
+    };
+    const value = [{type: 'default'}];
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const changeSpy = jest.fn();
+    const fieldBlocks = mount(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            dataPath=""
+            defaultType="editor"
+            fieldTypeOptions={{}}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaPath=""
+            types={types}
+            value={value}
+        />
+    );
+
+    fieldBlocks.find('Block').simulate('click');
+    fieldBlocks.find('FieldRenderer').prop('onChange')(0, 'alignment', 'left', {isDefaultValue: true});
+
+    expect(changeSpy).toBeCalledWith(
+        [{type: 'default', alignment: 'left'}],
+        {isDefaultValue: true}
+    );
 });
 
 test('Should call onFinish when the order of the blocks has changed', () => {
@@ -1922,7 +1963,8 @@ test('Should set correct default values for multiple single_select in blocks', (
                 'position_right': 'right',
                 'type': 'default',
             },
-        ]
+        ],
+        {isDefaultValue: true}
     );
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldRenderer.test.js
@@ -118,7 +118,32 @@ test('Should call onChange callback with correct index', () => {
 
     formRenderer.find(Renderer).prop('onChange')('test', 'value');
 
-    expect(changeSpy).toBeCalledWith(2, 'test', 'value');
+    expect(changeSpy).toBeCalledWith(2, 'test', 'value', undefined);
+});
+
+test('Should pass context through onChange callback', () => {
+    const changeSpy = jest.fn();
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+
+    const formRenderer = shallow(
+        <FieldRenderer
+            data={{}}
+            dataPath=""
+            formInspector={formInspector}
+            index={0}
+            onChange={changeSpy}
+            onFieldFinish={jest.fn()}
+            onSuccess={jest.fn()}
+            router={undefined}
+            schema={{}}
+            schemaPath=""
+            value={{}}
+        />
+    );
+
+    formRenderer.find(Renderer).prop('onChange')('alignment', 'left', {isDefaultValue: true});
+
+    expect(changeSpy).toBeCalledWith(0, 'alignment', 'left', {isDefaultValue: true});
 });
 
 test('Should call onFieldFinish when some subfield finishes editing', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -5,7 +5,9 @@ import SingleSelectComponent from '../../../components/SingleSelect';
 import type {FieldTypeProps} from '../../../types';
 
 export default class SingleSelect extends React.Component<FieldTypeProps<string | number>> {
-    componentDidMount() {
+    constructor(props: FieldTypeProps<string | number>) {
+        super(props);
+
         const {onChange, schemaOptions, value} = this.props;
 
         const {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelect.js
@@ -5,9 +5,7 @@ import SingleSelectComponent from '../../../components/SingleSelect';
 import type {FieldTypeProps} from '../../../types';
 
 export default class SingleSelect extends React.Component<FieldTypeProps<string | number>> {
-    constructor(props: FieldTypeProps<string | number>) {
-        super(props);
-
+    componentDidMount() {
         const {onChange, schemaOptions, value} = this.props;
 
         const {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #4682, #6115
| License | MIT
| Documentation PR | 

#### What's in this PR?

Fixes `single_select` `default_value` not being applied when the field is used inside a block. The select displays "PLEASE CHOOSE" instead of the configured default value. The same `single_select` with `default_value` works correctly at page level (outside blocks).

Two issues were identified and fixed:

1. **`FieldRenderer.handleChange` drops the `ChangeContext` parameter**
   The handler signature only accepted `(name, value)`, silently discarding the third `context` argument passed by `Field.js`. This `context` carries `{isDefaultValue: true}`, which is needed by the form store to apply defaults without marking the form as dirty (introduced in #6115). The fix propagates `context` through `FieldRenderer` → `FieldBlocks.handleBlockChange` → `onChange`.

2. **`SingleSelect` calls `onChange` in the `constructor`**
   Calling `onChange` during construction is a React anti-pattern. At that point, the component tree is not fully mounted, and MobX observable updates triggered through the `FieldBlocks` chain are not properly propagated. Moving the default value logic to `componentDidMount` ensures the component is fully mounted and the observable chain works correctly.

Both fixes are required for a complete solution: `componentDidMount` ensures proper timing for MobX observable propagation in blocks, and context propagation ensures the form is not incorrectly marked as dirty when defaults are applied.

#### Why?

When adding a block containing a `single_select` with `default_value`, the default is never applied. Users see "PLEASE CHOOSE" and must manually select a value, even though the XML template specifies a default.

**Steps to reproduce:**
1. Create a page template with a block containing a `single_select` with `default_value`
2. Create a page using this template
3. Click "Add block"
4. The `single_select` inside the block shows "PLEASE CHOOSE" instead of the default value
5. A `single_select` with the same configuration at page level (outside blocks) works correctly

#### Example Usage

```xml
<block name="content" default-type="text">
    <types>
        <type name="text">
            <properties>
                <property name="alignment" type="single_select">
                    <params>
                        <param name="default_value" value="left"/>
                        <param name="values" type="collection">
                            <param name="left"><meta><title lang="en">Left</title></meta></param>
                            <param name="center"><meta><title lang="en">Center</title></meta></param>
                        </param>
                    </params>
                </property>
            </properties>
        </type>
    </types>
</block>
```

#### To Do

- [ ] Create a documentation PR