### PR TITLE
Fix no url found exception for multiple locales

### DIFF
--- a/packages/content/src/Infrastructure/Sulu/Route/Exception/WebspaceUrlNotFoundException.php
+++ b/packages/content/src/Infrastructure/Sulu/Route/Exception/WebspaceUrlNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Sulu\Route\Exception;
+
+/**
+ * @internal
+ */
+class WebspaceUrlNotFoundException extends \RuntimeException
+{
+    public function __construct(string $slug, string $locale, string $site, int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(
+            \sprintf('No url found for "%s" in locale "%s" and site "%s".', $slug, $locale, $site),
+            $code,
+            $previous,
+        );
+    }
+}

--- a/packages/content/src/UserInterface/Controller/Website/ContentController.php
+++ b/packages/content/src/UserInterface/Controller/Website/ContentController.php
@@ -22,6 +22,7 @@ use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\RoutableInterface;
+use Sulu\Content\Infrastructure\Sulu\Route\Exception\WebspaceUrlNotFoundException;
 use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -182,15 +183,19 @@ class ContentController extends AbstractController
         $localizations = [];
         foreach ($webspaceLocales as $webspaceLocale) {
             $locale = $webspaceLocale->getLocale(Localization::UNDERSCORE);
-            $localizations[$locale] = [
-                'url' => $this->container->get('sulu_route.route_generator')->generate(
-                    '/',
-                    $locale,
-                    $webspaceKey,
-                ),
-                'locale' => $locale,
-                'alternate' => false,
-            ];
+            try {
+                $localizations[$locale] = [
+                    'url' => $this->container->get('sulu_route.route_generator')->generate(
+                        '/',
+                        $locale,
+                        $webspaceKey,
+                    ),
+                    'locale' => $locale,
+                    'alternate' => false,
+                ];
+            } catch (WebspaceUrlNotFoundException) {
+                continue;
+            }
         }
 
         $routes = [];
@@ -204,15 +209,19 @@ class ContentController extends AbstractController
 
         foreach ($routes as $route) {
             $locale = $route->getLocale();
-            $localizations[$locale] = [
-                'url' => $this->container->get('sulu_route.route_generator')->generate(
-                    $route->getSlug(),
-                    $route->getLocale(),
-                    $webspaceKey,
-                ),
-                'locale' => $locale,
-                'alternate' => true,
-            ];
+            try {
+                $localizations[$locale] = [
+                    'url' => $this->container->get('sulu_route.route_generator')->generate(
+                        $route->getSlug(),
+                        $route->getLocale(),
+                        $webspaceKey,
+                    ),
+                    'locale' => $locale,
+                    'alternate' => true,
+                ];
+            } catch (WebspaceUrlNotFoundException) {
+                continue;
+            }
         }
 
         return $localizations;

--- a/packages/page/src/Infrastructure/Sulu/Route/PageWebspaceRouteGenerator.php
+++ b/packages/page/src/Infrastructure/Sulu/Route/PageWebspaceRouteGenerator.php
@@ -12,6 +12,7 @@
 namespace Sulu\Page\Infrastructure\Sulu\Route;
 
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Content\Infrastructure\Sulu\Route\Exception\WebspaceUrlNotFoundException;
 use Sulu\Route\Application\Routing\Generator\WebspaceRouteGeneratorInterface;
 use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
@@ -52,7 +53,7 @@ class PageWebspaceRouteGenerator implements WebspaceRouteGeneratorInterface
         $url = $this->webspaceManager->findUrlByResourceLocator($slug, null, $locale, $site, $requestContext->getHost(), $requestContext->getScheme());
 
         if (null === $url) {
-            throw new \RuntimeException(\sprintf('No url found for "%s" in locale "%s" and site "%s".', $slug, $locale, $site));
+            throw new WebspaceUrlNotFoundException($slug, $locale, $site);
         }
 
         return $url;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add try/catch continue to route generator, to fix problem with multiple locales but only one url like this `<url language="en">{host}</url>` 
