### PR TITLE
Add enum() and const() resolver for visibleCondition/disabledCondition

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/ConditionEnumResolverFormMetadataVisitor.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/FormMetadata/Visitor/ConditionEnumResolverFormMetadataVisitor.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadataVisitorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\ItemMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadataVisitorInterface;
+
+/**
+ * Resolves enum() and const() placeholders in visibleCondition and disabledCondition.
+ *
+ * This allows using PHP backed enums and constants in form metadata conditions:
+ *
+ *     <property name="title" visibleCondition="status == enum(App\Enum\Status::ACTIVE)">
+ *     <property name="title" disabledCondition="type == const(App\MyClass::TYPE_DRAFT)">
+ *
+ * @author Pascal CESCON <pascal.cescon@gmail.com>
+ */
+class ConditionEnumResolverFormMetadataVisitor implements FormMetadataVisitorInterface, TypedFormMetadataVisitorInterface
+{
+    private const PATTERN = '/\b(enum|const)\(([^)]+)\)/';
+
+    public function visitFormMetadata(FormMetadata $formMetadata, string $locale, array $metadataOptions = []): void
+    {
+        $this->resolveConditions($formMetadata->getItems());
+    }
+
+    public function visitTypedFormMetadata(TypedFormMetadata $formMetadata, string $key, string $locale, array $metadataOptions = []): void
+    {
+        foreach ($formMetadata->getForms() as $formType) {
+            $this->resolveConditions($formType->getItems());
+        }
+    }
+
+    /**
+     * @param ItemMetadata[] $items
+     */
+    private function resolveConditions(array $items): void
+    {
+        foreach ($items as $item) {
+            $this->resolveItemCondition($item);
+
+            if ($item instanceof SectionMetadata) {
+                $this->resolveConditions($item->getItems());
+            }
+
+            if ($item instanceof FieldMetadata) {
+                foreach ($item->getTypes() as $type) {
+                    $this->resolveConditions($type->getItems());
+                }
+            }
+        }
+    }
+
+    private function resolveItemCondition(ItemMetadata $item): void
+    {
+        $visibleCondition = $item->getVisibleCondition();
+        if (null !== $visibleCondition && \preg_match(self::PATTERN, $visibleCondition)) {
+            $item->setVisibleCondition($this->resolveExpression($visibleCondition));
+        }
+
+        $disabledCondition = $item->getDisabledCondition();
+        if (null !== $disabledCondition && \preg_match(self::PATTERN, $disabledCondition)) {
+            $item->setDisabledCondition($this->resolveExpression($disabledCondition));
+        }
+    }
+
+    private function resolveExpression(string $expression): string
+    {
+        return (string) \preg_replace_callback(self::PATTERN, static function (array $matches): string {
+            $type = $matches[1];
+            $reference = \trim($matches[2]);
+
+            if ('enum' === $type) {
+                return self::resolveEnum($reference);
+            }
+
+            return self::resolveConst($reference);
+        }, $expression);
+    }
+
+    private static function resolveEnum(string $reference): string
+    {
+        if (!\str_contains($reference, '::')) {
+            throw new \InvalidArgumentException(\sprintf('Invalid enum reference "%s". Expected format: "App\Enum\MyEnum::CASE".', $reference));
+        }
+
+        [$class, $case] = \explode('::', $reference, 2);
+
+        if (!\enum_exists($class)) {
+            throw new \InvalidArgumentException(\sprintf('Enum class "%s" does not exist.', $class));
+        }
+
+        $reflection = new \ReflectionEnum($class);
+        if (!$reflection->isBacked()) {
+            throw new \InvalidArgumentException(\sprintf('Enum "%s" must be a backed enum to be used in conditions.', $class));
+        }
+
+        if (!$reflection->hasCase($case)) {
+            throw new \InvalidArgumentException(\sprintf('Enum case "%s::%s" does not exist.', $class, $case));
+        }
+
+        $value = $reflection->getCase($case)->getValue()->value;
+
+        return \is_string($value) ? "'" . $value . "'" : (string) $value;
+    }
+
+    private static function resolveConst(string $reference): string
+    {
+        if (!\defined($reference)) {
+            throw new \InvalidArgumentException(\sprintf('Constant "%s" is not defined.', $reference));
+        }
+
+        $value = \constant($reference);
+
+        if (\is_string($value)) {
+            return "'" . $value . "'";
+        }
+
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (\is_int($value) || \is_float($value)) {
+            return (string) $value;
+        }
+
+        throw new \InvalidArgumentException(\sprintf('Constant "%s" must resolve to a scalar value, got "%s".', $reference, \get_debug_type($value)));
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/ConditionEnumResolverFormMetadataVisitorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/FormMetadata/Visitor/ConditionEnumResolverFormMetadataVisitorTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\SectionMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\Visitor\ConditionEnumResolverFormMetadataVisitor;
+
+class ConditionEnumResolverFormMetadataVisitorTest extends TestCase
+{
+    private ConditionEnumResolverFormMetadataVisitor $visitor;
+
+    public function setUp(): void
+    {
+        $this->visitor = new ConditionEnumResolverFormMetadataVisitor();
+    }
+
+    public function testResolveEnumInVisibleCondition(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setVisibleCondition("status == enum(Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor\TestStringStatus::ACTIVE)");
+        $formMetadata->addItem($field);
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertSame("status == 'active'", $field->getVisibleCondition());
+    }
+
+    public function testResolveIntEnumInDisabledCondition(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setDisabledCondition("priority == enum(Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor\TestIntPriority::HIGH)");
+        $formMetadata->addItem($field);
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertSame('priority == 3', $field->getDisabledCondition());
+    }
+
+    public function testResolveConstInCondition(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setVisibleCondition("type == const(Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor\TestConstants::TYPE_DRAFT)");
+        $formMetadata->addItem($field);
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertSame("type == 'draft'", $field->getVisibleCondition());
+    }
+
+    public function testResolveMultipleExpressionsInCondition(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setVisibleCondition("status == enum(Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor\TestStringStatus::ACTIVE) && priority == enum(Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor\TestIntPriority::HIGH)");
+        $formMetadata->addItem($field);
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertSame("status == 'active' && priority == 3", $field->getVisibleCondition());
+    }
+
+    public function testResolveInSectionItems(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $section = new SectionMetadata('details');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setVisibleCondition("status == enum(Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor\TestStringStatus::ACTIVE)");
+        $section->addItem($field);
+
+        $formMetadata->addItem($section);
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertSame("status == 'active'", $field->getVisibleCondition());
+    }
+
+    public function testResolveInTypedFormMetadata(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setVisibleCondition("status == enum(Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\FormMetadata\Visitor\TestStringStatus::ACTIVE)");
+        $formMetadata->addItem($field);
+
+        $typedFormMetadata->addForm($formMetadata->getKey(), $formMetadata);
+
+        $this->visitor->visitTypedFormMetadata($typedFormMetadata, 'page', 'en');
+
+        $this->assertSame("status == 'active'", $field->getVisibleCondition());
+    }
+
+    public function testNoConditionLeftUntouched(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setVisibleCondition("status == 'active'");
+        $formMetadata->addItem($field);
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertSame("status == 'active'", $field->getVisibleCondition());
+    }
+
+    public function testNullConditionLeftUntouched(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $formMetadata->addItem($field);
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+
+        $this->assertNull($field->getVisibleCondition());
+        $this->assertNull($field->getDisabledCondition());
+    }
+
+    public function testInvalidEnumClassThrowsException(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setVisibleCondition('status == enum(App\NonExistentEnum::CASE)');
+        $formMetadata->addItem($field);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+    }
+
+    public function testInvalidConstThrowsException(): void
+    {
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('test');
+
+        $field = new FieldMetadata('title');
+        $field->setType('text_line');
+        $field->setVisibleCondition('status == const(App\NonExistent::CONST)');
+        $formMetadata->addItem($field);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not defined');
+
+        $this->visitor->visitFormMetadata($formMetadata, 'en');
+    }
+}
+
+enum TestStringStatus: string
+{
+    case ACTIVE = 'active';
+    case INACTIVE = 'inactive';
+}
+
+enum TestIntPriority: int
+{
+    case LOW = 1;
+    case MEDIUM = 2;
+    case HIGH = 3;
+}
+
+class TestConstants
+{
+    public const TYPE_DRAFT = 'draft';
+    public const TYPE_PUBLISHED = 'published';
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8691
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

A new `ConditionEnumResolverFormMetadataVisitor` that resolves `enum()` and `const()` placeholders in `visibleCondition` and `disabledCondition` expressions.

This allows using PHP backed enums and constants directly in form metadata XML conditions:

```xml
<property name="title" visibleCondition="status == enum(App\Enum\Status::ACTIVE)">
<property name="title" disabledCondition="type == const(App\MyClass::TYPE_DRAFT)">
```

The visitor resolves these at metadata build time, producing clean JS-evaluable expressions like `status == 'active'`.

#### Why?

Currently there is no way to reference PHP constants or backed enums in `visibleCondition`/`disabledCondition`. This forces developers to hardcode string or int values, which is error-prone and breaks the single source of truth principle.

As @alexander-schranz suggested, this uses the `FormMetadataVisitorInterface` pattern. I implemented it directly in the core rather than as a separate bundle since it's lightweight and uses the existing visitor infrastructure.

#### Example Usage

```xml
<!-- String backed enum -->
<property name="title" visibleCondition="status == enum(App\Enum\Status::ACTIVE)">

<!-- Int backed enum -->
<property name="priority_field" disabledCondition="priority == enum(App\Enum\Priority::HIGH)">

<!-- Class constant -->
<property name="draft_notice" visibleCondition="type == const(App\Entity\Page::TYPE_DRAFT)">

<!-- Multiple expressions -->
<property name="special" visibleCondition="status == enum(App\Enum\Status::ACTIVE) && priority == enum(App\Enum\Priority::HIGH)">
```

#### To Do

- [ ] Create a documentation PR