### PR TITLE
Fix PHPCR cleanup command causing unbounded filesystem cache growth

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Bundle\DocumentManagerBundle\Command;
 
 use PHPCR\SessionInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -45,6 +46,8 @@ class PHPCRCleanupCommand extends Command
         private WebspaceManagerInterface $webspaceManager,
         private ServicesResetter $servicesResetter,
         private string $projectDirectory,
+        private ?CacheItemPoolInterface $phpcrNodesCachePool = null,
+        private ?CacheItemPoolInterface $phpcrMetaCachePool = null,
     ) {
         parent::__construct();
     }
@@ -273,6 +276,8 @@ class PHPCRCleanupCommand extends Command
             }
 
             $this->servicesResetter->reset();
+            $this->phpcrNodesCachePool?->clear();
+            $this->phpcrMetaCachePool?->clear();
         }
 
         $progressBar->finish();

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/command.xml
@@ -28,6 +28,8 @@
             <argument type="service" id="sulu_core.webspace.webspace_manager" />
             <argument type="service" id="services_resetter" />
             <argument>%kernel.project_dir%</argument>
+            <argument type="service" id="doctrine_phpcr.nodes_cache_pool" on-invalid="null" />
+            <argument type="service" id="doctrine_phpcr.meta_cache_pool" on-invalid="null" />
 
             <tag name="console.command" />
         </service>


### PR DESCRIPTION
 | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  Clears the `doctrine_phpcr.nodes_cache_pool` and `doctrine_phpcr.meta_cache_pool` between parallel groups in the PHPCR cleanup command. The pools are injected as optional dependencies (`on-invalid="null"`),
  making this a no-op when PHPCR caches are not configured.

  #### Why?

  In production, Jackalope's `CachedClient` writes every accessed node to the filesystem-backed `nodes_cache_pool`. The cleanup command spawns subprocesses that each cache their nodes to disk, but
  `documentManager->clear()` only clears in-memory state. Clearing it between parallel groups prevents the growth while preserving the in-process cache during each subprocess's execution.