### PR TITLE
Add redirects for internal links

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -20,6 +20,7 @@ use Sulu\Content\Application\ContentEnhancer\DimensionContentEnhancerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 
 /**
@@ -52,7 +53,7 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
 
         return match ($linkData['provider'] ?? null) {
             null => $dimensionContent,
-            'page' => $this->resolvePage(
+            PageLinkProvider::ALIAS => $this->resolvePage(
                 $dimensionContent,
                 $dimensionContent::getEffectiveDimensionAttributes(
                     [

--- a/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageLinkProvider.php
@@ -15,6 +15,7 @@ namespace Sulu\Page\Infrastructure\Sulu\Content;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStoreInterface;
+use Sulu\Bundle\MarkupBundle\Markup\Link\ExternalLinkProvider;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
@@ -169,7 +170,7 @@ final class PageLinkProvider implements LinkProviderInterface
         $linkProvider = $row['linkProvider'];
         $linkData = $row['linkData'];
 
-        if ('external' === $linkProvider && \is_array($linkData) && \is_string($linkData['href'] ?? null)) {
+        if (ExternalLinkProvider::ALIAS === $linkProvider && \is_array($linkData) && \is_string($linkData['href'] ?? null)) {
             return $this->appendQueryAndAnchor($linkData['href'], $linkData);
         }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
@@ -17,6 +17,7 @@ use Sulu\Bundle\AdminBundle\Teaser\Configuration\TeaserConfiguration;
 use Sulu\Bundle\AdminBundle\Teaser\Provider\TeaserProviderInterface;
 use Sulu\Bundle\AdminBundle\Teaser\Teaser;
 use Sulu\Bundle\AdminBundle\Teaser\TeaserTagPropertyExtractor;
+use Sulu\Bundle\MarkupBundle\Markup\Link\ExternalLinkProvider;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentEnhancer\ContentEnhancerInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
@@ -150,7 +151,7 @@ class PageTeaserProvider implements TeaserProviderInterface
     protected function resolveUrl(PageDimensionContentInterface $dimensionContent): ?string
     {
         $linkData = $dimensionContent->getLinkData();
-        if ('external' === ($linkData['provider'] ?? null) && \is_string($linkData['href'] ?? null)) {
+        if (ExternalLinkProvider::ALIAS === ($linkData['provider'] ?? null) && \is_string($linkData['href'] ?? null)) {
             return $linkData['href'];
         }
 

--- a/packages/page/src/Infrastructure/Sulu/Route/PageRouteDefaultsProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Route/PageRouteDefaultsProvider.php
@@ -20,13 +20,21 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeRequestStore;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
+use Sulu\Bundle\MarkupBundle\Markup\Link\ExternalLinkProvider;
+use Sulu\Bundle\MarkupBundle\Markup\Link\LinkUrlTrait;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\LinkInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
+use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Application\Routing\Matcher\RouteDefaultsProviderInterface;
 use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -34,11 +42,15 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class PageRouteDefaultsProvider implements RouteDefaultsProviderInterface
 {
+    use LinkUrlTrait;
+
     public function __construct(
         private PageRepositoryInterface $pageRepository,
         private ContentAggregatorInterface $contentAggregator,
         private MetadataProviderRegistry $metadataProviderRegistry,
         private CacheLifetimeResolverInterface $cacheLifetimeResolver,
+        private RouteRepositoryInterface $routeRepository,
+        private RouteGeneratorInterface $routeGenerator,
         private bool $audienceTargetingEnabled = false,
     ) {
     }
@@ -80,6 +92,11 @@ class PageRouteDefaultsProvider implements RouteDefaultsProviderInterface
             throw new NotFoundHttpException(\sprintf('No page found for id "%s" and locale "%s"', $id, $locale));
         }
 
+        $redirectDefaults = $this->resolveRedirectDefaults($dimensionContent, $contentLocale);
+        if (null !== $redirectDefaults) {
+            return $redirectDefaults;
+        }
+
         $templateKey = $dimensionContent->getTemplateKey();
         if (!$templateKey) {
             throw new NotFoundHttpException(\sprintf('No template found for id "%s" and locale "%s"', $id, $locale));
@@ -99,6 +116,65 @@ class PageRouteDefaultsProvider implements RouteDefaultsProviderInterface
         }
 
         return $defaults;
+    }
+
+    /**
+     * @param DimensionContentInterface<PageInterface> $dimensionContent
+     *
+     * @return array{_controller: class-string<RedirectController>, path: string, permanent: true, _sulu_route_target?: Route}|null
+     */
+    private function resolveRedirectDefaults(DimensionContentInterface $dimensionContent, string $locale): ?array
+    {
+        if (!$dimensionContent instanceof LinkInterface) {
+            return null;
+        }
+
+        $linkData = $dimensionContent->getLinkData();
+        if (!\is_array($linkData)) {
+            return null;
+        }
+
+        $provider = $linkData['provider'] ?? null;
+        $href = $linkData['href'] ?? null;
+
+        if (!\is_string($provider) || !\is_string($href)) {
+            return null;
+        }
+
+        if (ExternalLinkProvider::ALIAS === $provider) {
+            return [
+                '_controller' => RedirectController::class,
+                'path' => $this->appendQueryAndAnchor($href, $linkData),
+                'permanent' => true,
+            ];
+        }
+
+        if (PageLinkProvider::ALIAS !== $provider) {
+            return null;
+        }
+
+        $targetRoute = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $href,
+            'locale' => $locale,
+        ]);
+
+        if (!$targetRoute instanceof Route) {
+            throw new NotFoundHttpException(\sprintf('No linked target route found for page "%s" and locale "%s"', $href, $locale));
+        }
+
+        $url = $this->routeGenerator->generate(
+            $targetRoute->getSlug(),
+            $targetRoute->getLocale(),
+            $targetRoute->getWebspace(),
+        );
+
+        return [
+            '_controller' => RedirectController::class,
+            'path' => $this->appendQueryAndAnchor($url, $linkData),
+            'permanent' => true,
+            '_sulu_route_target' => $targetRoute,
+        ];
     }
 
     /**

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -438,6 +438,8 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('sulu_http_cache.cache_lifetime.resolver'),
+                new Reference('sulu_route.route_repository'),
+                new Reference('sulu_route.route_generator'),
                 expr("container.hasParameter('sulu_audience_targeting.enabled')"),
             ])
             ->tag('sulu_route.route_defaults_provider', ['resource_key' => 'pages']);

--- a/packages/page/tests/Functional/Integration/PageLinkRedirectTest.php
+++ b/packages/page/tests/Functional/Integration/PageLinkRedirectTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\MarkupBundle\Markup\Link\ExternalLinkProvider;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+#[CoversNothing]
+class PageLinkRedirectTest extends SuluTestCase
+{
+    use CreatePageTrait;
+
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createWebsiteClient();
+        self::purgeDatabase();
+    }
+
+    public function testInternalLinkedPageRedirectsToTargetPage(): void
+    {
+        $targetPage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Link Target Page',
+                    'url' => '/link-target',
+                    'template' => 'default',
+                ],
+            ],
+        ]);
+
+        self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Internal Link Page',
+                    'url' => '/internal-link',
+                    'template' => 'default',
+                    'linkOn' => true,
+                    'linkData' => [
+                        'href' => $targetPage->getUuid(),
+                        'provider' => PageLinkProvider::ALIAS,
+                    ],
+                ],
+            ],
+        ]);
+
+        self::getEntityManager()->clear();
+
+        $this->client->request('GET', 'http://sulu.io/en/internal-link');
+
+        $response = $this->client->getResponse();
+
+        $this->assertSame(301, $response->getStatusCode(), 'Unexpected response: ' . ($response->getContent() ?: ''));
+        $this->assertSame('http://sulu.io/en/link-target', $response->headers->get('Location'));
+    }
+
+    public function testExternalLinkedPageRedirectsToExternalUrl(): void
+    {
+        self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'External Link Page',
+                    'url' => '/external-link',
+                    'template' => 'default',
+                    'linkOn' => true,
+                    'linkData' => [
+                        'href' => 'https://example.com/target',
+                        'provider' => ExternalLinkProvider::ALIAS,
+                    ],
+                ],
+            ],
+        ]);
+
+        self::getEntityManager()->clear();
+
+        $this->client->request('GET', 'http://sulu.io/en/external-link');
+
+        $response = $this->client->getResponse();
+
+        $this->assertSame(301, $response->getStatusCode(), 'Unexpected response: ' . ($response->getContent() ?: ''));
+        $this->assertSame('https://example.com/target', $response->headers->get('Location'));
+    }
+}

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Route/PageRouteDefaultsProviderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Route/PageRouteDefaultsProviderTest.php
@@ -25,6 +25,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolver;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
+use Sulu\Bundle\MarkupBundle\Markup\Link\ExternalLinkProvider;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
@@ -32,8 +33,12 @@ use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Sulu\Page\Infrastructure\Sulu\Route\PageRouteDefaultsProvider;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -50,6 +55,12 @@ class PageRouteDefaultsProviderTest extends TestCase
     /** @var ObjectProphecy<FormMetadataProvider> */
     private ObjectProphecy $formMetadataProvider;
 
+    /** @var ObjectProphecy<RouteRepositoryInterface> */
+    private ObjectProphecy $routeRepository;
+
+    /** @var ObjectProphecy<RouteGeneratorInterface> */
+    private ObjectProphecy $routeGenerator;
+
     private CacheLifetimeResolver $cacheLifetimeResolver;
 
     private MetadataProviderRegistry $metadataProviderRegistry;
@@ -60,6 +71,8 @@ class PageRouteDefaultsProviderTest extends TestCase
         $this->contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
         $this->cacheLifetimeResolver = new CacheLifetimeResolver();
         $this->formMetadataProvider = $this->prophesize(FormMetadataProvider::class);
+        $this->routeRepository = $this->prophesize(RouteRepositoryInterface::class);
+        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
         $container = new Container();
         $container->set('form', $this->formMetadataProvider->reveal());
         $this->metadataProviderRegistry = new MetadataProviderRegistry($container);
@@ -72,6 +85,8 @@ class PageRouteDefaultsProviderTest extends TestCase
             $this->contentAggregator->reveal(),
             $this->metadataProviderRegistry,
             $this->cacheLifetimeResolver,
+            $this->routeRepository->reveal(),
+            $this->routeGenerator->reveal(),
         );
 
         $page = new Page('123-123-123');
@@ -134,6 +149,8 @@ class PageRouteDefaultsProviderTest extends TestCase
             $this->contentAggregator->reveal(),
             $this->metadataProviderRegistry,
             $this->cacheLifetimeResolver,
+            $this->routeRepository->reveal(),
+            $this->routeGenerator->reveal(),
             true,
         );
 
@@ -186,6 +203,8 @@ class PageRouteDefaultsProviderTest extends TestCase
             $this->contentAggregator->reveal(),
             $this->metadataProviderRegistry,
             $this->cacheLifetimeResolver,
+            $this->routeRepository->reveal(),
+            $this->routeGenerator->reveal(),
         );
 
         $this->expectException(NotFoundHttpException::class);
@@ -205,6 +224,219 @@ class PageRouteDefaultsProviderTest extends TestCase
         $provider->getDefaults(
             new Route(Page::RESOURCE_KEY, '123-123-123', 'en', '/example')
         );
+    }
+
+    public function testGetDefaultsReturnsRedirectForInternalPageLink(): void
+    {
+        $provider = new PageRouteDefaultsProvider(
+            $this->pageRepository->reveal(),
+            $this->contentAggregator->reveal(),
+            $this->metadataProviderRegistry,
+            $this->cacheLifetimeResolver,
+            $this->routeRepository->reveal(),
+            $this->routeGenerator->reveal(),
+        );
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu-io');
+        $resolvedDimensionContent = new PageDimensionContent($page);
+        $resolvedDimensionContent->setLocale('en');
+        $resolvedDimensionContent->setTemplateKey('default');
+        $resolvedDimensionContent->setLinkData([
+            'provider' => PageLinkProvider::ALIAS,
+            'href' => '456-456-456',
+        ]);
+
+        $this->pageRepository->findOneBy(
+            Argument::cetera()
+        )->willReturn($page);
+
+        $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live', 'version' => 0])
+            ->willReturn($resolvedDimensionContent);
+
+        $targetRoute = new Route(Page::RESOURCE_KEY, '456-456-456', 'en', '/target-page', 'sulu-io');
+        $this->routeRepository->findOneBy([
+            'resourceKey' => Page::RESOURCE_KEY,
+            'resourceId' => '456-456-456',
+            'locale' => 'en',
+        ])->willReturn($targetRoute);
+
+        $this->routeGenerator->generate('/target-page', 'en', 'sulu-io')->willReturn('/en/target-page');
+
+        $result = $provider->getDefaults(
+            new Route(Page::RESOURCE_KEY, '123-123-123', 'en', '/example', 'sulu-io')
+        );
+
+        $this->assertSame([
+            '_controller' => RedirectController::class,
+            'path' => '/en/target-page',
+            'permanent' => true,
+            '_sulu_route_target' => $targetRoute,
+        ], $result);
+    }
+
+    public function testGetDefaultsReturnsRedirectForExternalLink(): void
+    {
+        $provider = new PageRouteDefaultsProvider(
+            $this->pageRepository->reveal(),
+            $this->contentAggregator->reveal(),
+            $this->metadataProviderRegistry,
+            $this->cacheLifetimeResolver,
+            $this->routeRepository->reveal(),
+            $this->routeGenerator->reveal(),
+        );
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu-io');
+        $resolvedDimensionContent = new PageDimensionContent($page);
+        $resolvedDimensionContent->setLocale('en');
+        $resolvedDimensionContent->setTemplateKey('default');
+        $resolvedDimensionContent->setLinkData([
+            'provider' => ExternalLinkProvider::ALIAS,
+            'href' => 'https://example.com/target',
+        ]);
+
+        $this->pageRepository->findOneBy(
+            Argument::cetera()
+        )->willReturn($page);
+
+        $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live', 'version' => 0])
+            ->willReturn($resolvedDimensionContent);
+
+        $result = $provider->getDefaults(
+            new Route(Page::RESOURCE_KEY, '123-123-123', 'en', '/example', 'sulu-io')
+        );
+
+        $this->assertSame([
+            '_controller' => RedirectController::class,
+            'path' => 'https://example.com/target',
+            'permanent' => true,
+        ], $result);
+    }
+
+    public function testGetDefaultsThrowsNotFoundForMissingTargetRoute(): void
+    {
+        $provider = new PageRouteDefaultsProvider(
+            $this->pageRepository->reveal(),
+            $this->contentAggregator->reveal(),
+            $this->metadataProviderRegistry,
+            $this->cacheLifetimeResolver,
+            $this->routeRepository->reveal(),
+            $this->routeGenerator->reveal(),
+        );
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu-io');
+        $resolvedDimensionContent = new PageDimensionContent($page);
+        $resolvedDimensionContent->setLocale('en');
+        $resolvedDimensionContent->setTemplateKey('default');
+        $resolvedDimensionContent->setLinkData([
+            'provider' => PageLinkProvider::ALIAS,
+            'href' => '999-999-999',
+        ]);
+
+        $this->pageRepository->findOneBy(
+            Argument::cetera()
+        )->willReturn($page);
+
+        $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live', 'version' => 0])
+            ->willReturn($resolvedDimensionContent);
+
+        $this->routeRepository->findOneBy([
+            'resourceKey' => Page::RESOURCE_KEY,
+            'resourceId' => '999-999-999',
+            'locale' => 'en',
+        ])->willReturn(null);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('No linked target route found for page "999-999-999" and locale "en"');
+
+        $provider->getDefaults(
+            new Route(Page::RESOURCE_KEY, '123-123-123', 'en', '/example', 'sulu-io')
+        );
+    }
+
+    public function testGetDefaultsAppendsQueryAndAnchorForInternalPageLink(): void
+    {
+        $provider = new PageRouteDefaultsProvider(
+            $this->pageRepository->reveal(),
+            $this->contentAggregator->reveal(),
+            $this->metadataProviderRegistry,
+            $this->cacheLifetimeResolver,
+            $this->routeRepository->reveal(),
+            $this->routeGenerator->reveal(),
+        );
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu-io');
+        $resolvedDimensionContent = new PageDimensionContent($page);
+        $resolvedDimensionContent->setLocale('en');
+        $resolvedDimensionContent->setTemplateKey('default');
+        $resolvedDimensionContent->setLinkData([
+            'provider' => PageLinkProvider::ALIAS,
+            'href' => '456-456-456',
+            'query' => 'foo=bar',
+            'anchor' => 'section',
+        ]);
+
+        $this->pageRepository->findOneBy(
+            Argument::cetera()
+        )->willReturn($page);
+
+        $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live', 'version' => 0])
+            ->willReturn($resolvedDimensionContent);
+
+        $targetRoute = new Route(Page::RESOURCE_KEY, '456-456-456', 'en', '/target-page', 'sulu-io');
+        $this->routeRepository->findOneBy([
+            'resourceKey' => Page::RESOURCE_KEY,
+            'resourceId' => '456-456-456',
+            'locale' => 'en',
+        ])->willReturn($targetRoute);
+
+        $this->routeGenerator->generate('/target-page', 'en', 'sulu-io')->willReturn('/en/target-page');
+
+        $result = $provider->getDefaults(
+            new Route(Page::RESOURCE_KEY, '123-123-123', 'en', '/example', 'sulu-io')
+        );
+
+        $this->assertSame('/en/target-page?foo=bar#section', $result['path']);
+    }
+
+    public function testGetDefaultsAppendsQueryAndAnchorForExternalLink(): void
+    {
+        $provider = new PageRouteDefaultsProvider(
+            $this->pageRepository->reveal(),
+            $this->contentAggregator->reveal(),
+            $this->metadataProviderRegistry,
+            $this->cacheLifetimeResolver,
+            $this->routeRepository->reveal(),
+            $this->routeGenerator->reveal(),
+        );
+
+        $page = new Page('123-123-123');
+        $page->setWebspaceKey('sulu-io');
+        $resolvedDimensionContent = new PageDimensionContent($page);
+        $resolvedDimensionContent->setLocale('en');
+        $resolvedDimensionContent->setTemplateKey('default');
+        $resolvedDimensionContent->setLinkData([
+            'provider' => ExternalLinkProvider::ALIAS,
+            'href' => 'https://example.com/target',
+            'query' => 'utm_source=sulu',
+            'anchor' => 'top',
+        ]);
+
+        $this->pageRepository->findOneBy(
+            Argument::cetera()
+        )->willReturn($page);
+
+        $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live', 'version' => 0])
+            ->willReturn($resolvedDimensionContent);
+
+        $result = $provider->getDefaults(
+            new Route(Page::RESOURCE_KEY, '123-123-123', 'en', '/example', 'sulu-io')
+        );
+
+        $this->assertSame('https://example.com/target?utm_source=sulu#top', $result['path']);
     }
 
     private function prepareTemplateMetadata(string $controller, string $view, string $cacheLifeTimeType, string $cacheLifeTimeValue): void

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/ExternalLinkProvider.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/ExternalLinkProvider.php
@@ -19,6 +19,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 final class ExternalLinkProvider implements LinkProviderInterface
 {
+    public const ALIAS = 'external';
+
     public function __construct(
         private TranslatorInterface $translator,
     ) {


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
  | Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

  #### What's in this PR?

  - Added redirect handling to page route defaults so linked pages respond with permanent redirects instead of rendering the linked page as regular content
  - Resolved internal page links via the target page route and preserved configured query strings and anchors on both internal and external redirects
  - Replaced hardcoded provider aliases with shared constants for page and external link providers
  - Added unit and functional coverage for internal and external page-link redirects

  #### Why?

  Pages with internal/external links enabled are intended to behave as redirects to their configured target. Before this change, internal page links were not resolved at the routing layer, so linked pages could be treated like
  normal pages instead of issuing a redirect.

  This change makes linked pages consistently return a `301` redirect for both internal page targets and external URLs, including appended query parameters and anchors, and fails explicitly if an internal target
  route cannot be resolved.