### PR TITLE
Move `getAdminConfigs` to AdminPool

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/AdminPool.php
@@ -82,12 +82,28 @@ class AdminPool
     }
 
     /**
+     * @return array<string, array<mixed>>
+     */
+    public function getAdminConfigs(): array
+    {
+        $configs = [];
+        foreach ($this->pool as $admin) {
+            $adminConfigKey = $admin->getConfigKey();
+            $adminConfig = $admin->getConfig();
+
+            if (null !== $adminConfigKey && null !== $adminConfig) {
+                $configs[$adminConfigKey] = $adminConfig;
+            }
+        }
+
+        return $configs;
+    }
+
+    /**
      * Helper function to iterate over all available Admin objects.
      */
     private function iterateAdmins(callable $callback): void
     {
-        foreach ($this->pool as $admin) {
-            $callback($admin);
-        }
+        \array_walk($this->pool, $callback);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/AdminController.php
@@ -151,16 +151,8 @@ class AdminController
                 'collaborationEnabled' => $this->collaborationEnabled,
                 'collaborationInterval' => $this->collaborationInterval * 1000,
             ],
+            ...$this->adminPool->getAdminConfigs(),
         ];
-
-        foreach ($this->adminPool->getAdmins() as $admin) {
-            $adminConfigKey = $admin->getConfigKey();
-            $adminConfig = $admin->getConfig();
-
-            if ($adminConfigKey && $adminConfig) {
-                $config[$adminConfigKey] = $adminConfig;
-            }
-        }
 
         $view = View::create($config);
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/AdminPoolTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/AdminPoolTest.php
@@ -98,4 +98,23 @@ class AdminPoolTest extends TestCase
             $contexts['Sulu']['Portal']
         );
     }
+
+    public function testAdminConfig(): void
+    {
+        $this->admin1->getConfigKey()->willReturn('sulu_media');
+        $this->admin1->getConfig()->willReturn([
+            'config' => true,
+            'number' => 1,
+        ]);
+
+        $this->admin2->getConfigKey()->willReturn(null);
+        $this->admin2->getConfig()->willReturn(null);
+
+        $this->assertSame(
+            [
+                'sulu_media' => ['config' => true, 'number' => 1],
+            ],
+            $this->adminPool->getAdminConfigs()
+        );
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Controller/AdminControllerTest.php
@@ -18,7 +18,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\AdminPool;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItem;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry;
@@ -267,25 +266,15 @@ class AdminControllerTest extends TestCase
         $dataProviders = [];
         $this->dataProviderPool->getAll()->willReturn($dataProviders);
 
-        $admin1 = $this->prophesize(Admin::class);
-        $admin1Config = ['test1' => 'value1'];
-        $admin1->getConfig()->willReturn($admin1Config);
-        $admin1->getConfigKey()->willReturn('admin1');
-
-        $admin2 = $this->prophesize(Admin::class);
-        $admin2Config = ['test2' => 'value2'];
-        $admin2->getConfig()->willReturn($admin2Config);
-        $admin2->getConfigKey()->willReturn('admin2');
-
-        $admin3 = $this->prophesize(Admin::class);
-        $admin3->getConfig()->shouldBeCalled();
-        $admin3->getConfigKey()->shouldBeCalled();
-
-        $this->adminPool->getAdmins()->willReturn([$admin1, $admin2, $admin3]);
+        $this->adminPool->getAdminConfigs()
+            ->willReturn([
+                'admin1' => ['test1' => 'value1'],
+                'admin2' => ['test2' => 'value2'],
+            ]);
 
         $this->viewHandler->handle(
             Argument::that(
-                function(View $view) use ($dataProviders, $fieldTypeOptions, $views, $admin1Config, $admin2Config) {
+                function(View $view) use ($dataProviders, $fieldTypeOptions, $views) {
                     $data = $view->getData();
 
                     return 'json' === $view->getFormat()
@@ -297,8 +286,8 @@ class AdminControllerTest extends TestCase
                         && $data['sulu_admin']['resources'] === $this->resources
                         && true === $data['sulu_admin']['collaborationEnabled']
                         && 10000 === $data['sulu_admin']['collaborationInterval']
-                        && $data['admin1'] === $admin1Config
-                        && $data['admin2'] === $admin2Config;
+                        && $data['admin1'] === ['test1' => 'value1']
+                        && $data['admin2'] === ['test2' => 'value2'];
                 }
             )
         )->shouldBeCalled()->willReturn(new Response());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Moving the `getAdminConfigs` out of the controller into the AdminPool.

#### Why?
This makes the controller easier to test and together with #8680 this makes the code in the controller easier to understand.