### PR TITLE
Fix form grid misalignment when info_text is present on some fields

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/Field.js
@@ -140,11 +140,9 @@ class Field<T: string | number> extends React.Component<Props<T>> {
                         </label>
                     }
                     {children}
-                    {description &&
-                        <div className={fieldStyles.descriptionLabel}>
-                            {description}
-                        </div>
-                    }
+                    <div className={fieldStyles.descriptionLabel}>
+                        {description}
+                    </div>
                     <div className={fieldStyles.errorLabel}>
                         {error}
                     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Field.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Field.test.js.snap
@@ -18,6 +18,9 @@ exports[`Display a field with a required label 1`] = `
         Test
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -42,6 +45,9 @@ exports[`Display a field with an error 1`] = `
         Test
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       >
         Error! Help!
@@ -62,6 +68,9 @@ exports[`Display a field with colSpan and after space 1`] = `
       <div>
         Test
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -111,6 +120,9 @@ exports[`Display a field with label 1`] = `
         Test
       </p>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -150,6 +162,9 @@ exports[`Display a field with label and type 1`] = `
         Test
       </p>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -168,6 +183,9 @@ exports[`Display a field without label 1`] = `
       <p>
         Test
       </p>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Form.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Form/tests/__snapshots__/Form.test.js.snap
@@ -18,6 +18,9 @@ exports[`Render a form 1`] = `
         </label>
         Test 1
         <div
+          class="descriptionLabel"
+        />
+        <div
           class="errorLabel"
         />
       </div>
@@ -34,6 +37,9 @@ exports[`Render a form 1`] = `
           Test1
         </label>
         Test 2
+        <div
+          class="descriptionLabel"
+        />
         <div
           class="errorLabel"
         />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -112,6 +112,9 @@ exports[`Render block with schema 1`] = `
                   </div>
                 </div>
                 <div
+                  class="descriptionLabel"
+                />
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -140,6 +143,9 @@ exports[`Render block with schema 1`] = `
                     />
                   </div>
                 </div>
+                <div
+                  class="descriptionLabel"
+                />
                 <div
                   class="errorLabel"
                 />
@@ -237,6 +243,9 @@ exports[`Render block with schema 1`] = `
                   </div>
                 </div>
                 <div
+                  class="descriptionLabel"
+                />
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -265,6 +274,9 @@ exports[`Render block with schema 1`] = `
                     />
                   </div>
                 </div>
+                <div
+                  class="descriptionLabel"
+                />
                 <div
                   class="errorLabel"
                 />
@@ -408,6 +420,9 @@ exports[`Render block with schema and error on fields already being modified 1`]
                   </div>
                 </div>
                 <div
+                  class="descriptionLabel"
+                />
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -504,6 +519,9 @@ exports[`Render block with schema and error on fields already being modified 1`]
                     />
                   </div>
                 </div>
+                <div
+                  class="descriptionLabel"
+                />
                 <div
                   class="errorLabel"
                 >
@@ -602,6 +620,9 @@ exports[`Render block with schema and error on fields already being modified 1`]
                     />
                   </div>
                 </div>
+                <div
+                  class="descriptionLabel"
+                />
                 <div
                   class="errorLabel"
                 />
@@ -745,6 +766,9 @@ exports[`Render block with schema and error on fields already being modified 2`]
                   </div>
                 </div>
                 <div
+                  class="descriptionLabel"
+                />
+                <div
                   class="errorLabel"
                 />
               </div>
@@ -841,6 +865,9 @@ exports[`Render block with schema and error on fields already being modified 2`]
                     />
                   </div>
                 </div>
+                <div
+                  class="descriptionLabel"
+                />
                 <div
                   class="errorLabel"
                 >
@@ -940,6 +967,9 @@ exports[`Render block with schema and error on fields already being modified 2`]
                     />
                   </div>
                 </div>
+                <div
+                  class="descriptionLabel"
+                />
                 <div
                   class="errorLabel"
                 >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Field.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Field.test.js.snap
@@ -61,6 +61,9 @@ exports[`Render a field with a error collection 1`] = `
       </div>
     </div>
     <div
+      class="descriptionLabel"
+    />
+    <div
       class="errorLabel"
     >
       sulu_admin.error_minitems
@@ -93,6 +96,9 @@ exports[`Render a field with an error 1`] = `
         />
       </div>
     </div>
+    <div
+      class="descriptionLabel"
+    />
     <div
       class="errorLabel"
     >
@@ -127,6 +133,9 @@ exports[`Render a field without a const error 1`] = `
       </div>
     </div>
     <div
+      class="descriptionLabel"
+    />
+    <div
       class="errorLabel"
     />
   </div>
@@ -151,6 +160,9 @@ exports[`Render a field without a label 1`] = `
         />
       </div>
     </div>
+    <div
+      class="descriptionLabel"
+    />
     <div
       class="errorLabel"
     />
@@ -183,6 +195,9 @@ exports[`Render a required field with correct field type 1`] = `
       </div>
     </div>
     <div
+      class="descriptionLabel"
+    />
+    <div
       class="errorLabel"
     />
   </div>
@@ -213,6 +228,9 @@ exports[`Render correct label with correct field type 1`] = `
         />
       </div>
     </div>
+    <div
+      class="descriptionLabel"
+    />
     <div
       class="errorLabel"
     />
@@ -245,6 +263,9 @@ exports[`Render correct label with correct field type 2`] = `
       </div>
     </div>
     <div
+      class="descriptionLabel"
+    />
+    <div
       class="errorLabel"
     />
   </div>
@@ -275,6 +296,9 @@ exports[`Render field with correct values for grid 1`] = `
         />
       </div>
     </div>
+    <div
+      class="descriptionLabel"
+    />
     <div
       class="errorLabel"
     />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/GhostDialog.test.js.snap
@@ -115,6 +115,9 @@ Array [
                   </div>
                 </div>
                 <div
+                  class="descriptionLabel"
+                />
+                <div
                   class="errorLabel"
                 />
               </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/MissingTypeDialog.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/MissingTypeDialog.test.js.snap
@@ -101,6 +101,9 @@ Array [
                   </button>
                 </div>
                 <div
+                  class="descriptionLabel"
+                />
+                <div
                   class="errorLabel"
                 />
               </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Renderer.test.js.snap
@@ -32,6 +32,9 @@ exports[`Should not render fields when the schema contains a visibleCondition ev
           </div>
         </div>
         <div
+          class="descriptionLabel"
+        />
+        <div
           class="errorLabel"
         />
       </div>
@@ -60,6 +63,9 @@ exports[`Should not render fields when the schema contains a visibleCondition ev
           />
         </div>
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -96,6 +102,9 @@ exports[`Should render field types based on schema 1`] = `
         </div>
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -123,6 +132,9 @@ exports[`Should render field types based on schema 1`] = `
           />
         </div>
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -160,6 +172,9 @@ exports[`Should render nested field types with based on schema 1`] = `
         </div>
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -188,6 +203,9 @@ exports[`Should render nested field types with based on schema 1`] = `
           />
         </div>
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -235,6 +253,9 @@ exports[`Should render nested sections 1`] = `
             />
           </div>
         </div>
+        <div
+          class="descriptionLabel"
+        />
         <div
           class="errorLabel"
         />
@@ -290,6 +311,9 @@ exports[`Should render nested sections 1`] = `
           </div>
         </div>
         <div
+          class="descriptionLabel"
+        />
+        <div
           class="errorLabel"
         />
       </div>
@@ -338,6 +362,9 @@ exports[`Should render sections with colSpan 1`] = `
           </div>
         </div>
         <div
+          class="descriptionLabel"
+        />
+        <div
           class="errorLabel"
         />
       </div>
@@ -378,6 +405,9 @@ exports[`Should render sections with colSpan 1`] = `
             />
           </div>
         </div>
+        <div
+          class="descriptionLabel"
+        />
         <div
           class="errorLabel"
         />
@@ -418,6 +448,9 @@ exports[`Should render sections without label 1`] = `
           </div>
         </div>
         <div
+          class="descriptionLabel"
+        />
+        <div
           class="errorLabel"
         />
       </div>
@@ -458,6 +491,9 @@ exports[`Should render sections without label 1`] = `
             />
           </div>
         </div>
+        <div
+          class="descriptionLabel"
+        />
         <div
           class="errorLabel"
         />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Section.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/__snapshots__/Section.test.js.snap
@@ -37,6 +37,9 @@ exports[`Render section with children 1`] = `
         </div>
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/ExternalLinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/ExternalLinkTypeOverlay.test.js.snap
@@ -67,6 +67,9 @@ exports[`Render overlay with a URL 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -122,6 +125,9 @@ exports[`Render overlay with a URL 1`] = `
         </button>
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -145,6 +151,9 @@ exports[`Render overlay with a URL 1`] = `
           value=""
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -173,6 +182,9 @@ exports[`Render overlay with a URL 1`] = `
           sulu_admin.no_follow
         </div>
       </label>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -248,6 +260,9 @@ exports[`Render overlay with an undefined URL 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -303,6 +318,9 @@ exports[`Render overlay with an undefined URL 1`] = `
         </button>
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -326,6 +344,9 @@ exports[`Render overlay with an undefined URL 1`] = `
           value=""
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -354,6 +375,9 @@ exports[`Render overlay with an undefined URL 1`] = `
           sulu_admin.no_follow
         </div>
       </label>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -429,6 +453,9 @@ exports[`Render overlay with mailto URL 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -453,6 +480,9 @@ exports[`Render overlay with mailto URL 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -473,6 +503,9 @@ exports[`Render overlay with mailto URL 1`] = `
       >
         Body
       </textarea>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -497,6 +530,9 @@ exports[`Render overlay with mailto URL 1`] = `
           value=""
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -525,6 +561,9 @@ exports[`Render overlay with mailto URL 1`] = `
           sulu_admin.no_follow
         </div>
       </label>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/LinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/LinkTypeOverlay.test.js.snap
@@ -46,6 +46,9 @@ exports[`Render overlay with anchor enabled 1`] = `
         single list overlay
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -69,6 +72,9 @@ exports[`Render overlay with anchor enabled 1`] = `
           value=""
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -123,6 +129,9 @@ exports[`Render overlay with minimal config 1`] = `
         single list overlay
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -176,6 +185,9 @@ exports[`Render overlay with query enabled 1`] = `
         single list overlay
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -199,6 +211,9 @@ exports[`Render overlay with query enabled 1`] = `
           value=""
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -252,6 +267,9 @@ exports[`Render overlay with target enabled 1`] = `
       <div>
         single list overlay
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -308,6 +326,9 @@ exports[`Render overlay with target enabled 1`] = `
         </button>
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -361,6 +382,9 @@ exports[`Render overlay with title enabled 1`] = `
         single list overlay
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -384,6 +408,9 @@ exports[`Render overlay with title enabled 1`] = `
           value=""
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/__snapshots__/List.test.js.snap
@@ -83,6 +83,9 @@ Array [
                       </button>
                     </div>
                     <div
+                      class="descriptionLabel"
+                    />
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -130,6 +133,9 @@ Array [
                         />
                       </button>
                     </div>
+                    <div
+                      class="descriptionLabel"
+                    />
                     <div
                       class="errorLabel"
                     />
@@ -183,6 +189,9 @@ Array [
                       </button>
                     </div>
                     <div
+                      class="descriptionLabel"
+                    />
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -232,6 +241,9 @@ Array [
                         />
                       </button>
                     </div>
+                    <div
+                      class="descriptionLabel"
+                    />
                     <div
                       class="errorLabel"
                     />

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/__snapshots__/RuleOverlay.test.js.snap
@@ -58,6 +58,9 @@ Array [
                     />
                   </div>
                   <div
+                    class="descriptionLabel"
+                  />
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -112,6 +115,9 @@ Array [
                       />
                     </button>
                   </div>
+                  <div
+                    class="descriptionLabel"
+                  />
                   <div
                     class="errorLabel"
                   />

--- a/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/tests/__snapshots__/ContactDetails.test.js.snap
+++ b/src/Sulu/Bundle/ContactBundle/Resources/js/components/ContactDetails/tests/__snapshots__/ContactDetails.test.js.snap
@@ -59,6 +59,9 @@ exports[`Render ContactDetails with data 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -118,6 +121,9 @@ exports[`Render ContactDetails with data 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -176,6 +182,9 @@ exports[`Render ContactDetails with data 1`] = `
           tabindex="0"
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -269,6 +278,9 @@ exports[`Render ContactDetails with data 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -326,6 +338,9 @@ exports[`Render ContactDetails with data 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -359,6 +374,9 @@ exports[`Render ContactDetails with data 1`] = `
           class="su-angle-down dropdownIcon"
         />
       </button>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -424,6 +442,9 @@ exports[`Render empty ContactDetails 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -481,6 +502,9 @@ exports[`Render empty ContactDetails 1`] = `
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -514,6 +538,9 @@ exports[`Render empty ContactDetails 1`] = `
           class="su-angle-down dropdownIcon"
         />
       </button>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -579,6 +606,9 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -635,6 +665,9 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           tabindex="0"
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -694,6 +727,9 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           tabindex="0"
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -787,6 +823,9 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -844,6 +883,9 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
         />
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -877,6 +919,9 @@ exports[`Render empty phone and email fields even if other values are set 1`] = 
           class="su-angle-down dropdownIcon"
         />
       </button>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />

--- a/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
+++ b/src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/__snapshots__/LocationOverlay.test.js.snap
@@ -67,6 +67,9 @@ Array [
                     </div>
                   </div>
                   <div
+                    class="descriptionLabel"
+                  />
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -189,6 +192,9 @@ Array [
                     </div>
                   </div>
                   <div
+                    class="descriptionLabel"
+                  />
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -213,6 +219,9 @@ Array [
                       value="22"
                     />
                   </div>
+                  <div
+                    class="descriptionLabel"
+                  />
                   <div
                     class="errorLabel"
                   />
@@ -239,6 +248,9 @@ Array [
                     />
                   </div>
                   <div
+                    class="descriptionLabel"
+                  />
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -264,6 +276,9 @@ Array [
                       value="5"
                     />
                   </div>
+                  <div
+                    class="descriptionLabel"
+                  />
                   <div
                     class="errorLabel"
                   />
@@ -301,6 +316,9 @@ Array [
                       />
                     </div>
                     <div
+                      class="descriptionLabel"
+                    />
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -324,6 +342,9 @@ Array [
                         value="street-123"
                       />
                     </div>
+                    <div
+                      class="descriptionLabel"
+                    />
                     <div
                       class="errorLabel"
                     />
@@ -349,6 +370,9 @@ Array [
                       />
                     </div>
                     <div
+                      class="descriptionLabel"
+                    />
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -372,6 +396,9 @@ Array [
                         value="code-123"
                       />
                     </div>
+                    <div
+                      class="descriptionLabel"
+                    />
                     <div
                       class="errorLabel"
                     />
@@ -397,6 +424,9 @@ Array [
                       />
                     </div>
                     <div
+                      class="descriptionLabel"
+                    />
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -420,6 +450,9 @@ Array [
                         value=""
                       />
                     </div>
+                    <div
+                      class="descriptionLabel"
+                    />
                     <div
                       class="errorLabel"
                     />
@@ -550,6 +583,9 @@ Array [
                       />
                     </div>
                   </div>
+                  <div
+                    class="descriptionLabel"
+                  />
                   <div
                     class="errorLabel"
                   />
@@ -691,6 +727,9 @@ Array [
                     </div>
                   </div>
                   <div
+                    class="descriptionLabel"
+                  />
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -715,6 +754,9 @@ Array [
                       value=""
                     />
                   </div>
+                  <div
+                    class="descriptionLabel"
+                  />
                   <div
                     class="errorLabel"
                   />
@@ -741,6 +783,9 @@ Array [
                     />
                   </div>
                   <div
+                    class="descriptionLabel"
+                  />
+                  <div
                     class="errorLabel"
                   />
                 </div>
@@ -766,6 +811,9 @@ Array [
                       value="1"
                     />
                   </div>
+                  <div
+                    class="descriptionLabel"
+                  />
                   <div
                     class="errorLabel"
                   />
@@ -803,6 +851,9 @@ Array [
                       />
                     </div>
                     <div
+                      class="descriptionLabel"
+                    />
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -826,6 +877,9 @@ Array [
                         value=""
                       />
                     </div>
+                    <div
+                      class="descriptionLabel"
+                    />
                     <div
                       class="errorLabel"
                     />
@@ -851,6 +905,9 @@ Array [
                       />
                     </div>
                     <div
+                      class="descriptionLabel"
+                    />
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -874,6 +931,9 @@ Array [
                         value=""
                       />
                     </div>
+                    <div
+                      class="descriptionLabel"
+                    />
                     <div
                       class="errorLabel"
                     />
@@ -899,6 +959,9 @@ Array [
                       />
                     </div>
                     <div
+                      class="descriptionLabel"
+                    />
+                    <div
                       class="errorLabel"
                     />
                   </div>
@@ -922,6 +985,9 @@ Array [
                         value=""
                       />
                     </div>
+                    <div
+                      class="descriptionLabel"
+                    />
                     <div
                       class="errorLabel"
                     />

--- a/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/MediaLinkTypeOverlay.test.js.snap
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/__snapshots__/MediaLinkTypeOverlay.test.js.snap
@@ -46,6 +46,9 @@ exports[`Render overlay with anchor enabled 1`] = `
         single media selection overlay
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -69,6 +72,9 @@ exports[`Render overlay with anchor enabled 1`] = `
           value=""
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -123,6 +129,9 @@ exports[`Render overlay with minimal config 1`] = `
         single media selection overlay
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -175,6 +184,9 @@ exports[`Render overlay with target enabled 1`] = `
       <div>
         single media selection overlay
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />
@@ -231,6 +243,9 @@ exports[`Render overlay with target enabled 1`] = `
         </button>
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -284,6 +299,9 @@ exports[`Render overlay with title enabled 1`] = `
         single media selection overlay
       </div>
       <div
+        class="descriptionLabel"
+      />
+      <div
         class="errorLabel"
       />
     </div>
@@ -307,6 +325,9 @@ exports[`Render overlay with title enabled 1`] = `
           value=""
         />
       </div>
+      <div
+        class="descriptionLabel"
+      />
       <div
         class="errorLabel"
       />


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

- Always render the `description-label` div in the `Field` component, even when no `description` (`info_text`) is provided.
- This ensures consistent field heights across a row, preventing layout misalignment.

#### Why?

When fields on the same row use `colspan` to share a 12-column line, and some fields have `<info_text>` while others don't, the next row becomes visually misaligned. Fields "staircase" instead of aligning on a clean horizontal line.

**Root cause:** The grid uses `float: left` for layout. The `description-label` div (which has `min-height: 20px` in CSS) was only rendered when a description was provided. Fields with `info_text` were taller than those without, causing subsequent floated items to latch onto different vertical positions.

**Fix:** Always render the `description-label` div (even when empty), matching the existing pattern already used by the `error-label` div which is always rendered regardless of whether an error exists. The existing `min-height: 20px` CSS rule ensures consistent heights.

#### Reproduction

Create a form XML with two visual rows where only some fields have `<info_text>`. The key is having `colspan` fields that don't add up to 12 on each "visual row" concept — the float layout wraps them, and height differences cause staircase alignment on the next row.

```xml
<!-- Row 1: 3 + 2 + 2 + 2 + 3 = 12 columns, only some fields have info_text -->
<property name="field_a" type="single_select" colspan="3">
    <meta>
        <title>Font Family</title>
    </meta>
    <params>
        <param name="values" type="collection">
            <param name="heading"><meta><title>Heading</title></meta></param>
            <param name="body"><meta><title>Body</title></meta></param>
            <param name="accent"><meta><title>Accent</title></meta></param>
        </param>
    </params>
</property>
<property name="field_b" type="single_select" colspan="2">
    <meta>
        <title>Font Weight</title>
    </meta>
    <params>
        <param name="values" type="collection">
            <param name="400"><meta><title>400 (Regular)</title></meta></param>
            <param name="700"><meta><title>700 (Bold)</title></meta></param>
        </param>
    </params>
</property>
<property name="field_c" type="text_line" colspan="2">
    <meta>
        <title>Font Size</title>
        <info_text>Use a valid CSS value (e.g. 1.5rem, 16px)</info_text>
    </meta>
</property>
<property name="field_d" type="single_select" colspan="2">
    <meta>
        <title>Font Style</title>
    </meta>
    <params>
        <param name="values" type="collection">
            <param name="normal"><meta><title>Normal</title></meta></param>
            <param name="italic"><meta><title>Italic</title></meta></param>
        </param>
    </params>
</property>
<property name="field_e" type="text_line" colspan="3">
    <meta>
        <title>Line Height</title>
        <info_text>Use a unitless value (e.g. 1.5) or CSS value</info_text>
    </meta>
</property>

<!-- Row 2: same structure but WITHOUT info_text — these fields staircase -->
<property name="field_f" type="single_select" colspan="3">
    <meta>
        <title>Font Family</title>
    </meta>
    <params>
        <param name="values" type="collection">
            <param name="heading"><meta><title>Heading</title></meta></param>
            <param name="body"><meta><title>Body</title></meta></param>
            <param name="accent"><meta><title>Accent</title></meta></param>
        </param>
    </params>
</property>
<property name="field_g" type="single_select" colspan="2">
    <meta><title>Font Weight</title></meta>
    <params>
        <param name="values" type="collection">
            <param name="400"><meta><title>400 (Regular)</title></meta></param>
            <param name="700"><meta><title>700 (Bold)</title></meta></param>
        </param>
    </params>
</property>
<property name="field_h" type="text_line" colspan="2">
    <meta><title>Font Size</title></meta>
</property>
<property name="field_i" type="single_select" colspan="2">
    <meta><title>Font Style</title></meta>
    <params>
        <param name="values" type="collection">
            <param name="normal"><meta><title>Normal</title></meta></param>
            <param name="italic"><meta><title>Italic</title></meta></param>
        </param>
    </params>
</property>
<property name="field_j" type="text_line" colspan="3">
    <meta><title>Line Height</title></meta>
</property>
```

**Expected:** Row 2 fields align on a clean horizontal line.
**Actual:** Row 2 fields "staircase" — fields below shorter ones (without `info_text`) start higher than fields below taller ones (with `info_text`).

<img width="895" height="328" alt="Capture d'écran 2026-03-04 à 13 28 35" src="https://github.com/user-attachments/assets/09d17252-01ad-46c1-b8c9-e9ea8649f633" />

#### Long-term recommendation

This fix is minimal and appropriate for `2.6`. However, the underlying issue stems from the `float: left` layout used by the `Grid` component (`item.scss`). A more robust long-term solution for `3.0` would be to replace the float-based grid with CSS Grid:

```scss
.grid {
    display: grid;
    grid-template-columns: repeat(12, 1fr);
    column-gap: 20px;
}

.colSpan-3 { grid-column: span 3; }
// etc.
```

CSS Grid automatically creates equal-height rows, which would eliminate this entire class of layout issues without needing to ensure every field has the same internal DOM structure.