### PR TITLE
Improve list builder and DimensionContentQueryEnhancer joins

### DIFF
--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Article\Tests\Functional\Integration;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Depends;
 use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
@@ -653,6 +654,76 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertIsArray($content['_embedded']['articles']);
         $this->assertIsArray($content['_embedded']['articles'][0]);
         $this->assertSame('Blog Template Test', $content['_embedded']['articles'][0]['title']);
+    }
+
+    public function testGetListWithTitleSearch(): void
+    {
+        self::purgeDatabase();
+
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'Needle Article',
+            'url' => '/needle-article',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'Haystack Article',
+            'url' => '/haystack-article',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        $this->client->request('GET', '/admin/api/articles?locale=en&search=Needle&searchFields=title&fields=title,id');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{total: int, _embedded: array{articles: array<int, array{title: string, id: string}>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+
+        $this->assertSame(1, $content['total']);
+        $this->assertCount(1, $content['_embedded']['articles']);
+        $this->assertSame('Needle Article', $content['_embedded']['articles'][0]['title']);
+    }
+
+    public function testGetListWithTagFiltering(): void
+    {
+        self::purgeDatabase();
+
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'Tagged Match Article',
+            'url' => '/tagged-match-article',
+            'excerptTags' => ['Tag Filter Match'],
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'Tagged Other Article',
+            'url' => '/tagged-other-article',
+            'excerptTags' => ['Tag Filter Other'],
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        /** @var TagInterface|null $tag */
+        $tag = self::getEntityManager()->getRepository(TagInterface::class)->findOneBy(['name' => 'Tag Filter Match']);
+        $this->assertNotNull($tag);
+
+        $this->client->request('GET', '/admin/api/articles?locale=en&filter[tagId]=' . $tag->getId() . '&fields=title,id');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{total: int, _embedded: array{articles: array<int, array{title: string, id: string}>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+
+        $this->assertSame(1, $content['total']);
+        $this->assertCount(1, $content['_embedded']['articles']);
+        $this->assertSame('Tagged Match Article', $content['_embedded']['articles'][0]['title']);
     }
 
     protected function getSnapshotFolder(): string

--- a/packages/content/src/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
+++ b/packages/content/src/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
@@ -109,7 +109,17 @@ class DimensionContentQueryEnhancer
     ): void {
         $effectiveAttributes = $dimensionContentClassName::getEffectiveDimensionAttributes($filters);
 
-        $queryBuilder->leftJoin(
+        // Use INNER JOIN when any filter adds a non-nullable WHERE on the joined table.
+        // These conditions eliminate NULL rows, making LEFT JOIN semantically equivalent
+        // to INNER JOIN — but MySQL can optimize INNER JOINs significantly better
+        // (reorder tables, push conditions into index access).
+        // Filters with "OR ... IS NULL" fallbacks (audienceTargeting, segmentKey) preserve
+        // NULLs and are excluded from this check.
+        $hasStrictFilters = $this->hasStrictDimensionContentFilters($dimensionContentClassName, $filters);
+
+        $joinMethod = $hasStrictFilters ? 'innerJoin' : 'leftJoin';
+
+        $queryBuilder->$joinMethod(
             $dimensionContentClassName,
             'filterDimensionContent',
             Join::WITH,
@@ -375,5 +385,37 @@ class DimensionContentQueryEnhancer
                 \sprintf('The operator "%s" is not supported for this filter.', $operator),
             );
         }
+    }
+
+    /**
+     * Checks if any filter adds a non-nullable WHERE condition on the dimension content join.
+     *
+     * @template T of DimensionContentInterface
+     *
+     * @param class-string<T> $dimensionContentClassName
+     * @param array<string, mixed> $filters
+     */
+    private function hasStrictDimensionContentFilters(string $dimensionContentClassName, array $filters): bool
+    {
+        if (\is_subclass_of($dimensionContentClassName, TemplateInterface::class)
+            && !empty($filters['templateKeys'] ?? null)
+        ) {
+            return true;
+        }
+
+        if (\is_subclass_of($dimensionContentClassName, ExcerptInterface::class)) {
+            if (!empty($filters['categoryIds'] ?? null)
+                || !empty($filters['categoryKeys'] ?? null)
+                || !empty($filters['tagIds'] ?? null)
+                || !empty($filters['tagNames'] ?? null)
+            ) {
+                return true;
+            }
+        }
+
+        // audienceTargeting and segmentKey use "OR ... IS NULL" fallbacks,
+        // so they preserve NULLs and don't qualify as strict filters.
+
+        return false;
     }
 }

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -942,6 +942,63 @@ class PageControllerTest extends SuluTestCase
     }
 
     /* --- The following tests are independent tests and purge the database on their own --- */
+
+    public function testGetListWithExpandedIdsFlatAndSelectedJoinedFields(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
+
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', $homepage->getId()),
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'default',
+                'title' => 'Expanded Child Page',
+                'url' => '/expanded-child-page',
+                'author' => null,
+                'authored' => '2020-05-08T00:00:00+00:00',
+            ]) ?: null,
+        );
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        self::ensureKernelShutdown();
+
+        $this->client->request(
+            'GET',
+            \sprintf(
+                '/admin/api/pages?exclude-ghosts=false&exclude-shadows=false&locale=en&webspace=sulu-io&expandedIds=%s&fields=title,author,creator,id&flat=true',
+                $homepage->getId(),
+            ),
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{_embedded: array{pages: array<int, array<string, mixed>>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pages = $content['_embedded']['pages'];
+
+        $this->assertCount(1, $pages);
+        $this->assertSame($homepage->getId(), $pages[0]['id']);
+        $this->assertArrayHasKey('_embedded', $pages[0]);
+
+        /** @var array{pages: array<int, array<string, mixed>>} $embedded */
+        $embedded = $pages[0]['_embedded'];
+        $this->assertCount(1, $embedded['pages']);
+
+        /** @var array<string, mixed> $childPage */
+        $childPage = $embedded['pages'][0];
+
+        $this->assertSame('Expanded Child Page', $childPage['title']);
+        $this->assertArrayHasKey('author', $childPage);
+        $this->assertArrayHasKey('creator', $childPage);
+        $this->assertIsString($childPage['creator']);
+        $this->assertNotSame('', $childPage['creator']);
+    }
+
     public function testNestedTemplatePropertyWithSlash(): void
     {
         self::purgeDatabase();

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -779,69 +779,74 @@ class DoctrineListBuilder extends AbstractListBuilder
         $entityNames = [];
 
         foreach ($this->expressions as $expression) {
-            $fieldNames = $this->getExpressionFieldNames([$expression]);
-
-            foreach ($fieldNames as $fieldName) {
-                $joinEntityNames = $this->getJoinEntityNamesForField($fieldName);
-                if ([] === $joinEntityNames) {
-                    continue;
-                }
-
-                if ($this->requiresLeftJoin($expression, $fieldName)) {
-                    continue;
-                }
-
-                $entityNames = \array_merge($entityNames, $joinEntityNames);
-            }
+            $entityNames = \array_merge($entityNames, $this->getStrictJoinEntityNamesForExpression($expression));
         }
 
         if (null !== $this->search && [] !== $this->searchFields) {
-            $searchJoinSets = \array_map(
-                static fn (DoctrineFieldDescriptorInterface $field): array => \array_keys($field->getJoins()),
-                $this->searchFields,
+            $searchFields = \array_values(
+                \array_filter(
+                    $this->searchFields,
+                    static fn (DoctrineFieldDescriptorInterface $field): bool => !$field instanceof DoctrineCaseFieldDescriptor,
+                ),
             );
 
-            $entityNames = \array_merge(
-                $entityNames,
-                \array_intersect(...$searchJoinSets),
-            );
+            if ([] !== $searchFields) {
+                $searchJoinSets = \array_map(
+                    static fn (DoctrineFieldDescriptorInterface $field): array => \array_keys($field->getJoins()),
+                    $searchFields,
+                );
+
+                $entityNames = \array_merge(
+                    $entityNames,
+                    \array_intersect(...$searchJoinSets),
+                );
+            }
         }
 
         return \array_values(\array_unique($entityNames));
     }
 
     /**
-     * @param AbstractDoctrineExpression[] $expressions
-     *
      * @return list<string>
      */
-    private function getExpressionFieldNames(array $expressions): array
+    private function getStrictJoinEntityNamesForExpression(AbstractDoctrineExpression $expression): array
     {
-        $fieldNames = [];
+        if ($expression instanceof DoctrineAndExpression) {
+            $entityNames = [];
 
-        foreach ($expressions as $expression) {
-            if ($expression instanceof ConjunctionExpressionInterface) {
-                $fieldNames = \array_merge(
-                    $fieldNames,
-                    $this->getExpressionFieldNames(
-                        \array_values(
-                            \array_filter(
-                                $expression->getExpressions(),
-                                static fn ($subExpression): bool => $subExpression instanceof AbstractDoctrineExpression,
-                            )
-                        )
-                    )
-                );
+            foreach ($expression->getExpressions() as $subExpression) {
+                if (!$subExpression instanceof AbstractDoctrineExpression) {
+                    continue;
+                }
 
-                continue;
+                $entityNames = \array_merge($entityNames, $this->getStrictJoinEntityNamesForExpression($subExpression));
             }
 
-            if ($expression instanceof BasicExpressionInterface) {
-                $fieldNames[] = $expression->getFieldName();
-            }
+            return \array_values(\array_unique($entityNames));
         }
 
-        return \array_values(\array_unique($fieldNames));
+        if ($expression instanceof DoctrineOrExpression) {
+            $strictJoinEntityNames = null;
+
+            foreach ($expression->getExpressions() as $subExpression) {
+                if (!$subExpression instanceof AbstractDoctrineExpression) {
+                    continue;
+                }
+
+                $subExpressionStrictJoinEntityNames = $this->getStrictJoinEntityNamesForExpression($subExpression);
+                $strictJoinEntityNames = null === $strictJoinEntityNames
+                    ? $subExpressionStrictJoinEntityNames
+                    : \array_values(\array_intersect($strictJoinEntityNames, $subExpressionStrictJoinEntityNames));
+            }
+
+            return $strictJoinEntityNames ?? [];
+        }
+
+        if (!$expression instanceof BasicExpressionInterface || $this->allowsNullJoinResult($expression)) {
+            return [];
+        }
+
+        return $this->getJoinEntityNamesForField($expression->getFieldName());
     }
 
     /**
@@ -857,21 +862,9 @@ class DoctrineListBuilder extends AbstractListBuilder
         return \array_keys($field->getJoins());
     }
 
-    private function requiresLeftJoin(AbstractDoctrineExpression $expression, string $fieldName): bool
+    private function allowsNullJoinResult(AbstractDoctrineExpression $expression): bool
     {
-        if ($expression instanceof ConjunctionExpressionInterface) {
-            foreach ($expression->getExpressions() as $subExpression) {
-                if ($subExpression instanceof AbstractDoctrineExpression
-                    && $this->requiresLeftJoin($subExpression, $fieldName)
-                ) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        if (!$expression instanceof BasicExpressionInterface || $expression->getFieldName() !== $fieldName) {
+        if (!$expression instanceof BasicExpressionInterface) {
             return false;
         }
 
@@ -929,8 +922,31 @@ class DoctrineListBuilder extends AbstractListBuilder
         DoctrineCaseFieldDescriptor $caseField,
         array $values,
     ): AbstractDoctrineExpression {
-        $case1 = $caseField->getCase1FieldDescriptor();
-        $case2 = $caseField->getCase2FieldDescriptor();
+        $case1Original = $caseField->getCase1FieldDescriptor();
+        $case2Original = $caseField->getCase2FieldDescriptor();
+
+        /** @var array<DoctrineJoinDescriptor> $case1Joins */
+        $case1Joins = $case1Original->getJoins();
+        /** @var array<DoctrineJoinDescriptor> $case2Joins */
+        $case2Joins = $case2Original->getJoins();
+
+        $case1 = new DoctrineFieldDescriptor(
+            $case1Original->getFieldName(),
+            $caseField->getName() . '__case1',
+            $case1Original->getEntityName(),
+            null,
+            $case1Joins,
+        );
+        $case2 = new DoctrineFieldDescriptor(
+            $case2Original->getFieldName(),
+            $caseField->getName() . '__case2',
+            $case2Original->getEntityName(),
+            null,
+            $case2Joins,
+        );
+
+        $this->fieldDescriptors[$case1->getName()] = $case1;
+        $this->fieldDescriptors[$case2->getName()] = $case2;
 
         return new DoctrineOrExpression([
             new DoctrineAndExpression([

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -731,8 +731,22 @@ class DoctrineListBuilder extends AbstractListBuilder
             $joins = $this->getJoins();
         }
 
+        // Collect join entity names referenced by WHERE expressions (filters) and search fields.
+        // When an expression filters on a LEFT JOINed table (e.g. templateKey IN (...)),
+        // it eliminates NULL rows, making LEFT JOIN semantically equivalent to INNER JOIN.
+        // Using INNER JOIN allows MySQL to reorder tables and choose better query plans.
+        $filteredJoinEntityNames = $this->getFilteredJoinEntityNames();
+
         foreach ($joins as $entity => $join) {
-            switch ($join->getJoinMethod()) {
+            $joinMethod = $join->getJoinMethod();
+
+            if (DoctrineJoinDescriptor::JOIN_METHOD_LEFT === $joinMethod
+                && \in_array($entity, $filteredJoinEntityNames, true)
+            ) {
+                $joinMethod = DoctrineJoinDescriptor::JOIN_METHOD_INNER;
+            }
+
+            switch ($joinMethod) {
                 case DoctrineJoinDescriptor::JOIN_METHOD_LEFT:
                     $queryBuilder->leftJoin(
                         $join->getJoin() ?: $entity,
@@ -751,6 +765,123 @@ class DoctrineListBuilder extends AbstractListBuilder
                     break;
             }
         }
+    }
+
+    /**
+     * Returns entity names of joins that are referenced by filter expressions or search fields.
+     * These joins have WHERE conditions that eliminate NULL rows, so LEFT JOIN
+     * can safely be upgraded to INNER JOIN for better query optimization.
+     *
+     * @return list<string>
+     */
+    private function getFilteredJoinEntityNames(): array
+    {
+        $entityNames = [];
+
+        foreach ($this->expressions as $expression) {
+            $fieldNames = $this->getExpressionFieldNames([$expression]);
+
+            foreach ($fieldNames as $fieldName) {
+                $joinEntityNames = $this->getJoinEntityNamesForField($fieldName);
+                if ([] === $joinEntityNames) {
+                    continue;
+                }
+
+                if ($this->requiresLeftJoin($expression, $fieldName)) {
+                    continue;
+                }
+
+                $entityNames = \array_merge($entityNames, $joinEntityNames);
+            }
+        }
+
+        if (null !== $this->search && [] !== $this->searchFields) {
+            $searchJoinSets = \array_map(
+                static fn (DoctrineFieldDescriptorInterface $field): array => \array_keys($field->getJoins()),
+                $this->searchFields,
+            );
+
+            $entityNames = \array_merge(
+                $entityNames,
+                \array_intersect(...$searchJoinSets),
+            );
+        }
+
+        return \array_values(\array_unique($entityNames));
+    }
+
+    /**
+     * @param AbstractDoctrineExpression[] $expressions
+     *
+     * @return list<string>
+     */
+    private function getExpressionFieldNames(array $expressions): array
+    {
+        $fieldNames = [];
+
+        foreach ($expressions as $expression) {
+            if ($expression instanceof ConjunctionExpressionInterface) {
+                $fieldNames = \array_merge(
+                    $fieldNames,
+                    $this->getExpressionFieldNames(
+                        \array_values(
+                            \array_filter(
+                                $expression->getExpressions(),
+                                static fn ($subExpression): bool => $subExpression instanceof AbstractDoctrineExpression,
+                            )
+                        )
+                    )
+                );
+
+                continue;
+            }
+
+            if ($expression instanceof BasicExpressionInterface) {
+                $fieldNames[] = $expression->getFieldName();
+            }
+        }
+
+        return \array_values(\array_unique($fieldNames));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getJoinEntityNamesForField(string $fieldName): array
+    {
+        $field = $this->fieldDescriptors[$fieldName] ?? null;
+        if (!$field instanceof DoctrineFieldDescriptorInterface) {
+            return [];
+        }
+
+        return \array_keys($field->getJoins());
+    }
+
+    private function requiresLeftJoin(AbstractDoctrineExpression $expression, string $fieldName): bool
+    {
+        if ($expression instanceof ConjunctionExpressionInterface) {
+            foreach ($expression->getExpressions() as $subExpression) {
+                if ($subExpression instanceof AbstractDoctrineExpression
+                    && $this->requiresLeftJoin($subExpression, $fieldName)
+                ) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (!$expression instanceof BasicExpressionInterface || $expression->getFieldName() !== $fieldName) {
+            return false;
+        }
+
+        if ($expression instanceof DoctrineIsNullExpression) {
+            return true;
+        }
+
+        return $expression instanceof DoctrineWhereExpression
+            && null === $expression->getValue()
+            && self::WHERE_COMPARATOR_EQUAL === $expression->getComparator();
     }
 
     public function createNotExpression(ExpressionInterface $expression)

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderCaseFieldTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderCaseFieldTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineCaseFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineDescriptor;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescriptor;
 use Sulu\Component\Rest\ListBuilder\Filter\FilterTypeRegistry;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -28,7 +29,7 @@ class DoctrineListBuilderCaseFieldTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testCreateInExpressionForCaseFieldUsesRegisteredFieldDescriptor(): void
+    public function testCreateInExpressionForCaseFieldRegistersIndividualCaseDescriptors(): void
     {
         $entityManager = $this->prophesize(EntityManager::class);
         $filterTypeRegistry = $this->prophesize(FilterTypeRegistry::class);
@@ -45,28 +46,19 @@ class DoctrineListBuilderCaseFieldTest extends TestCase
             new AccessControlQueryEnhancer($systemStore->reveal(), $entityManager->reveal())
         );
 
+        $case1Join = new DoctrineJoinDescriptor(
+            'dimensionContent',
+            'Sulu\Bundle\CoreBundle\Entity\Example.dimensionContents'
+        );
+        $case2Join = new DoctrineJoinDescriptor(
+            'ghostDimensionContent',
+            'Sulu\Bundle\CoreBundle\Entity\Example.dimensionContents'
+        );
+
         $templateKeyFieldDescriptor = new DoctrineCaseFieldDescriptor(
             'templateKey',
-            new DoctrineDescriptor(
-                'dimensionContent',
-                'templateKey',
-                [
-                    'dimensionContent' => new DoctrineJoinDescriptor(
-                        'dimensionContent',
-                        'Sulu\Bundle\CoreBundle\Entity\Example.dimensionContents'
-                    ),
-                ]
-            ),
-            new DoctrineDescriptor(
-                'ghostDimensionContent',
-                'templateKey',
-                [
-                    'ghostDimensionContent' => new DoctrineJoinDescriptor(
-                        'ghostDimensionContent',
-                        'Sulu\Bundle\CoreBundle\Entity\Example.dimensionContents'
-                    ),
-                ]
-            )
+            new DoctrineDescriptor('dimensionContent', 'templateKey', ['dimensionContent' => $case1Join]),
+            new DoctrineDescriptor('ghostDimensionContent', 'templateKey', ['ghostDimensionContent' => $case2Join])
         );
 
         $doctrineListBuilder->setFieldDescriptors([
@@ -79,11 +71,16 @@ class DoctrineListBuilderCaseFieldTest extends TestCase
             ->getMethod('getUniqueExpressionFieldDescriptors');
         $getUniqueExpressionFieldDescriptors->setAccessible(true);
 
+        /** @var DoctrineFieldDescriptor[] $expressionFieldDescriptors */
         $expressionFieldDescriptors = $getUniqueExpressionFieldDescriptors->invoke(
             $doctrineListBuilder,
             [$expression]
         );
 
-        $this->assertSame([$templateKeyFieldDescriptor], $expressionFieldDescriptors);
+        $this->assertCount(2, $expressionFieldDescriptors);
+        $this->assertSame('templateKey__case1', $expressionFieldDescriptors[0]->getName());
+        $this->assertSame('templateKey__case2', $expressionFieldDescriptors[1]->getName());
+        $this->assertSame(['dimensionContent' => $case1Join], $expressionFieldDescriptors[0]->getJoins());
+        $this->assertSame(['ghostDimensionContent' => $case2Join], $expressionFieldDescriptors[1]->getJoins());
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -28,8 +28,10 @@ use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\ReadObjectAttributeTrait;
 use Sulu\Component\Rest\Exception\InvalidSearchException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineCaseFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineConcatenationFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineCountFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescriptor;
@@ -1164,18 +1166,8 @@ class DoctrineListBuilderTest extends TestCase
 
     public function testLeftJoinUpgradedToInnerJoinWhenFilterExpressionReferencesJoin(): void
     {
-        $fieldDescriptor = new DoctrineFieldDescriptor(
-            'name', 'name', self::$translationEntityName, 'translation', [
-                self::$translationEntityName => new DoctrineJoinDescriptor(
-                    self::$translationEntityName,
-                    self::$entityNameAlias . '.translations',
-                    '',
-                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
-                ),
-            ]
-        );
+        $fieldDescriptor = $this->createLeftJoinedTranslationFieldDescriptor();
 
-        // in() adds an expression referencing the joined entity — should upgrade LEFT to INNER
         $this->doctrineListBuilder->in($fieldDescriptor, ['value1', 'value2']);
 
         $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
@@ -1200,16 +1192,7 @@ class DoctrineListBuilderTest extends TestCase
 
     public function testLeftJoinNotUpgradedWhenIsNullExpressionReferencesJoin(): void
     {
-        $fieldDescriptor = new DoctrineFieldDescriptor(
-            'name', 'name', self::$translationEntityName, 'translation', [
-                self::$translationEntityName => new DoctrineJoinDescriptor(
-                    self::$translationEntityName,
-                    self::$entityNameAlias . '.translations',
-                    '',
-                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
-                ),
-            ]
-        );
+        $fieldDescriptor = $this->createLeftJoinedTranslationFieldDescriptor();
 
         $this->doctrineListBuilder->setFieldDescriptors(['name' => $fieldDescriptor]);
         $this->doctrineListBuilder->addExpression(
@@ -1237,16 +1220,7 @@ class DoctrineListBuilderTest extends TestCase
 
     public function testLeftJoinNotUpgradedWhenNullEqualityExpressionReferencesJoin(): void
     {
-        $fieldDescriptor = new DoctrineFieldDescriptor(
-            'name', 'name', self::$translationEntityName, 'translation', [
-                self::$translationEntityName => new DoctrineJoinDescriptor(
-                    self::$translationEntityName,
-                    self::$entityNameAlias . '.translations',
-                    '',
-                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
-                ),
-            ]
-        );
+        $fieldDescriptor = $this->createLeftJoinedTranslationFieldDescriptor();
 
         $this->doctrineListBuilder->where($fieldDescriptor, null);
 
@@ -1271,16 +1245,7 @@ class DoctrineListBuilderTest extends TestCase
 
     public function testLeftJoinNotUpgradedWhenOrExpressionContainsNullCheckForJoin(): void
     {
-        $fieldDescriptor = new DoctrineFieldDescriptor(
-            'name', 'name', self::$translationEntityName, 'translation', [
-                self::$translationEntityName => new DoctrineJoinDescriptor(
-                    self::$translationEntityName,
-                    self::$entityNameAlias . '.translations',
-                    '',
-                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
-                ),
-            ]
-        );
+        $fieldDescriptor = $this->createLeftJoinedTranslationFieldDescriptor();
 
         $this->doctrineListBuilder->setFieldDescriptors(['name' => $fieldDescriptor]);
         $this->doctrineListBuilder->addExpression(
@@ -1310,20 +1275,45 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->execute();
     }
 
+    public function testLeftJoinNotUpgradedWhenOrExpressionContainsNullCheckOnSiblingFieldOfSameJoin(): void
+    {
+        $nameFieldDescriptor = $this->createLeftJoinedTranslationFieldDescriptor();
+        $descriptionFieldDescriptor = $this->createLeftJoinedTranslationFieldDescriptor('description');
+
+        $this->doctrineListBuilder->setFieldDescriptors([
+            'name' => $nameFieldDescriptor,
+            'description' => $descriptionFieldDescriptor,
+        ]);
+        $this->doctrineListBuilder->addExpression(
+            $this->doctrineListBuilder->createOrExpression([
+                $this->doctrineListBuilder->createIsNullExpression($nameFieldDescriptor),
+                $this->doctrineListBuilder->createInExpression($descriptionFieldDescriptor, ['value1', 'value2']),
+            ])
+        );
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString(' IS NULL'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::cetera())->willReturn($this->queryBuilder->reveal());
+
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->innerJoin(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
     public function testLeftJoinNotUpgradedWhenNoExpressionReferencesJoin(): void
     {
-        $this->doctrineListBuilder->addSelectField(
-            new DoctrineFieldDescriptor(
-                'name', 'name', self::$translationEntityName, 'translation', [
-                    self::$translationEntityName => new DoctrineJoinDescriptor(
-                        self::$translationEntityName,
-                        self::$entityNameAlias . '.translations',
-                        '',
-                        DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
-                    ),
-                ]
-            )
-        );
+        $this->doctrineListBuilder->addSelectField($this->createLeftJoinedTranslationFieldDescriptor());
 
         $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
@@ -1332,7 +1322,6 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->addSelect(Argument::any())->willReturn($this->queryBuilder->reveal());
 
-        // No expression references the join — stays LEFT
         $this->queryBuilder->leftJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
@@ -1345,16 +1334,7 @@ class DoctrineListBuilderTest extends TestCase
 
     public function testLeftJoinUpgradedToInnerJoinWhenSearchReferencesJoin(): void
     {
-        $fieldDescriptor = new DoctrineFieldDescriptor(
-            'name', 'name', self::$translationEntityName, 'translation', [
-                self::$translationEntityName => new DoctrineJoinDescriptor(
-                    self::$translationEntityName,
-                    self::$entityNameAlias . '.translations',
-                    '',
-                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
-                ),
-            ]
-        );
+        $fieldDescriptor = $this->createLeftJoinedTranslationFieldDescriptor();
 
         $this->doctrineListBuilder->addSearchField($fieldDescriptor);
         $this->doctrineListBuilder->search('test-search');
@@ -1367,7 +1347,6 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->andWhere(Argument::any())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('search', '%test-search%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        // search() is set and references the join — should upgrade LEFT to INNER
         $this->queryBuilder->innerJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
@@ -1376,6 +1355,70 @@ class DoctrineListBuilderTest extends TestCase
         )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->leftJoin(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testLeftJoinNotUpgradedWhenCaseFieldDescriptorUsedForSearch(): void
+    {
+        $case1EntityName = 'Sulu\Bundle\CoreBundle\Entity\ExampleTranslation';
+        $case2EntityName = 'Sulu\Bundle\CoreBundle\Entity\ExampleFallback';
+        $case2EntityNameAlias = 'Sulu_Bundle_CoreBundle_Entity_ExampleFallback';
+
+        $caseFieldDescriptor = new DoctrineCaseFieldDescriptor(
+            'title',
+            new DoctrineDescriptor(
+                $case1EntityName,
+                'title',
+                [
+                    $case1EntityName => new DoctrineJoinDescriptor(
+                        $case1EntityName,
+                        self::$entityNameAlias . '.translations',
+                        '',
+                        DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                    ),
+                ]
+            ),
+            new DoctrineDescriptor(
+                $case2EntityName,
+                'title',
+                [
+                    $case2EntityName => new DoctrineJoinDescriptor(
+                        $case2EntityName,
+                        self::$entityNameAlias . '.fallbacks',
+                        '',
+                        DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                    ),
+                ]
+            ),
+        );
+
+        $this->doctrineListBuilder->addSearchField($caseFieldDescriptor);
+        $this->doctrineListBuilder->search('test-search');
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::any())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('search', '%test-search%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.fallbacks',
+            $case2EntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->innerJoin(Argument::cetera())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -2228,5 +2271,23 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addOrderBy(Argument::cetera())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->count();
+    }
+
+    private function createLeftJoinedTranslationFieldDescriptor(string $fieldName = 'name'): DoctrineFieldDescriptor
+    {
+        return new DoctrineFieldDescriptor(
+            $fieldName,
+            $fieldName,
+            self::$translationEntityName,
+            'translation',
+            [
+                self::$translationEntityName => new DoctrineJoinDescriptor(
+                    self::$translationEntityName,
+                    self::$entityNameAlias . '.translations',
+                    '',
+                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                ),
+            ]
+        );
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -331,14 +331,14 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->andWhere(Argument::containingString('anotherEntityName.name = :name_alias'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('name_alias'), 'test')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $this->queryBuilder->leftJoin(
+        $this->queryBuilder->innerJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             DoctrineJoinDescriptor::JOIN_CONDITION_METHOD_WITH,
             ''
         )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        $this->queryBuilder->leftJoin(
+        $this->queryBuilder->innerJoin(
             'anotherEntityName.translations',
             'anotherEntityName',
             DoctrineJoinDescriptor::JOIN_CONDITION_METHOD_WITH,
@@ -501,8 +501,8 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
-        // join is only needed in the preselect query, not in the main query. therefore it should be added a one time
-        $this->queryBuilder->leftJoin(
+        // where() expression references the joined entity, so LEFT JOIN is upgraded to INNER JOIN
+        $this->queryBuilder->innerJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             'WITH',
@@ -1158,6 +1158,224 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->leftJoin('a.test', 'a', 'WITH', '')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         // called when select ids and for selecting data
         $this->queryBuilder->innerJoin('b.test', 'b', 'WITH', '')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testLeftJoinUpgradedToInnerJoinWhenFilterExpressionReferencesJoin(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor(
+            'name', 'name', self::$translationEntityName, 'translation', [
+                self::$translationEntityName => new DoctrineJoinDescriptor(
+                    self::$translationEntityName,
+                    self::$entityNameAlias . '.translations',
+                    '',
+                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                ),
+            ]
+        );
+
+        // in() adds an expression referencing the joined entity — should upgrade LEFT to INNER
+        $this->doctrineListBuilder->in($fieldDescriptor, ['value1', 'value2']);
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::any())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::cetera())->willReturn($this->queryBuilder->reveal());
+
+        $this->queryBuilder->innerJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->leftJoin(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testLeftJoinNotUpgradedWhenIsNullExpressionReferencesJoin(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor(
+            'name', 'name', self::$translationEntityName, 'translation', [
+                self::$translationEntityName => new DoctrineJoinDescriptor(
+                    self::$translationEntityName,
+                    self::$entityNameAlias . '.translations',
+                    '',
+                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                ),
+            ]
+        );
+
+        $this->doctrineListBuilder->setFieldDescriptors(['name' => $fieldDescriptor]);
+        $this->doctrineListBuilder->addExpression(
+            $this->doctrineListBuilder->createIsNullExpression($fieldDescriptor)
+        );
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString(' IS NULL'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->innerJoin(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testLeftJoinNotUpgradedWhenNullEqualityExpressionReferencesJoin(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor(
+            'name', 'name', self::$translationEntityName, 'translation', [
+                self::$translationEntityName => new DoctrineJoinDescriptor(
+                    self::$translationEntityName,
+                    self::$entityNameAlias . '.translations',
+                    '',
+                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                ),
+            ]
+        );
+
+        $this->doctrineListBuilder->where($fieldDescriptor, null);
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString(' IS NULL'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->innerJoin(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testLeftJoinNotUpgradedWhenOrExpressionContainsNullCheckForJoin(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor(
+            'name', 'name', self::$translationEntityName, 'translation', [
+                self::$translationEntityName => new DoctrineJoinDescriptor(
+                    self::$translationEntityName,
+                    self::$entityNameAlias . '.translations',
+                    '',
+                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                ),
+            ]
+        );
+
+        $this->doctrineListBuilder->setFieldDescriptors(['name' => $fieldDescriptor]);
+        $this->doctrineListBuilder->addExpression(
+            $this->doctrineListBuilder->createOrExpression([
+                $this->doctrineListBuilder->createIsNullExpression($fieldDescriptor),
+                $this->doctrineListBuilder->createInExpression($fieldDescriptor, ['value1', 'value2']),
+            ])
+        );
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString(' IS NULL'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::cetera())->willReturn($this->queryBuilder->reveal());
+
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->innerJoin(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testLeftJoinNotUpgradedWhenNoExpressionReferencesJoin(): void
+    {
+        $this->doctrineListBuilder->addSelectField(
+            new DoctrineFieldDescriptor(
+                'name', 'name', self::$translationEntityName, 'translation', [
+                    self::$translationEntityName => new DoctrineJoinDescriptor(
+                        self::$translationEntityName,
+                        self::$entityNameAlias . '.translations',
+                        '',
+                        DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                    ),
+                ]
+            )
+        );
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(Argument::any())->willReturn($this->queryBuilder->reveal());
+
+        // No expression references the join — stays LEFT
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testLeftJoinUpgradedToInnerJoinWhenSearchReferencesJoin(): void
+    {
+        $fieldDescriptor = new DoctrineFieldDescriptor(
+            'name', 'name', self::$translationEntityName, 'translation', [
+                self::$translationEntityName => new DoctrineJoinDescriptor(
+                    self::$translationEntityName,
+                    self::$entityNameAlias . '.translations',
+                    '',
+                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                ),
+            ]
+        );
+
+        $this->doctrineListBuilder->addSearchField($fieldDescriptor);
+        $this->doctrineListBuilder->search('test-search');
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::any())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('search', '%test-search%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        // search() is set and references the join — should upgrade LEFT to INNER
+        $this->queryBuilder->innerJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->leftJoin(Argument::cetera())->shouldNotBeCalled();
 
         $this->doctrineListBuilder->execute();
     }
@@ -1915,7 +2133,7 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(Argument::containingString('.name = :name'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter(Argument::containingString('name'), 'test-value')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
-        $this->queryBuilder->leftJoin(
+        $this->queryBuilder->innerJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
             'WITH',
@@ -1986,7 +2204,7 @@ class DoctrineListBuilderTest extends TestCase
 
         // Verify COUNT(DISTINCT ...) is used in the select
         $this->queryBuilder->select(Argument::containingString('COUNT(DISTINCT'))->shouldBeCalled()->willReturn($this->queryBuilder->reveal());
-        $this->queryBuilder->leftJoin(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->innerJoin(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->andWhere(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('search', '%value%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes # |
| Related issues/PRs | # |
| License | MIT |
| Documentation PR | sulu/sulu-docs# |

#### What's in this PR?

- `DoctrineListBuilder::assignJoins()` now upgrades certain `LEFT JOIN`s to `INNER JOIN`s when filter expressions or search conditions already eliminate `NULL` rows.
- `DimensionContentQueryEnhancer::addFilters()` now uses `INNER JOIN` for strict dimension-content filters such as `templateKeys`, `categoryIds`, `categoryKeys`, `tagIds`, and `tagNames`.
- Null-preserving filters still keep `LEFT JOIN`s. Cases such as `IS NULL`, `= null`, and filters with `OR ... IS NULL` fallbacks are explicitly excluded.
- Unit tests were added to cover both the upgraded-join cases and the null-sensitive edge cases.

#### Why?

On installations with large datasets (150K+ articles), admin list endpoints can take 3-8 seconds per request. The root cause is that unnecessary `LEFT JOIN`s restrict MySQL's optimizer and can prevent it from choosing efficient join orders and index access paths.

When a `WHERE` condition filters on a `LEFT JOIN`ed table in a null-rejecting way, for example `templateKey IN ('default')`, rows without a matching join are already excluded by the filter. In that case, the `LEFT JOIN` is semantically equivalent to an `INNER JOIN`, but MySQL can optimize the `INNER JOIN` much better.

This PR applies that optimization where it is safe, while explicitly keeping `LEFT JOIN`s for null-preserving cases such as `IS NULL`, `= null`, or conditions with `OR ... IS NULL` fallbacks.
