### PR TITLE
Add metadata options support to update form store

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js
@@ -3,6 +3,7 @@ import {mount} from 'enzyme';
 import symfonyRouting from 'fos-jsrouting/router';
 import UpdateFormStoreToolbarAction from '../../toolbarActions/UpdateFormStoreToolbarAction';
 import {ResourceFormStore} from '../../../../containers/Form';
+import memoryFormStoreFactory from '../../../../containers/Form/stores/memoryFormStoreFactory';
 import ResourceStore from '../../../../stores/ResourceStore';
 import Router from '../../../../services/Router';
 import Form from '../../../../views/Form';
@@ -23,6 +24,14 @@ jest.mock('../../../../utils/Translator', () => ({
 jest.mock('../../../../containers/Form/stores/metadataStore', () => ({
     getSchema: jest.fn().mockReturnValue(Promise.resolve({})),
     getJsonSchema: jest.fn().mockReturnValue(Promise.resolve({})),
+}));
+
+jest.mock('../../../../containers/Form/stores/memoryFormStoreFactory', () => ({
+    createFromFormKey: jest.fn(() => ({
+        data: {},
+        validate: jest.fn().mockReturnValue(true),
+        destroy: jest.fn(),
+    })),
 }));
 
 jest.mock('../../../../containers/Form/stores/ResourceFormStore', () => (
@@ -136,6 +145,32 @@ test('Open dialog on button click when content exists', async() => {
     expect(action.showDialog).toBe(true);
 });
 
+test('Pass form metadata options to dialog form store', async() => {
+    const action = createUpdateFormStoreToolbarAction({
+        formKey: 'test_form',
+        formMetadataOptionsExpressions: [
+            {
+                property: 'excludedLocale',
+                get: '_locale',
+            },
+        ],
+    });
+    action.resourceFormStore.resourceStore.data = {test: 'test content'};
+    // $FlowFixMe
+    action.resourceFormStore.locale.get = jest.fn().mockReturnValue('en');
+
+    const config = action.getToolbarItemConfig();
+    await config.onClick();
+
+    expect(memoryFormStoreFactory.createFromFormKey).toHaveBeenCalledWith(
+        'test_form',
+        undefined,
+        undefined,
+        undefined,
+        {excludedLocale: 'en'}
+    );
+});
+
 test('Fetch data directly when no content exists', async() => {
     const action = createUpdateFormStoreToolbarAction();
     action.resourceFormStore.resourceStore.data = {};
@@ -212,7 +247,40 @@ test('Handle error on fetch', async() => {
     expect(action.showDialog).toBe(false);
     expect(action.form.errors).toContain('error.message');
 });
+test('Handle plain object error on fetch', async() => {
+    const action = createUpdateFormStoreToolbarAction();
+    action.showDialog = true;
 
+    Requester.post.mockRejectedValue({messageKey: 'plain.error'});
+
+    const element = mount(action.getNode());
+    element.find('Button[skin="primary"]').simulate('click');
+
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(action.loading).toBe(false);
+    expect(action.showDialog).toBe(false);
+    expect(action.form.errors).toContain('plain.error');
+});
+
+test('Handle invalid json error on fetch', async() => {
+    const action = createUpdateFormStoreToolbarAction();
+    action.showDialog = true;
+
+    const error = new Error('Test Error');
+    // $FlowFixMe
+    error.json = jest.fn().mockRejectedValue(new Error('invalid json'));
+    Requester.post.mockRejectedValue(error);
+
+    const element = mount(action.getNode());
+    element.find('Button[skin="primary"]').simulate('click');
+
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(action.loading).toBe(false);
+    expect(action.showDialog).toBe(false);
+    expect(action.form.errors).toContain('sulu_admin.error');
+});
 test('Render dialog with correct props', () => {
     const action = createUpdateFormStoreToolbarAction({
         dialogCancelText: 'Cancel Test',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js
@@ -247,10 +247,10 @@ test('Handle error on fetch', async() => {
     expect(action.showDialog).toBe(false);
     expect(action.form.errors).toContain('error.message');
 });
+
 test('Handle plain object error on fetch', async() => {
     const action = createUpdateFormStoreToolbarAction();
     action.showDialog = true;
-
     Requester.post.mockRejectedValue({messageKey: 'plain.error'});
 
     const element = mount(action.getNode());
@@ -281,6 +281,7 @@ test('Handle invalid json error on fetch', async() => {
     expect(action.showDialog).toBe(false);
     expect(action.form.errors).toContain('sulu_admin.error');
 });
+
 test('Render dialog with correct props', () => {
     const action = createUpdateFormStoreToolbarAction({
         dialogCancelText: 'Cancel Test',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/UpdateFormStoreToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/UpdateFormStoreToolbarAction.js
@@ -187,9 +187,7 @@ export default class UpdateFormStoreToolbarAction extends AbstractFormToolbarAct
     }
 
     async getCurrentContent() {
-        const context = {
-            ...this.resourceFormStore.data,
-        };
+        const context = this.getExpressionContext();
 
         const content = {};
         for (const expr of this.contentExpressions) {
@@ -201,6 +199,46 @@ export default class UpdateFormStoreToolbarAction extends AbstractFormToolbarAct
         return content;
     }
 
+    @computed get formMetadataOptionsExpressions(): ?Array<{ get: string, property: string }> {
+        const {
+            formMetadataOptionsExpressions,
+        } = this.options;
+
+        if (undefined === formMetadataOptionsExpressions) {
+            return undefined;
+        }
+
+        if (!Array.isArray(formMetadataOptionsExpressions)) {
+            throw new Error('The "formMetadataOptionsExpressions" option must be an array value!');
+        }
+
+        return ((formMetadataOptionsExpressions: any): Array<{ get: string, property: string }>);
+    }
+
+    getExpressionContext() {
+        return {
+            ...this.resourceFormStore.data,
+            _locale: this.resourceFormStore.locale?.get(),
+        };
+    }
+
+    async getFormMetadataOptions() {
+        if (!this.formMetadataOptionsExpressions) {
+            return undefined;
+        }
+
+        const context = this.getExpressionContext();
+        const metadataOptions = {};
+
+        for (const expr of this.formMetadataOptionsExpressions) {
+            if (expr.get) {
+                metadataOptions[expr.property] = await this.evaluateJexl(expr.get, context);
+            }
+        }
+
+        return metadataOptions;
+    }
+
     hasExistingContent(content: Object) {
         return Object.values(content).some((value) => value);
     }
@@ -210,7 +248,14 @@ export default class UpdateFormStoreToolbarAction extends AbstractFormToolbarAct
 
         if (this.hasExistingContent(contentData)) {
             if (this.formKey) {
-                this.formStore = memoryFormStoreFactory.createFromFormKey(this.formKey);
+                const formMetadataOptions = await this.getFormMetadataOptions();
+                this.formStore = memoryFormStoreFactory.createFromFormKey(
+                    this.formKey,
+                    undefined,
+                    undefined,
+                    undefined,
+                    formMetadataOptions,
+                );
             }
 
             this.openDialog();
@@ -253,13 +298,33 @@ export default class UpdateFormStoreToolbarAction extends AbstractFormToolbarAct
             this.closeDialog();
             this.loading = false;
 
-            const data = await error.json();
+            const data = await this.getErrorData(error);
             this.setError(data.messageKey);
         }));
     };
 
-    @action setError = (messageKey: string) => {
-        this.form.errors = [...this.form.errors, translate(messageKey)];
+    async getErrorData(error: any): Promise<{messageKey?: string}> {
+        if (error && typeof error.json === 'function') {
+            try {
+                const data = await error.json();
+
+                if (data && typeof data === 'object') {
+                    return data;
+                }
+            } catch (e) {
+                // Fall through to the generic object fallback below.
+            }
+        }
+
+        if (error && typeof error === 'object') {
+            return error;
+        }
+
+        return {};
+    }
+
+    @action setError = (messageKey: ?string) => {
+        this.form.errors = [...this.form.errors, translate(messageKey || 'sulu_admin.error')];
     };
 
     getNode() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/UpdateFormStoreToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/UpdateFormStoreToolbarAction.js
@@ -223,14 +223,15 @@ export default class UpdateFormStoreToolbarAction extends AbstractFormToolbarAct
     }
 
     async getFormMetadataOptions() {
-        if (!this.formMetadataOptionsExpressions) {
+        const formMetadataOptionsExpressions = this.formMetadataOptionsExpressions;
+        if (!formMetadataOptionsExpressions) {
             return undefined;
         }
 
         const context = this.getExpressionContext();
         const metadataOptions = {};
 
-        for (const expr of this.formMetadataOptionsExpressions) {
+        for (const expr of formMetadataOptionsExpressions) {
             if (expr.get) {
                 metadataOptions[expr.property] = await this.evaluateJexl(expr.get, context);
             }
@@ -245,16 +246,17 @@ export default class UpdateFormStoreToolbarAction extends AbstractFormToolbarAct
 
     @action handleClick = async() => {
         const contentData = await this.getCurrentContent();
+        const formKey = this.formKey;
 
         if (this.hasExistingContent(contentData)) {
-            if (this.formKey) {
+            if (formKey) {
                 const formMetadataOptions = await this.getFormMetadataOptions();
                 this.formStore = memoryFormStoreFactory.createFromFormKey(
-                    this.formKey,
+                    formKey,
                     undefined,
                     undefined,
                     undefined,
-                    formMetadataOptions,
+                    formMetadataOptions
                 );
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | N/A |
| Related issues/PRs | N/A |
| License | MIT |
| Documentation PR | N/A |

#### What's in this PR?

This PR extends UpdateFormStoreToolbarAction so dialog forms can receive metadata options derived from the current form
state.

The error handling was also hardened so rejected requests no longer assume error.json() is always available.

#### Why?

Some dialog forms need metadata that depends on the currently edited resource. A concrete example is locale selection
dialogs where the current locale should be excluded from the available target locales.

#### Example Usage

```
new ToolbarAction('sulu_admin.update_form_store', [
    'icon' => 'su-language',
    'route' => 'app.translate',
    'dialogKey' => 'app-translate',
    'dialogTitle' => 'Translate',
    'dialogDescription' => 'Choose target locales.',
    'dialogOkText' => 'Translate',
    'dialogCancelText' => 'Cancel',
    'formKey' => 'translate',
    'formMetadataOptionsExpressions' => [
        [
            'property' => 'excludedLocale',
            'get' => '_locale',
        ],
    ],
    'contentExpressions' => [
        [
            'property' => '_dialog',
            'get' => 'true',
            'path' => '',
        ],
    ],
]);
```