### PR TITLE
Fix articles_page_tree provider to support includeSubFolders filter

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/PageTreeArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PageTreeArticleSmartContentProvider.php
@@ -88,12 +88,9 @@ readonly class PageTreeArticleSmartContentProvider extends ArticleSmartContentPr
         $queryBuilder->join('articleRoute.parentRoute', 'parentRoute');
 
         if (!$includeSubFolders) {
-            // Only match articles whose parent route points directly to the dataSource page
             $queryBuilder->andWhere('parentRoute.resourceId = :dataSource');
             $queryBuilder->setParameter('dataSource', $dataSource);
         } else {
-            // Match articles whose parent route points to the dataSource page or any of its descendants
-            // Using the nested set model (lft/rgt) of Page to efficiently query descendants
             $queryBuilder->join(
                 PageInterface::class,
                 'dataSourcePage',

--- a/packages/article/src/Infrastructure/Sulu/Content/PageTreeArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/PageTreeArticleSmartContentProvider.php
@@ -59,6 +59,7 @@ readonly class PageTreeArticleSmartContentProvider extends ArticleSmartContentPr
      *     websiteTagOperator: 'AND'|'OR',
      *     dataSource?: string|null,
      *     locale?: string|null,
+     *     includeSubFolders?: bool,
      * } $filters
      */
     protected function addInternalFilters(QueryBuilder $queryBuilder, array $filters, string $alias): void
@@ -71,6 +72,7 @@ readonly class PageTreeArticleSmartContentProvider extends ArticleSmartContentPr
         }
 
         $locale = $filters['locale'] ?? null;
+        $includeSubFolders = $filters['includeSubFolders'] ?? false;
 
         $queryBuilder->join(
             Route::class,
@@ -84,8 +86,29 @@ readonly class PageTreeArticleSmartContentProvider extends ArticleSmartContentPr
         $queryBuilder->setParameter('routeLocale', $locale);
 
         $queryBuilder->join('articleRoute.parentRoute', 'parentRoute');
-        $queryBuilder->andWhere('parentRoute.resourceId = :dataSource');
-        $queryBuilder->setParameter('dataSource', $dataSource);
+
+        if (!$includeSubFolders) {
+            // Only match articles whose parent route points directly to the dataSource page
+            $queryBuilder->andWhere('parentRoute.resourceId = :dataSource');
+            $queryBuilder->setParameter('dataSource', $dataSource);
+        } else {
+            // Match articles whose parent route points to the dataSource page or any of its descendants
+            // Using the nested set model (lft/rgt) of Page to efficiently query descendants
+            $queryBuilder->join(
+                PageInterface::class,
+                'dataSourcePage',
+                'WITH',
+                'dataSourcePage.uuid = :dataSource'
+            );
+            $queryBuilder->join(
+                PageInterface::class,
+                'targetPage',
+                'WITH',
+                'targetPage.uuid = parentRoute.resourceId'
+            );
+            $queryBuilder->andWhere('targetPage.lft BETWEEN dataSourcePage.lft AND dataSourcePage.rgt');
+            $queryBuilder->setParameter('dataSource', $dataSource);
+        }
     }
 
     public function getType(): string

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/PageTreeArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/PageTreeArticleSmartContentProviderTest.php
@@ -95,6 +95,29 @@ class PageTreeArticleSmartContentProviderTest extends SuluTestCase
             ],
         ]);
 
+        // Create child pages for testing includeSubFolders
+        self::$pages['blog_tech'] = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Tech Blog',
+                    'url' => '/blog/tech',
+                    'template' => 'default',
+                    'parentId' => self::$pages['blog']->getUuid(),
+                ],
+            ],
+        ]);
+
+        self::$pages['blog_tech_ai'] = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'AI Tech Blog',
+                    'url' => '/blog/tech/ai',
+                    'template' => 'default',
+                    'parentId' => self::$pages['blog_tech']->getUuid(),
+                ],
+            ],
+        ]);
+
         // Create articles
         self::$articles['blog_article_1'] = self::createArticle([
             'en' => [
@@ -146,11 +169,35 @@ class PageTreeArticleSmartContentProviderTest extends SuluTestCase
             ],
         ]);
 
+        // Create articles for child pages (to test includeSubFolders)
+        self::$articles['tech_article_1'] = self::createArticle([
+            'en' => [
+                'live' => [
+                    'title' => 'Tech Article',
+                    'url' => '/blog/tech/tech-article',
+                    'template' => 'article',
+                ],
+            ],
+        ]);
+
+        self::$articles['ai_article_1'] = self::createArticle([
+            'en' => [
+                'live' => [
+                    'title' => 'AI Article',
+                    'url' => '/blog/tech/ai/ai-article',
+                    'template' => 'article',
+                ],
+            ],
+        ]);
+
         // Link article routes to page routes
         self::linkArticleToPage($entityManager, $routeRepository, self::$articles['blog_article_1'], self::$pages['blog']);
         self::linkArticleToPage($entityManager, $routeRepository, self::$articles['blog_article_2'], self::$pages['blog']);
         self::linkArticleToPage($entityManager, $routeRepository, self::$articles['news_article_1'], self::$pages['news']);
         self::linkArticleToPage($entityManager, $routeRepository, self::$articles['news_article_2'], self::$pages['news']);
+        // Link child page articles
+        self::linkArticleToPage($entityManager, $routeRepository, self::$articles['tech_article_1'], self::$pages['blog_tech']);
+        self::linkArticleToPage($entityManager, $routeRepository, self::$articles['ai_article_1'], self::$pages['blog_tech_ai']);
 
         $entityManager->flush();
     }
@@ -250,7 +297,8 @@ class PageTreeArticleSmartContentProviderTest extends SuluTestCase
         ], []);
 
         // Without dataSource filter, all published articles should be returned
-        $this->assertCount(5, $result);
+        // blog_article_1, blog_article_2, news_article_1, news_article_2, standalone_article, tech_article_1, ai_article_1
+        $this->assertCount(7, $result);
     }
 
     public function testCountByWithBlogDataSource(): void
@@ -332,6 +380,100 @@ class PageTreeArticleSmartContentProviderTest extends SuluTestCase
         $this->assertCount(2, $result);
         $this->assertSame('Second Blog Post', $result[0]['title']);
         $this->assertSame('First Blog Post', $result[1]['title']);
+    }
+
+    public function testFindFlatByWithIncludeSubFoldersDisabled(): void
+    {
+        // Without includeSubFolders, should only return articles directly linked to the blog page
+        $result = $this->smartContentProvider->findFlatBy([
+            ...$this->getDefaultFilters(),
+            'locale' => 'en',
+            'dataSource' => self::$pages['blog']->getUuid(),
+            'includeSubFolders' => false,
+        ], []);
+
+        $this->assertCount(2, $result);
+
+        $resultIds = \array_map(fn ($article) => $article['id'], $result);
+
+        // Only direct blog articles should be included
+        $this->assertContains(self::$articles['blog_article_1']->getUuid(), $resultIds);
+        $this->assertContains(self::$articles['blog_article_2']->getUuid(), $resultIds);
+        // Articles from child pages should NOT be included
+        $this->assertNotContains(self::$articles['tech_article_1']->getUuid(), $resultIds);
+        $this->assertNotContains(self::$articles['ai_article_1']->getUuid(), $resultIds);
+    }
+
+    public function testFindFlatByWithIncludeSubFoldersEnabled(): void
+    {
+        // With includeSubFolders, should return articles from blog page AND all subpages
+        $result = $this->smartContentProvider->findFlatBy([
+            ...$this->getDefaultFilters(),
+            'locale' => 'en',
+            'dataSource' => self::$pages['blog']->getUuid(),
+            'includeSubFolders' => true,
+        ], []);
+
+        $this->assertCount(4, $result);
+
+        $resultIds = \array_map(fn ($article) => $article['id'], $result);
+
+        // Direct blog articles should be included
+        $this->assertContains(self::$articles['blog_article_1']->getUuid(), $resultIds);
+        $this->assertContains(self::$articles['blog_article_2']->getUuid(), $resultIds);
+        // Articles from child pages should also be included
+        $this->assertContains(self::$articles['tech_article_1']->getUuid(), $resultIds);
+        $this->assertContains(self::$articles['ai_article_1']->getUuid(), $resultIds);
+        // News articles should NOT be included
+        $this->assertNotContains(self::$articles['news_article_1']->getUuid(), $resultIds);
+    }
+
+    public function testFindFlatByWithIncludeSubFoldersFromChildPage(): void
+    {
+        // includeSubFolders from a child page (blog_tech) should include grandchild articles
+        $result = $this->smartContentProvider->findFlatBy([
+            ...$this->getDefaultFilters(),
+            'locale' => 'en',
+            'dataSource' => self::$pages['blog_tech']->getUuid(),
+            'includeSubFolders' => true,
+        ], []);
+
+        $this->assertCount(2, $result);
+
+        $resultIds = \array_map(fn ($article) => $article['id'], $result);
+
+        // Tech article (direct child of blog_tech) should be included
+        $this->assertContains(self::$articles['tech_article_1']->getUuid(), $resultIds);
+        // AI article (grandchild via blog_tech_ai) should be included
+        $this->assertContains(self::$articles['ai_article_1']->getUuid(), $resultIds);
+        // Blog articles (parent page) should NOT be included
+        $this->assertNotContains(self::$articles['blog_article_1']->getUuid(), $resultIds);
+    }
+
+    public function testCountByWithIncludeSubFoldersEnabled(): void
+    {
+        $count = $this->smartContentProvider->countBy([
+            ...$this->getDefaultFilters(),
+            'locale' => 'en',
+            'dataSource' => self::$pages['blog']->getUuid(),
+            'includeSubFolders' => true,
+        ]);
+
+        // Should count blog articles (2) + tech article (1) + AI article (1) = 4
+        $this->assertSame(4, $count);
+    }
+
+    public function testCountByWithIncludeSubFoldersDisabled(): void
+    {
+        $count = $this->smartContentProvider->countBy([
+            ...$this->getDefaultFilters(),
+            'locale' => 'en',
+            'dataSource' => self::$pages['blog']->getUuid(),
+            'includeSubFolders' => false,
+        ]);
+
+        // Should only count direct blog articles (2)
+        $this->assertSame(2, $count);
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8699
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

This PR adds support for the `includeSubFolders` filter in the `articles_page_tree` SmartContent provider.

**Changes:**
- Modified `PageTreeArticleSmartContentProvider::addInternalFilters()` to handle the `includeSubFolders` filter
- When `includeSubFolders` is `false`: only articles directly linked to the datasource page are returned (existing behavior)
- When `includeSubFolders` is `true`: articles linked to the datasource page **and all its descendant pages** are returned using the nested set model (`lft`/`rgt`)

**Tests added:**
- Created child pages (`blog_tech`, `blog_tech_ai`) with their associated articles
- `testFindFlatByWithIncludeSubFoldersDisabled()` - verifies only direct articles are returned
- `testFindFlatByWithIncludeSubFoldersEnabled()` - verifies articles from all descendant pages are included
- `testFindFlatByWithIncludeSubFoldersFromChildPage()` - verifies nested hierarchy works correctly
- `testCountByWithIncludeSubFoldersEnabled/Disabled()` - verifies count respects the filter

#### Why?

The `articles_page_tree` SmartContent provider was not respecting the "Include sub folders" toggle in the admin UI. When enabled, articles associated with subpages of the selected datasource page were not being returned, making the toggle appear non-functional.

#### Example Usage

```twig
{# In a template with smart_content using articles_page_tree provider #}
{# When "Include sub folders" is enabled, articles from /blog, /blog/tech, /blog/tech/ai will all be returned #}
{% for article in content.articles %}
    <h2>{{ article.title }}</h2>
{% endfor %}
```

#### To Do

- [ ] ~Create a documentation PR~ (no documentation changes needed)
- [x] ~Add breaking changes to UPGRADE.md~ (no breaking changes)