### PR TITLE
Fix partial JSON field merges in form stores

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -7,6 +7,28 @@ import type {Schema, SchemaEntry} from '../types';
 
 export const SECTION_TYPE = 'section';
 
+function deepMerge(base: Object, override: Object): Object {
+    const result = {...base};
+    for (const key of Object.keys(override)) {
+        const overrideVal = override[key];
+        const baseVal = result[key];
+
+        if (
+            overrideVal !== null
+            && typeof overrideVal === 'object'
+            && !Array.isArray(overrideVal)
+            && baseVal !== null
+            && typeof baseVal === 'object'
+            && !Array.isArray(baseVal)
+        ) {
+            result[key] = deepMerge(baseVal, overrideVal);
+        } else {
+            result[key] = overrideVal;
+        }
+    }
+    return result;
+}
+
 function addSchemaProperties(data: Object, key: string, schema: Schema) {
     const type = schema[key].type;
 
@@ -208,7 +230,7 @@ export default class AbstractFormStore
     @action addMissingSchemaProperties() {
         const schemaFields = Object.keys(this.schema)
             .reduce((data, key) => addSchemaProperties(data, key, this.schema), {});
-        set(this.data, {...schemaFields, ...this.data});
+        set(this.data, deepMerge(schemaFields, this.data));
     }
 
     destroy() {}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
@@ -64,6 +64,110 @@ test('Create data object for schema while keeping existing data', () => {
     });
 });
 
+test('Create data object for schema with partial nested data', () => {
+    const schema = {
+        'seo/title': {label: 'SEO Title', type: 'text_line'},
+        'seo/description': {label: 'SEO Description', type: 'text_line'},
+        'seo/keywords': {label: 'SEO Keywords', type: 'text_line'},
+    };
+
+    const memoryFormStore = new MemoryFormStore({seo: {title: 'Existing Title'}}, schema);
+
+    expect(memoryFormStore.data).toEqual({
+        seo: {
+            title: 'Existing Title',
+            description: undefined,
+            keywords: undefined,
+        },
+    });
+});
+
+test('Create data object for schema with empty nested object', () => {
+    const schema = {
+        'excerpt/title': {label: 'Title', type: 'text_line'},
+        'excerpt/description': {label: 'Description', type: 'text_line'},
+    };
+
+    const memoryFormStore = new MemoryFormStore({excerpt: {}}, schema);
+
+    expect(memoryFormStore.data).toEqual({
+        excerpt: {
+            title: undefined,
+            description: undefined,
+        },
+    });
+});
+
+test('Create data object for schema preserving array values from data', () => {
+    const schema = {
+        'settings/tags': {label: 'Tags', type: 'tag_selection'},
+        'settings/name': {label: 'Name', type: 'text_line'},
+    };
+
+    const memoryFormStore = new MemoryFormStore({settings: {tags: ['tag1', 'tag2']}}, schema);
+
+    expect(memoryFormStore.data).toEqual({
+        settings: {
+            tags: ['tag1', 'tag2'],
+            name: undefined,
+        },
+    });
+});
+
+test('Create data object for schema with fully populated nested data', () => {
+    const schema = {
+        'seo/title': {label: 'SEO Title', type: 'text_line'},
+        'seo/description': {label: 'SEO Description', type: 'text_line'},
+    };
+
+    const memoryFormStore = new MemoryFormStore(
+        {seo: {title: 'Title', description: 'Desc'}},
+        schema
+    );
+
+    expect(memoryFormStore.data).toEqual({
+        seo: {
+            title: 'Title',
+            description: 'Desc',
+        },
+    });
+});
+
+test('Create data object for schema with null nested value', () => {
+    const schema = {
+        'seo/title': {label: 'SEO Title', type: 'text_line'},
+    };
+
+    const memoryFormStore = new MemoryFormStore({seo: null}, schema);
+
+    expect(memoryFormStore.data).toEqual({
+        seo: null,
+    });
+});
+
+test('Create data object for schema with deeply nested partial data', () => {
+    const schema = {
+        'ext/seo/og/title': {label: 'OG Title', type: 'text_line'},
+        'ext/seo/og/description': {label: 'OG Description', type: 'text_line'},
+    };
+
+    const memoryFormStore = new MemoryFormStore(
+        {ext: {seo: {og: {title: 'OG Title'}}}},
+        schema
+    );
+
+    expect(memoryFormStore.data).toEqual({
+        ext: {
+            seo: {
+                og: {
+                    title: 'OG Title',
+                    description: undefined,
+                },
+            },
+        },
+    });
+});
+
 test('Create data object for schema with sections', () => {
     const schema = {
         section1: {


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Replaced shallow spread merge with a `deepMerge` function in
  `AbstractFormStore.addMissingSchemaProperties()`
  - Schema-defined nested properties (e.g., `excerpt/title`,
  `seo/description`) are now correctly initialized even when the data
  contains a partial nested object
  - Added comprehensive tests covering partial, empty, fully populated,
  null, and deeply nested data scenarios

  #### Why?

  When `addMissingSchemaProperties()` merged schema defaults with existing
   data using a shallow spread (`{...schemaFields, ...this.data}`), any
  partial nested object in the data (e.g., `{excerpt: {title: 'value'}}`)
  would completely overwrite the schema-generated defaults for that key.
  This caused sibling properties like `excerpt/description` or
  `excerpt/keywords` to be lost, breaking MobX observability for those
  fields and preventing form components from rendering or reacting to
  changes on them.

  The `deepMerge` approach recursively merges nested plain objects while
  still allowing data values (including `null` and arrays) to take
  precedence over schema defaults.