### PR TITLE
Making Admin Menu items behave like links

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
@@ -9,8 +9,10 @@ type Props = {
     active?: boolean,
     children?: ChildrenArray<Element<typeof Item> | false>,
     expanded?: boolean,
+    href?: string,
     icon?: string,
     onClick?: (value: string) => void,
+    onLinkClick?: (event: SyntheticMouseEvent<HTMLAnchorElement>, value: string) => void,
     title: string,
     value: string,
 };
@@ -26,8 +28,18 @@ export default class Item extends React.PureComponent<Props> {
         onClick(value);
     };
 
+    handleLinkClick = (event: SyntheticMouseEvent<HTMLAnchorElement>) => {
+        const {onLinkClick, value} = this.props;
+
+        if (!onLinkClick) {
+            return;
+        }
+
+        onLinkClick(event, value);
+    };
+
     render() {
-        const {title, children, expanded, icon} = this.props;
+        const {title, children, expanded, icon, href} = this.props;
         let {active} = this.props;
 
         // check for active children
@@ -46,18 +58,46 @@ export default class Item extends React.PureComponent<Props> {
             }
         );
 
+        const ariaCurrent = active ? 'page' : undefined;
+
         return (
             <div className={itemClass}>
-                <button className={itemStyles.title} onClick={this.handleClick} type="button">
-                    {icon && <Icon className={itemStyles.icon} name={icon} />}
-                    <span className={itemStyles.text}>{title}</span>
-                    {children &&
-                        <Icon
-                            className={itemStyles.childrenIndicator}
-                            name={expanded ? 'su-angle-down' : 'su-angle-right'}
-                        />
-                    }
-                </button>
+                {href
+                    ? (
+                        <a
+                            aria-current={ariaCurrent}
+                            className={itemStyles.title}
+                            href={href}
+                            onClick={this.handleLinkClick}
+                        >
+                            {icon && <Icon className={itemStyles.icon} name={icon} />}
+                            <span className={itemStyles.text}>{title}</span>
+                            {children &&
+                                <Icon
+                                    className={itemStyles.childrenIndicator}
+                                    name={expanded ? 'su-angle-down' : 'su-angle-right'}
+                                />
+                            }
+                        </a>
+                    )
+                    : (
+                        <button
+                            aria-current={ariaCurrent}
+                            className={itemStyles.title}
+                            onClick={this.handleClick}
+                            type="button"
+                        >
+                            {icon && <Icon className={itemStyles.icon} name={icon} />}
+                            <span className={itemStyles.text}>{title}</span>
+                            {children &&
+                                <Icon
+                                    className={itemStyles.childrenIndicator}
+                                    name={expanded ? 'su-angle-down' : 'su-angle-right'}
+                                />
+                            }
+                        </button>
+                    )
+                }
 
                 {expanded && children &&
                     <div>{children}</div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/Item.js
@@ -58,14 +58,11 @@ export default class Item extends React.PureComponent<Props> {
             }
         );
 
-        const ariaCurrent = active ? 'page' : undefined;
-
         return (
             <div className={itemClass}>
                 {href
                     ? (
                         <a
-                            aria-current={ariaCurrent}
                             className={itemStyles.title}
                             href={href}
                             onClick={this.handleLinkClick}
@@ -82,7 +79,6 @@ export default class Item extends React.PureComponent<Props> {
                     )
                     : (
                         <button
-                            aria-current={ariaCurrent}
                             className={itemStyles.title}
                             onClick={this.handleClick}
                             type="button"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Navigation/item.scss
@@ -25,6 +25,7 @@ $hoverColor: $shakespeare;
         justify-content: flex-start;
         width: 100%;
         color: $color;
+        text-decoration: none;
         padding: 20px;
         border: 0;
         background-color: transparent;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/Navigation.js
@@ -51,6 +51,23 @@ class Navigation extends React.Component<Props> {
         this.props.onNavigate(view);
     };
 
+    handleNavigationItemLinkClick = (event: SyntheticMouseEvent<HTMLAnchorElement>, value: string) => {
+        // Keep href for accessibility / open-in-new-tab, but use SPA navigation for normal clicks.
+        if (
+            event.button !== 0
+            || event.metaKey
+            || event.altKey
+            || event.ctrlKey
+            || event.shiftKey
+            || event.defaultPrevented
+        ) {
+            return;
+        }
+
+        event.preventDefault();
+        this.handleNavigationItemClick(value);
+    };
+
     handleProfileEditClick = () => {
         this.props.onProfileClick();
     };
@@ -91,8 +108,10 @@ class Navigation extends React.Component<Props> {
                 {navigationItems.filter((item: NavigationItem) => item.visible).map((item: NavigationItem) => (
                     <NavigationComponent.Item
                         active={this.isItemActive(item)}
+                        href={item.view ? this.props.router.getHref(item.view) : undefined}
                         icon={item.icon}
                         key={item.id}
+                        onLinkClick={this.handleNavigationItemLinkClick}
                         title={item.label}
                         value={item.id}
                     >
@@ -101,7 +120,9 @@ class Navigation extends React.Component<Props> {
                             item.items.filter((subItem: NavigationItem) => subItem.visible).map((subItem) => (
                                 <NavigationComponent.Item
                                     active={this.isItemActive(subItem)}
+                                    href={subItem.view ? this.props.router.getHref(subItem.view) : undefined}
                                     key={subItem.id}
+                                    onLinkClick={this.handleNavigationItemLinkClick}
                                     title={subItem.label}
                                     value={subItem.id}
                                 />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js
@@ -11,6 +11,7 @@ jest.mock('../../../utils/Translator', () => ({
 
 jest.mock('../../../services/Router/Router', () => jest.fn(function() {
     this.navigate = jest.fn();
+    this.getHref = jest.fn((view) => '#/' + view);
 }));
 
 jest.mock('../registries/navigationRegistry', () => ({
@@ -158,7 +159,17 @@ test('Should call the navigation callback, pin callback and router navigate', ()
         />
     );
 
-    navigation.find('Item').at(4).find('.title').simulate('click');
+    const preventDefault = jest.fn();
+    navigation.find('Item').at(4).find('.title').simulate('click', {
+        button: 0,
+        metaKey: false,
+        altKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        defaultPrevented: false,
+        preventDefault,
+    });
+    expect(preventDefault).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalledWith('returned_main_route');
     expect(handleNavigate).toHaveBeenCalledWith('returned_main_route');
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -33,7 +33,6 @@ exports[`Should render navigation 1`] = `
       class="item active"
     >
       <a
-        aria-current="page"
         class="title"
         href="#/sulu_admin.form_tab"
       >
@@ -66,7 +65,6 @@ exports[`Should render navigation 1`] = `
       class="item active"
     >
       <button
-        aria-current="page"
         class="title"
         type="button"
       >
@@ -87,7 +85,6 @@ exports[`Should render navigation 1`] = `
           class="item active"
         >
           <a
-            aria-current="page"
             class="title"
             href="#/sulu_admin.form_tab"
           >
@@ -208,7 +205,6 @@ exports[`Should render navigation without appVersion 1`] = `
       class="item active"
     >
       <a
-        aria-current="page"
         class="title"
         href="#/sulu_admin.form_tab"
       >
@@ -241,7 +237,6 @@ exports[`Should render navigation without appVersion 1`] = `
       class="item active"
     >
       <button
-        aria-current="page"
         class="title"
         type="button"
       >
@@ -262,7 +257,6 @@ exports[`Should render navigation without appVersion 1`] = `
           class="item active"
         >
           <a
-            aria-current="page"
             class="title"
             href="#/sulu_admin.form_tab"
           >

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/__snapshots__/Navigation.test.js.snap
@@ -32,9 +32,10 @@ exports[`Should render navigation 1`] = `
     <div
       class="item active"
     >
-      <button
+      <a
+        aria-current="page"
         class="title"
-        type="button"
+        href="#/sulu_admin.form_tab"
       >
         <span
           aria-label="su-options"
@@ -43,14 +44,14 @@ exports[`Should render navigation 1`] = `
         <span
           class="text"
         />
-      </button>
+      </a>
     </div>
     <div
       class="item"
     >
-      <button
+      <a
         class="title"
-        type="button"
+        href="#/sulu_article.list"
       >
         <span
           aria-label="su-article"
@@ -59,12 +60,13 @@ exports[`Should render navigation 1`] = `
         <span
           class="text"
         />
-      </button>
+      </a>
     </div>
     <div
       class="item active"
     >
       <button
+        aria-current="page"
         class="title"
         type="button"
       >
@@ -84,26 +86,27 @@ exports[`Should render navigation 1`] = `
         <div
           class="item active"
         >
-          <button
+          <a
+            aria-current="page"
             class="title"
-            type="button"
+            href="#/sulu_admin.form_tab"
           >
             <span
               class="text"
             />
-          </button>
+          </a>
         </div>
         <div
           class="item"
         >
-          <button
+          <a
             class="title"
-            type="button"
+            href="#/sulu_article.list"
           >
             <span
               class="text"
             />
-          </button>
+          </a>
         </div>
       </div>
     </div>
@@ -204,9 +207,10 @@ exports[`Should render navigation without appVersion 1`] = `
     <div
       class="item active"
     >
-      <button
+      <a
+        aria-current="page"
         class="title"
-        type="button"
+        href="#/sulu_admin.form_tab"
       >
         <span
           aria-label="su-options"
@@ -215,14 +219,14 @@ exports[`Should render navigation without appVersion 1`] = `
         <span
           class="text"
         />
-      </button>
+      </a>
     </div>
     <div
       class="item"
     >
-      <button
+      <a
         class="title"
-        type="button"
+        href="#/sulu_article.list"
       >
         <span
           aria-label="su-article"
@@ -231,12 +235,13 @@ exports[`Should render navigation without appVersion 1`] = `
         <span
           class="text"
         />
-      </button>
+      </a>
     </div>
     <div
       class="item active"
     >
       <button
+        aria-current="page"
         class="title"
         type="button"
       >
@@ -256,26 +261,27 @@ exports[`Should render navigation without appVersion 1`] = `
         <div
           class="item active"
         >
-          <button
+          <a
+            aria-current="page"
             class="title"
-            type="button"
+            href="#/sulu_admin.form_tab"
           >
             <span
               class="text"
             />
-          </button>
+          </a>
         </div>
         <div
           class="item"
         >
-          <button
+          <a
             class="title"
-            type="button"
+            href="#/sulu_article.list"
           >
             <span
               class="text"
             />
-          </button>
+          </a>
         </div>
       </div>
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -358,7 +358,9 @@ export default class Router {
         };
 
         for (const [key, observableValue] of this.bindings.entries()) {
-            attributesWithBindings[key] = observableValue.get();
+            if (attributesWithBindings[key] === undefined) {
+                attributesWithBindings[key] = observableValue.get();
+            }
         }
 
         return this.buildUrl(route, attributesWithBindings);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -317,13 +317,7 @@ export default class Router {
     @action update(name: string, attributes: Object, updateRouteMethod: UpdateRouteMethod): void {
         const route = routeRegistry.get(name);
 
-        const updatedAttributes = {
-            ...this.updateAttributesHooks.reduce((hookAttributes: Object, updateAttributeHook) => ({
-                ...updateAttributeHook(route, attributes),
-                ...hookAttributes,
-            }), {}),
-            ...attributes,
-        };
+        const updatedAttributes = this.getAttributesForRoute(route, attributes);
 
         const attributeDefaults = route.attributeDefaults;
         Object.keys(attributeDefaults).forEach((key) => {
@@ -355,22 +349,55 @@ export default class Router {
         }
     }
 
-    @computed get url(): string {
-        if (!this.route) {
-            return '';
-        }
+    getUrl(name: string, attributes: Object = {}): string {
+        const route = routeRegistry.get(name);
+        const updatedAttributes = this.getAttributesForRoute(route, attributes);
 
-        const attributes = toJS(this.attributes);
+        const attributesWithBindings = {
+            ...updatedAttributes,
+        };
+
         for (const [key, observableValue] of this.bindings.entries()) {
-            const value = observableValue.get();
-            attributes[key] = value;
+            attributesWithBindings[key] = observableValue.get();
         }
 
-        const url = compile(this.route.path)(attributes);
+        return this.buildUrl(route, attributesWithBindings);
+    }
+
+    getHref(name: string, attributes: Object = {}): string {
+        return '#' + this.getUrl(name, attributes);
+    }
+
+    getAttributesForRoute(route: Route, attributes: Object): Object {
+        return {
+            ...this.updateAttributesHooks.reduce((hookAttributes: Object, updateAttributeHook) => ({
+                ...updateAttributeHook(route, attributes),
+                ...hookAttributes,
+            }), {}),
+            ...attributes,
+        };
+    }
+
+    buildUrl(route: Route, attributes: Object): string {
+        const attributeDefaults = route.attributeDefaults;
+        const updatedAttributes = {...attributes};
+
+        Object.keys(attributeDefaults).forEach((key) => {
+            // set default attributes if not passed, to automatically set important omitted attributes everywhere
+            // e.g. allows to always pass the default locale if nothing is passed
+            if (updatedAttributes[key] !== undefined) {
+                return;
+            }
+
+            updatedAttributes[key] = attributeDefaults[key];
+        });
+
+        const url = compile(route.path)(updatedAttributes);
         const searchParameters = new URLSearchParams();
-        const {availableAttributes} = this.route;
-        Object.keys(attributes).forEach((key) => {
-            const value = toJS(attributes[key]);
+        const {availableAttributes} = route;
+
+        Object.keys(updatedAttributes).forEach((key) => {
+            const value = toJS(updatedAttributes[key]);
             if (availableAttributes.includes(key) || value == this.bindingDefaults.get(key)) {
                 return;
             }
@@ -381,6 +408,19 @@ export default class Router {
         const queryString = searchParameters.toString();
 
         return url + (queryString ? '?' + queryString : '');
+    }
+
+    @computed get url(): string {
+        if (!this.route) {
+            return '';
+        }
+
+        const attributes = toJS(this.attributes);
+        for (const [key, observableValue] of this.bindings.entries()) {
+            attributes[key] = observableValue.get();
+        }
+
+        return this.buildUrl(this.route, attributes);
     }
 
     createAttributesHistory() {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | maybe?
| Deprecations? | no
| Fixed tickets | refs #admin
| Related issues/PRs | #7081
| License | MIT
| Documentation PR | -

#### What's in this PR?
If the `NavigationItem` has a link, then you can use it like a link. Things like middle mouse click or open in new tab should now work.

#### Why?
Making the admin interface usable for power user and easily spawn new tabs for other Sulu segments.