### PR TITLE
Fix TypeError when switching snippet template with block fields

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {action, observable, toJS, reaction, computed, runInAction} from 'mobx';
+import {action, isArrayLike, observable, toJS, reaction, computed, runInAction} from 'mobx';
 import {observer} from 'mobx-react';
 import classNames from 'classnames';
 import {arrayMove, translate, clipboard} from '../../utils';
@@ -35,11 +35,13 @@ type Props<T: string, U: {_id?: string, type: T, ...}> = {|
 const BLOCKS_CLIPBOARD_KEY = 'blocks';
 
 /**
- * Ensures that the value is an array. When switching templates, the value might be
+ * Ensures that the value is an array-like object. When switching templates, the value might be
  * an object {} instead of an array [], which would cause errors when calling array methods.
+ * Uses isArrayLike from MobX to also handle MobX observable arrays.
  */
 function ensureArray<V>(value: mixed): Array<V> {
-    if (Array.isArray(value)) {
+    if (isArrayLike(value)) {
+        // $FlowFixMe: flow does not recognize that isArrayLike(value) means that value is an array
         return value;
     }
     return [];
@@ -176,90 +178,102 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
         }
     };
 
-    @action fillArrays = async() => {
+    @action fillArrays = () => {
         const {collapsable, defaultType, generateBlockIds, minOccurs, onChange, value} = this.props;
         const {expandedBlocks, generatedBlockIds, selectedBlocks} = this;
         const valueArray = ensureArray(value);
 
-        // Prevent concurrent executions
-        if (this.isFillingArrays) {
+        // Synchronize tracking arrays with current value
+        if (expandedBlocks.length > valueArray.length) {
+            expandedBlocks.splice(valueArray.length);
+        }
+
+        if (selectedBlocks.length > valueArray.length) {
+            selectedBlocks.splice(valueArray.length);
+        }
+
+        if (generatedBlockIds.length > valueArray.length) {
+            generatedBlockIds.splice(valueArray.length);
+        }
+
+        const collapsed = collapsable ? false : true;
+
+        expandedBlocks.push(...new Array(valueArray.length - expandedBlocks.length).fill(collapsed));
+        selectedBlocks.push(...new Array(valueArray.length - selectedBlocks.length).fill(false));
+        generatedBlockIds.push(
+            ...new Array(valueArray.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
+        );
+
+        // Handle minOccurs - add blocks if needed
+        if (minOccurs && valueArray.length < minOccurs) {
+            const newBlockCount = minOccurs - valueArray.length;
+
+            // If generateBlockIds is provided, handle async ID generation
+            if (generateBlockIds) {
+                this.fillMinOccursBlocksAsync(newBlockCount, valueArray);
+            } else {
+                // Create blocks without IDs synchronously
+                expandedBlocks.push(...new Array(newBlockCount).fill(true));
+                selectedBlocks.push(...new Array(newBlockCount).fill(false));
+                generatedBlockIds.push(
+                    ...new Array(newBlockCount).fill(false).map(() => ++BlockCollection.idCounter)
+                );
+
+                const newBlocks = Array.from(
+                    {length: newBlockCount},
+                    // $FlowFixMe
+                    () => ({type: defaultType})
+                );
+
+                // $FlowFixMe
+                onChange([...valueArray, ...newBlocks]);
+            }
+        }
+    };
+
+    @action fillMinOccursBlocksAsync = async(newBlockCount: number, valueArray: Array<any>) => {
+        const {defaultType, generateBlockIds, onChange} = this.props;
+        const {expandedBlocks, generatedBlockIds, selectedBlocks} = this;
+
+        if (!generateBlockIds || this.isFillingArrays) {
             return;
         }
 
         this.isFillingArrays = true;
 
         try {
-            if (expandedBlocks.length > valueArray.length) {
-                expandedBlocks.splice(valueArray.length);
+            const blockIds = await generateBlockIds(newBlockCount);
+
+            if (!blockIds || !Array.isArray(blockIds) || blockIds.length !== newBlockCount) {
+                return;
             }
 
-            if (selectedBlocks.length > valueArray.length) {
-                selectedBlocks.splice(valueArray.length);
-            }
-
-            if (generatedBlockIds.length > valueArray.length) {
-                generatedBlockIds.splice(valueArray.length);
-            }
-
-            const collapsed = collapsable ? false : true;
-
-            expandedBlocks.push(...new Array(valueArray.length - expandedBlocks.length).fill(collapsed));
-            selectedBlocks.push(...new Array(valueArray.length - selectedBlocks.length).fill(false));
-            generatedBlockIds.push(
-                ...new Array(valueArray.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
-            );
-
-            if (minOccurs && valueArray.length < minOccurs) {
-                const newBlockCount = minOccurs - valueArray.length;
-
-                // Create blocks and generate IDs if needed
-                let newBlocks;
-                if (generateBlockIds) {
-                    try {
-                        const blockIds = await generateBlockIds(newBlockCount);
-
-                        if (!blockIds || !Array.isArray(blockIds) || blockIds.length !== newBlockCount) {
-                            throw new Error(
-                                `generateBlockIds must return an array with exactly ${newBlockCount} elements`
-                            );
-                        }
-
-                        // Create blocks with IDs
-                        newBlocks = Array.from(
-                            {length: newBlockCount},
-                            (_, index) => {
-                                if (blockIds[index] === undefined || blockIds[index] === null) {
-                                    throw new Error(`generateBlockIds returned an invalid ID at index ${index}`);
-                                }
-                                // $FlowFixMe
-                                return {type: defaultType, _id: blockIds[index]};
-                            }
-                        );
-                    } catch (error) {
-                        // On error, don't add blocks to maintain consistent state
-                        // Return early to prevent adding blocks with invalid or missing IDs
-                        return;
+            // Create blocks with IDs
+            const newBlocks = Array.from(
+                {length: newBlockCount},
+                (_, index) => {
+                    if (blockIds[index] === undefined || blockIds[index] === null) {
+                        return null;
                     }
-                } else {
-                    // Create blocks without IDs when generateBlockIds is not provided
-                    newBlocks = Array.from(
-                        {length: newBlockCount},
-                        // $FlowFixMe
-                        () => ({type: defaultType})
-                    );
-                }
-
-                runInAction(() => {
-                    expandedBlocks.push(...new Array(newBlockCount).fill(true));
-                    selectedBlocks.push(...new Array(newBlockCount).fill(false));
-                    generatedBlockIds.push(
-                        ...new Array(newBlockCount).fill(false).map(() => ++BlockCollection.idCounter)
-                    );
-
                     // $FlowFixMe
-                    onChange([...valueArray, ...newBlocks]);
-                });
+                    return {type: defaultType, _id: blockIds[index]};
+                }
+            ).filter(Boolean);
+
+            if (newBlocks.length !== newBlockCount) {
+                return;
             }
+
+            runInAction(() => {
+                expandedBlocks.push(...new Array(newBlockCount).fill(true));
+                selectedBlocks.push(...new Array(newBlockCount).fill(false));
+                generatedBlockIds.push(
+                    ...new Array(newBlockCount).fill(false).map(() => ++BlockCollection.idCounter)
+                );
+
+                // $FlowFixMe
+                onChange([...valueArray, ...newBlocks]);
+            });
         } finally {
             this.isFillingArrays = false;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -34,6 +34,17 @@ type Props<T: string, U: {_id?: string, type: T, ...}> = {|
 
 const BLOCKS_CLIPBOARD_KEY = 'blocks';
 
+/**
+ * Ensures that the value is an array. When switching templates, the value might be
+ * an object {} instead of an array [], which would cause errors when calling array methods.
+ */
+function ensureArray<V>(value: mixed): Array<V> {
+    if (Array.isArray(value)) {
+        return value;
+    }
+    return [];
+}
+
 @observer
 class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.Component<Props<T, U>> {
     static idCounter = 0;
@@ -85,7 +96,11 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     constructor(props: Props<T, U>) {
         super(props);
 
-        this.fillArraysDisposer = reaction(() => this.props.value.length, this.fillArrays, {fireImmediately: true});
+        this.fillArraysDisposer = reaction(
+            () => ensureArray(this.props.value).length,
+            this.fillArrays,
+            {fireImmediately: true}
+        );
         this.setPasteableBlocksDisposer = clipboard.observe(BLOCKS_CLIPBOARD_KEY, action((blocks) => {
             this.pasteableBlocks = blocks || [];
         }), true);
@@ -106,7 +121,8 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
         // 2. The value reference changed
         // 3. There are actually blocks without IDs
         if (generateBlockIds && prevProps.value !== value) {
-            const hasBlocksWithoutIds = value && value.some((block) => !block._id);
+            const valueArray = ensureArray(value);
+            const hasBlocksWithoutIds = valueArray.length > 0 && valueArray.some((block) => !block._id);
             if (hasBlocksWithoutIds) {
                 this.ensureBlockIds();
             }
@@ -120,14 +136,15 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     @action ensureBlockIds = async() => {
         const {generateBlockIds, onChange, value} = this.props;
+        const valueArray = ensureArray(value);
 
         // Prevent multiple simultaneous ID generation operations
-        if (this.isGeneratingIds || !value || !generateBlockIds) {
+        if (this.isGeneratingIds || valueArray.length === 0 || !generateBlockIds) {
             return;
         }
 
         // Find all blocks without IDs
-        const blocksWithoutIds = value.filter((block) => !block._id);
+        const blocksWithoutIds = valueArray.filter((block) => !block._id);
 
         if (blocksWithoutIds.length === 0) {
             return;
@@ -146,7 +163,7 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
             // Update the value with the generated IDs
             let generatedIdIndex = 0;
-            const updatedValue = value.map((block) => {
+            const updatedValue = valueArray.map((block) => {
                 if (!block._id) {
                     return {...block, _id: generatedIds[generatedIdIndex++]};
                 }
@@ -162,37 +179,38 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     @action fillArrays = async() => {
         const {collapsable, defaultType, generateBlockIds, minOccurs, onChange, value} = this.props;
         const {expandedBlocks, generatedBlockIds, selectedBlocks} = this;
+        const valueArray = ensureArray(value);
 
         // Prevent concurrent executions
-        if (this.isFillingArrays || !value) {
+        if (this.isFillingArrays) {
             return;
         }
 
         this.isFillingArrays = true;
 
         try {
-            if (expandedBlocks.length > value.length) {
-                expandedBlocks.splice(value.length);
+            if (expandedBlocks.length > valueArray.length) {
+                expandedBlocks.splice(valueArray.length);
             }
 
-            if (selectedBlocks.length > value.length) {
-                selectedBlocks.splice(value.length);
+            if (selectedBlocks.length > valueArray.length) {
+                selectedBlocks.splice(valueArray.length);
             }
 
-            if (generatedBlockIds.length > value.length) {
-                generatedBlockIds.splice(value.length);
+            if (generatedBlockIds.length > valueArray.length) {
+                generatedBlockIds.splice(valueArray.length);
             }
 
             const collapsed = collapsable ? false : true;
 
-            expandedBlocks.push(...new Array(value.length - expandedBlocks.length).fill(collapsed));
-            selectedBlocks.push(...new Array(value.length - selectedBlocks.length).fill(false));
+            expandedBlocks.push(...new Array(valueArray.length - expandedBlocks.length).fill(collapsed));
+            selectedBlocks.push(...new Array(valueArray.length - selectedBlocks.length).fill(false));
             generatedBlockIds.push(
-                ...new Array(value.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
+                ...new Array(valueArray.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
             );
 
-            if (minOccurs && value.length < minOccurs) {
-                const newBlockCount = minOccurs - value.length;
+            if (minOccurs && valueArray.length < minOccurs) {
+                const newBlockCount = minOccurs - valueArray.length;
 
                 // Create blocks and generate IDs if needed
                 let newBlocks;
@@ -239,7 +257,7 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
                     );
 
                     // $FlowFixMe
-                    onChange([...value, ...newBlocks]);
+                    onChange([...valueArray, ...newBlocks]);
                 });
             }
         } finally {
@@ -261,14 +279,15 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     @action handleAddBlock = async(insertionIndex: number) => {
         const {defaultType, generateBlockIds, onChange, value} = this.props;
+        const valueArray = ensureArray(value);
 
         if (this.hasMaximumReached) {
             throw new Error('The maximum amount of blocks has already been reached!');
         }
 
-        if (value) {
-            const elementsBefore = value.slice(0, insertionIndex);
-            const elementsAfter = value.slice(insertionIndex);
+        if (valueArray.length > 0 || insertionIndex === 0) {
+            const elementsBefore = valueArray.slice(0, insertionIndex);
+            const elementsAfter = valueArray.slice(insertionIndex);
 
             // Create new block - field components will apply defaults in their constructors
             let newBlock;
@@ -310,13 +329,10 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     @action handlePasteBlocks = async(insertionIndex: number) => {
         const {generateBlockIds, onChange, onDisplaySnackbar, value} = this.props;
+        const valueArray = ensureArray(value);
 
         if (this.hasMaximumReached) {
             throw new Error('The maximum amount of blocks has already been reached!');
-        }
-
-        if (!value) {
-            return;
         }
 
         this.expandedBlocks.splice(
@@ -349,8 +365,8 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
             return newBlock;
         });
 
-        const elementsBefore = value.slice(0, insertionIndex);
-        const elementsAfter = value.slice(insertionIndex);
+        const elementsBefore = valueArray.slice(0, insertionIndex);
+        const elementsAfter = valueArray.slice(insertionIndex);
 
         // $FlowFixMe
         onChange([...elementsBefore, ...newElements, ...elementsAfter]);
@@ -375,8 +391,9 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     @action removeBlocks = (indexes: Array<number>, shouldDisplaySnackbar: boolean = true) => {
         const {onChange, onDisplaySnackbar, movable, value} = this.props;
+        const valueArray = ensureArray(value);
 
-        if (!value) {
+        if (valueArray.length === 0) {
             return;
         }
 
@@ -397,7 +414,7 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
             this.mode = movable ? 'sortable' : 'static';
         }
 
-        onChange(value.filter((block, index) => indexes.indexOf(index) === -1));
+        onChange(valueArray.filter((block, index) => indexes.indexOf(index) === -1));
 
         if (shouldDisplaySnackbar && onDisplaySnackbar) {
             onDisplaySnackbar({
@@ -410,8 +427,9 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     handleDuplicateSelectedBlocks = () => {
         const {value} = this.props;
+        const valueArray = ensureArray(value);
 
-        this.duplicateBlocks(this.selectedBlockIndexes, value.length);
+        this.duplicateBlocks(this.selectedBlockIndexes, valueArray.length);
     };
 
     handleDuplicateBlock = (index: number) => {
@@ -420,13 +438,14 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     @action duplicateBlocks = async(indexes: Array<number>, insertAfterIndex: number) => {
         const {generateBlockIds, onChange, onDisplaySnackbar, value} = this.props;
+        const valueArray = ensureArray(value);
 
-        if (!value || indexes.length === 0) {
+        if (valueArray.length === 0 || indexes.length === 0) {
             return;
         }
 
         // Validate maximum limit before any operations
-        if (value.length + indexes.length > (this.props.maxOccurs || Infinity)) {
+        if (valueArray.length + indexes.length > (this.props.maxOccurs || Infinity)) {
             throw new Error('The maximum amount of blocks has already been reached!');
         }
 
@@ -459,8 +478,8 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
         const duplicatedBlocks = indexes.map((sourceIndex, count) => {
             // Remove all _id fields (including nested ones) from the duplicated block
             const duplicatedBlock = generateBlockIds
-                ? this.removeBlockIds(toJS(value[sourceIndex]))
-                : {...toJS(value[sourceIndex])};
+                ? this.removeBlockIds(toJS(valueArray[sourceIndex]))
+                : {...toJS(valueArray[sourceIndex])};
 
             // Assign new ID to top-level block
             if (generateBlockIds && generatedIds.length > count) {
@@ -470,8 +489,8 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
             return duplicatedBlock;
         });
 
-        const elementsBefore = value.slice(0, insertionIndex);
-        const elementsAfter = value.slice(insertionIndex);
+        const elementsBefore = valueArray.slice(0, insertionIndex);
+        const elementsAfter = valueArray.slice(insertionIndex);
         onChange([...elementsBefore, ...duplicatedBlocks, ...elementsAfter]);
 
         if (onDisplaySnackbar) {
@@ -493,15 +512,16 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     copyBlocks = (indexes: Array<number>, shouldDisplaySnackbar: boolean = true) => {
         const {generateBlockIds, onDisplaySnackbar, value} = this.props;
+        const valueArray = ensureArray(value);
 
-        if (!value) {
+        if (valueArray.length === 0) {
             return;
         }
 
         const blocks = [];
 
         indexes.forEach(( index) => {
-            let block = toJS(value[index]);
+            let block = toJS(valueArray[index]);
 
             // Remove _id from copied blocks (including nested blocks) so new IDs are generated on paste
             if (generateBlockIds) {
@@ -533,16 +553,16 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     };
 
     cutBlocks = (indexes: Array<number>) => {
-        const {generateBlockIds, onDisplaySnackbar, value} = this.props;
+        const {generateBlockIds, onDisplaySnackbar, value} = this.props;       const valueArray = ensureArray(value);
 
-        if (!value) {
+        if (valueArray.length === 0) {
             return;
         }
 
         const blocks = [];
 
         indexes.forEach(( index) => {
-            let block = toJS(value[index]);
+            let block = toJS(valueArray[index]);
 
             // Remove _id from cut blocks (including nested blocks) so new IDs are generated on paste
             if (generateBlockIds) {
@@ -612,14 +632,16 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     @computed get hasMaximumReached() {
         const {maxOccurs, value} = this.props;
+        const valueArray = ensureArray(value);
 
-        return !!maxOccurs && value.length >= maxOccurs;
+        return !!maxOccurs && valueArray.length >= maxOccurs;
     }
 
     @computed get hasMinimumReached() {
         const {minOccurs, value} = this.props;
+        const valueArray = ensureArray(value);
 
-        return !!minOccurs && value.length <= minOccurs;
+        return !!minOccurs && valueArray.length <= minOccurs;
     }
 
     @computed get blockActions() {
@@ -670,7 +692,8 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     renderAddButton = (aboveBlockIndex: number) => {
         const {addButtonText, pasteButtonText, disabled, value} = this.props;
-        const isDividerButton = aboveBlockIndex < value.length - 1;
+        const valueArray = ensureArray(value);
+        const isDividerButton = aboveBlockIndex < valueArray.length - 1;
 
         const containerClass = classNames(
             blockCollectionStyles.addButtonContainer,
@@ -750,6 +773,7 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
 
     renderBlockToolbar = (isSticky: boolean) => {
         const {value} = this.props;
+        const valueArray = ensureArray(value);
         const selectedBlocksCount = this.selectedBlocks.filter((element) => element).length;
 
         return (
@@ -776,7 +800,7 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
                         handleClick: this.handleRemoveSelectedBlocks,
                     },
                 ]}
-                allSelected={selectedBlocksCount === value.length}
+                allSelected={selectedBlocksCount === valueArray.length}
                 mode={isSticky ? 'sticky' : 'static'}
                 onCancel={this.handleBlockToolbarCancel}
                 onSelectAll={this.handleBlockToolbarSelectAll}
@@ -835,11 +859,12 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
             types,
             value,
         } = this.props;
+        const valueArray = ensureArray(value);
 
         return (
             <section className={blockCollectionStyles.blocks}>
                 {
-                    value.length > 1 ? (
+                    valueArray.length > 1 ? (
                         this.mode === 'selectable'
                             ? <Sticky top={10}>
                                 {this.renderBlockToolbar}
@@ -870,9 +895,9 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
                     selectedBlocks={this.selectedBlocks}
                     types={types}
                     useDragHandle={true}
-                    value={value}
+                    value={valueArray}
                 />
-                {this.renderAddButton(value.length - 1)}
+                {this.renderAddButton(valueArray.length - 1)}
             </section>
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -201,7 +201,9 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
         expandedBlocks.push(...new Array(valueArray.length - expandedBlocks.length).fill(collapsed));
         selectedBlocks.push(...new Array(valueArray.length - selectedBlocks.length).fill(false));
         generatedBlockIds.push(
-            ...new Array(valueArray.length - generatedBlockIds.length).fill(false).map(() => ++BlockCollection.idCounter)
+            ...new Array(valueArray.length - generatedBlockIds.length)
+                .fill(false)
+                .map(() => ++BlockCollection.idCounter)
         );
 
         // Handle minOccurs - add blocks if needed
@@ -567,7 +569,8 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     };
 
     cutBlocks = (indexes: Array<number>) => {
-        const {generateBlockIds, onDisplaySnackbar, value} = this.props;       const valueArray = ensureArray(value);
+        const {generateBlockIds, onDisplaySnackbar, value} = this.props;
+        const valueArray = ensureArray(value);
 
         if (valueArray.length === 0) {
             return;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
@@ -151,7 +151,7 @@ class SortableBlockList<T: string, U: {type: T}> extends React.Component<Props<T
 
         return (
             <div className={sortableBlockListClass}>
-                {value && value.map((block, index) => (
+                {Array.isArray(value) && value.map((block, index) => (
                     <Fragment key={index}>
                         <SortableBlock
                             actions={this.blockActions}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/SortableBlockList.js
@@ -4,7 +4,7 @@ import {observer} from 'mobx-react';
 import {SortableContainer} from 'react-sortable-hoc';
 import classNames from 'classnames';
 import log from 'loglevel';
-import {computed} from 'mobx';
+import {computed, isArrayLike} from 'mobx';
 import {translate} from '../../utils';
 import SortableBlock from './SortableBlock';
 import sortableBlockListStyles from './sortableBlockList.scss';
@@ -151,7 +151,7 @@ class SortableBlockList<T: string, U: {type: T}> extends React.Component<Props<T
 
         return (
             <div className={sortableBlockListClass}>
-                {Array.isArray(value) && value.map((block, index) => (
+                {isArrayLike(value) && value.map((block, index) => (
                     <Fragment key={index}>
                         <SortableBlock
                             actions={this.blockActions}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -1864,11 +1864,9 @@ test('Should handle undefined value gracefully', () => {
 test('Should handle blocks with nested object properties when switching templates (menu.xml scenario)', () => {
     // Simulates the menu.xml structure: pages → subpages → subpages2
     // When switching templates, nested block data might temporarily be objects instead of arrays
-    const renderBlockContent = jest.fn((value, type, index, expanded) => {
+    const renderBlockContent = jest.fn((value, type, index) => {
         // Simulate rendering nested BlockCollection for subpages
         // The nested value might be an object {} instead of array []
-        const subpages = value.subpages;
-        // ensureArray should handle this in the actual component
         return <div data-testid={`block-content-${index}`}>{JSON.stringify(value)}</div>;
     });
 
@@ -1904,7 +1902,7 @@ test('Should handle blocks with nested object properties when switching template
 
 test('Should handle deeply nested blocks becoming objects (3-level nesting from menu.xml)', () => {
     // Simulates the 3-level nesting in menu.xml: pages → subpages → subpages2
-    const renderBlockContent = jest.fn((value, type, index, expanded) => {
+    const renderBlockContent = jest.fn((value, type, index) => {
         return <div data-testid={`block-content-${index}`}>{JSON.stringify(value)}</div>;
     });
 
@@ -1936,7 +1934,7 @@ test('Should handle deeply nested blocks becoming objects (3-level nesting from 
                 title: 'Main Page',
                 subpages: {
                     // First level becomes object
-                    0: {
+                    '0': {
                         type: 'subpage',
                         title: 'Subpage',
                         subpages2: {}, // Second level also becomes object
@@ -1952,7 +1950,7 @@ test('Should handle deeply nested blocks becoming objects (3-level nesting from 
 
 test('Should handle footer.xml scenario with multiple nested block types becoming objects', () => {
     // Simulates footer.xml structure with pages and socials nested blocks
-    const renderBlockContent = jest.fn((value, type, index, expanded) => {
+    const renderBlockContent = jest.fn((value, type, index) => {
         return <div data-testid={`block-content-${index}`}>{JSON.stringify(value)}</div>;
     });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -1829,3 +1829,34 @@ test('Should not generate IDs when generateBlockIds is not provided', async() =>
     // Should not try to generate IDs or call onChange since generateBlockIds is not provided
     expect(changeSpy).not.toHaveBeenCalled();
 });
+
+test('Should handle object value gracefully when switching templates', () => {
+    // When switching templates, the value might temporarily be an object {} instead of an array []
+    // This should not cause a crash
+    const {rerenderBlockCollection} = renderBlockCollection({
+        value: [{type: 'editor', content: 'Test'}],
+    });
+
+    // Simulate template switch where value becomes an object instead of array
+    // $FlowFixMe - intentionally passing wrong type to test error handling
+    rerenderBlockCollection({value: {}});
+
+    // Should render without crashing, with no blocks visible
+    expect(getBlocks()).toHaveLength(0);
+});
+
+test('Should handle null value gracefully', () => {
+    // $FlowFixMe - intentionally passing wrong type to test error handling
+    renderBlockCollection({value: null});
+
+    // Should render without crashing, with no blocks visible
+    expect(getBlocks()).toHaveLength(0);
+});
+
+test('Should handle undefined value gracefully', () => {
+    // $FlowFixMe - intentionally passing wrong type to test error handling
+    renderBlockCollection({value: undefined});
+
+    // Should render without crashing, with no blocks visible
+    expect(getBlocks()).toHaveLength(0);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -1860,3 +1860,145 @@ test('Should handle undefined value gracefully', () => {
     // Should render without crashing, with no blocks visible
     expect(getBlocks()).toHaveLength(0);
 });
+
+test('Should handle blocks with nested object properties when switching templates (menu.xml scenario)', () => {
+    // Simulates the menu.xml structure: pages → subpages → subpages2
+    // When switching templates, nested block data might temporarily be objects instead of arrays
+    const renderBlockContent = jest.fn((value, type, index, expanded) => {
+        // Simulate rendering nested BlockCollection for subpages
+        // The nested value might be an object {} instead of array []
+        const subpages = value.subpages;
+        // ensureArray should handle this in the actual component
+        return <div data-testid={`block-content-${index}`}>{JSON.stringify(value)}</div>;
+    });
+
+    const {rerenderBlockCollection} = renderBlockCollection({
+        value: [
+            {
+                type: 'page',
+                title: 'Page 1',
+                subpages: [{type: 'subpage', title: 'Subpage 1'}],
+            },
+        ],
+        renderBlockContent,
+    });
+
+    expect(getBlocks()).toHaveLength(1);
+
+    // Simulate template switch where nested blocks become objects instead of arrays
+    // This is what happens in the bug reported in issue #8697
+    // $FlowFixMe - intentionally passing wrong type to test error handling
+    rerenderBlockCollection({
+        value: [
+            {
+                type: 'page',
+                title: 'Page 1',
+                subpages: {}, // Object instead of array (bug scenario)
+            },
+        ],
+    });
+
+    // Should render without crashing
+    expect(getBlocks()).toHaveLength(1);
+});
+
+test('Should handle deeply nested blocks becoming objects (3-level nesting from menu.xml)', () => {
+    // Simulates the 3-level nesting in menu.xml: pages → subpages → subpages2
+    const renderBlockContent = jest.fn((value, type, index, expanded) => {
+        return <div data-testid={`block-content-${index}`}>{JSON.stringify(value)}</div>;
+    });
+
+    const {rerenderBlockCollection} = renderBlockCollection({
+        value: [
+            {
+                type: 'page',
+                title: 'Main Page',
+                subpages: [
+                    {
+                        type: 'subpage',
+                        title: 'Subpage',
+                        subpages2: [{type: 'subpage2', title: 'Deep Subpage'}],
+                    },
+                ],
+            },
+        ],
+        renderBlockContent,
+    });
+
+    expect(getBlocks()).toHaveLength(1);
+
+    // Simulate deep nesting becoming objects at multiple levels
+    // $FlowFixMe - intentionally passing wrong type to test error handling
+    rerenderBlockCollection({
+        value: [
+            {
+                type: 'page',
+                title: 'Main Page',
+                subpages: {
+                    // First level becomes object
+                    0: {
+                        type: 'subpage',
+                        title: 'Subpage',
+                        subpages2: {}, // Second level also becomes object
+                    },
+                },
+            },
+        ],
+    });
+
+    // Should render without crashing
+    expect(getBlocks()).toHaveLength(1);
+});
+
+test('Should handle footer.xml scenario with multiple nested block types becoming objects', () => {
+    // Simulates footer.xml structure with pages and socials nested blocks
+    const renderBlockContent = jest.fn((value, type, index, expanded) => {
+        return <div data-testid={`block-content-${index}`}>{JSON.stringify(value)}</div>;
+    });
+
+    const {rerenderBlockCollection} = renderBlockCollection({
+        value: [
+            {
+                type: 'footer',
+                pages: [{type: 'page', title: 'About'}],
+                socials: [{type: 'social', icon: 'facebook'}],
+            },
+        ],
+        renderBlockContent,
+    });
+
+    expect(getBlocks()).toHaveLength(1);
+
+    // Simulate both nested blocks becoming objects (typical during template switch)
+    // $FlowFixMe - intentionally passing wrong type to test error handling
+    rerenderBlockCollection({
+        value: [
+            {
+                type: 'footer',
+                pages: {}, // Object instead of array
+                socials: {}, // Object instead of array
+            },
+        ],
+    });
+
+    // Should render without crashing
+    expect(getBlocks()).toHaveLength(1);
+});
+
+test('Should handle transition from valid array to object and back to array', () => {
+    // Tests the complete lifecycle: array → object (bug) → array (fixed)
+    const {rerenderBlockCollection} = renderBlockCollection({
+        value: [{type: 'editor', content: 'Test'}],
+    });
+
+    expect(getBlocks()).toHaveLength(1);
+
+    // Transition to object (simulating bug condition)
+    // $FlowFixMe - intentionally passing wrong type to test error handling
+    rerenderBlockCollection({value: {}});
+    expect(getBlocks()).toHaveLength(0);
+
+    // Transition back to array (after fix/template load completes)
+    rerenderBlockCollection({value: [{type: 'editor', content: 'Updated'}]});
+    expect(getBlocks()).toHaveLength(1);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/fixtures/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/fixtures/README.md
@@ -1,0 +1,23 @@
+# BlockCollection Test Fixtures
+
+These XML template files are examples that reproduce the bug described in issue #8697.
+
+## Files
+
+- **menu.xml**: Template with 3 levels of nested blocks (pages → subpages → subpages2)
+- **footer.xml**: Template with multiple nested block types (pages, socials)
+
+## Context
+
+When switching snippet templates in the admin panel, the block data from the old template might arrive as an object `{}` instead of an array `[]`. This caused crashes because array methods (`.map()`, `.filter()`, `.length`) were called directly on the object without type checking.
+
+These templates demonstrate real-world scenarios with deeply nested block structures that trigger the bug.
+
+## Related
+
+- Issue: https://github.com/sulu/sulu/issues/8697
+- PR: https://github.com/sulu/sulu/pull/8706
+
+## Credits
+
+Templates provided by @Leanid554 in the issue discussion.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/fixtures/footer.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/fixtures/footer.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>footer</key>
+    <areas>
+        <area key="footer">
+            <meta>
+                <title lang="en">Footer</title>
+                <title lang="pl">Stopka</title>
+                <title lang="hy">Ետնամաս</title>
+                <title lang="hu">Lábléc</title>
+            </meta>
+        </area>
+    </areas>
+    <meta>
+        <title lang="en">Footer</title>
+        <title lang="pl">Dolna nawigacja</title>
+        <title lang="hy">Ետնամաս</title>
+        <title lang="hu">Lábléc</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="pl">Nazwa</title>
+                <title lang="hy">Անվանում</title>
+                <title lang="hu">Név</title>
+            </meta>
+
+            <tag name="sulu.node.name"/>
+        </property>
+        <section name="logo_and_contact">
+            <meta>
+                <title lang="en">Logo and contact</title>
+                <title lang="pl">Logo i kontakt</title>
+                <title lang="hy">Լոգո և կապ</title>
+                <title lang="hu">Logo és kapcsolat</title>
+            </meta>
+            <properties>
+                <property name="logo" type="single_media_selection" mandatory="true">
+                    <meta>
+                        <title lang="en">Logo</title>
+                        <title lang="pl">Logo</title>
+                        <title lang="hy">Լոգո</title>
+                        <title lang="hu">Logo</title>
+                    </meta>
+                    <params>
+                        <param name="types" value="image"/>
+                    </params>
+                </property>
+                <property name="address" type="text_editor" mandatory="true">
+                    <meta>
+                        <title lang="en">Address</title>
+                        <title lang="pl">Adres</title>
+                        <title lang="hy">Հասցե</title>
+                        <title lang="hu">Cím</title>
+                    </meta>
+                </property>
+                <property name="phone" type="phone" colspan="6" mandatory="true">
+                    <meta>
+                        <title lang="en">Phone</title>
+                        <title lang="pl">Telefon</title>
+                        <title lang="hy">Հեռախոս</title>
+                        <title lang="hu">Telefon</title>
+                    </meta>
+                </property>
+                <property name="email" type="email" colspan="6" mandatory="true">
+                    <meta>
+                        <title lang="en">Email</title>
+                        <title lang="pl">Email</title>
+                        <title lang="hy">Էլ. փոստ</title>
+                        <title lang="hu">E-mail</title>
+                    </meta>
+                </property>
+                <property name="identification_data" type="text_editor" mandatory="false">
+                    <meta>
+                        <title lang="en">Identification data</title>
+                        <title lang="pl">Dane identyfikacji</title>
+                        <title lang="hy">Համաձայնագրային տվյալներ</title>
+                        <title lang="hu">Azonosítási adatok</title>
+                    </meta>
+                </property>
+            </properties>
+        </section>
+        <section name="pages_and_socials">
+            <meta>
+                <title lang="en">Pages and socials</title>
+                <title lang="pl">Strony i media</title>
+                <title lang="hy">Էջեր և սոցիալական ցանցեր</title>
+                <title lang="hu">Oldalak és közösségi média</title>
+            </meta>
+            <properties>
+                <property name="pages_title" type="text_line" mandatory="true">
+                    <meta>
+                        <title lang="en">Pages title</title>
+                        <title lang="pl">Tytuł stron</title>
+                        <title lang="hy">Էջերի վերնագիր</title>
+                        <title lang="hu">Oldalak címe</title>
+                    </meta>
+                </property>
+                <block name="pages">
+                    <meta>
+                        <title lang="en">Menu pages</title>
+                        <title lang="pl">Elementy menu</title>
+                        <title lang="hy">Մենյու էջեր</title>
+                        <title lang="hu">Menü oldalak</title>
+                    </meta>
+                    <types>
+                        <type name="page">
+                            <meta>
+                                <title lang="en">Menu element</title>
+                                <title lang="pl">Element menu</title>
+                                <title lang="hy">Մենյու տարր</title>
+                                <title lang="hu">Menü elem</title>
+                            </meta>
+
+                            <properties>
+                                <xi:include
+                                    href="../fragments/partials/button.xml"
+                                    xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
+                                    xpointer(/sulu:properties/sulu:property)"/>
+                            </properties>
+                        </type>
+                    </types>
+                </block>
+                <property name="socials_title" type="text_line" mandatory="true">
+                    <meta>
+                        <title lang="en">Socials title</title>
+                        <title lang="pl">Tytuł medium społecznościowych</title>
+                        <title lang="hy">Սոցիալական ցանցերի վերնագիր</title>
+                        <title lang="hu">Közösségi média címe</title>
+                    </meta>
+                </property>
+                <block name="socials">
+                    <meta>
+                        <title lang="en">Socials</title>
+                        <title lang="pl">Media społecznościowe</title>
+                        <title lang="hy">Սոցիալական ցանցեր</title>
+                        <title lang="hu">Közösségi média</title>
+                    </meta>
+
+                    <types>
+                        <type name="social">
+                            <meta>
+                                <title lang="en">Social</title>
+                                <title lang="pl">Medium społecznościowe</title>
+                                <title lang="hy">Սոցիալական ցանց</title>
+                                <title lang="hu">Közösségi média</title>
+                            </meta>
+
+                            <properties>
+                                <xi:include
+                                        href="../fragments/partials/button.xml"
+                                        xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
+                                    xpointer(/sulu:properties/sulu:property)"/>
+                            </properties>
+                        </type>
+                    </types>
+                </block>
+            </properties>
+        </section>
+        <section name="form">
+            <meta>
+                <title lang="en">Form section</title>
+                <title lang="pl">Sekcja formularza</title>
+                <title lang="hy">Ֆորմայի բաժին</title>
+                <title lang="hu">Űrlap szakasz</title>
+            </meta>
+            <properties>
+                <property name="form_title" type="text_line" mandatory="true">
+                    <meta>
+                        <title lang="en">Form title</title>
+                        <title lang="pl">Tytuł formularza</title>
+                        <title lang="hy">Ֆորմայի վերնագիր</title>
+                        <title lang="hu">Űrlap címe</title>
+                    </meta>
+                </property>
+                <property name="form_full_name" type="text_line" mandatory="true">
+                    <meta>
+                        <title lang="en">Form full name label</title>
+                        <title lang="pl">Etykieta imienia i nazwiska w formularzu</title>
+                        <title lang="hy">Ֆորմայի ամբողջական անունի պիտակ</title>
+                        <title lang="hu">Teljes név címke a űrlapon</title>
+                    </meta>
+                </property>
+                <property name="form_email" type="text_line" mandatory="true">
+                    <meta>
+                        <title lang="en">Form email label</title>
+                        <title lang="pl">Etykieta maila w formularzu</title>
+                        <title lang="hy">Ֆորմայի էլ. փոստի պիտակ</title>
+                        <title lang="hu">E-mail címke a űrlapon</title>
+                    </meta>
+                </property>
+                <property name="form_message" type="text_line" mandatory="true">
+                    <meta>
+                        <title lang="en">Form message label</title>
+                        <title lang="pl">Etykieta wiadomości w formularzu</title>
+                        <title lang="hy">Ֆորմայի հաղորդագրության պիտակ</title>
+                        <title lang="hu">Üzenet címke a űrlapon</title>
+                    </meta>
+                </property>
+            </properties>
+        </section>
+        <section name="copyright">
+            <meta>
+                <title lang="en">Copyright notice</title>
+                <title lang="pl">Informacja o prawach autorskich</title>
+                <title lang="hy">Հեղինակային իրավունքների հայտարարություն</title>
+                <title lang="hu">Szerzői jogi közlemény</title>
+            </meta>
+            <properties>
+                <property name="copyright" type="text_line">
+                    <meta>
+                        <title lang="en">Text</title>
+                        <title lang="pl">Tekst</title>
+                        <title lang="hy">Տեքստ</title>
+                        <title lang="hu">Szöveg</title>
+                    </meta>
+                </property>
+            </properties>
+        </section>
+    </properties>
+</template>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/fixtures/menu.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/fixtures/menu.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xi="http://www.w3.org/2001/XInclude"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>menu</key>
+    <areas>
+        <area key="menu">
+            <meta>
+                <title lang="en">Menu</title>
+                <title lang="pl">Menu</title>
+                <title lang="hy">Մենյու</title>
+                <title lang="hu">Menü</title>
+            </meta>
+        </area>
+    </areas>
+    <meta>
+        <title lang="en">Menu</title>
+        <title lang="pl">Górna nawigacja</title>
+        <title lang="hy">Մենյու</title>
+        <title lang="hu">Felső navigáció</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="pl">Nazwa</title>
+                <title lang="hy">Անվանում</title>
+                <title lang="hu">Név</title>
+            </meta>
+
+            <tag name="sulu.node.name"/>
+        </property>
+        <section name="logo_and_links">
+            <meta>
+                <title lang="en">Logo and links</title>
+                <title lang="pl">Logo i linki</title>
+                <title lang="hy">Լոգո և հղումներ</title>
+                <title lang="hu">Logó és linkek</title>
+            </meta>
+            <properties>
+                <property name="logo" type="single_media_selection">
+                    <meta>
+                        <title lang="pl">Logo</title>
+                        <title lang="en">Logo</title>
+                        <title lang="hy">Լոգո</title>
+                        <title lang="hu">Logó</title>
+                    </meta>
+                    <params>
+                        <param name="types" value="image"/>
+                    </params>
+                </property>
+                <block name="pages" maxOccurs="6">
+                    <meta>
+                        <title lang="pl">Strony</title>
+                        <title lang="en">Pages</title>
+                        <title lang="hy">Էջեր</title>
+                        <title lang="hu">Oldalak</title>
+                    </meta>
+                    <types>
+                        <type name="page">
+                            <properties>
+                                <xi:include
+                                        href="../fragments/partials/button.xml"
+                                        xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
+                                    xpointer(/sulu:properties/sulu:property)"/>
+                                <block name="subpages">
+                                    <meta>
+                                        <title lang="en">Subpages</title>
+                                        <title lang="pl">Podstrony</title>
+                                        <title lang="hy">Ենթէջեր</title>
+                                        <title lang="hu">Aloldalak</title>
+                                    </meta>
+
+                                    <types>
+                                        <type name="subpage">
+                                            <meta>
+                                                <title lang="en">Subpage</title>
+                                                <title lang="pl">Podstrona</title>
+                                                <title lang="hy">Ենթէջ</title>
+                                                <title lang="hu">Aloldal</title>
+                                            </meta>
+
+                                            <properties>
+                                                <xi:include
+                                                        href="../fragments/partials/button.xml"
+                                                        xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
+                                                    xpointer(/sulu:properties/sulu:property)"/>
+
+												<block name="subpages2">
+													<meta>
+														<title lang="en">Subpages 2</title>
+														<title lang="pl">Podstrony 2</title>
+                                                        <title lang="hy">Ենթէջեր 2</title>
+                                                        <title lang="hu">Aloldalak 2</title>
+													</meta>
+
+													<types>
+														<type name="subpage2">
+															<meta>
+																<title lang="en">Subpage 2</title>
+																<title lang="pl">Podstrona 2</title>
+                                                                <title lang="hy">Ենթէջ 2</title>
+                                                                <title lang="hu">Aloldal 2</title>
+															</meta>
+
+															<properties>
+																<xi:include
+																	href="../fragments/partials/button.xml"
+																	xpointer="xmlns(sulu=http://schemas.sulu.io/template/template)
+                                                    xpointer(/sulu:properties/sulu:property)"/>
+															</properties>
+														</type>
+													</types>
+												</block>
+                                            </properties>
+                                        </type>
+                                    </types>
+                                </block>
+                            </properties>
+                        </type>
+                    </types>
+                </block>
+            </properties>
+        </section>
+    </properties>
+</template>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8697
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

This PR adds `Array.isArray()` checks to prevent crashes when switching snippet templates that contain block fields.

**Root cause:** When switching templates, block data from the old template arrives as an object `{}` instead of an array `[]`. The component calls `.map()`, `.filter()`, `.length` directly on this value without type checking.

**Solution:** Added an `ensureArray()` helper function and used it throughout `BlockCollection.js` before any array operations.

**Changes:**
- `BlockCollection.js`: Added `ensureArray()` helper and applied it in:
  - Constructor reaction
  - `componentDidUpdate`
  - `ensureBlockIds`
  - `fillArrays`
  - `handleAddBlock`, `handlePasteBlocks`, `removeBlocks`, `duplicateBlocks`, `copyBlocks`, `cutBlocks`
  - Computed getters (`hasMaximumReached`, `hasMinimumReached`)
  - Render methods (`renderAddButton`, `renderBlockToolbar`, `render`)
- `SortableBlockList.js`: Added `Array.isArray()` check before `value.map()`
- Added 3 tests for handling object, null, and undefined values

#### Why?

The admin panel crashes with `TypeError: g.map is not a function` when switching between snippet templates that both contain block fields.

#### ⚠️ Note

We may have jumped too quickly into this PR. The scope of changes might be broader than what the original issue described. Only the maintainers can properly assess whether this approach is the right one and if the fix covers all edge cases correctly.

The reporter suggested adding checks in `fillArrays`, `ensureBlockIds`, and `SortableBlockList.js`, but we found that many other methods also needed protection. This comprehensive approach might be over-engineered, or it might be exactly what's needed - we defer to the maintainers' judgment.

#### To Do

- [ ] ~Create a documentation PR~ (no documentation changes needed)
- [x] ~Add breaking changes to UPGRADE.md~ (no breaking changes)