### PR TITLE
Add missing preview activity translation

### DIFF
--- a/packages/article/translations/admin.de.json
+++ b/packages/article/translations/admin.de.json
@@ -33,5 +33,6 @@
     "sulu_activity.description.articles.translation_removed": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" des Artikels \"{resourceTitle}\" gelöscht",
     "sulu_activity.description.articles.translation_restored": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" des Artikels \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.articles.version_restored": "{userFullName} hat die Version \"{context_version}\" des Artikels \"{resourceTitle}\" wiederhergestellt",
-    "sulu_activity.description.articles.route_removed": "{userFullName} hat die Route \"{resourceTitle}\" gelöscht."
+    "sulu_activity.description.articles.route_removed": "{userFullName} hat die Route \"{resourceTitle}\" gelöscht.",
+    "sulu_activity.description.articles.preview_link_generated": "{userFullName} hat einen Preview-Link für den Artikel \"{resourceTitle}\" generiert.",
 }

--- a/packages/article/translations/admin.de.json
+++ b/packages/article/translations/admin.de.json
@@ -34,5 +34,6 @@
     "sulu_activity.description.articles.translation_restored": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" des Artikels \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.articles.version_restored": "{userFullName} hat die Version \"{context_version}\" des Artikels \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.articles.route_removed": "{userFullName} hat die Route \"{resourceTitle}\" gelöscht.",
-    "sulu_activity.description.articles.preview_link_generated": "{userFullName} hat einen Preview-Link für den Artikel \"{resourceTitle}\" generiert."
+    "sulu_activity.description.articles.preview_link_generated": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" erstellt",
+    "sulu_activity.description.articles.preview_link_revoked": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" widerrufen"
 }

--- a/packages/article/translations/admin.de.json
+++ b/packages/article/translations/admin.de.json
@@ -34,5 +34,5 @@
     "sulu_activity.description.articles.translation_restored": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" des Artikels \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.articles.version_restored": "{userFullName} hat die Version \"{context_version}\" des Artikels \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.articles.route_removed": "{userFullName} hat die Route \"{resourceTitle}\" gelöscht.",
-    "sulu_activity.description.articles.preview_link_generated": "{userFullName} hat einen Preview-Link für den Artikel \"{resourceTitle}\" generiert.",
+    "sulu_activity.description.articles.preview_link_generated": "{userFullName} hat einen Preview-Link für den Artikel \"{resourceTitle}\" generiert."
 }

--- a/packages/article/translations/admin.en.json
+++ b/packages/article/translations/admin.en.json
@@ -33,5 +33,6 @@
     "sulu_activity.description.articles.translation_restored": "{userFullName} has restored the \"{resourceLocale}\" translation of the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.version_restored": "{userFullName} has restored the version \"{context_version}\" of the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.route_removed": "{userFullName} has removed the route \"{resourceTitle}\".",
-    "sulu_activity.description.articles.preview_link_generated": "{userFullName} has generated a preview link for the article \"{resourceTitle}\"."
+    "sulu_activity.description.articles.preview_link_generated": "{userFullName} has generated a public preview link \"{resourceTitle}\"",
+    "sulu_activity.description.articles.preview_link_revoked": "{userFullName} has revoked the public preview link \"{resourceTitle}\""
 }

--- a/packages/article/translations/admin.en.json
+++ b/packages/article/translations/admin.en.json
@@ -32,5 +32,6 @@
     "sulu_activity.description.articles.translation_removed": "{userFullName} has removed the \"{resourceLocale}\" translation of the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.translation_restored": "{userFullName} has restored the \"{resourceLocale}\" translation of the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.version_restored": "{userFullName} has restored the version \"{context_version}\" of the article \"{resourceTitle}\"",
-    "sulu_activity.description.articles.route_removed": "{userFullName} has removed the route \"{resourceTitle}\"."
+    "sulu_activity.description.articles.route_removed": "{userFullName} has removed the route \"{resourceTitle}\".",
+    "sulu_activity.description.articles.preview_link_generated": "{userFullName} has generated a preview link for the article \"{resourceTitle}\"."
 }

--- a/packages/page/translations/admin.de.json
+++ b/packages/page/translations/admin.de.json
@@ -54,5 +54,7 @@
     "sulu_activity.description.pages.translation_removed": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" der Seite \"{resourceTitle}\" gelöscht",
     "sulu_activity.description.pages.translation_restored": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" der Seite \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.pages.version_restored": "{userFullName} hat die Version \"{context_version}\" der Seite \"{resourceTitle}\" wiederhergestellt",
-    "sulu_activity.description.pages.ordered": "{userFullName} hat die Seite \"{resourceTitle}\" auf die Position {targetPosition} verschoben."
+    "sulu_activity.description.pages.ordered": "{userFullName} hat die Seite \"{resourceTitle}\" auf die Position {targetPosition} verschoben.",
+    "sulu_activity.description.pages.preview_link_generated": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" erstellt",
+    "sulu_activity.description.pages.preview_link_revoked": "{userFullName} hat den öffentlichen Vorschaulink \"{resourceTitle}\" widerrufen"
 }

--- a/packages/page/translations/admin.en.json
+++ b/packages/page/translations/admin.en.json
@@ -55,5 +55,7 @@
     "sulu_activity.description.pages.translation_restored": "{userFullName} has restored the \"{resourceLocale}\" translation of the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.version_restored": "{userFullName} has restored the version \"{context_version}\" of the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.route_removed": "{userFullName} has removed the route \"{resourceTitle}\".",
-    "sulu_activity.description.pages.ordered": "{userFullName} has reordered the page \"{resourceTitle}\" to position {context_targetPosition}."
+    "sulu_activity.description.pages.ordered": "{userFullName} has reordered the page \"{resourceTitle}\" to position {context_targetPosition}.",
+    "sulu_activity.description.pages.preview_link_generated": "{userFullName} has generated a public preview link \"{resourceTitle}\"",
+    "sulu_activity.description.pages.preview_link_revoked": "{userFullName} has revoked the public preview link \"{resourceTitle}\""
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8635
| Related issues/PRs | #8635
| License | MIT

#### What's in this PR?

Adds missing translations for the PreviewLinkGeneratedEvent

#### Why?

#8635

#### Example Usage

Generate a Preview Link