### PR TITLE
Fix missing title on article/snippet admin views

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -173,7 +173,7 @@ class ArticleAdmin extends Admin
                 ->setResourceKey($resourceKey)
                 ->addLocales($locales)
                 ->setBackView(static::LIST_VIEW . '_' . $groupIdentifier)
-                ->setTitleProperty('name'),
+                ->setTitleProperty('title'),
         );
 
         $formToolbarActions = $this->contentViewBuilderFactory->getDefaultToolbarActions(ArticleInterface::class);

--- a/packages/content/src/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
+++ b/packages/content/src/Infrastructure/Sulu/Admin/ContentViewBuilderFactory.php
@@ -362,6 +362,7 @@ class ContentViewBuilderFactory implements ContentViewBuilderFactoryInterface
             $this->viewBuilderFactory
                 ->createResourceTabViewBuilder($insightsResourceTabViewName, '/insights')
                 ->setResourceKey($resourceKey)
+                ->setTitleProperty('')
                 ->setTabOrder(6144)
                 ->setTabTitle('sulu_admin.insights')
                 ->addRouterAttributesToBackView(['webspace'])

--- a/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAdmin.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAdmin.php
@@ -107,7 +107,7 @@ class SnippetAdmin extends Admin
                     ->setResourceKey($resourceKey)
                     ->addLocales($locales)
                     ->setBackView(static::LIST_VIEW)
-                    ->setTitleProperty('name')
+                    ->setTitleProperty('title')
             );
 
             $formToolbarActions = $this->contentViewBuilderFactory->getDefaultToolbarActions(SnippetInterface::class);


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Fixed `setTitleProperty('name')` → `setTitleProperty('title')` in `ArticleAdmin` and `SnippetAdmin` — the dimension content models only have a `getTitle()` method, not `getName()`, so the title was never
  resolved
  - Added `setTitleProperty('')` on the Insights `ResourceTabView` in `ContentViewBuilderFactory` to prevent the parent route's `titleProperty` option from being inherited, which caused a duplicate title heading on
   the Insights tab

  #### Why?

  The article and snippet edit views used `setTitleProperty('name')` but the underlying `ArticleDimensionContent` and `SnippetDimensionContent` models only expose `getTitle()`. The API response contains a `title`
  field, not `name`, so the admin never resolved the title on the edit tabs.

  After correcting to `setTitleProperty('title')`, the route option was inherited by child routes (including the Insights tab), causing the title to render twice — once from the parent view's prop leaking via
  `React.cloneElement`, and again from the Insights `ResourceTabs` computing its own title via the inherited route option. Setting `setTitleProperty('')` on the Insights view overrides the inherited value and
  prevents the duplicate, matching the existing behavior of the Page admin.