### PR TITLE
Add content context checkbox to WritingAssistant

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, {Component} from 'react';
-import {action, computed, observable} from 'mobx';
+import {action, computed, observable, toJS} from 'mobx';
 import {observer} from 'mobx-react';
 import symfonyRouting from 'fos-jsrouting/router';
 import {translate} from '../../utils';
@@ -45,6 +45,7 @@ type Props = {|
 @observer
 export default class AiApplication extends Component<Props> {
     @observable selectedComponent: {
+        dataPath: string,
         formInspector: FormInspector,
         getValue: () => string,
         isInsideBlock: boolean,
@@ -96,6 +97,7 @@ export default class AiApplication extends Component<Props> {
         }
 
         const detail: {
+            dataPath: string,
             formInspector: FormInspector,
             getValue: () => string,
             schemaPath: string,
@@ -108,6 +110,7 @@ export default class AiApplication extends Component<Props> {
         }
 
         this.selectedComponent = {
+            dataPath: detail.dataPath,
             formInspector: detail.formInspector,
             getValue: detail.getValue,
             isInsideBlock: this.isInsideBlock(detail.formInspector, detail.schemaPath),
@@ -250,6 +253,30 @@ export default class AiApplication extends Component<Props> {
         });
     }
 
+    @computed get contentData(): ?Object {
+        if (!this.selectedComponent?.formInspector?.formStore) {
+            return undefined;
+        }
+
+        const {schema, data} = this.selectedComponent.formInspector.formStore;
+        const contentData = {};
+
+        const collectFields = (schemaLevel) => {
+            Object.keys(schemaLevel).forEach((key) => {
+                const entry = schemaLevel[key];
+                if (entry.type === 'section' && entry.items) {
+                    collectFields(entry.items);
+                } else if (data[key] !== undefined) {
+                    contentData[key] = toJS(data[key]);
+                }
+            });
+        };
+
+        collectFields(schema);
+
+        return Object.keys(contentData).length > 0 ? contentData : undefined;
+    }
+
     @computed get actionUrl() {
         if (!this.props.feedback) {
             return undefined;
@@ -306,10 +333,13 @@ export default class AiApplication extends Component<Props> {
                             url: this.actionUrl,
                         }}
                         configuration={this.props.writingAssistant}
+                        contentData={this.contentData}
+                        dataPath={this.selectedComponent.dataPath}
                         locale={locale}
                         messages={{
                             addMessage: translate('sulu_admin.writing_assistant_prompt_placeholder'),
                             copiedToClipboard: translate('sulu_admin.sucessfully_copied_to_clipboard'),
+                            includeContentContext: translate('sulu_admin.include_content_context'),
                             initialMessage: translate('sulu_admin.selected_text'),
                             predefinedPrompts: translate('sulu_admin.predefined_prompts'),
                             send: translate('sulu_admin.send'),
@@ -317,6 +347,8 @@ export default class AiApplication extends Component<Props> {
                         }}
                         onConfirm={this.handleWritingAssistantConfirm}
                         onDialogClose={this.handleWritingAssistantClose}
+                        resourceId={this.selectedComponent.formInspector.id}
+                        resourceKey={this.selectedComponent.formInspector.resourceKey}
                         type={schemaType}
                         url={this.writingAssistantUrl}
                         value={this.selectedText}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
@@ -356,6 +356,7 @@ export default class AiApplication extends Component<Props> {
                         type={schemaType}
                         url={this.writingAssistantUrl}
                         value={this.selectedText}
+                        webspaceKey={this.selectedComponent.formInspector.options?.webspace}
                     />
                 )}
                 {this.translateOpen && translationEnabled && (
@@ -374,11 +375,14 @@ export default class AiApplication extends Component<Props> {
                         }}
                         onConfirm={this.handleTranslateConfirm}
                         onDialogClose={this.handleTranslateClose}
+                        resourceId={this.selectedComponent.formInspector.id}
+                        resourceKey={this.selectedComponent.formInspector.resourceKey}
                         sourceLanguages={this.props.translation.sourceLanguages}
                         targetLanguages={this.props.translation.targetLanguages}
                         type={schemaType}
                         url={this.translationUrl}
                         value={this.selectedText}
+                        webspaceKey={this.selectedComponent.formInspector.options?.webspace}
                     />
                 )}
             </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
@@ -259,6 +259,10 @@ export default class AiApplication extends Component<Props> {
         }
 
         const {schema, data} = this.selectedComponent.formInspector.formStore;
+        if (!schema || !data) {
+            return undefined;
+        }
+
         const contentData = {};
 
         const collectFields = (schemaLevel) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
@@ -349,6 +349,146 @@ describe('AiApplication', () => {
         expect(instance.hasFocus).toBe(false);
     });
 
+    test('captures dataPath from sulu.focus event', () => {
+        render(<AiApplication {...props} />);
+
+        const mockElement = document.createElement('div');
+        Object.defineProperty(mockElement, 'parentElement', {
+            // $FlowFixMe
+            value: {
+                getBoundingClientRect: jest.fn().mockReturnValue({
+                    top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0,
+                }),
+            },
+        });
+
+        const event = new Event('sulu.focus');
+        Object.defineProperty(event, 'target', {value: mockElement});
+        // $FlowFixMe
+        Object.defineProperty(event, 'detail', {
+            value: {
+                dataPath: '/block/0/text',
+                formInspector: {locale: {get: () => 'en'}, getSchemaEntryByPath: jest.fn()},
+                getValue: jest.fn().mockReturnValue('some text'),
+                schemaPath: 'title',
+                schemaType: 'text_line',
+                setValue: jest.fn(),
+            },
+        });
+
+        fireEvent(document, event);
+
+        const instance = new AiApplication(props);
+        // $FlowFixMe
+        instance.selectedComponent = {
+            dataPath: '/block/0/text',
+            // $FlowFixMe
+            formInspector: {locale: {get: () => 'en'}},
+            getValue: jest.fn(),
+            schemaType: 'text_line',
+            setValue: jest.fn(),
+        };
+
+        expect(instance.selectedComponent.dataPath).toBe('/block/0/text');
+    });
+
+    test('contentData computed returns form data filtered by schema', () => {
+        const instance = new AiApplication(props);
+        // $FlowFixMe
+        instance.selectedComponent = {
+            // $FlowFixMe
+            formInspector: {
+                formStore: {
+                    schema: {
+                        title: {type: 'text_line'},
+                        description: {type: 'text_area'},
+                    },
+                    data: {
+                        title: 'My Page',
+                        description: 'A description',
+                        internalField: 'should not appear',
+                    },
+                },
+            },
+        };
+
+        const result = instance.contentData;
+
+        expect(result).toEqual({
+            title: 'My Page',
+            description: 'A description',
+        });
+    });
+
+    test('contentData computed handles nested sections', () => {
+        const instance = new AiApplication(props);
+        // $FlowFixMe
+        instance.selectedComponent = {
+            // $FlowFixMe
+            formInspector: {
+                formStore: {
+                    schema: {
+                        details: {
+                            type: 'section',
+                            items: {
+                                title: {type: 'text_line'},
+                                summary: {type: 'text_area'},
+                            },
+                        },
+                        metadata: {
+                            type: 'section',
+                            items: {
+                                author: {type: 'text_line'},
+                            },
+                        },
+                    },
+                    data: {
+                        title: 'Page Title',
+                        summary: 'Page Summary',
+                        author: 'John',
+                    },
+                },
+            },
+        };
+
+        const result = instance.contentData;
+
+        expect(result).toEqual({
+            title: 'Page Title',
+            summary: 'Page Summary',
+            author: 'John',
+        });
+    });
+
+    test('contentData computed returns undefined when no formStore', () => {
+        const instance = new AiApplication(props);
+        // $FlowFixMe
+        instance.selectedComponent = {
+            // $FlowFixMe
+            formInspector: {},
+        };
+
+        expect(instance.contentData).toBeUndefined();
+    });
+
+    test('contentData computed returns undefined when data is empty', () => {
+        const instance = new AiApplication(props);
+        // $FlowFixMe
+        instance.selectedComponent = {
+            // $FlowFixMe
+            formInspector: {
+                formStore: {
+                    schema: {
+                        title: {type: 'text_line'},
+                    },
+                    data: {},
+                },
+            },
+        };
+
+        expect(instance.contentData).toBeUndefined();
+    });
+
     test('handles translate confirm', () => {
         render(<AiApplication {...props} />);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
@@ -350,7 +350,7 @@ describe('AiApplication', () => {
     });
 
     test('captures dataPath from sulu.focus event', () => {
-        render(<AiApplication {...props} />);
+        const instance = new AiApplication(props);
 
         const mockElement = document.createElement('div');
         Object.defineProperty(mockElement, 'parentElement', {
@@ -376,18 +376,7 @@ describe('AiApplication', () => {
             },
         });
 
-        fireEvent(document, event);
-
-        const instance = new AiApplication(props);
-        // $FlowFixMe
-        instance.selectedComponent = {
-            dataPath: '/block/0/text',
-            // $FlowFixMe
-            formInspector: {locale: {get: () => 'en'}},
-            getValue: jest.fn(),
-            schemaType: 'text_line',
-            setValue: jest.fn(),
-        };
+        instance.handleSuluFocus(event);
 
         expect(instance.selectedComponent.dataPath).toBe('/block/0/text');
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Translator/Translator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Translator/Translator.js
@@ -21,6 +21,8 @@ type Props = {|
     |},
     onConfirm: (text: string) => void,
     onDialogClose: () => void,
+    resourceId?: ?(string | number),
+    resourceKey?: ?string,
     sourceLanguages: Array<{|
         label: string,
         locale: string,
@@ -32,6 +34,7 @@ type Props = {|
     type: 'text_line' | 'text_area' | 'text_editor',
     url: string,
     value?: string,
+    webspaceKey?: ?string,
 |};
 
 /**
@@ -87,6 +90,9 @@ export default class Translator extends React.Component<Props> {
         const {
             url,
             type,
+            resourceId,
+            resourceKey,
+            webspaceKey,
             messages: {
                 errorTranslatingText: errorTranslatingTextMessage,
             },
@@ -102,6 +108,9 @@ export default class Translator extends React.Component<Props> {
                 sourceLanguage: this.sourceLanguage,
                 targetLanguage: this.targetLanguage,
                 type,
+                resourceId,
+                resourceKey,
+                webspaceKey,
             }
         ).then(action((data: {
             response: {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Translator/tests/Translator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Translator/tests/Translator.test.js
@@ -60,6 +60,9 @@ describe('Translator', () => {
                 sourceLanguage: undefined,
                 targetLanguage: 'en',
                 type: 'text_line',
+                resourceId: undefined,
+                resourceKey: undefined,
+                webspaceKey: undefined,
             });
         });
 
@@ -79,6 +82,9 @@ describe('Translator', () => {
                 sourceLanguage: undefined,
                 targetLanguage: 'en',
                 type: 'text_editor',
+                resourceId: undefined,
+                resourceKey: undefined,
+                webspaceKey: undefined,
             });
         });
     });
@@ -104,6 +110,9 @@ describe('Translator', () => {
                 sourceLanguage: undefined,
                 targetLanguage: 'en',
                 type: 'text_line',
+                resourceId: undefined,
+                resourceKey: undefined,
+                webspaceKey: undefined,
             });
         });
 
@@ -137,6 +146,9 @@ describe('Translator', () => {
                 sourceLanguage: 'de',
                 targetLanguage: 'en',
                 type: 'text_line',
+                resourceId: undefined,
+                resourceKey: undefined,
+                webspaceKey: undefined,
             });
         });
     });
@@ -168,6 +180,9 @@ describe('Translator', () => {
                 sourceLanguage: undefined,
                 targetLanguage: 'fr',
                 type: 'text_line',
+                resourceId: undefined,
+                resourceKey: undefined,
+                webspaceKey: undefined,
             });
         });
 
@@ -211,6 +226,33 @@ describe('Translator', () => {
         await userEvent.click(closeButton);
 
         expect(mockProps.onDialogClose).toHaveBeenCalled();
+    });
+
+    test('sends webspaceKey, resourceId and resourceKey when provided', async() => {
+        Requester.post.mockResolvedValue({
+            response: {text: 'Hello', sourceLanguage: undefined, targetLanguage: 'en'},
+        });
+
+        render(
+            <Translator
+                {...mockProps}
+                resourceId="page-123"
+                resourceKey="pages"
+                webspaceKey="sulu_io"
+            />
+        );
+
+        await waitFor(() => {
+            expect(Requester.post).toHaveBeenCalledWith('/api/translate', {
+                text: 'Hallo',
+                sourceLanguage: undefined,
+                targetLanguage: 'en',
+                type: 'text_line',
+                resourceId: 'page-123',
+                resourceKey: 'pages',
+                webspaceKey: 'sulu_io',
+            });
+        });
     });
 
     test('calls action prop with correct parameters when translation occurs', async() => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/PromptInput.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/PromptInput.js
@@ -3,10 +3,11 @@
 import React, {Component} from 'react';
 import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
-import {Button, Input, SingleSelect, DropdownButton} from '../../components';
+import {Button, Checkbox, Input, SingleSelect, DropdownButton} from '../../components';
 import promptInputStyles from './prompt-input.scss';
 
 type Props = {|
+    canIncludeContentContext?: boolean,
     experts: {
         name: string,
         text: string,
@@ -18,12 +19,15 @@ type Props = {|
         selected: string,
         type: 'select',
     },
+    includeContentContext?: boolean,
+    includeContentContextLabel?: string,
     isLoading: boolean,
     messages: {
         addMessage: string,
         send: string,
     },
     onAddMessage: (text: string) => Promise<void>,
+    onIncludeContentContextChange?: (checked: boolean) => void,
     predefinedPrompts: ?{
         handleClick: (index: number) => void,
         label: string,
@@ -85,6 +89,31 @@ class PromptInput extends Component<Props> {
         );
     };
 
+    renderContentContextCheckbox = () => {
+        const {
+            canIncludeContentContext,
+            includeContentContext,
+            includeContentContextLabel,
+            onIncludeContentContextChange,
+        } = this.props;
+
+        if (!canIncludeContentContext) {
+            return null;
+        }
+
+        return (
+            <div className={promptInputStyles.contentContextCheckbox}>
+                <Checkbox
+                    checked={includeContentContext}
+                    onChange={onIncludeContentContextChange}
+                    size="small"
+                >
+                    {includeContentContextLabel}
+                </Checkbox>
+            </div>
+        );
+    };
+
     render() {
         const {
             experts,
@@ -116,6 +145,7 @@ class PromptInput extends Component<Props> {
                         </div>
                     )}
                     {this.renderPredefinedPrompts()}
+                    {this.renderContentContextCheckbox()}
                 </div>
                 <div className={promptInputStyles.input}>
                     {predefinedPrompts === undefined && (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/WritingAssistant.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/WritingAssistant.js
@@ -17,10 +17,13 @@ type Props = {|
             [string]: ExpertType,
         },
     },
+    contentData?: ?Object,
+    dataPath?: ?string,
     locale: string,
     messages: {
         addMessage: string,
         copiedToClipboard: string,
+        includeContentContext: string,
         initialMessage: string,
         predefinedPrompts: string,
         send: string,
@@ -28,6 +31,8 @@ type Props = {|
     },
     onConfirm: (text: string) => void,
     onDialogClose: () => void,
+    resourceId?: ?(string | number),
+    resourceKey?: ?string,
     type: 'text_line' | 'text_area' | 'text_editor',
     url: string,
     value?: string,
@@ -47,6 +52,8 @@ export default class WritingAssistant extends React.Component<Props> {
     @observable snackbarMessage = undefined;
     @observable lastResponse = undefined;
     @observable currentValue: string;
+    @observable includeContentContext: boolean =
+        sessionStorage.getItem('sulu_ai.include_content_context') === 'true';
 
     constructor(props: Props) {
         super(props);
@@ -101,15 +108,22 @@ export default class WritingAssistant extends React.Component<Props> {
             commandTitle: title ?? prompt,
             expert: this.props.configuration.experts[this.selectedExpert].name,
         };
-        return Requester.post(
-            url,
-            {
-                text: this.currentValue,
-                message: prompt,
-                expertUuid: this.selectedExpert,
-                locale,
-            }
-        ).then(action((data) => {
+
+        const body: Object = {
+            text: this.currentValue,
+            message: prompt,
+            expertUuid: this.selectedExpert,
+            locale,
+            resourceId: String(this.props.resourceId || ''),
+            resourceKey: this.props.resourceKey || '',
+        };
+
+        if (this.includeContentContext && this.props.contentData) {
+            body.data = toJS(this.props.contentData);
+            body.dataPath = this.props.dataPath;
+        }
+
+        return Requester.post(url, body).then(action((data) => {
             this.loader = undefined;
             this.lastResponse = data;
             return data.response;
@@ -136,6 +150,15 @@ export default class WritingAssistant extends React.Component<Props> {
     @action handleExpertSelect = (expert: string) => {
         this.selectedExpert = expert;
     };
+
+    @action handleIncludeContentContextChange = (checked: boolean) => {
+        this.includeContentContext = checked;
+        sessionStorage.setItem('sulu_ai.include_content_context', String(checked));
+    };
+
+    @computed get canIncludeContentContext(): boolean {
+        return !!this.props.contentData;
+    }
 
     @action handleOnRetry = (prompt: string, title: string) => {
         void this.handleAddMessage(prompt, title);
@@ -231,6 +254,7 @@ export default class WritingAssistant extends React.Component<Props> {
             messages: {
                 writingAssistant: writingAssistantMessage,
                 addMessage: addMessageMessage,
+                includeContentContext: includeContentContextMessage,
                 send: sendMessage,
             },
         } = this.props;
@@ -268,13 +292,17 @@ export default class WritingAssistant extends React.Component<Props> {
                             onRetry={this.handleOnRetry}
                         />
                         <PromptInput
+                            canIncludeContentContext={this.canIncludeContentContext}
                             experts={this.expertsButton}
+                            includeContentContext={this.includeContentContext}
+                            includeContentContextLabel={includeContentContextMessage}
                             isLoading={!!this.loader}
                             messages={{
                                 addMessage: addMessageMessage,
                                 send: sendMessage,
                             }}
                             onAddMessage={this.handleAddMessage}
+                            onIncludeContentContextChange={this.handleIncludeContentContextChange}
                             predefinedPrompts={this.predefinedPrompts}
                         />
                     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/WritingAssistant.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/WritingAssistant.js
@@ -52,13 +52,14 @@ export default class WritingAssistant extends React.Component<Props> {
     @observable snackbarMessage = undefined;
     @observable lastResponse = undefined;
     @observable currentValue: string;
-    @observable includeContentContext: boolean =
-        sessionStorage.getItem('sulu_ai.include_content_context') === 'true';
+    @observable includeContentContext: boolean = false;
 
     constructor(props: Props) {
         super(props);
 
         this.selectedExpert = this.experts[0].uuid;
+        this.includeContentContext =
+            sessionStorage.getItem('sulu_admin.include_content_context') === 'true';
         // push initial message
         this.messages.push(
             {
@@ -114,8 +115,8 @@ export default class WritingAssistant extends React.Component<Props> {
             message: prompt,
             expertUuid: this.selectedExpert,
             locale,
-            resourceId: String(this.props.resourceId || ''),
-            resourceKey: this.props.resourceKey || '',
+            resourceId: String(this.props.resourceId ?? ''),
+            resourceKey: this.props.resourceKey ?? '',
         };
 
         if (this.includeContentContext && this.props.contentData) {
@@ -153,7 +154,7 @@ export default class WritingAssistant extends React.Component<Props> {
 
     @action handleIncludeContentContextChange = (checked: boolean) => {
         this.includeContentContext = checked;
-        sessionStorage.setItem('sulu_ai.include_content_context', String(checked));
+        sessionStorage.setItem('sulu_admin.include_content_context', String(checked));
     };
 
     @computed get canIncludeContentContext(): boolean {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/WritingAssistant.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/WritingAssistant.js
@@ -36,6 +36,7 @@ type Props = {|
     type: 'text_line' | 'text_area' | 'text_editor',
     url: string,
     value?: string,
+    webspaceKey?: ?string,
 |};
 
 /**
@@ -117,6 +118,7 @@ export default class WritingAssistant extends React.Component<Props> {
             locale,
             resourceId: String(this.props.resourceId ?? ''),
             resourceKey: this.props.resourceKey ?? '',
+            webspaceKey: this.props.webspaceKey,
         };
 
         if (this.includeContentContext && this.props.contentData) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/prompt-input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/prompt-input.scss
@@ -47,3 +47,12 @@
         min-width: 80px;
     }
 }
+
+.content-context-checkbox {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+    margin-right: auto;
+    border-left: 1px solid #ccc;
+    padding-left: 8px;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/prompt-input.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/prompt-input.scss
@@ -1,3 +1,5 @@
+@import '../Application/colors.scss';
+
 .predefined-prompts-dropdown {
     max-width: 20vh;
 }
@@ -10,7 +12,7 @@
 .expert-select {
     flex-grow: 1;
     flex-basis: 0;
-    border-right: 1px solid #ccc;
+    border-right: 1px solid $silver;
     padding-right: 8px;
     min-width: 10vh;
 }
@@ -18,7 +20,7 @@
 .single-expert {
     flex-grow: 1;
     flex-basis: 0;
-    border-right: 1px solid #ccc;
+    border-right: 1px solid $silver;
     padding-right: 8px;
     min-width: 10vh;
     line-height: 30px;
@@ -53,6 +55,6 @@
     align-items: center;
     white-space: nowrap;
     margin-right: auto;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid $silver;
     padding-left: 8px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/tests/PromptInput.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/tests/PromptInput.test.js
@@ -121,4 +121,77 @@ describe('PromptInput Component', () => {
         const button = screen.getByText('Send');
         expect(button).toBeEnabled();
     });
+
+    test('does not render content context checkbox when canIncludeContentContext is false', () => {
+        render(<PromptInput {...defaultProps} canIncludeContentContext={false} />);
+
+        expect(screen.queryByText('Add content context')).not.toBeInTheDocument();
+    });
+
+    test('does not render content context checkbox when canIncludeContentContext is undefined', () => {
+        render(<PromptInput {...defaultProps} />);
+
+        expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    test('renders content context checkbox when canIncludeContentContext is true', () => {
+        render(
+            <PromptInput
+                {...defaultProps}
+                canIncludeContentContext={true}
+                includeContentContext={false}
+                includeContentContextLabel="Add whole content as context"
+                predefinedPrompts={{
+                    handleClick: jest.fn(),
+                    label: 'Predefined Prompts',
+                    options: [{id: 1, name: 'Prompt 1'}],
+                }}
+            />
+        );
+
+        expect(screen.getByText('Add whole content as context')).toBeInTheDocument();
+    });
+
+    test('calls onIncludeContentContextChange when checkbox is toggled', async() => {
+        const onIncludeContentContextChange = jest.fn();
+
+        render(
+            <PromptInput
+                {...defaultProps}
+                canIncludeContentContext={true}
+                includeContentContext={false}
+                includeContentContextLabel="Add whole content as context"
+                onIncludeContentContextChange={onIncludeContentContextChange}
+                predefinedPrompts={{
+                    handleClick: jest.fn(),
+                    label: 'Predefined Prompts',
+                    options: [{id: 1, name: 'Prompt 1'}],
+                }}
+            />
+        );
+
+        const checkbox = screen.getByRole('checkbox');
+        await userEvent.click(checkbox);
+
+        expect(onIncludeContentContextChange).toHaveBeenCalledWith(true, undefined);
+    });
+
+    test('renders checkbox as checked when includeContentContext is true', () => {
+        render(
+            <PromptInput
+                {...defaultProps}
+                canIncludeContentContext={true}
+                includeContentContext={true}
+                includeContentContextLabel="Add whole content as context"
+                predefinedPrompts={{
+                    handleClick: jest.fn(),
+                    label: 'Predefined Prompts',
+                    options: [{id: 1, name: 'Prompt 1'}],
+                }}
+            />
+        );
+
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).toBeChecked();
+    });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/tests/WritingAssistant.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/tests/WritingAssistant.test.js
@@ -38,6 +38,7 @@ describe('WritingAssistant Component', () => {
         messages: {
             addMessage: 'Add Message',
             copiedToClipboard: 'Copied to Clipboard',
+            includeContentContext: 'Add whole content as context',
             initialMessage: 'Initial Message',
             predefinedPrompts: 'Predefined Prompts',
             send: 'Send',
@@ -102,6 +103,8 @@ describe('WritingAssistant Component', () => {
             expertUuid: '1',
             locale: 'en',
             message: 'Test message',
+            resourceId: '',
+            resourceKey: '',
             text: 'Initial value',
         });
     });
@@ -145,5 +148,135 @@ describe('WritingAssistant Component', () => {
         await userEvent.click(copyButton);
 
         expect(writeText).toHaveBeenCalledWith('Optimized text');
+    });
+
+    test('sends resourceId and resourceKey even without content context', async() => {
+        render(
+            <WritingAssistant
+                {...defaultProps}
+                resourceId="page-123"
+                resourceKey="pages"
+            />
+        );
+
+        const input = screen.getByPlaceholderText(defaultProps.messages.addMessage);
+        await userEvent.type(input, 'Test message{enter}');
+
+        await waitFor(() => {
+            expect(screen.getByText('Optimized text')).toBeInTheDocument();
+        });
+
+        expect(Requester.post).toHaveBeenCalledWith('https://example.com/api', {
+            expertUuid: '1',
+            locale: 'en',
+            message: 'Test message',
+            resourceId: 'page-123',
+            resourceKey: 'pages',
+            text: 'Initial value',
+        });
+    });
+
+    test('sends content data when includeContentContext is enabled', async() => {
+        sessionStorage.setItem('sulu_ai.include_content_context', 'true');
+
+        const contentData = {title: 'Page Title', description: 'Page Description'};
+
+        render(
+            <WritingAssistant
+                {...defaultProps}
+                contentData={contentData}
+                dataPath="/block/0/text"
+                resourceId="page-123"
+                resourceKey="pages"
+            />
+        );
+
+        const input = screen.getByPlaceholderText(defaultProps.messages.addMessage);
+        await userEvent.type(input, 'Improve this{enter}');
+
+        await waitFor(() => {
+            expect(screen.getByText('Optimized text')).toBeInTheDocument();
+        });
+
+        expect(Requester.post).toHaveBeenCalledWith('https://example.com/api', {
+            data: contentData,
+            dataPath: '/block/0/text',
+            expertUuid: '1',
+            locale: 'en',
+            message: 'Improve this',
+            resourceId: 'page-123',
+            resourceKey: 'pages',
+            text: 'Initial value',
+        });
+
+        sessionStorage.removeItem('sulu_ai.include_content_context');
+    });
+
+    test('does not send content data when includeContentContext is disabled', async() => {
+        sessionStorage.setItem('sulu_ai.include_content_context', 'false');
+
+        const contentData = {title: 'Page Title'};
+
+        render(
+            <WritingAssistant
+                {...defaultProps}
+                contentData={contentData}
+                dataPath="/block/0/text"
+                resourceId="page-123"
+                resourceKey="pages"
+            />
+        );
+
+        const input = screen.getByPlaceholderText(defaultProps.messages.addMessage);
+        await userEvent.type(input, 'Improve this{enter}');
+
+        await waitFor(() => {
+            expect(screen.getByText('Optimized text')).toBeInTheDocument();
+        });
+
+        expect(Requester.post).toHaveBeenCalledWith('https://example.com/api', {
+            expertUuid: '1',
+            locale: 'en',
+            message: 'Improve this',
+            resourceId: 'page-123',
+            resourceKey: 'pages',
+            text: 'Initial value',
+        });
+
+        sessionStorage.removeItem('sulu_ai.include_content_context');
+    });
+
+    test('does not show content context checkbox when no contentData is provided', () => {
+        render(<WritingAssistant {...defaultProps} />);
+
+        expect(screen.queryByText('Add whole content as context')).not.toBeInTheDocument();
+    });
+
+    test('shows content context checkbox when contentData is provided', () => {
+        const predefinedPrompts = [
+            {id: 1, name: 'Prompt 1', prompt: 'Prompt 1 text'},
+            {id: 2, name: 'Prompt 2', prompt: 'Prompt 2 text'},
+        ];
+        const configuration = {
+            ...defaultProps.configuration,
+            experts: {
+                '1': {
+                    ...defaultProps.configuration.experts['1'],
+                    options: {predefinedPrompts},
+                },
+            },
+        };
+
+        render(
+            <WritingAssistant
+                {...defaultProps}
+                configuration={configuration}
+                contentData={{title: 'Test'}}
+                resourceId="page-123"
+                resourceKey="pages"
+            />
+        );
+
+        expect(screen.getByText('Add whole content as context')).toBeInTheDocument();
     });
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/tests/WritingAssistant.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/tests/WritingAssistant.test.js
@@ -177,7 +177,7 @@ describe('WritingAssistant Component', () => {
     });
 
     test('sends content data when includeContentContext is enabled', async() => {
-        sessionStorage.setItem('sulu_ai.include_content_context', 'true');
+        sessionStorage.setItem('sulu_admin.include_content_context', 'true');
 
         const contentData = {title: 'Page Title', description: 'Page Description'};
 
@@ -209,11 +209,11 @@ describe('WritingAssistant Component', () => {
             text: 'Initial value',
         });
 
-        sessionStorage.removeItem('sulu_ai.include_content_context');
+        sessionStorage.removeItem('sulu_admin.include_content_context');
     });
 
     test('does not send content data when includeContentContext is disabled', async() => {
-        sessionStorage.setItem('sulu_ai.include_content_context', 'false');
+        sessionStorage.setItem('sulu_admin.include_content_context', 'false');
 
         const contentData = {title: 'Page Title'};
 
@@ -243,7 +243,7 @@ describe('WritingAssistant Component', () => {
             text: 'Initial value',
         });
 
-        sessionStorage.removeItem('sulu_ai.include_content_context');
+        sessionStorage.removeItem('sulu_admin.include_content_context');
     });
 
     test('does not show content context checkbox when no contentData is provided', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/tests/WritingAssistant.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/WritingAssistant/tests/WritingAssistant.test.js
@@ -106,6 +106,7 @@ describe('WritingAssistant Component', () => {
             resourceId: '',
             resourceKey: '',
             text: 'Initial value',
+            webspaceKey: undefined,
         });
     });
 
@@ -173,6 +174,7 @@ describe('WritingAssistant Component', () => {
             resourceId: 'page-123',
             resourceKey: 'pages',
             text: 'Initial value',
+            webspaceKey: undefined,
         });
     });
 
@@ -207,6 +209,7 @@ describe('WritingAssistant Component', () => {
             resourceId: 'page-123',
             resourceKey: 'pages',
             text: 'Initial value',
+            webspaceKey: undefined,
         });
 
         sessionStorage.removeItem('sulu_admin.include_content_context');
@@ -241,9 +244,38 @@ describe('WritingAssistant Component', () => {
             resourceId: 'page-123',
             resourceKey: 'pages',
             text: 'Initial value',
+            webspaceKey: undefined,
         });
 
         sessionStorage.removeItem('sulu_admin.include_content_context');
+    });
+
+    test('sends webspaceKey when provided', async() => {
+        render(
+            <WritingAssistant
+                {...defaultProps}
+                resourceId="page-123"
+                resourceKey="pages"
+                webspaceKey="sulu_io"
+            />
+        );
+
+        const input = screen.getByPlaceholderText(defaultProps.messages.addMessage);
+        await userEvent.type(input, 'Test message{enter}');
+
+        await waitFor(() => {
+            expect(screen.getByText('Optimized text')).toBeInTheDocument();
+        });
+
+        expect(Requester.post).toHaveBeenCalledWith('https://example.com/api', {
+            expertUuid: '1',
+            locale: 'en',
+            message: 'Test message',
+            resourceId: 'page-123',
+            resourceKey: 'pages',
+            text: 'Initial value',
+            webspaceKey: 'sulu_io',
+        });
     });
 
     test('does not show content context checkbox when no contentData is provided', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js
@@ -194,6 +194,32 @@ test('Fetch data on confirm', async() => {
     expect(action.showDialog).toBe(false);
 });
 
+test('Passes webspaceKey from options to route generation', async() => {
+    const action = createUpdateFormStoreToolbarAction();
+    action.showDialog = true;
+    action.resourceFormStore.resourceStore.id = 5;
+    action.resourceFormStore.resourceStore.data = {id: 5};
+    action.resourceFormStore.options = {webspace: 'sulu_io'};
+    // $FlowFixMe
+    action.resourceFormStore.locale.get = jest.fn().mockReturnValue('en');
+    // $FlowFixMe
+    action.resourceFormStore.change = jest.fn();
+
+    symfonyRouting.generate.mockReturnValue('/test/5?locale=en&webspaceKey=sulu_io');
+    Requester.post.mockResolvedValue({});
+
+    const element = mount(action.getNode());
+    element.find('Button[skin="primary"]').simulate('click');
+
+    await new Promise((resolve) => setTimeout(resolve));
+
+    expect(symfonyRouting.generate).toHaveBeenCalledWith('test_route', expect.objectContaining({
+        id: 5,
+        locale: 'en',
+        webspaceKey: 'sulu_io',
+    }));
+});
+
 test('Handle error on fetch', async() => {
     const action = createUpdateFormStoreToolbarAction();
     action.showDialog = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/UpdateFormStoreToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/UpdateFormStoreToolbarAction.js
@@ -236,6 +236,7 @@ export default class UpdateFormStoreToolbarAction extends AbstractFormToolbarAct
         const url = symfonyRouting.generate(this.options.route, {
             id,
             locale: locale?.get(),
+            ...(this.resourceFormStore.options?.webspace ? {webspaceKey: this.resourceFormStore.options.webspace} : {}),
             ...(this.options.routeParams || {}),
         });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -251,6 +251,7 @@
     "sulu_admin.translator": "Übersetzer",
     "sulu_admin.detected": "Erkannt",
     "sulu_admin.translator_error": "Fehler beim Übersetzen",
+    "sulu_admin.include_content_context": "Gesamten Inhalt als Kontext hinzufügen",
     "sulu_admin.send_feedback": "Feedback senden",
     "sulu_admin.feedback": "Feedback",
     "sulu_admin.send": "Senden",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -251,6 +251,7 @@
     "sulu_admin.translator": "Translator",
     "sulu_admin.detected": "Detected",
     "sulu_admin.translator_error": "Issue with translator",
+    "sulu_admin.include_content_context": "Add whole content as context",
     "sulu_admin.send_feedback": "Send feedback",
     "sulu_admin.feedback": "Feedback",
     "sulu_admin.send": "Send"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add an "Add whole content as context" checkbox in the WritingAssistant toolbar row. When checked, schema-filtered form data and the current field's dataPath are sent alongside the prompt. The checkbox state is persisted in sessionStorage.

#### Why?

This is a feature needed for AI-Integrations.