### PR TITLE
Restore default tree order sorting for page smart content

### DIFF
--- a/packages/content/src/Application/PropertyResolver/Resolver/SmartContentPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/SmartContentPropertyResolver.php
@@ -117,7 +117,8 @@ class SmartContentPropertyResolver implements PropertyResolverInterface
             'includeSubFolders' => $data['includeSubFolders'] ?? false,
             'excludeDuplicates' => 'true' === $parameters['exclude_duplicates'] || true === $parameters['exclude_duplicates'],
         ];
-        $sortBys = $data['sortBy'] ?? null ? [$data['sortBy'] => $data['sortMethod'] ?? 'ASC'] : null;
+        $sortBy = $data['sortBy'] ?? null;
+        $sortBys = null !== $sortBy ? [$sortBy => $data['sortMethod'] ?? 'ASC'] : [];
 
         foreach ($this->smartContentFiltersVisitors as $visitor) {
             $filters = $visitor->visit($data, $filters, $parameters);

--- a/packages/content/tests/Functional/Application/ContentResolver/SmartContentContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/SmartContentContentResolverTest.php
@@ -563,6 +563,55 @@ class SmartContentContentResolverTest extends SuluTestCase
         self::assertSame(3, $view['total']);
     }
 
+    public function testResolveSmartContentWithoutSortByUsesDefaultOrder(): void
+    {
+        static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Charlie',
+                    'url' => '/charlie-no-sort',
+                ],
+            ],
+        ]);
+        static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Alpha',
+                    'url' => '/alpha-no-sort',
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-smart-content',
+                    'title' => 'No Sort Page',
+                    'url' => '/no-sort',
+                    'examples' => [
+                        'types' => ['default'],
+                    ],
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $this->pushWebsiteRequest();
+
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array<int, array<string, mixed>> $examples */
+        $examples = $result['content']['examples'];
+        self::assertGreaterThanOrEqual(2, \count($examples));
+        $titles = \array_map(static fn (array $item): string => \is_string($item['title']) ? $item['title'] : '', $examples);
+        self::assertContains('Charlie', $titles);
+        self::assertContains('Alpha', $titles);
+    }
+
     public function testRecursionMaxDepthReplacesDeepWithNull(): void
     {
         // Create two pages with smart content that selects itself first via title ASC

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -137,6 +137,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
             ->enableDatasource(PageInterface::RESOURCE_KEY, PageInterface::RESOURCE_KEY, 'column_list')
             ->enableSorting(
                 [
+                    ['column' => '', 'title' => 'sulu_admin.default'],
                     ['column' => 'workflowPublished', 'title' => 'sulu_admin.published'],
                     ['column' => 'authored', 'title' => 'sulu_admin.authored'],
                     ['column' => 'created', 'title' => 'sulu_admin.created'],
@@ -214,6 +215,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
             $sortBys,
         );
         $this->addInternalFilters($queryBuilder, $filters, $alias);
+        $this->addInternalSortBys($queryBuilder, $sortBys, $alias);
         $this->enhanceQueryBuilderWithAccessControl($queryBuilder, $filters, $alias);
 
         // TODO refactor this part to not use distinct
@@ -359,6 +361,26 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
                 $websiteTagNames,
                 $filters['websiteTagOperator'],
             );
+        }
+    }
+
+    /**
+     * @param array<string, string> $sortBys
+     */
+    protected function addInternalSortBys(QueryBuilder $queryBuilder, array $sortBys, string $alias): void
+    {
+        if ([] === $sortBys) {
+            $queryBuilder->addOrderBy($alias . '.lft', 'ASC');
+
+            return;
+        }
+
+        foreach ($sortBys as $sortBy => $sortMethod) {
+            if ('' !== $sortBy) {
+                continue;
+            }
+
+            $queryBuilder->addOrderBy($alias . '.lft', $sortMethod);
         }
     }
 

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentProviderTest.php
@@ -814,6 +814,21 @@ class PageSmartContentProviderTest extends SuluTestCase
     public static function sortingProvider(): array
     {
         return [
+            'default_no_sort' => [
+                [],
+                'Latest in Tech',
+                'External Link Page',
+            ],
+            'default_asc' => [
+                ['' => 'ASC'],
+                'Latest in Tech',
+                'External Link Page',
+            ],
+            'default_desc' => [
+                ['' => 'DESC'],
+                'External Link Page',
+                'Latest in Tech',
+            ],
             'title_asc' => [
                 ['title' => 'asc'],
                 'Digital Lifestyle',
@@ -973,6 +988,36 @@ class PageSmartContentProviderTest extends SuluTestCase
         // Last should have oldest authored date among sulu-io pages (not parent page)
         $this->assertStringContainsString('Latest in Tech', $result[10]['title']);
         $this->assertSame(self::$pages['tech1']->getUuid(), $result[10]['id']);
+    }
+
+    public function testDefaultSortUsesTreeOrder(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy([...$this->getDefaultFilters(), ...['locale' => 'en']], []);
+
+        $this->assertCount(11, $result);
+
+        // Pages should be in tree order (lft), which matches creation order for same-level siblings
+        $expectedOrder = [
+            'tech1',
+            'sports1',
+            'health1',
+            'business1',
+            'entertainment1',
+            'tech_health',
+            'business_tech',
+            'multi_category_multi_tag',
+            'link_target',
+            'link_internal',
+            'link_external',
+        ];
+
+        foreach ($expectedOrder as $index => $key) {
+            $this->assertSame(
+                self::$pages[$key]->getUuid(),
+                $result[$index]['id'],
+                \sprintf("Expected '%s' at position %d, got '%s'", $key, $index, $result[$index]['title']),
+            );
+        }
     }
 
     public function testFindFlatByTypesSingleTemplateFilter(): void

--- a/src/Sulu/Bundle/AdminBundle/Controller/SmartContentItemController.php
+++ b/src/Sulu/Bundle/AdminBundle/Controller/SmartContentItemController.php
@@ -82,11 +82,9 @@ class SmartContentItemController extends AbstractRestController
         $params = $this->getParams($decodedParams);
         $providerType = (string) ($filters['provider'] ?? null);
 
-        $sortBys = [];
-        if ($filters['sortBy'] ?? null) {
-            $sortBys[$filters['sortBy']] = $filters['sortMethod'] ?? 'asc';
-            unset($filters['sortBy'], $filters['sortMethod']);
-        }
+        $sortBy = $filters['sortBy'] ?? null;
+        $sortBys = null !== $sortBy ? [$sortBy => $filters['sortMethod'] ?? 'ASC'] : [];
+        unset($filters['sortBy'], $filters['sortMethod']);
 
         $filters = [
             // Categories


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Always pass sort configuration to smart content providers instead of conditionally skipping when no sort field is selected
  - Added a "Default" sort option to the page smart content provider that maps to tree order (`lft`)
  - When no explicit sort field is chosen, pages now fall back to tree order instead of having no deterministic sort
  - Added functional tests covering default sort behavior in both `PageSmartContentProvider` and `SmartContentContentResolver`

  #### Why?

  In Sulu 2.6, page smart content without an explicit sort field returned pages in tree order by default. After the 3.0 rewrite, the sort configuration was only passed to the provider when a sort field was explicitly selected. When no sort field was set, sorting was skipped entirely, resulting in pages being returned in an unpredictable order. This fix restores the 2.6 behavior by defaulting to tree order when no sort column is specified.