### PR TITLE
Fix linting after phpstan update

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -93131,3 +93131,9 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/phpstan/object-manager.php
+
+		-
+			message: '#^Method Sulu\\Bundle\\TestBundle\\Kernel\\SuluTestKernel\:\:registerBundles\(\) should return iterable\<Symfony\\Component\\HttpKernel\\Bundle\\BundleInterface\> but returns list\<.*\>\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ExposeResourceRoutesPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ExposeResourceRoutesPass.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Webmozart\Assert\Assert;
 
 /**
  * This compiler pass is responsible for adding all configured admin resource
@@ -45,6 +46,8 @@ class ExposeResourceRoutesPass implements CompilerPassInterface
         if (!\is_array($alreadyDefinedRouteNames)) {
             throw new \InvalidArgumentException('Invalid type of the second argument of service "fos_js_routing.extractor". Expected array.');
         }
+
+        Assert::allString($alreadyDefinedRouteNames, 'Expecting route names to be string when extracting routes');
 
         $allRouteNames = \array_unique(\array_merge($alreadyDefinedRouteNames, $routeNames));
         $extractorDefinition->replaceArgument(1, $allRouteNames);

--- a/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
+++ b/src/Sulu/Bundle/AdminBundle/Entity/CollaborationRepository.php
@@ -44,6 +44,7 @@ class CollaborationRepository
         $cacheItem = $this->cache->getItem($this->getCacheIdFromCollaboration($collaboration));
         $value = $cacheItem->get() ?? [];
         \assert(\is_array($value), 'Value from collaboration cache should be an array.');
+        /** @var Collaboration[] $value */
         $value[$collaboration->getConnectionId()] = $collaboration;
 
         $value = \array_filter($value, function(Collaboration $collaboration) {

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -247,24 +247,21 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
      * Sets the medias of the given account to the given medias.
      * Currently associated medias are replaced.
      *
-     * @param array $mediaIds
+     * @param array<int> $mediaIds
      *
      * @throws EntityNotFoundException
      */
     public function setMedias(Account $account, $mediaIds)
     {
-        /** @var MediaInterface[] $foundMedias */
         $foundMedias = [];
         if (\count($mediaIds) > 0) {
+            /** @var MediaInterface[] $foundMedias */
             $foundMedias = $this->mediaRepository->findById($mediaIds);
         }
         $foundMediaIds = \array_map(
-            function($mediaEntity) {
-                return $mediaEntity->getId();
-            },
+            fn (MediaInterface $mediaEntity) => $mediaEntity->getId(),
             $foundMedias
         );
-
         if ($missingMediaIds = \array_diff($mediaIds, $foundMediaIds)) {
             throw new EntityNotFoundException($this->mediaRepository->getClassName(), \reset($missingMediaIds));
         }

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -693,8 +693,10 @@ class AccountController extends AbstractRestController implements ClassResourceI
             $accountManager->setLogo($account, $request->get('logo')['id']);
             $accountModified = true;
         }
-        if (null !== $request->get('medias')) {
-            $accountManager->setMedias($account, $request->get('medias'));
+        /** @var array<int>|null $medias */
+        $medias = $request->get('medias');
+        if (null !== $medias) {
+            $accountManager->setMedias($account, $medias);
         }
 
         $mainContact = null;

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -86,6 +86,7 @@ class AccountControllerTest extends SuluTestCase
         $this->em->clear();
 
         // Get ids of new accounts.
+        /** @var array<string> $ids */
         $ids = \array_map(
             function($account) {
                 return $account->getId();
@@ -118,6 +119,7 @@ class AccountControllerTest extends SuluTestCase
         $this->em->clear();
 
         // Get ids of new accounts.
+        /** @var array<string> $ids */
         $ids = \array_map(
             function($account) {
                 return $account->getId();

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlControllerTest.php
@@ -750,7 +750,7 @@ class CustomUrlControllerTest extends SuluTestCase
         foreach ($items as $url => $data) {
             $uuids[] = $this->testPost($data, $url);
         }
-
+        /** @var array<string> $uuids */
         $this->client->jsonRequest('DELETE', '/api/webspaces/sulu_io/custom-urls?ids=' . \implode(',', $uuids));
 
         $response = $this->client->getResponse();

--- a/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlRouteControllerTest.php
+++ b/src/Sulu/Bundle/CustomUrlBundle/Tests/Functional/Controller/CustomUrlRouteControllerTest.php
@@ -145,7 +145,7 @@ class CustomUrlRouteControllerTest extends SuluTestCase
                 $uuids[] = $customUrlRoute[0]['id'];
             }
         }
-
+        /** @var array<string> $uuids */
         $this->client->jsonRequest(
             'DELETE',
             '/api/webspaces/sulu_io/custom-urls/' . $uuid . '/routes?ids=' . \implode(',', $uuids)

--- a/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Bridge/DocumentInspector.php
@@ -210,7 +210,7 @@ class DocumentInspector extends BaseDocumentInspector
      *
      * @param ShadowLocaleBehavior $document
      *
-     * @return array
+     * @return array<string>
      */
     public function getConcreteLocales($document)
     {

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/FixturesLoadCommand.php
@@ -155,6 +155,7 @@ EOT
             }
 
             // add to fixtures when one of the provided groups match
+            /** @var string[] $fixtureGroups */
             if (\count(\array_intersect($groups, $fixtureGroups))) {
                 $fixtures[] = $fixture;
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Session/Session.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Session/Session.php
@@ -167,7 +167,7 @@ class Session implements SessionInterface
         $xpath->registerNamespace('sv', 'http://www.jcp.org/jcr/sv/1.0');
 
         foreach ($xpath->query('//sv:property[@sv:name="sulu:versions" or @sv:name="jcr:versionHistory" or @sv:name="jcr:baseVersion" or @sv:name="jcr:predecessors" or @sv:name="jcr:isCheckedOut"]') as $element) {
-            if ($element->parentNode) {
+            if ($element instanceof \DOMNode && $element->parentNode) {
                 $element->parentNode->removeChild($element);
             }
         }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Slugifier/Urlizer.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Slugifier/Urlizer.php
@@ -415,6 +415,7 @@ class Urlizer
             }
         }
 
+        /** @var array<string> $chars */
         return \implode('', $chars);
     }
 

--- a/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
+++ b/src/Sulu/Bundle/LocationBundle/Geolocator/Service/GoogleGeolocator.php
@@ -119,6 +119,7 @@ class GoogleGeolocator implements GeolocatorInterface
                     foreach ($map[$field] as $fieldValue) {
                         $parts[] = $fieldValue[$property['field']];
                     }
+                    /** @var array<string> $parts */
                     $location->{$property['method']}(\implode(', ', $parts));
                 }
             }

--- a/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tag/TagRegistry.php
@@ -17,7 +17,7 @@ namespace Sulu\Bundle\MarkupBundle\Tag;
 class TagRegistry implements TagRegistryInterface
 {
     /**
-     * @param TagInterface[] $tags
+     * @param array<string, array<string, array<string, TagInterface>>> $tags
      */
     public function __construct(private array $tags)
     {

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Tag/TagRegistryTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Tag/TagRegistryTest.php
@@ -33,7 +33,7 @@ class TagRegistryTest extends TestCase
     {
         $this->expectException(TagNotFoundException::class);
 
-        $registry = new TagRegistry(['test' => $this->prophesize(TagInterface::class)->reveal()]);
+        $registry = new TagRegistry(['test' => ['sulu' => ['namespace' => $this->prophesize(TagInterface::class)->reveal()]]]);
         $registry->getTag('test-2', 'html');
     }
 

--- a/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/CollectionRepository.php
@@ -208,6 +208,7 @@ class CollectionRepository extends NestedTreeRepository implements CollectionRep
             } elseif (null !== $depth) {
                 // the combination of depth and parent needs a bigger refactoring of this query.
                 $qb->andWhere('collection.depth <= :depth');
+                /** @var int|string $depth */
                 $qb->setParameter('depth', \intval($depth));
             }
             if (null !== $search) {

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -264,6 +264,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
         );
         /** @var int|string $result */
         $result = $query->getSingleResult()[1];
+
         /** @var int<0, max> */
         return \intval($result);
     }

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -262,8 +262,8 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             null,
             'COUNT(media)'
         );
+        /** @var int|string $result */
         $result = $query->getSingleResult()[1];
-
         /** @var int<0, max> */
         return \intval($result);
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/CropTransformation.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/ImageConverter/Transformation/CropTransformation.php
@@ -22,6 +22,9 @@ use Imagine\Image\Point;
  */
 class CropTransformation implements TransformationInterface
 {
+    /**
+     * @param array{x?: int|string, y?: int|string, w?: int|string, h?: int|string, retina?: string} $parameters
+     */
     public function execute(ImageInterface $image, $parameters)
     {
         @trigger_deprecation(

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -595,7 +595,9 @@ class MediaControllerTest extends SuluTestCase
         $media2 = $this->createMedia('photo2');
         $this->createMedia('photo3');
 
-        $excludedIds = \implode(',', [$media->getId(), $media2->getId()]);
+        /** @var array<string> $excludedIdsList */
+        $excludedIdsList = [$media->getId(), $media2->getId()];
+        $excludedIds = \implode(',', $excludedIdsList);
 
         $this->client->jsonRequest(
             'GET',

--- a/src/Sulu/Bundle/PageBundle/Controller/VersionController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/VersionController.php
@@ -61,8 +61,9 @@ class VersionController extends AbstractRestController implements
         $locale = $this->getRequestParameter($request, 'locale', true);
 
         $document = $this->documentManager->find($id, $request->query->get('locale'));
+        /** @var Version[] $versions */
         $versions = \array_reverse(\array_filter($document->getVersions(), function($version) use ($locale) {
-            /* @var Version $version */
+            /** @var Version $version */
             return $version->getLocale() === $locale;
         }));
         $total = \count($versions);
@@ -71,11 +72,10 @@ class VersionController extends AbstractRestController implements
 
         $versions = \array_slice($versions, $this->listRestHelper->getOffset(), $limit);
 
-        /** @var int[] $mappedUserIds */
-        $mappedUserIds = \array_map(function($version) {
-            /* @var Version $version */
-            return $version->getAuthor();
-        }, $versions);
+        $mappedUserIds = \array_map(
+            fn (Version $version) => $version->getAuthor(),
+            $versions
+        );
         $userIds = \array_unique($mappedUserIds);
 
         $users = $this->userRepository->findUsersById($userIds);

--- a/src/Sulu/Bundle/PageBundle/Controller/VersionController.php
+++ b/src/Sulu/Bundle/PageBundle/Controller/VersionController.php
@@ -71,10 +71,12 @@ class VersionController extends AbstractRestController implements
 
         $versions = \array_slice($versions, $this->listRestHelper->getOffset(), $limit);
 
-        $userIds = \array_unique(\array_map(function($version) {
+        /** @var int[] $mappedUserIds */
+        $mappedUserIds = \array_map(function($version) {
             /* @var Version $version */
             return $version->getAuthor();
-        }, $versions));
+        }, $versions);
+        $userIds = \array_unique($mappedUserIds);
 
         $users = $this->userRepository->findUsersById($userIds);
         $fullNamesByIds = [];

--- a/src/Sulu/Bundle/PageBundle/EventListener/PageRemoveSubscriber.php
+++ b/src/Sulu/Bundle/PageBundle/EventListener/PageRemoveSubscriber.php
@@ -119,7 +119,9 @@ class PageRemoveSubscriber implements EventSubscriberInterface
 
         $anonymousRole = $this->systemStore->getAnonymousRole();
 
+        /** @var string[] $descendantPageIds */
         $descendantPageIds = \array_column($descendantPages, 'id');
+        /** @var string[] $descendantAuthorizedPageIds */
         $descendantAuthorizedPageIds = $this->accessControlRepository->findIdsWithGrantedPermissions(
             $this->getCurrentUser(),
             $this->permissions[PermissionTypes::DELETE],

--- a/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
+++ b/src/Sulu/Bundle/PageBundle/Repository/NodeRepository.php
@@ -235,6 +235,9 @@ class NodeRepository implements NodeRepositoryInterface
         return $result;
     }
 
+    /**
+     * @param array<string> $ids
+     */
     public function getNodesByIds(
         $ids,
         $webspaceKey,

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Controller/PageControllerTest.php
@@ -2596,7 +2596,12 @@ class PageControllerTest extends SuluTestCase
         return $role;
     }
 
-    private function setUpContent($data)
+    /**
+     * @param array<int, array<string, mixed>> $data
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function setUpContent(array $data): array
     {
         /** @var BasePageDocument $homeDocument */
         $homeDocument = $this->documentManager->find('/cmf/sulu_io/contents');
@@ -2610,7 +2615,9 @@ class PageControllerTest extends SuluTestCase
                 $pageData
             );
 
-            $data[$i] = (array) \json_decode($this->client->getResponse()->getContent(), true);
+            /** @var array<string, mixed> $decoded */
+            $decoded = \json_decode($this->client->getResponse()->getContent(), true);
+            $data[$i] = $decoded;
         }
 
         return $data;

--- a/src/Sulu/Bundle/ReferenceBundle/UserInterface/Controller/Admin/ReferenceController.php
+++ b/src/Sulu/Bundle/ReferenceBundle/UserInterface/Controller/Admin/ReferenceController.php
@@ -143,6 +143,7 @@ class ReferenceController extends AbstractRestController implements ClassResourc
     {
         $count = 0;
         foreach ($rows as $row) {
+            /** @var array<string, string> $row */
             // without a unique identifier the frontend currently has a problem with the list component
             $row['id'] = \implode('__', [$row['referenceResourceKey'], $row['referenceResourceId'], $row['referenceLocale']]);
 

--- a/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
+++ b/src/Sulu/Bundle/RouteBundle/Controller/RouteController.php
@@ -168,7 +168,7 @@ class RouteController extends AbstractRestController implements ClassResourceInt
         $entityClass = $this->getRequestParameter($request, 'entityClass') ?? $mapping['entityClass'] ?? null;
         $routeSchema = $this->getRequestParameter($request, 'routeSchema') ?? $mapping['options']['route_schema'] ?? null;
 
-        /** @var array $parts */
+        /** @var array<string, string> $parts */
         $parts = $this->getRequestParameter($request, 'parts', true);
         $route = '/' . \implode('-', $parts);
 

--- a/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
+++ b/src/Sulu/Bundle/RouteBundle/Generator/SymfonyExpressionTokenProvider.php
@@ -44,6 +44,7 @@ class SymfonyExpressionTokenProvider implements TokenProviderInterface
                 }
             }
 
+            /** @var array<string> $args */
             return \sprintf('\%s(%s)', 'implode', \implode(', ', $args));
         }, function($arguments, ...$args): string {
             foreach ($args as $i => $arg) {

--- a/src/Sulu/Bundle/SecurityBundle/Entity/AccessControlRepository.php
+++ b/src/Sulu/Bundle/SecurityBundle/Entity/AccessControlRepository.php
@@ -90,6 +90,7 @@ class AccessControlRepository extends EntityRepository implements AccessControlR
             ->setParameter('entityIds', $entityIds, Connection::PARAM_STR_ARRAY)
         ;
 
+        /** @var string[] $idsWithPermissions */
         $idsWithPermissions = \array_column($queryBuilder->getQuery()->getArrayResult(), 'id');
         $idsWithoutPermissions = \array_diff($entityIds, $idsWithPermissions);
 

--- a/src/Sulu/Bundle/TagBundle/Search/TagsConverter.php
+++ b/src/Sulu/Bundle/TagBundle/Search/TagsConverter.php
@@ -50,17 +50,16 @@ class TagsConverter implements ConverterInterface
         }
 
         if (\is_array($value)) {
+            /** @var int[] $ids */
             $ids = $this->tagManager->resolveTagNames($value);
             $resultValue = $ids;
             $tags = \array_combine($ids, $value);
 
-            if (false !== $tags) {
-                $index = 0;
-                foreach ($tags as $id => $tagName) {
-                    $fields[] = new Field($index . '#id', $id);
-                    $fields[] = new Field($index . '#name', $tagName);
-                    ++$index;
-                }
+            $index = 0;
+            foreach ($tags as $id => $tagName) {
+                $fields[] = new Field($index . '#id', $id);
+                $fields[] = new Field($index . '#name', $tagName);
+                ++$index;
             }
         }
 

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -354,12 +354,12 @@ class TagControllerTest extends SuluTestCase
         $this->client->getContainer()->get('event_dispatcher')
                 ->addListener('sulu.tag.merge', fn () => $eventListenerWasCalled = true);
 
+        /** @var array<string> $tagIds */
+        $tagIds = [$tag2Id, $tag3Id, $tag4Id];
         $this->client->jsonRequest(
             'POST',
             '/api/tags/merge',
-            ['src' => \implode(',', [
-                $tag2Id, $tag3Id, $tag4Id,
-            ]), 'dest' => $tag1Id]
+            ['src' => \implode(',', $tagIds), 'dest' => $tag1Id]
         );
         $this->assertHttpStatusCode(303, $this->client->getResponse());
         $this->assertEquals('/api/tags/' . $tag1->getId(), $this->client->getResponse()->headers->get('location'));

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -113,7 +113,6 @@ class SuluTestKernel extends SuluKernel
             $bundles[] = new \Symfony\Bundle\SecurityBundle\SecurityBundle();
         }
 
-        /** @var iterable<mixed, BundleInterface> */
         return $bundles;
     }
 

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -15,7 +15,6 @@ use Sulu\Bundle\TestBundle\SuluTestBundle;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
  * Represents a kernel for sulu-application tests.

--- a/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DataCollector/SuluCollector.php
@@ -59,9 +59,12 @@ class SuluCollector extends DataCollector
 
         if ($portal) {
             $this->data['portal'] = $portal->toArray();
+            $portalEnvironments = $this->data['portal']['environments'] ?? [];
+            /** @var string[] $portalEnvironmentTypes */
+            $portalEnvironmentTypes = \array_column($portalEnvironments, 'type');
             $this->data['portal']['environments'] = \array_combine(
-                \array_column($this->data['portal']['environments'] ?? [], 'type'),
-                $this->data['portal']['environments'] ?? [],
+                $portalEnvironmentTypes,
+                $portalEnvironments,
             );
             $this->flattenLocalization($this->data['portal']['localizations']);
             $this->data['environment'] = $portal->getEnvironment($this->kernelEnvironment);

--- a/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
+++ b/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
@@ -50,6 +50,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
 
         // extend comma separated list
         $categories = $request->get($categoriesParameter, '');
+        /** @var array<string> $categoriesArray */
         $categoriesArray = \array_filter(\array_merge(\explode(',', $categories), [$id]));
         $categories = \implode(',', \array_unique($categoriesArray));
 
@@ -74,6 +75,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
 
         // extend comma separated list
         $categories = $request->get($categoriesParameter, '');
+        /** @var array<string> $categoriesArray */
         $categoriesArray = \array_filter(\explode(',', $categories), function($categoryId) use ($id) {
             return $categoryId && $categoryId != $id;
         });
@@ -110,6 +112,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
             $categoriesArray = \array_merge($categoriesArray, [$id]);
         }
 
+        /** @var array<string> $categoriesArray */
         $categoriesArray = \array_filter($categoriesArray);
         $categories = \implode(',', \array_unique($categoriesArray));
 

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
@@ -219,10 +219,10 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
             ));
         }
 
+        /** @var array<string> $locales */
         $locales = $this->inspector->getConcreteLocales($document);
         if (!\in_array($document->getShadowLocale(), $locales)) {
             $this->inspector->getNode($document)->revert();
-
             throw new \RuntimeException(\sprintf(
                 'Attempting to create shadow for "%s" on a non-concrete locale "%s" for document at "%s". Concrete languages are "%s"',
                 $document->getLocale(),

--- a/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
+++ b/src/Sulu/Component/Content/Document/Subscriber/ShadowLocaleSubscriber.php
@@ -219,7 +219,6 @@ class ShadowLocaleSubscriber implements EventSubscriberInterface
             ));
         }
 
-        /** @var array<string> $locales */
         $locales = $this->inspector->getConcreteLocales($document);
         if (!\in_array($document->getShadowLocale(), $locales)) {
             $this->inspector->getNode($document)->revert();

--- a/src/Sulu/Component/Content/Exception/InvalidNavigationContextExtension.php
+++ b/src/Sulu/Component/Content/Exception/InvalidNavigationContextExtension.php
@@ -29,6 +29,8 @@ class InvalidNavigationContextExtension extends \Exception
      */
     public function __construct($selectedNavContext, $navContexts)
     {
+        /** @var array<string> $selectedNavContext */
+        /** @var array<string> $navContexts */
         parent::__construct(
             \sprintf(
                 'Navigation Context "%s" not found in [%s]',

--- a/src/Sulu/Component/Content/Import/WebspaceImport.php
+++ b/src/Sulu/Component/Content/Import/WebspaceImport.php
@@ -493,7 +493,7 @@ class WebspaceImport extends Import implements WebspaceImportInterface
                 $property->getContentTypeName()
             );
         }
-
+        /** @var array<string> $rlpParts */
         $title = \trim(\implode(' ', $rlpParts));
 
         return $this->rlpStrategy->generate($title, $parentUuid, $webspaceKey, $locale);

--- a/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
+++ b/src/Sulu/Component/Content/Metadata/Parser/PropertiesXmlParser.php
@@ -417,8 +417,12 @@ class PropertiesXmlParser
         $property->setSpaceAfter($data['spaceAfter']);
         $property->setCssClass($data['cssClass']);
         $property->setTags($data['tags']);
-        $property->setMinOccurs(null !== $data['minOccurs'] ? \intval($data['minOccurs']) : null);
-        $property->setMaxOccurs(null !== $data['maxOccurs'] ? \intval($data['maxOccurs']) : null);
+        /** @var int|string $minOccurs */
+        $minOccurs = $data['minOccurs'];
+        /** @var int|string $maxOccurs */
+        $maxOccurs = $data['maxOccurs'];
+        $property->setMinOccurs(null !== $data['minOccurs'] ? \intval($minOccurs) : null);
+        $property->setMaxOccurs(null !== $data['maxOccurs'] ? \intval($maxOccurs) : null);
         $property->setDisabledCondition($this->normalizeConditionData($data['disabledCondition'] ?? null));
         $property->setVisibleCondition($this->normalizeConditionData($data['visibleCondition'] ?? null));
         $property->setParameters($data['params']);

--- a/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
+++ b/src/Sulu/Component/Content/Query/ContentQueryBuilder.php
@@ -147,17 +147,22 @@ abstract class ContentQueryBuilder implements ContentQueryBuilderInterface
             return 'page.[jcr:mixinTypes] = "' . $mixinType . '"';
         }, static::$mixinTypes));
 
+        /** @var array<string> $select */
+        $selectString = \implode(', ', $select);
+        /** @var array<string> $order */
+        $orderString = \implode(', ', $order);
+
         $sql2 = \sprintf(
             'SELECT %s
              FROM [nt:unstructured] AS page
              WHERE (%s)
                 AND (%s)
                 %s %s',
-            \implode(', ', $select),
+            $selectString,
             $mixinTypeWhere,
             $where,
             \count($order) > 0 ? 'ORDER BY' : '',
-            \implode(', ', $order)
+            $orderString
         );
 
         return [$sql2, $additionalFields];

--- a/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+++ b/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
@@ -157,6 +157,7 @@ class QueryBuilder extends ContentQueryBuilder
             $sql2Where = \array_merge($sql2Where, $this->buildPageExclude());
         }
 
+        /** @var array<string> $sql2Where */
         $sql2Where = \array_filter($sql2Where);
 
         return \implode(' AND ', $sql2Where);

--- a/src/Sulu/Component/DocumentManager/PathBuilder.php
+++ b/src/Sulu/Component/DocumentManager/PathBuilder.php
@@ -53,6 +53,7 @@ class PathBuilder
 
             $results[] = $result;
         }
+
         /** @var array<string> $results */
         return '/' . \implode('/', $results);
     }

--- a/src/Sulu/Component/DocumentManager/PathBuilder.php
+++ b/src/Sulu/Component/DocumentManager/PathBuilder.php
@@ -53,7 +53,7 @@ class PathBuilder
 
             $results[] = $result;
         }
-
+        /** @var array<string> $results */
         return '/' . \implode('/', $results);
     }
 

--- a/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/FindSubscriber.php
+++ b/src/Sulu/Component/DocumentManager/Subscriber/Phpcr/FindSubscriber.php
@@ -76,9 +76,11 @@ class FindSubscriber implements EventSubscriberInterface
         if ($this->metadataFactory->hasAlias($aliasOrClass)) {
             $class = $this->metadataFactory->getMetadataForAlias($aliasOrClass)->getClass();
         } elseif (!\class_exists($aliasOrClass)) {
+            /** @var array<string> $aliases */
+            $aliases = $this->metadataFactory->getAliases();
             throw new DocumentManagerException(\sprintf(
                 'Unknown class specified and no alias exists for "%s", known aliases: "%s"',
-                $aliasOrClass, \implode('", "', $this->metadataFactory->getAliases())
+                $aliasOrClass, \implode('", "', $aliases)
             ));
         } else {
             $class = $aliasOrClass;

--- a/src/Sulu/Component/Media/SystemCollections/UnrecognizedSystemCollection.php
+++ b/src/Sulu/Component/Media/SystemCollections/UnrecognizedSystemCollection.php
@@ -17,27 +17,20 @@ namespace Sulu\Component\Media\SystemCollections;
 class UnrecognizedSystemCollection extends \Exception
 {
     /**
-     * @var string
+     * @param string $key
+     * @param string[] $recognizedSystemCollections
      */
-    private $key;
-
-    /**
-     * @var string[]
-     */
-    private $recognizedSystemCollections;
-
-    public function __construct($key, array $recognizedSystemCollections)
-    {
+    public function __construct(
+        private $key,
+        private array $recognizedSystemCollections
+    ) {
         parent::__construct(
             \sprintf(
                 'Unrecognized system collection "%s" available collections: [%s]',
-                $key,
-                \implode(', ', $recognizedSystemCollections)
+                $this->key,
+                \implode(', ', $this->recognizedSystemCollections)
             )
         );
-
-        $this->key = $key;
-        $this->recognizedSystemCollections = $recognizedSystemCollections;
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -683,6 +683,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         }
 
         // unify result
+        /** @var string[] $fieldEntityNames */
         return \array_unique($fieldEntityNames);
     }
 
@@ -860,7 +861,7 @@ class DoctrineListBuilder extends AbstractListBuilder
      *
      * @param AbstractDoctrineExpression[] $expressions
      *
-     * @return array
+     * @return array<string>
      */
     protected function getAllFieldNames($expressions)
     {

--- a/src/Sulu/Component/Rest/ListBuilder/Expression/ConjunctionExpressionInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Expression/ConjunctionExpressionInterface.php
@@ -26,7 +26,7 @@ interface ConjunctionExpressionInterface extends ExpressionInterface
     /**
      * Returns an array of the used field names of the current expression and all subexpressions.
      *
-     * @return array
+     * @return array<string>
      */
     public function getFieldNames();
 }

--- a/src/Sulu/Component/Rest/Listing/ListQueryBuilder.php
+++ b/src/Sulu/Component/Rest/Listing/ListQueryBuilder.php
@@ -351,7 +351,9 @@ class ListQueryBuilder
             // Get all fields which will appear in the where clause
             // The search fields already have the right format, and we have to use only the keys of where, because its
             // values contain the filter expression
-            $fields = \array_unique(\array_merge($whereKeys, $this->searchFields));
+            /** @var string[] $mergedFields */
+            $mergedFields = \array_merge($whereKeys, $this->searchFields);
+            $fields = \array_unique($mergedFields);
 
             foreach ($fields as $key) {
                 $keys = \explode('_', $key);

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -100,6 +100,7 @@ class ListRepository extends EntityRepository
         if ($justCount) {
             /** @var int|string $totalCount */
             $totalCount = $query->getSingleResult()['totalcount'];
+
             return \intval($totalCount);
         }
 

--- a/src/Sulu/Component/Rest/Listing/ListRepository.php
+++ b/src/Sulu/Component/Rest/Listing/ListRepository.php
@@ -98,7 +98,9 @@ class ListRepository extends EntityRepository
 
         // if just used for counting
         if ($justCount) {
-            return \intval($query->getSingleResult()['totalcount']);
+            /** @var int|string $totalCount */
+            $totalCount = $query->getSingleResult()['totalcount'];
+            return \intval($totalCount);
         }
 
         $results = $query->getArrayResult();

--- a/src/Sulu/Component/SmartContent/ContentType.php
+++ b/src/Sulu/Component/SmartContent/ContentType.php
@@ -221,6 +221,7 @@ class ContentType extends ComplexContentType implements ContentTypeExportInterfa
 
         // prepare pagination, limitation and options
         $page = 1;
+        /** @var int|string|null $limit */
         $limit = (\array_key_exists('limitResult', $filters) && $configuration->hasLimit()) ?
             $filters['limitResult'] : null;
         $options = [

--- a/src/Sulu/Component/Tag/Request/TagRequestHandler.php
+++ b/src/Sulu/Component/Tag/Request/TagRequestHandler.php
@@ -48,6 +48,7 @@ class TagRequestHandler implements TagRequestHandlerInterface
 
         // extend comma separated list
         $tags = $request->get($tagsParameter, '');
+        /** @var array<string> $tagsArray */
         $tagsArray = \array_filter(\array_merge(\explode(',', $tags), [$tag['name']]));
         $tags = \implode(',', \array_unique($tagsArray));
 


### PR DESCRIPTION
 | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #8684
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Fixed PHPStan errors introduced by a stricter PHPStan update for built-in PHP function signatures (`implode`, `array_unique`, `array_diff`, `array_intersect`, `array_combine`, `intval`)
  - Added proper `@param`/`@return` type annotations to fix types at the source (e.g., `TagRegistry`, `CropTransformation`, `AccountManager`, `DoctrineListBuilder`, `ConjunctionExpressionInterface`)
  - Used `Webmozart\Assert` for runtime validation where appropriate (`ExposeResourceRoutesPass`)
  - Refactored `UnrecognizedSystemCollection` to use constructor promotion with typed `@param`
  - Added `instanceof \DOMNode` guard in `Session.php` for `DOMNameSpaceNode|DOMNode` union type
  - Added one entry to the PHPStan baseline for `SuluTestKernel::registerBundles()` return type (PHPStan limitation)

  #### Why?

  A PHPStan update tightened type signatures for built-in PHP functions like `implode()`, `array_unique()`, `array_diff()`, and `intval()`. This caused ~45 new errors across the codebase.

  #### To Do

  - [ ] Create a documentation PR
  - [ ] Add breaking changes to UPGRADE.md