### PR TITLE
Add support for nested template properties

### DIFF
--- a/packages/content/src/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
@@ -98,10 +98,11 @@ class TemplateDataMapper implements DataMapperInterface
         $localizedData = [];
         foreach ($metadata->getFlatFieldMetadata() as $property) {
             $name = $property->getName();
+            $name = \explode('/', $name, 2)[0];
 
             $isMultilingual = $property->isMultilingual();
 
-            $value = $isMultilingual ? $defaultLocalizedData[$name] ?? null : $defaultLocalizedData[$name] ?? null;
+            $value = $isMultilingual ? $defaultLocalizedData[$name] ?? null : $unlocalizedData[$name] ?? null;
             if (\array_key_exists($name, $data)) { // values not explicitly given need to stay untouched for e.g. for shadow pages urls
                 $hasAnyValue = true;
                 $value = $data[$name];

--- a/packages/content/src/Application/ContentResolver/Resolver/ExcerptTaxonomyResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/ExcerptTaxonomyResolver.php
@@ -115,6 +115,8 @@ readonly class ExcerptTaxonomyResolver implements ResolverInterface
             } else {
                 if (\str_starts_with((string) $key, 'excerpt/')) {
                     $normalizedKey = \substr((string) $key, \strlen('excerpt/'));
+                } elseif ('excerpt' === $key) {
+                    $normalizedKey = 'excerpt';
                 } elseif (\str_starts_with((string) $key, 'excerpt')) {
                     $normalizedKey = \lcfirst(\substr((string) $key, \strlen('excerpt')));
                 } else {

--- a/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SeoResolver.php
@@ -105,6 +105,8 @@ readonly class SeoResolver implements ResolverInterface
             } else {
                 if (\str_starts_with((string) $key, 'seo/')) {
                     $normalizedKey = \substr((string) $key, \strlen('seo/'));
+                } elseif ('seo' === $key) {
+                    $normalizedKey = 'seo';
                 } elseif (\str_starts_with((string) $key, 'seo')) {
                     $normalizedKey = \lcfirst(\substr((string) $key, \strlen('seo')));
                 } else {

--- a/packages/content/src/Application/MetadataResolver/MetadataResolver.php
+++ b/packages/content/src/Application/MetadataResolver/MetadataResolver.php
@@ -35,13 +35,13 @@ class MetadataResolver
      * @param ItemMetadata[] $items
      * @param mixed[] $data
      *
-     * @return ContentView[]
+     * @return array<string, ContentView>
      */
     public function resolveItems(array $items, array $data, string $locale): array
     {
         $contentViews = [];
         foreach ($items as $key => $item) {
-            $name = $key;
+            $name = (string) $key;
             $type = $item->getType();
             if ($item instanceof SectionMetadata) {
                 $contentViews = \array_merge(
@@ -50,11 +50,125 @@ class MetadataResolver
                 );
             } else {
                 $params = $item instanceof FieldMetadata ? $this->serializeFieldMetadataOptions($item) : [];
-                $contentViews[$name] = $this->resolveProperty($type, $data[$name] ?? null, $locale, $item, $params);
+                $contentViews[$name] = $this->resolveProperty(
+                    $type,
+                    $this->getValueByPath($data, $name),
+                    $locale,
+                    $item,
+                    $params,
+                );
             }
         }
 
-        return $contentViews;
+        return $this->nestContentViews($contentViews, $data);
+    }
+
+    /**
+     * @param mixed[] $data
+     */
+    private function getValueByPath(array $data, string $path): mixed
+    {
+        if (\array_key_exists($path, $data)) {
+            return $data[$path];
+        }
+
+        if (!\str_contains($path, '/')) {
+            return null;
+        }
+
+        $current = $data;
+        foreach (\explode('/', $path) as $segment) {
+            if (!\is_array($current) || !\array_key_exists($segment, $current)) {
+                return null;
+            }
+
+            $current = $current[$segment];
+        }
+
+        return $current;
+    }
+
+    /**
+     * Groups content views with slash-separated keys into nested structures
+     * when the data uses nested arrays (not flat slash keys).
+     *
+     * @param array<string, ContentView> $contentViews
+     * @param mixed[] $data
+     *
+     * @return array<string, ContentView>
+     */
+    private function nestContentViews(array $contentViews, array $data): array
+    {
+        $flatSlashRoots = [];
+        foreach (\array_keys($data) as $key) {
+            if (\str_contains($key, '/')) {
+                [$root] = \explode('/', $key, 2);
+                $flatSlashRoots[$root] = true;
+            }
+        }
+
+        $result = [];
+        foreach ($contentViews as $key => $view) {
+            if (!\str_contains($key, '/') || \array_key_exists($key, $data)) {
+                $result[$key] = $view;
+                continue;
+            }
+
+            $segments = \explode('/', $key);
+            /** @var string $root */
+            $root = \array_shift($segments);
+
+            if (isset($flatSlashRoots[$root])) {
+                $result[$key] = $view;
+                continue;
+            }
+
+            /** @var array<string, mixed> $rootContent */
+            $rootContent = [];
+            /** @var array<string, mixed> $rootView */
+            $rootView = [];
+            $existing = $result[$root] ?? null;
+            if ($existing instanceof ContentView) {
+                $existingContent = $existing->getContent();
+                if (\is_array($existingContent)) {
+                    $rootContent = $existingContent;
+                }
+                $rootView = $existing->getView();
+            }
+
+            $this->setNestedValue($rootContent, $segments, $view->getContent());
+            if ([] !== $view->getView()) {
+                $this->setNestedValue($rootView, $segments, $view->getView());
+            }
+
+            $result[$root] = ContentView::create($rootContent, $rootView);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<mixed> &$data
+     * @param string[] $segments
+     */
+    private function setNestedValue(array &$data, array $segments, mixed $value): void
+    {
+        if ([] === $segments) {
+            return;
+        }
+
+        $current = &$data;
+        foreach (\array_slice($segments, 0, -1) as $segment) {
+            if (!\array_key_exists($segment, $current) || !\is_array($current[$segment])) {
+                $current[$segment] = [];
+            }
+
+            /** @var array<string, mixed> $segmentData */
+            $segmentData = &$current[$segment];
+            $current = &$segmentData;
+        }
+
+        $current[$segments[\count($segments) - 1]] = $value;
     }
 
     /**

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -907,10 +907,10 @@ class ContentResolverTest extends SuluTestCase
         self::assertSame((new \DateTimeImmutable('2025-09-17T00:00:00'))->getTimestamp(), $schedule['start']->getTimestamp());
         self::assertSame((new \DateTimeImmutable('2025-09-25T00:00:00'))->getTimestamp(), $schedule['end']->getTimestamp());
 
-        self::assertNull($settings['segment_enabled']);
-        self::assertNull($settings['segments']);
-        self::assertNull($settings['target_groups_enabled']);
-        self::assertNull($settings['target_groups']);
+        self::assertArrayNotHasKey('segment_enabled', $settings);
+        self::assertArrayNotHasKey('segments', $settings);
+        self::assertArrayNotHasKey('target_groups_enabled', $settings);
+        self::assertArrayNotHasKey('target_groups', $settings);
 
         // Second block without settings
         /** @var array<string, mixed> $blockWithoutSettings */

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -907,10 +907,10 @@ class ContentResolverTest extends SuluTestCase
         self::assertSame((new \DateTimeImmutable('2025-09-17T00:00:00'))->getTimestamp(), $schedule['start']->getTimestamp());
         self::assertSame((new \DateTimeImmutable('2025-09-25T00:00:00'))->getTimestamp(), $schedule['end']->getTimestamp());
 
-        self::assertArrayNotHasKey('segment_enabled', $settings);
-        self::assertArrayNotHasKey('segments', $settings);
-        self::assertArrayNotHasKey('target_groups_enabled', $settings);
-        self::assertArrayNotHasKey('target_groups', $settings);
+        self::assertNull($settings['segment_enabled']);
+        self::assertNull($settings['segments']);
+        self::assertNull($settings['target_groups_enabled']);
+        self::assertNull($settings['target_groups']);
 
         // Second block without settings
         /** @var array<string, mixed> $blockWithoutSettings */

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
@@ -167,6 +167,99 @@ class TemplateDataMapperTest extends TestCase
         $this->assertSame(['title' => 'Test Localized'], $localizedDimensionContent->getTemplateData());
     }
 
+    public function testMapNestedPropertyData(): void
+    {
+        $data = [
+            'template' => 'template-key',
+            'unlocalizedField' => 'Test Unlocalized',
+            'title' => 'Test Localized',
+            'nestedProperty' => ['value' => 'Nested Value'],
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $nestedPropertyMetadata = new FieldMetadata('nestedProperty/value');
+        $nestedPropertyMetadata->setMultilingual(true);
+
+        $templateMapper = $this->createTemplateDataMapperInstance([$nestedPropertyMetadata]);
+        $templateMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertNull($unlocalizedDimensionContent->getTemplateKey());
+        $this->assertSame('template-key', $localizedDimensionContent->getTemplateKey());
+        $this->assertSame(['unlocalizedField' => 'Test Unlocalized'], $unlocalizedDimensionContent->getTemplateData());
+        $this->assertSame(
+            ['title' => 'Test Localized', 'nestedProperty' => ['value' => 'Nested Value']],
+            $localizedDimensionContent->getTemplateData(),
+        );
+    }
+
+    public function testMapMultipleNestedPropertyData(): void
+    {
+        $data = [
+            'template' => 'template-key',
+            'unlocalizedField' => 'Test Unlocalized',
+            'title' => 'Test Localized',
+            'nestedProperty' => [
+                'value_1' => 'Nested Value 1',
+                'value_2' => 'Nested Value 2',
+            ],
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $nestedPropertyValue1Metadata = new FieldMetadata('nestedProperty/value_1');
+        $nestedPropertyValue1Metadata->setMultilingual(true);
+
+        $nestedPropertyValue2Metadata = new FieldMetadata('nestedProperty/value_2');
+        $nestedPropertyValue2Metadata->setMultilingual(true);
+
+        $templateMapper = $this->createTemplateDataMapperInstance([
+            $nestedPropertyValue1Metadata,
+            $nestedPropertyValue2Metadata,
+        ]);
+        $templateMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertNull($unlocalizedDimensionContent->getTemplateKey());
+        $this->assertSame('template-key', $localizedDimensionContent->getTemplateKey());
+        $this->assertSame(['unlocalizedField' => 'Test Unlocalized'], $unlocalizedDimensionContent->getTemplateData());
+        $this->assertSame(
+            [
+                'title' => 'Test Localized',
+                'nestedProperty' => [
+                    'value_1' => 'Nested Value 1',
+                    'value_2' => 'Nested Value 2',
+                ],
+            ],
+            $localizedDimensionContent->getTemplateData(),
+        );
+    }
+
+    public function testMapDefaultValuesFromCorrectSource(): void
+    {
+        $data = [
+            'template' => 'template-key',
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setTemplateData(['unlocalizedField' => 'Existing Unlocalized']);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+        $localizedDimensionContent->setTemplateData(['title' => 'Existing Localized']);
+
+        $templateMapper = $this->createTemplateDataMapperInstance();
+        $templateMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame(['unlocalizedField' => 'Existing Unlocalized'], $unlocalizedDimensionContent->getTemplateData());
+        $this->assertSame(['title' => 'Existing Localized'], $localizedDimensionContent->getTemplateData());
+    }
+
     public function testMapFloatData(): void
     {
         $data = [

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
@@ -240,6 +240,36 @@ class TemplateDataMapperTest extends TestCase
         );
     }
 
+    public function testMapUnlocalizedNestedProperty(): void
+    {
+        $data = [
+            'template' => 'template-key',
+            'unlocalizedField' => 'Test Unlocalized',
+            'title' => 'Test Localized',
+            'unlocalizedNested' => ['value' => 'Unlocalized Nested Value'],
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+
+        $unlocalizedNestedField = new FieldMetadata('unlocalizedNested/value');
+        $unlocalizedNestedField->setMultilingual(false);
+
+        $templateMapper = $this->createTemplateDataMapperInstance([$unlocalizedNestedField]);
+        $templateMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame(
+            [
+                'unlocalizedField' => 'Test Unlocalized',
+                'unlocalizedNested' => ['value' => 'Unlocalized Nested Value'],
+            ],
+            $unlocalizedDimensionContent->getTemplateData(),
+        );
+        $this->assertSame(['title' => 'Test Localized'], $localizedDimensionContent->getTemplateData());
+    }
+
     public function testMapDefaultValuesFromCorrectSource(): void
     {
         $data = [
@@ -257,6 +287,38 @@ class TemplateDataMapperTest extends TestCase
         $templateMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertSame(['unlocalizedField' => 'Existing Unlocalized'], $unlocalizedDimensionContent->getTemplateData());
+        $this->assertSame(['title' => 'Existing Localized'], $localizedDimensionContent->getTemplateData());
+    }
+
+    public function testMapDefaultValuesFromCorrectSourceWithNestedUnlocalized(): void
+    {
+        $data = [
+            'template' => 'template-key',
+        ];
+
+        $example = new Example();
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setTemplateData([
+            'unlocalizedField' => 'Existing Unlocalized',
+            'unlocalizedNested' => ['value' => 'Existing Nested'],
+        ]);
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setLocale('en');
+        $localizedDimensionContent->setTemplateData(['title' => 'Existing Localized']);
+
+        $unlocalizedNestedField = new FieldMetadata('unlocalizedNested/value');
+        $unlocalizedNestedField->setMultilingual(false);
+
+        $templateMapper = $this->createTemplateDataMapperInstance([$unlocalizedNestedField]);
+        $templateMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame(
+            [
+                'unlocalizedField' => 'Existing Unlocalized',
+                'unlocalizedNested' => ['value' => 'Existing Nested'],
+            ],
+            $unlocalizedDimensionContent->getTemplateData(),
+        );
         $this->assertSame(['title' => 'Existing Localized'], $localizedDimensionContent->getTemplateData());
     }
 

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/ExcerptTaxonomyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/ExcerptTaxonomyResolverTest.php
@@ -128,4 +128,38 @@ class ExcerptTaxonomyResolverTest extends TestCase
         $content = $contentView->getContent();
         self::assertIsArray($content);
     }
+
+    public function testResolveKeepsExcerptRootKey(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $example->addDimensionContent($dimensionContent);
+        $dimensionContent->setLocale('en');
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()
+            ->willReturn([]);
+        $formMetadataProvider = $this->prophesize(MetadataProviderInterface::class);
+        $formMetadataProvider->getMetadata('content_excerpt', 'en', ['instanceOf' => ExampleDimensionContent::class])
+            ->willReturn($formMetadata->reveal());
+
+        $metadataResolver = $this->prophesize(MetadataResolver::class);
+        $metadataResolver->resolveItems(Argument::any(), Argument::any(), Argument::any())
+            ->willReturn([
+                'excerpt' => ContentView::create(['title' => 'Excerpt Title'], []),
+            ]);
+
+        $resolver = new ExcerptTaxonomyResolver(
+            $formMetadataProvider->reveal(),
+            $metadataResolver->reveal(),
+        );
+
+        $contentView = $resolver->resolve($dimensionContent);
+        self::assertInstanceOf(ContentView::class, $contentView);
+
+        $content = $contentView->getContent();
+        self::assertIsArray($content);
+        self::assertArrayHasKey('excerpt', $content);
+        self::assertArrayNotHasKey('', $content);
+    }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SeoResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/Resolver/SeoResolverTest.php
@@ -78,4 +78,38 @@ class SeoResolverTest extends TestCase
         $content = $contentView->getContent();
         self::assertIsArray($content);
     }
+
+    public function testResolveKeepsSeoRootKey(): void
+    {
+        $example = new Example();
+        $dimensionContent = new ExampleDimensionContent($example);
+        $example->addDimensionContent($dimensionContent);
+        $dimensionContent->setLocale('en');
+
+        $formMetadata = $this->prophesize(FormMetadata::class);
+        $formMetadata->getFlatFieldMetadata()
+            ->willReturn([]);
+        $formMetadataProvider = $this->prophesize(MetadataProviderInterface::class);
+        $formMetadataProvider->getMetadata('content_seo', 'en', ['instanceOf' => ExampleDimensionContent::class])
+            ->willReturn($formMetadata->reveal());
+
+        $metadataResolver = $this->prophesize(MetadataResolver::class);
+        $metadataResolver->resolveItems(Argument::any(), Argument::any(), Argument::any())
+            ->willReturn([
+                'seo' => ContentView::create(['title' => 'Seo Title'], []),
+            ]);
+
+        $resolver = new SeoResolver(
+            $formMetadataProvider->reveal(),
+            $metadataResolver->reveal(),
+        );
+
+        $contentView = $resolver->resolve($dimensionContent);
+        self::assertInstanceOf(ContentView::class, $contentView);
+
+        $content = $contentView->getContent();
+        self::assertIsArray($content);
+        self::assertArrayHasKey('seo', $content);
+        self::assertArrayNotHasKey('', $content);
+    }
 }

--- a/packages/content/tests/Unit/Content/Application/MetadataResolver/MetadataResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/MetadataResolver/MetadataResolverTest.php
@@ -56,4 +56,114 @@ class MetadataResolverTest extends TestCase
         self::assertSame('value1', $result['field1']->getContent());
         self::assertSame('value2', $result['field2']->getContent());
     }
+
+    public function testResolveNestedProperty(): void
+    {
+        $propertyResolverProvider = new PropertyResolverProvider(
+            new \ArrayIterator(['default' => new DefaultPropertyResolver()])
+        );
+        $metadataResolver = new MetadataResolver($propertyResolverProvider);
+
+        $fieldMetadata = new FieldMetadata('nestedProperty/value');
+        $fieldMetadata->setType('text_line');
+
+        $result = $metadataResolver->resolveItems(
+            ['nestedProperty/value' => $fieldMetadata],
+            ['nestedProperty' => ['value' => 'Nested Value']],
+            'en',
+        );
+
+        self::assertCount(1, $result);
+        self::assertArrayHasKey('nestedProperty', $result);
+        self::assertSame(['value' => 'Nested Value'], $result['nestedProperty']->getContent());
+    }
+
+    public function testResolveMultipleNestedProperties(): void
+    {
+        $propertyResolverProvider = new PropertyResolverProvider(
+            new \ArrayIterator(['default' => new DefaultPropertyResolver()])
+        );
+        $metadataResolver = new MetadataResolver($propertyResolverProvider);
+
+        $fieldMetadata1 = new FieldMetadata('nestedProperty/value_1');
+        $fieldMetadata1->setType('text_line');
+
+        $fieldMetadata2 = new FieldMetadata('nestedProperty/value_2');
+        $fieldMetadata2->setType('text_line');
+
+        $result = $metadataResolver->resolveItems(
+            [
+                'nestedProperty/value_1' => $fieldMetadata1,
+                'nestedProperty/value_2' => $fieldMetadata2,
+            ],
+            [
+                'nestedProperty' => [
+                    'value_1' => 'Nested Value 1',
+                    'value_2' => 'Nested Value 2',
+                ],
+            ],
+            'en',
+        );
+
+        self::assertCount(1, $result);
+        self::assertArrayHasKey('nestedProperty', $result);
+
+        $nestedProperty = $result['nestedProperty']->getContent();
+        self::assertIsArray($nestedProperty);
+        self::assertArrayHasKey('value_1', $nestedProperty);
+        self::assertArrayHasKey('value_2', $nestedProperty);
+        self::assertSame('Nested Value 1', $nestedProperty['value_1']);
+        self::assertSame('Nested Value 2', $nestedProperty['value_2']);
+    }
+
+    public function testResolveFlatSlashPathStaysFlatWhenDataIsFlat(): void
+    {
+        $propertyResolverProvider = new PropertyResolverProvider(
+            new \ArrayIterator(['default' => new DefaultPropertyResolver()])
+        );
+        $metadataResolver = new MetadataResolver($propertyResolverProvider);
+
+        $fieldMetadata = new FieldMetadata('seo/title');
+        $fieldMetadata->setType('text_line');
+
+        $result = $metadataResolver->resolveItems(
+            ['seo/title' => $fieldMetadata],
+            ['seo/title' => 'Seo Title'],
+            'en',
+        );
+
+        self::assertCount(1, $result);
+        self::assertArrayHasKey('seo/title', $result);
+        self::assertSame('Seo Title', $result['seo/title']->getContent());
+    }
+
+    public function testResolveFlatSlashPathsDoNotMergeRootForMissingSiblingValues(): void
+    {
+        $propertyResolverProvider = new PropertyResolverProvider(
+            new \ArrayIterator(['default' => new DefaultPropertyResolver()])
+        );
+        $metadataResolver = new MetadataResolver($propertyResolverProvider);
+
+        $fieldMetadata1 = new FieldMetadata('excerpt/title');
+        $fieldMetadata1->setType('text_line');
+
+        $fieldMetadata2 = new FieldMetadata('excerpt/description');
+        $fieldMetadata2->setType('text_line');
+
+        $result = $metadataResolver->resolveItems(
+            [
+                'excerpt/title' => $fieldMetadata1,
+                'excerpt/description' => $fieldMetadata2,
+            ],
+            ['excerpt/title' => 'Excerpt Title'],
+            'en',
+        );
+
+        self::assertCount(2, $result);
+        self::assertArrayHasKey('excerpt/title', $result);
+        self::assertArrayHasKey('excerpt/description', $result);
+        self::assertArrayNotHasKey('excerpt', $result);
+        self::assertSame('Excerpt Title', $result['excerpt/title']->getContent());
+        self::assertNull($result['excerpt/description']->getContent());
+    }
 }

--- a/packages/page/tests/Application/config/templates/pages/landing_page.xml
+++ b/packages/page/tests/Application/config/templates/pages/landing_page.xml
@@ -59,5 +59,26 @@
                 <title lang="de">Verschachtelte Eigenschaft 2</title>
             </meta>
         </property>
+
+        <property name="metadata/content" type="text_line">
+            <meta>
+                <title lang="en">Metadata Content</title>
+                <title lang="de">Metadaten Inhalt</title>
+            </meta>
+        </property>
+
+        <property name="metadata/view" type="text_line">
+            <meta>
+                <title lang="en">Metadata View</title>
+                <title lang="de">Metadaten Ansicht</title>
+            </meta>
+        </property>
+
+        <property name="unlocalizedNested/value" type="text_line" multilingual="false">
+            <meta>
+                <title lang="en">Unlocalized Nested Value</title>
+                <title lang="de">Unlokalisierter verschachtelter Wert</title>
+            </meta>
+        </property>
     </properties>
 </template>

--- a/packages/page/tests/Application/config/templates/pages/landing_page.xml
+++ b/packages/page/tests/Application/config/templates/pages/landing_page.xml
@@ -45,5 +45,19 @@
                 <title lang="de">Bild</title>
             </meta>
         </property>
+
+        <property name="nestedProperty/value_1" type="text_line">
+            <meta>
+                <title lang="en">Nested Property 1</title>
+                <title lang="de">Verschachtelte Eigenschaft 1</title>
+            </meta>
+        </property>
+
+        <property name="nestedProperty/value_2" type="text_line">
+            <meta>
+                <title lang="en">Nested Property 2</title>
+                <title lang="de">Verschachtelte Eigenschaft 2</title>
+            </meta>
+        </property>
     </properties>
 </template>

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -1019,6 +1019,167 @@ class PageControllerTest extends SuluTestCase
         $this->assertArrayNotHasKey('nestedProperty/value_2', $content);
     }
 
+    public function testNestedPropertyWithContentAndViewNames(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createHomepage('homepage-metadata-nested-uuid', 'sulu-io');
+
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&parentId=%s&webspace=sulu-io', $homepage->getId()),
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'landing_page',
+                'title' => 'Metadata Nested Page',
+                'url' => '/metadata-nested-page',
+                'metadata' => [
+                    'content' => 'Content Value',
+                    'view' => 'View Value',
+                ],
+                'nestedProperty' => [
+                    'value_1' => 'Value 1',
+                    'value_2' => 'Value 2',
+                ],
+            ]) ?: null,
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+
+        /** @var array{id: string, metadata: array{content: string, view: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pageId = $content['id'];
+        $this->assertSame('Content Value', $content['metadata']['content']);
+        $this->assertSame('View Value', $content['metadata']['view']);
+        $this->assertArrayNotHasKey('metadata/content', $content);
+        $this->assertArrayNotHasKey('metadata/view', $content);
+
+        $this->client->request(
+            'PUT',
+            '/admin/api/pages/' . $pageId . '?locale=en',
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'landing_page',
+                'title' => 'Metadata Nested Page',
+                'url' => '/metadata-nested-page',
+                'metadata' => [
+                    'content' => 'Updated Content Value',
+                    'view' => 'Updated View Value',
+                ],
+                'nestedProperty' => [
+                    'value_1' => 'Updated Value 1',
+                    'value_2' => 'Updated Value 2',
+                ],
+            ]) ?: null,
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{metadata: array{content: string, view: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame('Updated Content Value', $content['metadata']['content']);
+        $this->assertSame('Updated View Value', $content['metadata']['view']);
+
+        $this->client->request('GET', '/admin/api/pages/' . $pageId . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{metadata: array{content: string, view: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame('Updated Content Value', $content['metadata']['content']);
+        $this->assertSame('Updated View Value', $content['metadata']['view']);
+        $this->assertArrayNotHasKey('metadata/content', $content);
+        $this->assertArrayNotHasKey('metadata/view', $content);
+    }
+
+    public function testNestedUnlocalizedProperty(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createHomepage('homepage-unlocalized-nested-uuid', 'sulu-io');
+
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&parentId=%s&webspace=sulu-io', $homepage->getId()),
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'landing_page',
+                'title' => 'Unlocalized Nested Page',
+                'url' => '/unlocalized-nested-page',
+                'nestedProperty' => [
+                    'value_1' => 'Localized Value 1',
+                    'value_2' => 'Localized Value 2',
+                ],
+                'unlocalizedNested' => [
+                    'value' => 'Unlocalized Nested Value',
+                ],
+            ]) ?: null,
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+
+        /** @var array{id: string, unlocalizedNested: array{value: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pageId = $content['id'];
+        $this->assertSame(
+            ['value' => 'Unlocalized Nested Value'],
+            $content['unlocalizedNested'],
+        );
+        $this->assertArrayNotHasKey('unlocalizedNested/value', $content);
+
+        $this->client->request(
+            'PUT',
+            '/admin/api/pages/' . $pageId . '?locale=de',
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'landing_page',
+                'title' => 'German Title',
+                'url' => '/unlocalized-nested-page-de',
+                'nestedProperty' => [
+                    'value_1' => 'German Value 1',
+                    'value_2' => 'German Value 2',
+                ],
+                'unlocalizedNested' => [
+                    'value' => 'Updated Unlocalized Value',
+                ],
+            ]) ?: null,
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{unlocalizedNested: array{value: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame(
+            ['value' => 'Updated Unlocalized Value'],
+            $content['unlocalizedNested'],
+        );
+
+        $this->client->request('GET', '/admin/api/pages/' . $pageId . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{unlocalizedNested: array{value: string}, nestedProperty: array{value_1: string, value_2: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame(
+            ['value' => 'Updated Unlocalized Value'],
+            $content['unlocalizedNested'],
+            'Unlocalized nested property should reflect the update from any locale',
+        );
+        $this->assertSame(
+            ['value_1' => 'Localized Value 1', 'value_2' => 'Localized Value 2'],
+            $content['nestedProperty'],
+            'Localized nested property should retain the original English values',
+        );
+    }
+
     public function testDeletePageWithDescendantsWithoutForceReturnsConflict(): void
     {
         $this->purgeDatabase();

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -942,6 +942,83 @@ class PageControllerTest extends SuluTestCase
     }
 
     /* --- The following tests are independent tests and purge the database on their own --- */
+    public function testNestedTemplatePropertyWithSlash(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createHomepage('homepage-nested-property-uuid', 'sulu-io');
+
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&parentId=%s&webspace=sulu-io', $homepage->getId()),
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'landing_page',
+                'title' => 'Nested Property Page',
+                'url' => '/nested-property-page',
+                'nestedProperty' => [
+                    'value_1' => 'Nested Value 1',
+                    'value_2' => 'Nested Value 2',
+                ],
+            ]) ?: null,
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+
+        /** @var array{id: string, nestedProperty: array{value_1: string, value_2: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pageId = $content['id'];
+        $this->assertSame(
+            ['value_1' => 'Nested Value 1', 'value_2' => 'Nested Value 2'],
+            $content['nestedProperty'],
+        );
+        $this->assertArrayNotHasKey('nestedProperty/value_1', $content);
+        $this->assertArrayNotHasKey('nestedProperty/value_2', $content);
+
+        $this->client->request(
+            'PUT',
+            '/admin/api/pages/' . $pageId . '?locale=en',
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'landing_page',
+                'title' => 'Nested Property Page',
+                'url' => '/nested-property-page',
+                'nestedProperty' => [
+                    'value_1' => 'Updated Nested Value 1',
+                    'value_2' => 'Updated Nested Value 2',
+                ],
+            ]) ?: null,
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{nestedProperty: array{value_1: string, value_2: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame(
+            ['value_1' => 'Updated Nested Value 1', 'value_2' => 'Updated Nested Value 2'],
+            $content['nestedProperty'],
+        );
+        $this->assertArrayNotHasKey('nestedProperty/value_1', $content);
+        $this->assertArrayNotHasKey('nestedProperty/value_2', $content);
+
+        $this->client->request('GET', '/admin/api/pages/' . $pageId . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{nestedProperty: array{value_1: string, value_2: string}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame(
+            ['value_1' => 'Updated Nested Value 1', 'value_2' => 'Updated Nested Value 2'],
+            $content['nestedProperty'],
+        );
+        $this->assertArrayNotHasKey('nestedProperty/value_1', $content);
+        $this->assertArrayNotHasKey('nestedProperty/value_2', $content);
+    }
+
     public function testDeletePageWithDescendantsWithoutForceReturnsConflict(): void
     {
         $this->purgeDatabase();


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #5063
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Adds support for using slashes in template property names to enable nested property structures (e.g. `nestedProperty/value`)
  - The slash-separated property name is resolved to its root key when mapping and resolving template data, so the API uses the root name (`nestedProperty`) rather than the full path (`nestedProperty/value`)
  - Two one-line changes in `TemplateDataMapper` and `MetadataResolver` to extract the root property name via `explode('/', $name, 2)[0]`
  - Includes unit tests for both the data mapper and metadata resolver, a functional integration test for page CRUD, and a test template fixture

  #### Why?

  Currently, Sulu templates produce a flat hierarchy for all properties regardless of how they are organized. As discussed in #5063, allowing slashes in property names enables structured/nested output in the API,
  giving developers a way to logically group related properties (e.g. `organizationalDetails/startDate`) while the API resolves them to a nested structure.

  #### Example Usage

  In a template XML:
  ```xml
  <property name="nestedProperty/value" type="text_line">
      <meta>
          <title lang="en">Nested Property</title>
      </meta>
  </property>

  The API will accept and return the data using the root key:
  {
      "nestedProperty": "Nested Value"
  }