### PR TITLE
Do not serialize lazy objects in ArrayAdapter Cache

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -49,7 +49,10 @@
             <argument type="service" id="sulu_trash.trash_manager" on-invalid="null"/>
         </service>
 
-        <service id="sulu_contact.twig.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
+        <service id="sulu_contact.twig.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter">
+            <argument>0</argument>
+            <argument>false</argument>
+        </service>
         <service id="sulu_contact.twig" class="Sulu\Bundle\ContactBundle\Twig\ContactTwigExtension">
             <argument type="service" id="sulu_contact.twig.cache_adapter"/>
             <argument type="service" id="sulu.repository.contact"/>

--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.xml
@@ -50,8 +50,7 @@
         </service>
 
         <service id="sulu_contact.twig.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter">
-            <argument>0</argument>
-            <argument>false</argument>
+            <argument key="$storeSerialized">false</argument>
         </service>
         <service id="sulu_contact.twig" class="Sulu\Bundle\ContactBundle\Twig\ContactTwigExtension">
             <argument type="service" id="sulu_contact.twig.cache_adapter"/>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -219,7 +219,10 @@
             <tag name="sulu.context" context="admin"/>
         </service>
 
-        <service id="sulu_security.twig_extension.user.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
+        <service id="sulu_security.twig_extension.user.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter">
+            <argument>0</argument>
+            <argument>false</argument>
+        </service>
 
         <service id="sulu_security.twig_extension.user" class="Sulu\Bundle\SecurityBundle\Twig\UserTwigExtension">
             <argument type="service" id="sulu_security.twig_extension.user.cache_adapter"/>

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.xml
@@ -220,8 +220,7 @@
         </service>
 
         <service id="sulu_security.twig_extension.user.cache_adapter" class="Symfony\Component\Cache\Adapter\ArrayAdapter">
-            <argument>0</argument>
-            <argument>false</argument>
+            <argument key="$storeSerialized">false</argument>
         </service>
 
         <service id="sulu_security.twig_extension.user" class="Sulu\Bundle\SecurityBundle\Twig\UserTwigExtension">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/8719
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Configures the Cache-Adapter to not serialize lazy objects.

#### Why?

Per default, the lazy objects are serialized and afterwards deserialized, therefore they did lose the connection to Doctrine and the empty objects were returned in the twig extensions