### PR TITLE
Fix order of custom fields in SEO and Excerpt forms

### DIFF
--- a/packages/content/src/Infrastructure/Sulu/Form/InstanceOfFormMetadataVisitor.php
+++ b/packages/content/src/Infrastructure/Sulu/Form/InstanceOfFormMetadataVisitor.php
@@ -51,6 +51,13 @@ class InstanceOfFormMetadataVisitor implements FormMetadataVisitorInterface
 
         $forms = $this->getMatchingForms($instanceOf);
 
+        // Store original items (custom fields from the project) to append them at the end
+        $originalItems = $formMetadata->getItems();
+        $originalSchema = $formMetadata->getSchema();
+
+        // Reset items to collect sub-form items first
+        $formMetadata->setItems([]);
+
         foreach ($forms as $form) {
             $subFormMetadata = $this->xmlFormMetadataLoader->getMetadata($form, $locale, $metadataOptions);
 
@@ -61,6 +68,10 @@ class InstanceOfFormMetadataVisitor implements FormMetadataVisitorInterface
             $formMetadata->setItems(\array_merge($formMetadata->getItems(), $subFormMetadata->getItems()));
             $formMetadata->setSchema($formMetadata->getSchema()->merge($subFormMetadata->getSchema()));
         }
+
+        // Append original items (custom fields) at the end
+        $formMetadata->setItems(\array_merge($formMetadata->getItems(), $originalItems));
+        $formMetadata->setSchema($formMetadata->getSchema()->merge($originalSchema));
     }
 
     /**

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Form/InstanceOfFormMetadataVisitorTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Form/InstanceOfFormMetadataVisitorTest.php
@@ -206,6 +206,39 @@ class InstanceOfFormMetadataVisitorTest extends TestCase
         $this->assertSame('excerptTitle', $formMetadata->getItems()[0]->getName());
         $this->assertSame('excerptTags', $formMetadata->getItems()[1]->getName());
     }
+
+    public function testVisitFormMetadataCustomFieldsAddedAtBottom(): void
+    {
+        // Base form already has some fields (e.g., from the core SEO/Excerpt form)
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('content_excerpt');
+        $formMetadata->setItems([new FieldMetadata('customField1'), new FieldMetadata('customField2')]);
+        $formMetadata->setSchema(new SchemaMetadata());
+
+        $metadataOptions = [
+            'instanceOf' => ExcerptInterface::class,
+        ];
+
+        $subFormMetadata = new FormMetadata();
+        $subFormMetadata->setKey('content_excerpt_metadata');
+        $subFormMetadata->setItems([new FieldMetadata('excerptTitle'), new FieldMetadata('excerptDescription')]);
+        $subFormMetadata->setSchema(new SchemaMetadata());
+
+        $this->xmlFormMetadataLoader->getMetadata('content_excerpt_metadata', 'de', $metadataOptions)
+            ->willReturn($subFormMetadata);
+
+        $this->xmlFormMetadataLoader->getMetadata('content_excerpt_taxonomies', 'de', $metadataOptions)
+            ->willReturn(null);
+
+        $this->instanceOfFormMetadataVisitor->visitFormMetadata($formMetadata, 'de', $metadataOptions);
+
+        // Custom fields should appear at the bottom (after core fields)
+        $this->assertCount(4, $formMetadata->getItems());
+        $this->assertSame('excerptTitle', $formMetadata->getItems()[0]->getName());
+        $this->assertSame('excerptDescription', $formMetadata->getItems()[1]->getName());
+        $this->assertSame('customField1', $formMetadata->getItems()[2]->getName());
+        $this->assertSame('customField2', $formMetadata->getItems()[3]->getName());
+    }
 }
 
 /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | Fixes #8567

## Summary

Custom fields added via `instanceOf` forms were appearing at the top instead of at the bottom (as in Sulu 2.6).

This fix changes the merge order in `InstanceOfFormMetadataVisitor` so that:
1. Core fields from tagged sub-forms are collected first (in their original order)
2. Custom project fields are appended at the end

## Changes

- Store original form items before processing sub-forms
- Collect all sub-form items first
- Append original items (custom fields) at the end

## Test

Added `testVisitFormMetadataCustomFieldsAddedAtBottom` to verify custom fields appear after core fields.