### PR TITLE
Readding `admin/api` prefix for snippet routes

### DIFF
--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -51,6 +51,7 @@ sulu_category_api:
 
 sulu_snippet_api:
     resource: "@SuluSnippetBundle/config/routing_admin_api.yaml"
+    prefix: /admin/api
 
 sulu_location:
     resource: "@SuluLocationBundle/Resources/config/routing.yaml"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | yes
| Deprecations? | -
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding the `/admin/api` prefix to it after migrating to normal Symfony routing.

#### Why?
All routes for the admin api should be under `/admin/api`. Otherwise the routes might now work as intended.
