### PR TITLE
Add routePathName to the whitelist

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -58,6 +58,7 @@ class PHPCRCleanupSingleNodeCommand extends Command
         'creator',
         'changed',
         'changer',
+        'routePathName',
     ];
 
     private string $languagePrefix;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds `routePathName` to the whitelist.

#### Why?

The Sulu 3.0 phpcr migration requires this.