### PR TITLE
Fix PHPCR cleanup command corrupting node properties via cloned node

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -271,14 +271,14 @@ class PHPCRCleanupSingleNodeCommand extends Command
             Assert::isInstanceOf($document, UuidBehavior::class);
 
             $node = $this->session->getNodeByIdentifier($document->getUuid());
-            $defaultCleanupNode = new CleanupNode(clone $node);
+            $defaultCleanupNode = new CleanupNode($node);
             $this->persist($document, $defaultCleanupNode, $locale);
 
             $wasPublished = WorkflowStage::PUBLISHED === $workflowStage;
             $liveCleanupNode = null;
             if ($wasPublished) {
                 $liveNode = $this->liveSession->getNodeByIdentifier($document->getUuid());
-                $liveCleanupNode = new CleanupNode(clone $liveNode);
+                $liveCleanupNode = new CleanupNode($liveNode);
                 $this->publish($document, $liveCleanupNode, $locale);
             }
 

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
@@ -119,7 +119,7 @@ class CleanupNode implements \IteratorAggregate, NodeInterface
     {
         $this->writtenProperties[$name] = ['value' => $value, 'type' => $type];
 
-        return $this->node->setProperty($name, $value, $type);
+        return null;
     }
 
     public function getNode($relPath)
@@ -139,7 +139,7 @@ class CleanupNode implements \IteratorAggregate, NodeInterface
 
     public function getProperty($relPath)
     {
-        return $this->node->getProperty($relPath);
+        return new CleanupNodeProperty($this->node->getProperty($relPath));
     }
 
     public function getPropertyValue($name, $type = null)

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNode.php
@@ -119,7 +119,7 @@ class CleanupNode implements \IteratorAggregate, NodeInterface
     {
         $this->writtenProperties[$name] = ['value' => $value, 'type' => $type];
 
-        return null;
+        return null; // @phpstan-ignore return.type
     }
 
     public function getNode($relPath)

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNodeProperty.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNodeProperty.php
@@ -20,6 +20,8 @@ use PHPCR\PropertyInterface;
  * shared ObjectManager when used on a cloned node in the cleanup command.
  *
  * @internal
+ *
+ * @implements \IteratorAggregate<mixed, mixed>
  */
 class CleanupNodeProperty implements \IteratorAggregate, PropertyInterface
 {

--- a/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNodeProperty.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/PHPCR/CleanupNodeProperty.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Content\Document\Subscriber\PHPCR;
+
+use PHPCR\ItemInterface;
+use PHPCR\ItemVisitorInterface;
+use PHPCR\PropertyInterface;
+
+/**
+ * Wraps a PHPCR Property to prevent remove() from leaking through the
+ * shared ObjectManager when used on a cloned node in the cleanup command.
+ *
+ * @internal
+ */
+class CleanupNodeProperty implements \IteratorAggregate, PropertyInterface
+{
+    public function __construct(
+        private PropertyInterface $property,
+    ) {
+    }
+
+    public function remove(): void
+    {
+        // No-op: prevent remove() from reaching the ObjectManager
+        // and corrupting the original node's state.
+    }
+
+    public function setValue($value, $type = null)
+    {
+        $this->property->setValue($value, $type);
+    }
+
+    public function addValue($value)
+    {
+        $this->property->addValue($value);
+    }
+
+    public function getValue()
+    {
+        return $this->property->getValue();
+    }
+
+    public function getString()
+    {
+        return $this->property->getString();
+    }
+
+    public function getBinary()
+    {
+        return $this->property->getBinary();
+    }
+
+    public function getLong()
+    {
+        return $this->property->getLong();
+    }
+
+    public function getDouble()
+    {
+        return $this->property->getDouble();
+    }
+
+    public function getDecimal()
+    {
+        return $this->property->getDecimal();
+    }
+
+    public function getDate()
+    {
+        return $this->property->getDate();
+    }
+
+    public function getBoolean()
+    {
+        return $this->property->getBoolean();
+    }
+
+    public function getNode()
+    {
+        return $this->property->getNode();
+    }
+
+    public function getProperty()
+    {
+        return $this->property->getProperty();
+    }
+
+    public function getLength()
+    {
+        return $this->property->getLength();
+    }
+
+    public function getDefinition()
+    {
+        return $this->property->getDefinition();
+    }
+
+    public function getType()
+    {
+        return $this->property->getType();
+    }
+
+    public function isMultiple()
+    {
+        return $this->property->isMultiple();
+    }
+
+    public function getPath()
+    {
+        return $this->property->getPath();
+    }
+
+    public function getName()
+    {
+        return $this->property->getName();
+    }
+
+    public function getAncestor($depth)
+    {
+        return $this->property->getAncestor($depth);
+    }
+
+    public function getParent()
+    {
+        return $this->property->getParent();
+    }
+
+    public function getDepth()
+    {
+        return $this->property->getDepth();
+    }
+
+    public function getSession()
+    {
+        return $this->property->getSession();
+    }
+
+    public function isNode()
+    {
+        return $this->property->isNode();
+    }
+
+    public function isNew()
+    {
+        return $this->property->isNew();
+    }
+
+    public function isModified()
+    {
+        return $this->property->isModified();
+    }
+
+    public function isSame(ItemInterface $otherItem)
+    {
+        return $this->property->isSame($otherItem);
+    }
+
+    public function accept(ItemVisitorInterface $visitor)
+    {
+        $this->property->accept($visitor);
+    }
+
+    public function revert()
+    {
+        $this->property->revert();
+    }
+
+    #[\ReturnTypeWillChange]
+    public function getIterator()
+    {
+        if ($this->property instanceof \IteratorAggregate) {
+            return $this->property->getIterator();
+        }
+
+        $value = $this->getValue();
+        if (!\is_array($value)) {
+            $value = [$value];
+        }
+
+        return new \ArrayIterator($value);
+    }
+}


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #8655
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Made `CleanupNode::setProperty()` a no-op that only records written property names without delegating to the underlying PHPCR node
  - Added `CleanupNodeProperty` wrapper where `remove()` is a no-op, returned by `CleanupNode::getProperty()`
  - Removed `clone $node` from `PHPCRCleanupSingleNodeCommand` as it is no longer needed

  #### Why?

  The cleanup command used `clone $node` to create a `CleanupNode` for tracking written properties during simulated persist/publish events. PHP's shallow clone shares `Property` objects and the `ObjectManager` with
   the original node, causing `Property::remove()` calls (from `SuluNode` type-change detection and `ShadowCopyPropertiesSubscriber`) to leak through the `ObjectManager` and corrupt the original node's state.

  This led to `InvalidItemStateException` ("Item ... is deleted") and `ItemNotFoundException` ("Could not remove property from node because it is already gone") errors on nodes with legacy data where PHPCR property
   types didn't match the expected PHP types, or where shadow locales triggered property removal across locale iterations.

  Since `CleanupNode` only needs to track which property names are written (via `getWrittenPropertyKeys()`), it does not need to actually write to the underlying node. Making `setProperty()` a no-op and wrapping
  `getProperty()` to prevent `remove()` from reaching the `ObjectManager` eliminates the entire class of clone-related bugs without any behavior change to the cleanup logic.