### PR TITLE
Fixing the time mockery

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
@@ -91,7 +91,6 @@ class Collaboration
      */
     public function updateTime()
     {
-        $this->changed = \time();
-        dump(\date('Y-m-d H:i:s', $this->changed));
+        $this->changed = 'time'();
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
@@ -42,8 +42,8 @@ class Collaboration
         private $resourceKey,
         private $id,
     ) {
-        $this->started = time();
-        $this->changed = time();
+        $this->started = \time();
+        $this->changed = \time();
     }
 
     /**
@@ -91,7 +91,7 @@ class Collaboration
      */
     public function updateTime()
     {
-        $this->changed = time();
-        dump(date('Y-m-d H:i:s', $this->changed));
+        $this->changed = \time();
+        dump(\date('Y-m-d H:i:s', $this->changed));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
@@ -42,8 +42,8 @@ class Collaboration
         private $resourceKey,
         private $id,
     ) {
-        $this->started = \time();
-        $this->changed = \time();
+        $this->started = time();
+        $this->changed = time();
     }
 
     /**
@@ -91,6 +91,6 @@ class Collaboration
      */
     public function updateTime()
     {
-        $this->changed = \time();
+        $this->changed = time();
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
@@ -42,8 +42,8 @@ class Collaboration
         private $resourceKey,
         private $id,
     ) {
-        $this->started = \time();
-        $this->changed = \time();
+        $this->started = time();
+        $this->changed = time();
     }
 
     /**
@@ -91,6 +91,6 @@ class Collaboration
      */
     public function updateTime()
     {
-        $this->changed = 'time'();
+        $this->changed = time();
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/Collaboration.php
@@ -92,5 +92,6 @@ class Collaboration
     public function updateTime()
     {
         $this->changed = time();
+        dump(date('Y-m-d H:i:s', $this->changed));
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
@@ -47,7 +47,7 @@ class CollaborationRepository
         $value[$collaboration->getConnectionId()] = $collaboration;
 
         $value = \array_filter($value, function(Collaboration $collaboration) {
-            return $collaboration->getChanged() > \time() - $this->threshold;
+            return $collaboration->getChanged() > 'time'() - $this->threshold;
         });
 
         $cacheItem->set($value);

--- a/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
@@ -47,7 +47,7 @@ class CollaborationRepository
         $value[$collaboration->getConnectionId()] = $collaboration;
 
         $value = \array_filter($value, function(Collaboration $collaboration) {
-            return $collaboration->getChanged() > 'time'() - $this->threshold;
+            return $collaboration->getChanged() > time() - $this->threshold;
         });
 
         $cacheItem->set($value);

--- a/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
@@ -47,7 +47,7 @@ class CollaborationRepository
         $value[$collaboration->getConnectionId()] = $collaboration;
 
         $value = \array_filter($value, function(Collaboration $collaboration) {
-            return $collaboration->getChanged() > time() - $this->threshold;
+            return $collaboration->getChanged() > \time() - $this->threshold;
         });
 
         $cacheItem->set($value);

--- a/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
@@ -47,7 +47,7 @@ class CollaborationRepository
         $value[$collaboration->getConnectionId()] = $collaboration;
 
         $value = \array_filter($value, function(Collaboration $collaboration) {
-            return $collaboration->getChanged() > \time() - $this->threshold;
+            return $collaboration->getChanged() > time() - $this->threshold;
         });
 
         $cacheItem->set($value);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -34,8 +34,9 @@ class CollaborationRepositoryTest extends TestCase
         ClockMock::register(Collaboration::class);
         ClockMock::register(CollaborationRepository::class);
         ClockMock::withClockMock(\strtotime('2018-11-05 01:00:00'));
-        dump('setting up clock');
-        dump(date('Y-m-d H:i:s'));
+
+        // Checking that the mock is working
+        self::assertTrue(ClockMock::withClockMock());
     }
 
     public function setUp(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -33,8 +33,9 @@ class CollaborationRepositoryTest extends TestCase
     {
         ClockMock::register(Collaboration::class);
         ClockMock::register(CollaborationRepository::class);
-        ClockMock::withClockMock(strtotime('2018-11-05 01:00:00'));
-        dump("setting up clock");
+        ClockMock::withClockMock(\strtotime('2018-11-05 01:00:00'));
+        dump('setting up clock');
+        dump(date('Y-m-d H:i:s'));
     }
 
     public function setUp(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -31,6 +31,8 @@ class CollaborationRepositoryTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        ClockMock::register(Collaboration::class);
+        ClockMock::register(CollaborationRepository::class);
         ClockMock::withClockMock(true);
     }
 
@@ -177,7 +179,7 @@ class CollaborationRepositoryTest extends TestCase
 
         $this->assertEquals([$collaboration1, $collaboration2], $result);
 
-        \sleep($threshold + 1);
+        ClockMock::sleep($threshold + 1);
 
         $collaboration2 = new Collaboration(
             $collaborationId2,
@@ -237,7 +239,7 @@ class CollaborationRepositoryTest extends TestCase
         $started = $collaboration1->getStarted();
         $this->assertEquals($started, $collaboration1->getChanged());
 
-        \sleep(10);
+        ClockMock::sleep(10);
 
         $this->cache->save($cacheItem)->shouldBeCalled();
         $result = $collaborationRepository->update($collaboration1);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -34,6 +34,7 @@ class CollaborationRepositoryTest extends TestCase
         ClockMock::register(Collaboration::class);
         ClockMock::register(CollaborationRepository::class);
         ClockMock::withClockMock(strtotime('2018-11-05 01:00:00'));
+        dump("setting up clock");
     }
 
     public function setUp(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -33,7 +33,7 @@ class CollaborationRepositoryTest extends TestCase
     {
         ClockMock::register(Collaboration::class);
         ClockMock::register(CollaborationRepository::class);
-        ClockMock::withClockMock(true);
+        ClockMock::withClockMock(strtotime('2018-11-05 01:00:00'));
     }
 
     public function setUp(): void

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Entity/CollaborationRepositoryTest.php
@@ -37,6 +37,7 @@ class CollaborationRepositoryTest extends TestCase
 
         // Checking that the mock is working
         self::assertTrue(ClockMock::withClockMock());
+        self::assertEquals('2018', \Sulu\Bundle\AdminBundle\Entity\date('Y'));
     }
 
     public function setUp(): void

--- a/src/Sulu/Bundle/AdminBundle/phpunit.xml.dist
+++ b/src/Sulu/Bundle/AdminBundle/phpunit.xml.dist
@@ -19,6 +19,12 @@
         </testsuite>
     </testsuites>
 
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension">
+            <parameter name="clock-mock-namespaces" value="Sulu" />
+        </bootstrap>
+    </extensions>
+
     <php>
         <server name="APP_ENV" value="test" force="true"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\AdminBundle\Tests\Application\Kernel"/>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8584 
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Replacing the real clock with a mock clock. This speeds up the tests as there's no real waiting.

This however also requires that the functions aren't fully qualified as the Mock clock uses the php function resolution.
-> In tests: Looking into the current namespace for sleep function, finds mock uses mock
-> In prod: Looks into current namespace. Finds nothing, looks into the global namespace, finds real waiting implementation, uses wall clock.

#### Why?
Flakey tests are annoying.