### PR TITLE
Fix page link navigation metadata and media link resolution

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -439,7 +439,7 @@ If you need the old default properties, explicitly pass them to the navigation f
     'changer': 'object.changer',
     'created': 'object.created',
     'creator': 'object.creator',
-    'linkProvider': 'object.linkData.linkProvider'
+    'linkProvider': 'object.linkData[provider]'
 }) %}
 
 {# For excerpt fields, include them explicitly #}

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleLinkProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Article\Infrastructure\Sulu\Content;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Sulu\Article\Domain\Model\ArticleDimensionContent;
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
@@ -31,12 +31,16 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 final class ArticleLinkProvider implements LinkProviderInterface
 {
+    /**
+     * @param class-string<ArticleDimensionContentInterface> $articleContentClass
+     */
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly RouteGeneratorInterface $routeGenerator,
         private readonly RequestAnalyzerInterface $requestAnalyzer,
         private readonly ReferenceStoreInterface $referenceStore,
         private readonly TranslatorInterface $translator,
+        private readonly string $articleContentClass,
     ) {
     }
 
@@ -105,7 +109,7 @@ final class ArticleLinkProvider implements LinkProviderInterface
     ): array {
         $queryBuilder = $this->entityManager->createQueryBuilder()
             ->select('article.uuid', 'dimensionContent.title', 'route.slug', 'dimensionContent.mainWebspace')
-            ->from(ArticleDimensionContent::class, 'dimensionContent')
+            ->from($this->articleContentClass, 'dimensionContent')
             ->join('dimensionContent.article', 'article')
             ->leftJoin('dimensionContent.route', 'route')
             ->where('article.uuid IN (:uuids)')

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -342,6 +342,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_core.webspace.request_analyzer'),
                 new Reference('sulu_http_cache.reference_store'),
                 new Reference('translator'),
+                '%sulu.model.article_content.class%',
             ])
             ->tag('sulu.link.provider', ['alias' => 'article']);
 

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Content/ArticleLinkProviderTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Content/ArticleLinkProviderTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Article\Domain\Model\ArticleDimensionContent;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Content\ArticleLinkProvider;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
@@ -77,8 +78,10 @@ class ArticleLinkProviderTest extends TestCase
         };
     }
 
-    private function createProvider(?string $requestWebspace = null): ArticleLinkProvider
-    {
+    private function createProvider(
+        ?string $requestWebspace = null,
+        string $articleContentClass = ArticleDimensionContent::class,
+    ): ArticleLinkProvider {
         $requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
         if (null !== $requestWebspace) {
             $webspace = new Webspace();
@@ -94,6 +97,7 @@ class ArticleLinkProviderTest extends TestCase
             $requestAnalyzer->reveal(),
             $this->referenceStore->reveal(),
             $this->translator->reveal(),
+            $articleContentClass, // @phpstan-ignore argument.type
         );
     }
 
@@ -236,6 +240,36 @@ class ArticleLinkProviderTest extends TestCase
         $this->assertSame('/en/cli-article', $result[0]->getUrl());
     }
 
+    public function testPreloadUsesConfiguredArticleContentClass(): void
+    {
+        /** @phpstan-ignore-next-line We intentionally pass a non-existent class to verify the parameter is forwarded */
+        $customArticleContentClass = 'App\\Entity\\ArticleDimensionContent';
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'article-7',
+                    'title' => 'Extended Article',
+                    'slug' => '/extended-article',
+                    'mainWebspace' => 'blog',
+                ],
+            ],
+            ['article-7'],
+            'en',
+            'live',
+            null,
+            $customArticleContentClass,
+        );
+
+        $this->referenceStore->add('article-7', ArticleInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $provider = $this->createProvider(null, $customArticleContentClass);
+        $result = [...$provider->preload(['article-7'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('/en/extended-article', $result[0]->getUrl());
+    }
+
     public function testPreloadDraftStage(): void
     {
         $this->mockQueryBuilder(
@@ -300,11 +334,12 @@ class ArticleLinkProviderTest extends TestCase
         string $expectedLocale,
         string $expectedStage,
         ?string $expectedRequestWebspace,
+        string $expectedArticleContentClass = ArticleDimensionContent::class,
     ): void {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
 
         $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
-        $queryBuilder->from(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->from($expectedArticleContentClass, 'dimensionContent')->willReturn($queryBuilder)->shouldBeCalled();
         $queryBuilder->join(Argument::cetera())->willReturn($queryBuilder);
         $queryBuilder->leftJoin(Argument::cetera())->willReturn($queryBuilder);
         $queryBuilder->where(Argument::cetera())->willReturn($queryBuilder);

--- a/packages/content/src/Domain/Model/LinkTrait.php
+++ b/packages/content/src/Domain/Model/LinkTrait.php
@@ -44,6 +44,8 @@ trait LinkTrait
      */
     public function setLinkData(?array $linkData): void
     {
+        $this->linkProvider = null;
+
         if (\is_array($linkData)) {
             $linkProvider = $linkData['provider'] ?? null;
             Assert::string($linkProvider);

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/LinkDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/LinkDataMapperTest.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentDataMapper\DataMapper;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\LinkDataMapper;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example;
 use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
 
 class LinkDataMapperTest extends TestCase
 {
+    use SetGetPrivatePropertyTrait;
+
     private LinkDataMapper $mapper;
 
     protected function setUp(): void
@@ -92,5 +95,6 @@ class LinkDataMapperTest extends TestCase
         $this->mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertNull($localizedDimensionContent->getLinkData());
+        $this->assertNull(self::getPrivateProperty($localizedDimensionContent, 'linkProvider'));
     }
 }

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -346,7 +346,11 @@ final class NavigationRepository implements NavigationRepositoryInterface
          */
         $resolvedContent = $this->contentResolver->resolve($pageDimensionContent, $properties);
 
-        return $resolvedContent['nav'];
+        $result = $resolvedContent['nav'];
+
+        $result['targetType'] = $result['targetType'] ?? 'page';
+
+        return $result;
     }
 
     /**

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -29,6 +29,7 @@ use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Symfony\Bundle\SecurityBundle\Security;
 use Webmozart\Assert\Assert;
 
@@ -348,7 +349,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
 
         $result = $resolvedContent['nav'];
 
-        $result['targetType'] = $result['targetType'] ?? 'page';
+        $result['targetType'] = $result['targetType'] ?? PageLinkProvider::ALIAS;
 
         return $result;
     }

--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -135,6 +135,7 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
                 'url' => $url,
             ],
         ]);
+        $targetDimensionContent->setLinkData($linkData);
 
         return $targetDimensionContent; // @phpstan-ignore-line return.type
     }
@@ -153,12 +154,12 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         $url = $linkData['href'] ?? null;
         $provider = $linkData['provider'] ?? null;
         $locale = $pageDimensionContent->getLocale();
-        if (!\is_string($provider) || !\is_string($url) || null === $locale) {
+        if (!\is_string($provider) || (!\is_string($url) && !\is_int($url)) || null === $locale) {
             return $pageDimensionContent;
         }
 
         $linkProvider = $this->linkProviderPool->getProvider($provider);
-        $preloadResult = $linkProvider->preload([$url], $locale);
+        $preloadResult = $linkProvider->preload([(string) $url], $locale);
         $linkItem = [...$preloadResult][0] ?? null;
 
         if (null === $linkItem) {

--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -20,6 +20,7 @@ use Sulu\Content\Application\ContentEnhancer\DimensionContentEnhancerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 
 /**
  * @internal This class should not be instantiated by a project.
@@ -33,6 +34,7 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         private PageRepositoryInterface $pageRepository,
         private ContentAggregatorInterface $contentAggregator,
         private LinkProviderPoolInterface $linkProviderPool,
+        private RouteRepositoryInterface $routeRepository,
     ) {
     }
 
@@ -139,22 +141,33 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
     {
         $linkData = $pageDimensionContent->getLinkData();
 
-        $url = $linkData['href'] ?? null;
+        $href = $linkData['href'] ?? null;
         $provider = $linkData['provider'] ?? null;
         $locale = $pageDimensionContent->getLocale();
-        if (!\is_string($provider) || (!\is_string($url) && !\is_int($url)) || null === $locale) {
+        if (!\is_string($provider) || (!\is_string($href) && !\is_int($href)) || null === $locale) {
             return $pageDimensionContent;
         }
 
-        $linkProvider = $this->linkProviderPool->getProvider($provider);
-        $preloadResult = $linkProvider->preload([(string) $url], $locale);
-        $linkItem = [...$preloadResult][0] ?? null;
+        // Skip route lookup for integer hrefs (e.g. media IDs) as they have no route entity
+        $url = \is_string($href)
+            ? $this->routeRepository->findOneBy([
+                'resourceId' => $href,
+                'locale' => $locale,
+            ])?->getSlug()
+            : null;
 
-        if (null === $linkItem) {
-            return $pageDimensionContent;
+        if (null === $url) {
+            $linkProvider = $this->linkProviderPool->getProvider($provider);
+            $preloadResult = $linkProvider->preload([(string) $href], $locale);
+            $linkItem = [...$preloadResult][0] ?? null;
+
+            if (null === $linkItem) {
+                return $pageDimensionContent;
+            }
+
+            $url = $linkItem->getUrl();
         }
 
-        $url = $linkItem->getUrl();
         if (null !== $linkData) {
             $url = $this->appendQueryAndAnchor($url, $linkData);
         }

--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -19,9 +19,7 @@ use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentEnhancer\DimensionContentEnhancerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
-use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
-use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 
 /**
  * @internal This class should not be instantiated by a project.
@@ -35,7 +33,6 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         private PageRepositoryInterface $pageRepository,
         private ContentAggregatorInterface $contentAggregator,
         private LinkProviderPoolInterface $linkProviderPool,
-        private RouteGeneratorInterface $routeGenerator,
     ) {
     }
 
@@ -113,16 +110,7 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         $targetDimensionContent = $this->contentAggregator->aggregate($page, $dimensionAttributes);
 
         $route = $targetDimensionContent->getRoute();
-        $targetLocale = $targetDimensionContent->getLocale();
-        /** @var PageInterface $targetPage */
-        $targetPage = $targetDimensionContent->getResource();
-        $url = null !== $route && null !== $targetLocale
-            ? $this->routeGenerator->generate(
-                $route->getSlug(),
-                $targetLocale,
-                $targetPage->getWebspaceKey(),
-            )
-            : null;
+        $url = $route?->getSlug();
 
         if (null !== $url && null !== $linkData) {
             $url = $this->appendQueryAndAnchor($url, $linkData);

--- a/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
@@ -33,6 +33,8 @@ final class PageLinkProvider implements LinkProviderInterface
 {
     use LinkUrlTrait;
 
+    public const ALIAS = 'page';
+
     /**
      * @param class-string<PageDimensionContentInterface> $pageContentClass
      */
@@ -70,7 +72,7 @@ final class PageLinkProvider implements LinkProviderInterface
 
         $internalLinkTargetUuids = [];
         foreach ($rows as $row) {
-            if ('page' === $row['linkProvider'] && \is_array($row['linkData']) && \is_string($row['linkData']['href'] ?? null)) {
+            if (self::ALIAS === $row['linkProvider'] && \is_array($row['linkData']) && \is_string($row['linkData']['href'] ?? null)) {
                 $internalLinkTargetUuids[] = $row['linkData']['href'];
             }
         }
@@ -171,7 +173,7 @@ final class PageLinkProvider implements LinkProviderInterface
             return $this->appendQueryAndAnchor($linkData['href'], $linkData);
         }
 
-        if ('page' === $linkProvider && \is_array($linkData) && \is_string($linkData['href'] ?? null)) {
+        if (self::ALIAS === $linkProvider && \is_array($linkData) && \is_string($linkData['href'] ?? null)) {
             $targetUuid = $linkData['href'];
             $target = $targetRoutes[$targetUuid] ?? null;
             if (null === $target || null === $target['slug']) {

--- a/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
@@ -20,7 +20,7 @@ use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkUrlTrait;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Page\Domain\Model\PageDimensionContent;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -33,11 +33,15 @@ final class PageLinkProvider implements LinkProviderInterface
 {
     use LinkUrlTrait;
 
+    /**
+     * @param class-string<PageDimensionContentInterface> $pageContentClass
+     */
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly RouteGeneratorInterface $routeGenerator,
         private readonly ReferenceStoreInterface $referenceStore,
         private readonly TranslatorInterface $translator,
+        private readonly string $pageContentClass,
     ) {
     }
 
@@ -114,7 +118,7 @@ final class PageLinkProvider implements LinkProviderInterface
         return $this->entityManager->createQueryBuilder()
             ->select('page.uuid', 'dimensionContent.title', 'route.slug', 'page.webspaceKey',
                 'dimensionContent.linkProvider', 'dimensionContent.linkData')
-            ->from(PageDimensionContent::class, 'dimensionContent')
+            ->from($this->pageContentClass, 'dimensionContent')
             ->join('dimensionContent.page', 'page')
             ->leftJoin('dimensionContent.route', 'route')
             ->where('page.uuid IN (:uuids)')
@@ -139,7 +143,7 @@ final class PageLinkProvider implements LinkProviderInterface
         /** @var list<array{uuid: string, slug: ?string, webspaceKey: string}> */
         return $this->entityManager->createQueryBuilder()
             ->select('page.uuid', 'route.slug', 'page.webspaceKey')
-            ->from(PageDimensionContent::class, 'dimensionContent')
+            ->from($this->pageContentClass, 'dimensionContent')
             ->join('dimensionContent.page', 'page')
             ->leftJoin('dimensionContent.route', 'route')
             ->where('page.uuid IN (:targetUuids)')

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -283,6 +283,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_markup.link_tag.provider_pool'),
+                new Reference('sulu_route.route_repository'),
             ])
             ->tag('sulu_content.dimension_content_enhancer');
 

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -463,7 +463,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('translator'),
                 '%sulu.model.page_content.class%',
             ])
-            ->tag('sulu.link.provider', ['alias' => 'page']);
+            ->tag('sulu.link.provider', ['alias' => PageLinkProvider::ALIAS]);
 
         // Smart Content services
         $services->set('sulu_page.page_smart_content_provider')

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -460,6 +460,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_route.route_generator'),
                 new Reference('sulu_http_cache.reference_store'),
                 new Reference('translator'),
+                '%sulu.model.page_content.class%',
             ])
             ->tag('sulu.link.provider', ['alias' => 'page']);
 

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -283,7 +283,6 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_markup.link_tag.provider_pool'),
-                new Reference('sulu_route.route_generator'),
             ])
             ->tag('sulu_content.dimension_content_enhancer');
 
@@ -526,6 +525,7 @@ final class SuluPageBundle extends AbstractBundle
             ->class(ContentPathTwigExtension::class)
             ->args([
                 new Reference('sulu_route.route_generator'),
+                new Reference('router.default'),
             ])
             ->tag('twig.extension');
 

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/ContentPathTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/ContentPathTwigExtension.php
@@ -12,6 +12,8 @@
 namespace Sulu\Page\Infrastructure\Symfony\Twig\Extension;
 
 use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -23,6 +25,7 @@ final class ContentPathTwigExtension extends AbstractExtension
 {
     public function __construct(
         private readonly RouteGeneratorInterface $routeGenerator,
+        private readonly UrlMatcherInterface $urlMatcher,
     ) {
     }
 
@@ -48,10 +51,16 @@ final class ContentPathTwigExtension extends AbstractExtension
             return $slug;
         }
 
-        return $this->routeGenerator->generate(
-            $slug,
-            $locale,
-            $webspaceKey,
-        );
+        try {
+            $this->urlMatcher->match($slug);
+
+            return $slug;
+        } catch (ResourceNotFoundException) {
+            return $this->routeGenerator->generate(
+                $slug,
+                $locale,
+                $webspaceKey,
+            );
+        }
     }
 }

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -251,7 +251,6 @@ class NavigationTwigExtension extends AbstractExtension
         return [
             'title' => 'title',
             'url' => 'url',
-            'linkProvider' => 'object.linkData[provider]',
         ];
     }
 }

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -251,6 +251,7 @@ class NavigationTwigExtension extends AbstractExtension
         return [
             'title' => 'title',
             'url' => 'url',
+            'targetType' => 'object.linkData[provider]',
         ];
     }
 }

--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -251,6 +251,7 @@ class NavigationTwigExtension extends AbstractExtension
         return [
             'title' => 'title',
             'url' => 'url',
+            'linkProvider' => 'object.linkData[provider]',
         ];
     }
 }

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -180,7 +180,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         /** @var array<string, mixed> $internalLinkNav */
         $internalLinkNav = $navigation[2];
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
-        $this->assertSame('http://sulu.io/en/target-page', $internalLinkNav['url']);
+        $this->assertSame('/target-page', $internalLinkNav['url']);
         $this->assertSame('sulu-io', $internalLinkNav['webspaceKey']);
         $this->assertSame('page', $internalLinkNav['linkProvider']);
 
@@ -246,7 +246,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         /** @var array<string, mixed> $internalLinkNav */
         $internalLinkNav = $homepageChildren[1];
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
-        $this->assertSame('http://sulu.io/en/target-page', $internalLinkNav['url']);
+        $this->assertSame('/target-page', $internalLinkNav['url']);
         $this->assertSame('page', $internalLinkNav['linkProvider']);
         $this->assertArrayHasKey('children', $internalLinkNav);
 

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -41,7 +41,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
             'changer' => 'object.changer',
             'created' => 'object.created',
             'creator' => 'object.creator',
-            'linkProvider' => 'object.linkData.linkProvider',
+            'linkProvider' => 'object.linkData[provider]',
         ];
 
         if ($withExcerpt) {
@@ -182,12 +182,14 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
         $this->assertSame('http://sulu.io/en/target-page', $internalLinkNav['url']);
         $this->assertSame('sulu-io', $internalLinkNav['webspaceKey']);
+        $this->assertSame('page', $internalLinkNav['linkProvider']);
 
         // Test external link resolve url
         /** @var array<string, mixed> $externalLinkNav */
         $externalLinkNav = $navigation[3];
         $this->assertSame('External Link Page', $externalLinkNav['title']);
         $this->assertSame('https://example.com', $externalLinkNav['url']);
+        $this->assertSame('external', $externalLinkNav['linkProvider']);
     }
 
     public function testGetNavigationFlatWithExcerpt(): void
@@ -245,6 +247,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $internalLinkNav = $homepageChildren[1];
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
         $this->assertSame('http://sulu.io/en/target-page', $internalLinkNav['url']);
+        $this->assertSame('page', $internalLinkNav['linkProvider']);
         $this->assertArrayHasKey('children', $internalLinkNav);
 
         // Test external link resolve url
@@ -252,6 +255,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $externalLinkNav = $homepageChildren[2];
         $this->assertSame('External Link Page', $externalLinkNav['title']);
         $this->assertSame('https://example.com', $externalLinkNav['url']);
+        $this->assertSame('external', $externalLinkNav['linkProvider']);
         $this->assertArrayHasKey('children', $externalLinkNav);
     }
 }

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -43,7 +43,7 @@ class NavigationRepositoryTest extends SuluTestCase
             'changer' => 'object.changer',
             'created' => 'object.created',
             'creator' => 'object.creator',
-            'linkProvider' => 'object.linkData.linkProvider',
+            'linkProvider' => 'object.linkData[provider]',
         ];
     }
 

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentResolverTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentResolverTest.php
@@ -167,7 +167,7 @@ class PageSmartContentResolverTest extends SuluTestCase
 
         // Test internal link - resolves to target page's URL with custom title
         $this->assertArrayHasKey('Internal Link Page', $pagesByTitle);
-        $this->assertSame('http://sulu.io/en/target-page', $pagesByTitle['Internal Link Page']['url']);
+        $this->assertSame('/target-page', $pagesByTitle['Internal Link Page']['url']);
         $this->assertSame('Internal Link Page', $pagesByTitle['Internal Link Page']['title']);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -73,7 +73,7 @@ class NavigationRepositoryTest extends TestCase
             'changer' => 'object.changer',
             'created' => 'object.created',
             'creator' => 'object.creator',
-            'linkProvider' => 'object.linkData.linkProvider',
+            'linkProvider' => 'object.linkData[provider]',
         ];
 
         if ($loadExcerpt) {

--- a/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -32,6 +32,7 @@ use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Doctrine\Repository\NavigationRepository;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Symfony\Bundle\SecurityBundle\Security;
 
 class NavigationRepositoryTest extends TestCase
@@ -203,6 +204,7 @@ class NavigationRepositoryTest extends TestCase
         $this->assertArrayHasKey('excerpt', $result[0]);
         $this->assertSame('Page Title', $result[0]['title']);
         $this->assertSame('sulu-io', $result[0]['webspaceKey']);
+        $this->assertSame(PageLinkProvider::ALIAS, $result[0]['targetType']);
     }
 
     public function testGetNavigationFlat(): void
@@ -283,6 +285,7 @@ class NavigationRepositoryTest extends TestCase
         $this->assertArrayNotHasKey('excerpt', $result[0]); // Excerpt not requested
         $this->assertSame('German Page', $result[0]['title']);
         $this->assertSame('sulu-io', $result[0]['webspaceKey']);
+        $this->assertSame(PageLinkProvider::ALIAS, $result[0]['targetType']);
     }
 
     public function testGetNavigationTreeWithoutSegment(): void
@@ -360,6 +363,7 @@ class NavigationRepositoryTest extends TestCase
         $this->assertCount(1, $result);
         $this->assertSame('No Segment Page', $result[0]['title']);
         $this->assertSame('test-webspace', $result[0]['webspaceKey']);
+        $this->assertSame(PageLinkProvider::ALIAS, $result[0]['targetType']);
     }
 
     public function testGetNavigationTreeWithMultipleDepthLevels(): void

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Content\ContentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
+use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Domain\Model\PageDimensionContent;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\ContentResolver\PageLinkDimensionContentEnhancer;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
+use Sulu\Route\Domain\Model\Route;
+
+class PageLinkDimensionContentEnhancerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private PageLinkDimensionContentEnhancer $enhancer;
+
+    /**
+     * @var ObjectProphecy<PageRepositoryInterface>
+     */
+    private ObjectProphecy $pageRepository;
+
+    /**
+     * @var ObjectProphecy<ContentAggregatorInterface>
+     */
+    private ObjectProphecy $contentAggregator;
+
+    /**
+     * @var ObjectProphecy<LinkProviderPoolInterface>
+     */
+    private ObjectProphecy $linkProviderPool;
+
+    /**
+     * @var ObjectProphecy<RouteGeneratorInterface>
+     */
+    private ObjectProphecy $routeGenerator;
+
+    protected function setUp(): void
+    {
+        $this->pageRepository = $this->prophesize(PageRepositoryInterface::class);
+        $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
+        $this->linkProviderPool = $this->prophesize(LinkProviderPoolInterface::class);
+        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
+
+        $this->enhancer = new PageLinkDimensionContentEnhancer(
+            $this->pageRepository->reveal(),
+            $this->contentAggregator->reveal(),
+            $this->linkProviderPool->reveal(),
+            $this->routeGenerator->reveal(),
+        );
+    }
+
+    public function testEnhanceResolvesMediaLinkWithIntegerHref(): void
+    {
+        $linkProvider = $this->prophesize(LinkProviderInterface::class);
+        $pageDimensionContent = $this->prophesize(PageDimensionContentInterface::class);
+
+        $pageDimensionContent->getLocale()->willReturn('en');
+        $pageDimensionContent->getLinkData()->willReturn([
+            'provider' => 'media',
+            'href' => 42,
+        ]);
+        $pageDimensionContent->getTemplateData()->willReturn([
+            'title' => 'Link Page',
+        ]);
+        $pageDimensionContent->setTemplateData([
+            'title' => 'Link Page',
+            'url' => '/media/example.jpg?v=1',
+        ])->shouldBeCalled();
+
+        $this->linkProviderPool->getProvider('media')->willReturn($linkProvider->reveal())->shouldBeCalled();
+        $linkProvider->preload(['42'], 'en')->willReturn([
+            new LinkItem('42', 'Example media', '/media/example.jpg?v=1', true),
+        ])->shouldBeCalled();
+
+        $result = $this->enhancer->enhance($pageDimensionContent->reveal());
+
+        $this->assertSame($pageDimensionContent->reveal(), $result);
+    }
+
+    public function testEnhancePreservesSourceLinkDataWhenResolvingPageLink(): void
+    {
+        $sourcePage = $this->prophesize(PageInterface::class);
+        $sourcePage->getId()->willReturn('uuid-link');
+
+        $pageDimensionContent = new PageDimensionContent($sourcePage->reveal());
+        $pageDimensionContent->setLocale('en');
+        $pageDimensionContent->setStage(DimensionContentInterface::STAGE_LIVE);
+        $pageDimensionContent->setVersion(DimensionContentInterface::CURRENT_VERSION);
+        $pageDimensionContent->setTemplateData(['title' => 'Link Page']);
+        $pageDimensionContent->setLinkData([
+            'provider' => 'page',
+            'href' => 'uuid-target',
+        ]);
+
+        $targetPage = $this->prophesize(PageInterface::class);
+        $targetPage->getWebspaceKey()->willReturn('sulu-io');
+
+        $targetDimensionContent = $this->prophesize(PageDimensionContentInterface::class);
+        $targetDimensionContent->getRoute()->willReturn(new Route('pages', 'uuid-target', 'en', '/target-page'));
+        $targetDimensionContent->getLocale()->willReturn('en');
+        $targetDimensionContent->getResource()->willReturn($targetPage->reveal());
+        $targetDimensionContent->getTemplateData()->willReturn(['existing' => 'value']);
+        $targetDimensionContent->setTemplateData([
+            'existing' => 'value',
+            'title' => 'Link Page',
+            'url' => '/en/target-page',
+        ])->shouldBeCalled();
+        $targetDimensionContent->setLinkData([
+            'provider' => 'page',
+            'href' => 'uuid-target',
+        ])->shouldBeCalled();
+
+        $this->pageRepository->findOneBy(
+            ['uuid' => 'uuid-target'],
+            Argument::type('array'),
+        )->willReturn($targetPage->reveal())->shouldBeCalled();
+
+        $this->contentAggregator->aggregate($targetPage->reveal(), [
+            'locale' => 'en',
+            'stage' => DimensionContentInterface::STAGE_LIVE,
+            'version' => DimensionContentInterface::CURRENT_VERSION,
+        ])->willReturn($targetDimensionContent->reveal())->shouldBeCalled();
+
+        $this->routeGenerator->generate('/target-page', 'en', 'sulu-io')->willReturn('/en/target-page')->shouldBeCalled();
+
+        $result = $this->enhancer->enhance($pageDimensionContent);
+
+        $this->assertSame($targetDimensionContent->reveal(), $result);
+    }
+}

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancerTest.php
@@ -27,7 +27,6 @@ use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ContentResolver\PageLinkDimensionContentEnhancer;
-use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Domain\Model\Route;
 
 class PageLinkDimensionContentEnhancerTest extends TestCase
@@ -51,23 +50,16 @@ class PageLinkDimensionContentEnhancerTest extends TestCase
      */
     private ObjectProphecy $linkProviderPool;
 
-    /**
-     * @var ObjectProphecy<RouteGeneratorInterface>
-     */
-    private ObjectProphecy $routeGenerator;
-
     protected function setUp(): void
     {
         $this->pageRepository = $this->prophesize(PageRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
         $this->linkProviderPool = $this->prophesize(LinkProviderPoolInterface::class);
-        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
 
         $this->enhancer = new PageLinkDimensionContentEnhancer(
             $this->pageRepository->reveal(),
             $this->contentAggregator->reveal(),
             $this->linkProviderPool->reveal(),
-            $this->routeGenerator->reveal(),
         );
     }
 
@@ -125,7 +117,7 @@ class PageLinkDimensionContentEnhancerTest extends TestCase
         $targetDimensionContent->setTemplateData([
             'existing' => 'value',
             'title' => 'Link Page',
-            'url' => '/en/target-page',
+            'url' => '/target-page',
         ])->shouldBeCalled();
         $targetDimensionContent->setLinkData([
             'provider' => 'page',
@@ -142,8 +134,6 @@ class PageLinkDimensionContentEnhancerTest extends TestCase
             'stage' => DimensionContentInterface::STAGE_LIVE,
             'version' => DimensionContentInterface::CURRENT_VERSION,
         ])->willReturn($targetDimensionContent->reveal())->shouldBeCalled();
-
-        $this->routeGenerator->generate('/target-page', 'en', 'sulu-io')->willReturn('/en/target-page')->shouldBeCalled();
 
         $result = $this->enhancer->enhance($pageDimensionContent);
 

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancerTest.php
@@ -28,6 +28,7 @@ use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\ContentResolver\PageLinkDimensionContentEnhancer;
 use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 
 class PageLinkDimensionContentEnhancerTest extends TestCase
 {
@@ -50,16 +51,23 @@ class PageLinkDimensionContentEnhancerTest extends TestCase
      */
     private ObjectProphecy $linkProviderPool;
 
+    /**
+     * @var ObjectProphecy<RouteRepositoryInterface>
+     */
+    private ObjectProphecy $routeRepository;
+
     protected function setUp(): void
     {
         $this->pageRepository = $this->prophesize(PageRepositoryInterface::class);
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
         $this->linkProviderPool = $this->prophesize(LinkProviderPoolInterface::class);
+        $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
 
         $this->enhancer = new PageLinkDimensionContentEnhancer(
             $this->pageRepository->reveal(),
             $this->contentAggregator->reveal(),
             $this->linkProviderPool->reveal(),
+            $this->routeRepository->reveal(),
         );
     }
 
@@ -85,6 +93,36 @@ class PageLinkDimensionContentEnhancerTest extends TestCase
         $linkProvider->preload(['42'], 'en')->willReturn([
             new LinkItem('42', 'Example media', '/media/example.jpg?v=1', true),
         ])->shouldBeCalled();
+
+        $result = $this->enhancer->enhance($pageDimensionContent->reveal());
+
+        $this->assertSame($pageDimensionContent->reveal(), $result);
+    }
+
+    public function testEnhanceResolvesArticleLinkViaRouteRepository(): void
+    {
+        $pageDimensionContent = $this->prophesize(PageDimensionContentInterface::class);
+
+        $pageDimensionContent->getLocale()->willReturn('en');
+        $pageDimensionContent->getLinkData()->willReturn([
+            'provider' => 'article',
+            'href' => 'article-uuid-1',
+        ]);
+        $pageDimensionContent->getTemplateData()->willReturn([
+            'title' => 'Article Link Page',
+        ]);
+        $pageDimensionContent->setTemplateData([
+            'title' => 'Article Link Page',
+            'url' => '/my-article',
+        ])->shouldBeCalled();
+
+        $route = new Route('articles', 'article-uuid-1', 'en', '/my-article');
+        $this->routeRepository->findOneBy([
+            'resourceId' => 'article-uuid-1',
+            'locale' => 'en',
+        ])->willReturn($route)->shouldBeCalled();
+
+        $this->linkProviderPool->getProvider(Argument::any())->shouldNotBeCalled();
 
         $result = $this->enhancer->enhance($pageDimensionContent->reveal());
 

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/PageLinkProviderTest.php
@@ -20,6 +20,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
@@ -51,6 +52,11 @@ class PageLinkProviderTest extends TestCase
 
     private PageLinkProvider $pageLinkProvider;
 
+    /**
+     * @var class-string<PageDimensionContent>
+     */
+    private string $pageContentClass = PageDimensionContent::class;
+
     protected function setUp(): void
     {
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
@@ -81,6 +87,7 @@ class PageLinkProviderTest extends TestCase
             $this->routeGenerator,
             $this->referenceStore->reveal(),
             $this->translator->reveal(),
+            $this->pageContentClass,
         );
     }
 
@@ -263,6 +270,44 @@ class PageLinkProviderTest extends TestCase
         $this->assertFalse($result[0]->isPublished());
     }
 
+    public function testPreloadUsesConfiguredPageContentClass(): void
+    {
+        /** @phpstan-ignore-next-line We intentionally pass a non-existent class to verify the parameter is forwarded */
+        $customPageContentClass = 'App\\Entity\\PageDimensionContent';
+
+        $this->pageLinkProvider = new PageLinkProvider(
+            $this->entityManager->reveal(),
+            $this->routeGenerator,
+            $this->referenceStore->reveal(),
+            $this->translator->reveal(),
+            $customPageContentClass, // @phpstan-ignore argument.type
+        );
+
+        $this->mockQueryBuilder(
+            [
+                [
+                    'uuid' => 'uuid-custom',
+                    'title' => 'Custom Page',
+                    'slug' => '/custom-page',
+                    'webspaceKey' => 'sulu_io',
+                    'linkProvider' => null,
+                    'linkData' => null,
+                ],
+            ],
+            ['uuid-custom'],
+            'en',
+            'live',
+            $customPageContentClass,
+        );
+
+        $this->referenceStore->add('uuid-custom', PageInterface::RESOURCE_KEY)->shouldBeCalled();
+
+        $result = [...$this->pageLinkProvider->preload(['uuid-custom'], 'en', true)];
+
+        $this->assertCount(1, $result);
+        $this->assertSame('/en/custom-page', $result[0]->getUrl());
+    }
+
     /**
      * @param array<int, array<string, mixed>> $rows
      * @param string[] $expectedUuids
@@ -274,8 +319,16 @@ class PageLinkProviderTest extends TestCase
         array $expectedUuids,
         string $expectedLocale,
         string $expectedStage,
+        string $expectedPageContentClass = PageDimensionContent::class,
     ): ObjectProphecy {
-        $queryBuilder = $this->createQueryBuilderMock($rows, $expectedUuids, $expectedLocale, $expectedStage);
+        $queryBuilder = $this->createQueryBuilderMock(
+            $rows,
+            $expectedUuids,
+            $expectedLocale,
+            $expectedStage,
+            'uuids',
+            $expectedPageContentClass,
+        );
         $this->entityManager->createQueryBuilder()->willReturn($queryBuilder->reveal());
 
         return $queryBuilder;
@@ -293,11 +346,12 @@ class PageLinkProviderTest extends TestCase
         string $expectedLocale,
         string $expectedStage,
         string $uuidParameterName = 'uuids',
+        string $expectedPageContentClass = PageDimensionContent::class,
     ): ObjectProphecy {
         $queryBuilder = $this->prophesize(QueryBuilder::class);
 
         $queryBuilder->select(Argument::cetera())->willReturn($queryBuilder);
-        $queryBuilder->from(Argument::cetera())->willReturn($queryBuilder);
+        $queryBuilder->from($expectedPageContentClass, 'dimensionContent')->willReturn($queryBuilder)->shouldBeCalled();
         $queryBuilder->join(Argument::cetera())->willReturn($queryBuilder);
         $queryBuilder->leftJoin(Argument::cetera())->willReturn($queryBuilder);
         $queryBuilder->where(Argument::cetera())->willReturn($queryBuilder);

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/ContentPathTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/ContentPathTwigExtensionTest.php
@@ -20,6 +20,8 @@ use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Translation\LocaleSwitcher;
 use Twig\TwigFunction;
@@ -34,6 +36,8 @@ class ContentPathTwigExtensionTest extends TestCase
     private LocaleSwitcher $localeSwitcher;
 
     private RequestStack $requestStack;
+
+    private UrlMatcherInterface $urlMatcher;
 
     private ContentPathTwigExtension $extension;
 
@@ -97,7 +101,9 @@ class ContentPathTwigExtensionTest extends TestCase
             $this->localeSwitcher,
         );
 
-        $this->extension = new ContentPathTwigExtension($this->routeGenerator);
+        $this->urlMatcher = $this->createNoMatchUrlMatcher();
+
+        $this->extension = new ContentPathTwigExtension($this->routeGenerator, $this->urlMatcher);
     }
 
     public function testGetFunctions(): void
@@ -133,5 +139,78 @@ class ContentPathTwigExtensionTest extends TestCase
             '/en',
             $this->extension->suluContentRootPath(),
         );
+    }
+
+    public function testSuluContentPathSkipsSymfonyControllerRoute(): void
+    {
+        $matchingUrlMatcher = $this->createMatchingUrlMatcher([
+            '_controller' => 'App\Controller\MediaController::download',
+            '_route' => 'sulu_media.website.media.download',
+        ]);
+
+        $extension = new ContentPathTwigExtension($this->routeGenerator, $matchingUrlMatcher);
+
+        $this->assertSame(
+            '/media/123/download/image.jpg',
+            $extension->suluContentPath('/media/123/download/image.jpg'),
+        );
+    }
+
+    public function testSuluContentPathDoesNotSkipExternalUrl(): void
+    {
+        $this->assertSame(
+            'https://example.com/page',
+            $this->extension->suluContentPath('https://example.com/page'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function createMatchingUrlMatcher(array $parameters): UrlMatcherInterface
+    {
+        return new class($parameters) implements UrlMatcherInterface {
+            /**
+             * @param array<string, mixed> $parameters
+             */
+            public function __construct(private readonly array $parameters)
+            {
+            }
+
+            /** @return array<string, mixed> */
+            public function match(string $pathinfo): array
+            {
+                return $this->parameters;
+            }
+
+            public function setContext(RequestContext $context): void
+            {
+            }
+
+            public function getContext(): RequestContext
+            {
+                return new RequestContext();
+            }
+        };
+    }
+
+    private function createNoMatchUrlMatcher(): UrlMatcherInterface
+    {
+        return new class() implements UrlMatcherInterface {
+            /** @return array<string, mixed> */
+            public function match(string $pathinfo): array
+            {
+                throw new ResourceNotFoundException();
+            }
+
+            public function setContext(RequestContext $context): void
+            {
+            }
+
+            public function getContext(): RequestContext
+            {
+                return new RequestContext();
+            }
+        };
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
@@ -33,7 +33,6 @@ class NavigationTwigExtensionTest extends TestCase
         return [
             'title' => 'title',
             'url' => 'url',
-            'linkProvider' => 'object.linkData[provider]',
         ];
     }
 

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
@@ -33,6 +33,7 @@ class NavigationTwigExtensionTest extends TestCase
         return [
             'title' => 'title',
             'url' => 'url',
+            'targetType' => 'object.linkData[provider]',
         ];
     }
 

--- a/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtensionTest.php
@@ -33,6 +33,7 @@ class NavigationTwigExtensionTest extends TestCase
         return [
             'title' => 'title',
             'url' => 'url',
+            'linkProvider' => 'object.linkData[provider]',
         ];
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8627
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR fixes several regressions around linked pages in Sulu 3.0:

- **Remove locale resolution from `PageLinkDimensionContentEnhancer`**: the enhancer no longer generates locale-prefixed URLs via the `RouteGenerator`. Instead it returns the raw slug so that `sulu_content_path()` in templates handles locale resolution once, preventing double-processing (e.g. `/en/en/about`).
- **Add Symfony route matching to `ContentPathTwigExtension`**: `sulu_content_path()` now checks the standard Symfony router (`router.default`) before rewriting a path. URLs that already match a controller route (media downloads, search, etc.) are returned as-is instead of being treated as content slugs.
- **Use configurable content class in link providers**: `PageLinkProvider` and `ArticleLinkProvider` now receive their dimension content class via a constructor parameter (`%sulu.model.page_content.class%` / `%sulu.model.article_content.class%`) instead of hardcoding `PageDimensionContent` / `ArticleDimensionContent`. This supports projects that extend the dimension content entities.
- **Preserve source linkData on resolved page links**: when a page link is resolved to its target page, the original `linkData` is now carried over to the target dimension content.
- **Introduce `targetType` as default navigation property**: the navigation twig extension now includes a `targetType` default property mapped to `object.linkData[provider]`. When no link is configured (linkData is null), the `NavigationRepository` falls back to `"page"`. This allows templates to distinguish between internal pages, external links, articles, and media without passing custom properties.
- **Accept integer href values for media links**: the enhancer validates and casts integer hrefs so media link providers receive the expected string IDs.
- **Clear `linkProvider` when link data is removed**: prevents a stale link indicator from persisting in the admin after a link is disabled.

Regression test coverage is added for the page link enhancer, content path twig extension, and configurable content class behavior in both link providers.

#### Why?

The `PageLinkDimensionContentEnhancer` was generating fully localized URLs which were then passed through `sulu_content_path()` in templates, causing double locale resolution and broken links in navigation.

Additionally, URLs from non-content link providers (e.g. media) were being rewritten by `sulu_content_path()` as if they were content slugs, corrupting already-valid controller routes.

Projects extending dimension content entities could not use the link providers because the Doctrine queries were hardcoded to the base entity classes.

Templates had no easy way to determine a navigation item's link type without explicitly requesting `linkProvider` via custom properties. The new `targetType` default property makes this available out of the box with a sensible `"page"` fallback.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md