### PR TITLE
Prepare 3.1 translation files

### DIFF
--- a/.github/workflows/crowdin-upload.yaml
+++ b/.github/workflows/crowdin-upload.yaml
@@ -42,9 +42,22 @@ jobs:
               run: |
                   cat var/translations/admin-merged-3-0.en.json
 
+            - name: Switch Branch to 3.1
+              run: |
+                  git fetch origin 3.1
+                  git checkout origin/3.1
+
+            - name: Merge all translation files from 3.1
+              run: |
+                  jq -s '.|add' src/Sulu/Bundle/*/Resources/translations/admin.en.json packages/*/translations/admin.en.json > var/translations/admin-merged-3-1.en.json
+
+            - name: Output merged translations 3.1
+              run: |
+                  cat var/translations/admin-merged-3-1.en.json
+
             - name: Merge branches
               run: |
-                  jq -s '.|add' var/translations/admin-merged-2-6.en.json var/translations/admin-merged-3-0.en.json > admin.en.json
+                  jq -s '.|add' var/translations/admin-merged-2-6.en.json var/translations/admin-merged-3-0.en.json var/translations/admin-merged-3-1.en.json > admin.en.json
 
             - name: Output merged all translations
               run: |


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/skeleton/pull/327
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Include 3.1 translation files for all branches.

#### Why?

For crowding we merge 2.6 and 3.0 together, we now need keep the new 3.1 also in mind.