### PR TITLE
Fix navigation tree incorrectly promoting children of filtered parents

### DIFF
--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -13,7 +13,6 @@ namespace Sulu\Page\Infrastructure\Doctrine\Repository;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
@@ -83,7 +82,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
         int $depth = 1,
         array $properties = []
     ): array {
-        $pages = $this->findByAsTree([
+        $pages = $this->findBy([
             'locale' => $locale,
             'navigationContexts' => [$navigationContext],
             'depth' => $depth,
@@ -92,7 +91,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
-        return $this->normalizePageTree($pages, $properties, $locale, 1, $depth);
+        return $this->normalizePageTree($pages, $properties, $locale);
     }
 
     public function getNavigationFlat(
@@ -140,9 +139,9 @@ final class NavigationRepository implements NavigationRepositoryInterface
         array $properties = []
     ): array {
         $filters = $this->buildChildrenFilters($uuid, $locale, $webspaceKey, $depth, $navigationContext);
-        $pages = $this->findByAsTree($filters);
+        $pages = $this->findBy($filters);
 
-        return $this->normalizePageTree($pages, $properties, $locale, 1, $depth);
+        return $this->normalizePageTree($pages, $properties, $locale, $uuid);
     }
 
     public function getBreadcrumb(
@@ -272,50 +271,80 @@ final class NavigationRepository implements NavigationRepositoryInterface
     }
 
     /**
-     * @param array{
-     *      locale?: string|null,
-     *      stage?: string|null,
-     *      webspaceKey?: string,
-     *      segmentKey?: string|null,
-     *      page?: int,
-     *      limit?: int,
-     *      navigationContexts?: string[],
-     *      depth?: int,
-     *  } $filters
-     *
-     * @return \Generator<PageInterface>
-     */
-    private function findByAsTree(array $filters = []): \Generator
-    {
-        $queryBuilder = $this->createQueryBuilder($filters);
-
-        $query = $queryBuilder->getQuery();
-        // Hint is necessary for the TreeObjectHydrator to work
-        // https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/tree.md#building-trees-from-your-entities
-        $query->setHint(Query::HINT_INCLUDE_META_COLUMNS, true);
-
-        /** @var iterable<PageInterface> $pages */
-        $pages = $query->getResult('sulu_page_tree');
-
-        foreach ($pages as $page) {
-            yield $page;
-        }
-    }
-
-    /**
      * @param iterable<PageInterface> $pages
      * @param array<string, string> $properties
      *
      * @return array<string, mixed>[]
      */
-    private function normalizePageTree(iterable $pages, array $properties, string $locale, int $depth, int $maxDepth): array
-    {
-        $result = [];
+    private function normalizePageTree(
+        iterable $pages,
+        array $properties,
+        string $locale,
+        ?string $rootParentUuid = null,
+    ): array {
+        $pagesByUuid = [];
+        $rootDepth = null;
         foreach ($pages as $page) {
-            $normalizedContent = $this->resolvePageContent($page, $locale, $properties);
+            $pagesByUuid[$page->getUuid()] = $page;
 
-            $children = $depth < $maxDepth ? $page->getChildren() : [];
-            $normalizedContent['children'] = $this->normalizePageTree($children, $properties, $locale, $depth + 1, $maxDepth);
+            if (null === $rootParentUuid) {
+                $depth = $page->getDepth();
+                $rootDepth = null === $rootDepth ? $depth : \min($rootDepth, $depth);
+            }
+        }
+
+        $rootPageUuids = [];
+        $childPageUuidsByParent = [];
+
+        foreach ($pagesByUuid as $uuid => $page) {
+            $parentUuid = $page->getParent()?->getUuid();
+
+            $isRoot = null !== $rootParentUuid
+                ? $parentUuid === $rootParentUuid
+                : $page->getDepth() === $rootDepth;
+
+            if ($isRoot) {
+                $rootPageUuids[] = $uuid;
+            } elseif (null !== $parentUuid && \array_key_exists($parentUuid, $pagesByUuid)) {
+                $childPageUuidsByParent[$parentUuid][] = $uuid;
+            }
+        }
+
+        return $this->normalizePageTreeNodes(
+            $rootPageUuids,
+            $pagesByUuid,
+            $childPageUuidsByParent,
+            $properties,
+            $locale,
+        );
+    }
+
+    /**
+     * @param string[] $pageUuids
+     * @param array<string, PageInterface> $pagesByUuid
+     * @param array<string, string[]> $childPageUuidsByParent
+     * @param array<string, string> $properties
+     *
+     * @return array<string, mixed>[]
+     */
+    private function normalizePageTreeNodes(
+        array $pageUuids,
+        array $pagesByUuid,
+        array $childPageUuidsByParent,
+        array $properties,
+        string $locale,
+    ): array {
+        $result = [];
+        foreach ($pageUuids as $pageUuid) {
+            $page = $pagesByUuid[$pageUuid];
+            $normalizedContent = $this->resolvePageContent($page, $locale, $properties);
+            $normalizedContent['children'] = $this->normalizePageTreeNodes(
+                $childPageUuidsByParent[$pageUuid] ?? [],
+                $pagesByUuid,
+                $childPageUuidsByParent,
+                $properties,
+                $locale,
+            );
 
             $result[] = $normalizedContent;
         }
@@ -335,9 +364,6 @@ final class NavigationRepository implements NavigationRepositoryInterface
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
-        $sourceProperties = $properties;
-        $linkData = $pageDimensionContent->getLinkData();
-
         // prefix all properties with "nav." to only resolve navigation related content
         foreach ($properties as $key => $value) {
             unset($properties[$key]);
@@ -353,23 +379,6 @@ final class NavigationRepository implements NavigationRepositoryInterface
         $result = $resolvedContent['nav'];
 
         $result['targetType'] = $result['targetType'] ?? PageLinkProvider::ALIAS;
-
-        if (PageLinkProvider::ALIAS === ($linkData['provider'] ?? null)) {
-            foreach ($sourceProperties as $key => $value) {
-                $structurePropertyValue = match ($value) {
-                    'object.resource.depth' => $page->getDepth(),
-                    'object.resource.lft' => $page->getLft(),
-                    'object.resource.rgt' => $page->getRgt(),
-                    default => null,
-                };
-
-                if (null === $structurePropertyValue) {
-                    continue;
-                }
-
-                $result[$key] = $structurePropertyValue;
-            }
-        }
 
         return $result;
     }

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -335,6 +335,9 @@ final class NavigationRepository implements NavigationRepositoryInterface
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
 
+        $sourceProperties = $properties;
+        $linkData = $pageDimensionContent->getLinkData();
+
         // prefix all properties with "nav." to only resolve navigation related content
         foreach ($properties as $key => $value) {
             unset($properties[$key]);
@@ -350,6 +353,23 @@ final class NavigationRepository implements NavigationRepositoryInterface
         $result = $resolvedContent['nav'];
 
         $result['targetType'] = $result['targetType'] ?? PageLinkProvider::ALIAS;
+
+        if (PageLinkProvider::ALIAS === ($linkData['provider'] ?? null)) {
+            foreach ($sourceProperties as $key => $value) {
+                $structurePropertyValue = match ($value) {
+                    'object.resource.depth' => $page->getDepth(),
+                    'object.resource.lft' => $page->getLft(),
+                    'object.resource.rgt' => $page->getRgt(),
+                    default => null,
+                };
+
+                if (null === $structurePropertyValue) {
+                    continue;
+                }
+
+                $result[$key] = $structurePropertyValue;
+            }
+        }
 
         return $result;
     }

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -27,22 +27,10 @@ class NavigationRepositoryLinkTest extends SuluTestCase
 
     private NavigationRepositoryInterface $navigationRepository;
 
-    private static int $internalLinkPageDepth;
-
-    private static int $internalLinkPageLft;
-
-    private static int $internalLinkPageRgt;
-
-    private static int $targetPageDepth;
-
-    private static int $targetPageLft;
-
-    private static int $targetPageRgt;
-
     /**
      * @return array<string, string>
      */
-    private function getDefaultProperties(bool $withExcerpt = false, bool $withStructure = false): array
+    private function getDefaultProperties(bool $withExcerpt = false): array
     {
         $properties = [
             'uuid' => 'object.resource.id',
@@ -56,12 +44,6 @@ class NavigationRepositoryLinkTest extends SuluTestCase
             'creator' => 'object.creator',
             'linkProvider' => 'object.linkData[provider]',
         ];
-
-        if ($withStructure) {
-            $properties['depth'] = 'object.resource.depth';
-            $properties['lft'] = 'object.resource.lft';
-            $properties['rgt'] = 'object.resource.rgt';
-        }
 
         if ($withExcerpt) {
             $properties['excerpt.title'] = 'excerpt.title';
@@ -138,7 +120,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
             ],
         ]);
 
-        $internalLinkPage = self::createPage([
+        self::createPage([
             'en' => [
                 'live' => [
                     'title' => 'Internal Link Page',
@@ -158,14 +140,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
             ],
         ]);
 
-        self::$internalLinkPageDepth = $internalLinkPage->getDepth();
-        self::$internalLinkPageLft = $internalLinkPage->getLft();
-        self::$internalLinkPageRgt = $internalLinkPage->getRgt();
-        self::$targetPageDepth = $targetPage->getDepth();
-        self::$targetPageLft = $targetPage->getLft();
-        self::$targetPageRgt = $targetPage->getRgt();
-
-        $externalLinkPage = self::createPage([
+        self::createPage([
             'en' => [
                 'live' => [
                     'title' => 'External Link Page',
@@ -285,31 +260,39 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $this->assertArrayHasKey('children', $externalLinkNav);
     }
 
-    public function testGetNavigationTreePreservesSourcePositionMetadataForInternalLinks(): void
+    public function testGetNavigationTreeResolvesTargetPositionMetadataForInternalLinks(): void
     {
+        $properties = [
+            ...$this->getDefaultProperties(),
+            'depth' => 'object.resource.depth',
+            'lft' => 'object.resource.lft',
+            'rgt' => 'object.resource.rgt',
+        ];
+
         $navigation = $this->navigationRepository->getNavigationTree(
             'main',
             'en',
             'sulu-io',
             null,
             2,
-            $this->getDefaultProperties(false, true)
+            $properties
         );
 
         /** @var array<string, mixed> $homepageNav */
         $homepageNav = $navigation[0];
         /** @var array<int, array<string, mixed>> $homepageChildren */
         $homepageChildren = $homepageNav['children'];
+        /** @var array<string, mixed> $contentPageNav */
+        $contentPageNav = $homepageChildren[0];
         /** @var array<string, mixed> $internalLinkNav */
         $internalLinkNav = $homepageChildren[1];
+        /** @var array<string, mixed> $externalLinkNav */
+        $externalLinkNav = $homepageChildren[2];
 
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
         $this->assertSame('/target-page', $internalLinkNav['url']);
-        $this->assertSame(self::$internalLinkPageDepth, $internalLinkNav['depth']);
-        $this->assertSame(self::$internalLinkPageLft, $internalLinkNav['lft']);
-        $this->assertSame(self::$internalLinkPageRgt, $internalLinkNav['rgt']);
-        $this->assertNotSame(self::$targetPageDepth, $internalLinkNav['depth']);
-        $this->assertNotSame(self::$targetPageLft, $internalLinkNav['lft']);
-        $this->assertNotSame(self::$targetPageRgt, $internalLinkNav['rgt']);
+        $this->assertSame(2, $internalLinkNav['depth']);
+        $this->assertGreaterThan($contentPageNav['lft'], $internalLinkNav['lft']);
+        $this->assertLessThan($contentPageNav['rgt'], $internalLinkNav['rgt']);
     }
 }

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -16,6 +16,7 @@ namespace Sulu\Page\Tests\Functional\Infrastructure\Doctrine\Repository;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
 use Symfony\Component\Routing\RequestContext;
 
@@ -26,10 +27,22 @@ class NavigationRepositoryLinkTest extends SuluTestCase
 
     private NavigationRepositoryInterface $navigationRepository;
 
+    private static int $internalLinkPageDepth;
+
+    private static int $internalLinkPageLft;
+
+    private static int $internalLinkPageRgt;
+
+    private static int $targetPageDepth;
+
+    private static int $targetPageLft;
+
+    private static int $targetPageRgt;
+
     /**
      * @return array<string, string>
      */
-    private function getDefaultProperties(bool $withExcerpt = false): array
+    private function getDefaultProperties(bool $withExcerpt = false, bool $withStructure = false): array
     {
         $properties = [
             'uuid' => 'object.resource.id',
@@ -43,6 +56,12 @@ class NavigationRepositoryLinkTest extends SuluTestCase
             'creator' => 'object.creator',
             'linkProvider' => 'object.linkData[provider]',
         ];
+
+        if ($withStructure) {
+            $properties['depth'] = 'object.resource.depth';
+            $properties['lft'] = 'object.resource.lft';
+            $properties['rgt'] = 'object.resource.rgt';
+        }
 
         if ($withExcerpt) {
             $properties['excerpt.title'] = 'excerpt.title';
@@ -114,7 +133,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
                     'excerpt' => [
                         'title' => 'Target Page Excerpt',
                     ],
-                    'parentId' => $homepage->getId(),
+                    'parentId' => $contentPage->getId(),
                 ],
             ],
         ]);
@@ -129,7 +148,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
                     'linkOn' => true,
                     'linkData' => [
                         'href' => $targetPage->getUuid(),
-                        'provider' => 'page',
+                        'provider' => PageLinkProvider::ALIAS,
                     ],
                     'excerpt' => [
                         'title' => 'Internal Link Excerpt',
@@ -138,6 +157,13 @@ class NavigationRepositoryLinkTest extends SuluTestCase
                 ],
             ],
         ]);
+
+        self::$internalLinkPageDepth = $internalLinkPage->getDepth();
+        self::$internalLinkPageLft = $internalLinkPage->getLft();
+        self::$internalLinkPageRgt = $internalLinkPage->getRgt();
+        self::$targetPageDepth = $targetPage->getDepth();
+        self::$targetPageLft = $targetPage->getLft();
+        self::$targetPageRgt = $targetPage->getRgt();
 
         $externalLinkPage = self::createPage([
             'en' => [
@@ -257,5 +283,33 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $this->assertSame('https://example.com', $externalLinkNav['url']);
         $this->assertSame('external', $externalLinkNav['linkProvider']);
         $this->assertArrayHasKey('children', $externalLinkNav);
+    }
+
+    public function testGetNavigationTreePreservesSourcePositionMetadataForInternalLinks(): void
+    {
+        $navigation = $this->navigationRepository->getNavigationTree(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            2,
+            $this->getDefaultProperties(false, true)
+        );
+
+        /** @var array<string, mixed> $homepageNav */
+        $homepageNav = $navigation[0];
+        /** @var array<int, array<string, mixed>> $homepageChildren */
+        $homepageChildren = $homepageNav['children'];
+        /** @var array<string, mixed> $internalLinkNav */
+        $internalLinkNav = $homepageChildren[1];
+
+        $this->assertSame('Internal Link Page', $internalLinkNav['title']);
+        $this->assertSame('/target-page', $internalLinkNav['url']);
+        $this->assertSame(self::$internalLinkPageDepth, $internalLinkNav['depth']);
+        $this->assertSame(self::$internalLinkPageLft, $internalLinkNav['lft']);
+        $this->assertSame(self::$internalLinkPageRgt, $internalLinkNav['rgt']);
+        $this->assertNotSame(self::$targetPageDepth, $internalLinkNav['depth']);
+        $this->assertNotSame(self::$targetPageLft, $internalLinkNav['lft']);
+        $this->assertNotSame(self::$targetPageRgt, $internalLinkNav['rgt']);
     }
 }

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryPermissionTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryPermissionTest.php
@@ -358,7 +358,7 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         $this->assertContains($childPage->getUuid(), $uuids);
     }
 
-    public function testNavigationTreeWithDeniedParentStillShowsAllowedChildren(): void
+    public function testNavigationTreeWithDeniedParentDoesNotPromoteAllowedChildren(): void
     {
         $deniedParent = $this->createSimplePage('sulu-test-secure', 'en', 'Denied Parent');
 
@@ -393,7 +393,7 @@ class NavigationRepositoryPermissionTest extends SuluTestCase
         $uuids = $this->collectTreeUuids($result);
         $this->assertContains($allowedPage->getUuid(), $uuids);
         $this->assertNotContains($deniedParent->getUuid(), $uuids);
-        $this->assertContains($childOfDenied->getUuid(), $uuids);
+        $this->assertNotContains($childOfDenied->getUuid(), $uuids);
     }
 
     /**

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -267,6 +267,47 @@ class NavigationRepositoryTest extends SuluTestCase
         $this->assertSame('Grandchild 1', $result[0]['children'][0]['title']);
     }
 
+    public function testGetNavigationTreeDoesNotPromoteChildrenOfFilteredParentsToRootLevel(): void
+    {
+        $hiddenParent = self::createPage([
+            'en' => [
+                'live' => [
+                    'parentId' => $this->parent->getUuid(),
+                    'template' => 'default',
+                    'title' => 'Hidden Parent',
+                    'url' => '/hidden-parent',
+                    'navigationContexts' => ['footer'],
+                ],
+            ],
+        ]);
+
+        self::createPage([
+            'en' => [
+                'live' => [
+                    'parentId' => $hiddenParent->getUuid(),
+                    'template' => 'default',
+                    'title' => 'Promoted Grandchild',
+                    'url' => '/promoted-grandchild',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        $result = $this->navigationRepository->getNavigationTree(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            2,
+            $this->getDefaultProperties()
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Parent Page', $result[0]['title']);
+        \assert(\is_array($result[0]['children']));
+        $this->assertSame(['Child 1'], \array_column($result[0]['children'], 'title'));
+    }
+
     public function testGetNavigationTreeByUuidReturnsEmptyForInvalidUuid(): void
     {
         $result = $this->navigationRepository->getNavigationTreeByUuid(

--- a/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Tests\Unit\Infrastructure\Doctrine\Repository;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
@@ -128,7 +127,9 @@ class NavigationRepositoryTest extends TestCase
     public function testGetNavigationTree(): void
     {
         $page = $this->prophesize(PageInterface::class);
-        $page->getChildren()->willReturn(new ArrayCollection([]));
+        $page->getUuid()->willReturn('page-uuid-1');
+        $page->getDepth()->willReturn(1);
+        $page->getParent()->willReturn(null);
         $page->getWebspaceKey()->willReturn('sulu-io');
 
         $queryBuilder = $this->prophesize(QueryBuilder::class);
@@ -179,8 +180,7 @@ class NavigationRepositoryTest extends TestCase
         $queryBuilder->andWhere('filterNavigationContext.navigationContext IN (:navigationContexts)')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('navigationContexts', ['main'])->willReturn($queryBuilder->reveal());
 
-        $query->setHint('doctrine.includeMetaColumns', true)->willReturn($query->reveal())->shouldBeCalled();
-        $query->getResult('sulu_page_tree')->willReturn([$page->reveal()]);
+        $query->getResult()->willReturn([$page->reveal()]);
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($page->reveal(), ['locale' => 'en', 'stage' => 'live'])
@@ -291,7 +291,9 @@ class NavigationRepositoryTest extends TestCase
     public function testGetNavigationTreeWithoutSegment(): void
     {
         $page = $this->prophesize(PageInterface::class);
-        $page->getChildren()->willReturn(new ArrayCollection([]));
+        $page->getUuid()->willReturn('page-uuid-1');
+        $page->getDepth()->willReturn(1);
+        $page->getParent()->willReturn(null);
         $page->getWebspaceKey()->willReturn('test-webspace');
 
         $queryBuilder = $this->prophesize(QueryBuilder::class);
@@ -342,8 +344,7 @@ class NavigationRepositoryTest extends TestCase
         $queryBuilder->andWhere('filterNavigationContext.navigationContext IN (:navigationContexts)')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('navigationContexts', ['sidebar'])->willReturn($queryBuilder->reveal());
 
-        $query->setHint('doctrine.includeMetaColumns', true)->willReturn($query->reveal())->shouldBeCalled();
-        $query->getResult('sulu_page_tree')->willReturn([$page->reveal()]);
+        $query->getResult()->willReturn([$page->reveal()]);
 
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($page->reveal(), ['locale' => 'en', 'stage' => 'live'])
@@ -371,9 +372,13 @@ class NavigationRepositoryTest extends TestCase
         $parentPage = $this->prophesize(PageInterface::class);
         $childPage = $this->prophesize(PageInterface::class);
 
-        $parentPage->getChildren()->willReturn(new ArrayCollection([$childPage->reveal()]));
+        $parentPage->getUuid()->willReturn('parent-uuid');
+        $parentPage->getDepth()->willReturn(1);
+        $parentPage->getParent()->willReturn(null);
         $parentPage->getWebspaceKey()->willReturn('sulu-io');
-        $childPage->getChildren()->willReturn(new ArrayCollection([]));
+        $childPage->getUuid()->willReturn('child-uuid');
+        $childPage->getDepth()->willReturn(2);
+        $childPage->getParent()->willReturn($parentPage->reveal());
         $childPage->getWebspaceKey()->willReturn('sulu-io');
 
         $queryBuilder = $this->prophesize(QueryBuilder::class);
@@ -424,8 +429,7 @@ class NavigationRepositoryTest extends TestCase
         $queryBuilder->andWhere('filterNavigationContext.navigationContext IN (:navigationContexts)')->willReturn($queryBuilder->reveal());
         $queryBuilder->setParameter('navigationContexts', ['main'])->willReturn($queryBuilder->reveal());
 
-        $query->setHint('doctrine.includeMetaColumns', true)->willReturn($query->reveal())->shouldBeCalled();
-        $query->getResult('sulu_page_tree')->willReturn([$parentPage->reveal()]);
+        $query->getResult()->willReturn([$parentPage->reveal(), $childPage->reveal()]);
 
         $parentDimensionContent = $this->prophesize(DimensionContentInterface::class);
         $this->contentAggregator->aggregate($parentPage->reveal(), ['locale' => 'en', 'stage' => 'live'])


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8714
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

- Fixed navigation tree building to no longer promote children of filtered/denied parents to root level
- Replaced Doctrine tree hydrator (`sulu_page_tree`) with manual parent-child tree assembly using UUID lookups, ensuring only pages whose parents are present in the result set appear in the tree

#### Why?

When the navigation tree was built using Doctrine's `TreeObjectHydrator`, pages whose parents were filtered out (e.g., different navigation context or denied permissions) would get incorrectly promoted to the root level of the navigation. This happened because the tree hydrator doesn't account for missing intermediate nodes — it simply attaches orphaned children at the top level.

The new approach fetches a flat list of pages and reconstructs the tree manually, only including a child if its parent UUID exists in the result set. This ensures the navigation tree accurately reflects the page hierarchy.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md