### PR TITLE
Improve the document manager upgrade with hint about find for modify

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -818,7 +818,7 @@ sulu_media:
 
 This will only create the service `sulu_media.storage` as the alias to `sulu_media.storage.*` services has been removed.
 
-### PHPCR, Jackalope and DocumentManager related service got removed
+### PHPCR, Jackalope and Document Manager related service got removed
 
 A completely new content storage was written for Sulu 3.0. Instead of `PHPCR` and `Jackalope`,
 the new content storage uses `Doctrine ORM` entities, which most Symfony developers should be more familiar with.
@@ -835,6 +835,7 @@ Here are some quick examples of the most commonly used functions:
     - `PageRepositoryInterface::getOneBy(['uuid' => $uuid])`
     - `ArticleRepository::getOneBy(['uuid' => $uuid])`
     - `SnippetRepository::getOneBy(['uuid' => $uuid])`
+    - To modify something you no longer load it, instead use the `Modify...` messages listed below.
  - `DocumentManager::create`
     - `MessageBusInterface::dispatch(new Envelope(new CreatePageMessage($webspaceKey, $parentId, $data), [new EnableFlushStamp()]));`
     - `MessageBusInterface::dispatch(new Envelope(new CreateArticleMessage($webspaceKey, $parentId, $data), [new EnableFlushStamp()]));`


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | improves: https://github.com/sulu/sulu/pull/8614
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use `Document Manager` in headline so somebody searching for `Document Manager` find the section. Add additional hint in find that modify not longer require a find.

#### Why?

Improve UPGRADE.