### PR TITLE
Add better dropzone filetype errors

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/List/toolbarActions/UploadToolbarAction.js
@@ -153,6 +153,7 @@ export default class UploadToolbarAction extends AbstractListToolbarAction {
                 switch (code) {
                     case 'file-invalid-type':
                         error = translate('sulu_admin.dropzone_error_file-invalid-type', {
+                            fileType: fileRejection.file.type,
                             fileName: fileRejection.file.name,
                             allowedTypes: this.accept ? Object.keys(this.accept).join(', ') : undefined,
                         });

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -197,7 +197,7 @@
     "sulu_admin.missing_type_dialog_description": "Das Template der kopierten Seite steht in diesem Webspace nicht zur Verfügung.",
     "sulu_admin.upload": "Hochladen",
     "sulu_admin.unexpected_upload_error": "Unerwarteter Fehler beim Hochladen {fileName, select, undefined{einer Datei} other{von {fileName}}} auf den Server.",
-    "sulu_admin.dropzone_error_file-invalid-type": "Dateityp{fileName, select, undefined{} other{ von {fileName}}} ist nicht erlaubt{allowedTypes, select, undefined{} other{. Erlaubt sind ({allowedTypes})}}",
+    "sulu_admin.dropzone_error_file-invalid-type": "Dateityp{fileName, select, undefined{} other{ von {fileName}}} \"{fileType}\" ist nicht erlaubt. {allowedTypes, select, undefined{} other{Erlaubt sind ({allowedTypes})}}",
     "sulu_admin.dropzone_error_file-too-large": "{fileName, select, undefined{Datei} other{{fileName}}} ist {maxSize, select, undefined{zu groß} other{größer als {maxSize}}}",
     "sulu_admin.dropzone_error_file-too-small": "{fileName, select, undefined{Datei} other{{fileName}}} ist {minSize, select, undefined{zu klein} other{kleiner als {minSize}}}",
     "sulu_admin.dropzone_error_too-many-files": "Zu viele Dateien{maxFiles, select, undefined{} other{. Maximale Anzahl Dateien: {maxFiles}}}",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -197,7 +197,7 @@
     "sulu_admin.missing_type_dialog_description": "The template for the copied page does not exist in this webspace.",
     "sulu_admin.upload": "Upload",
     "sulu_admin.unexpected_upload_error": "Unexpected error while uploading {fileName, select, undefined{a file} other{the file {fileName}}} to the server.",
-    "sulu_admin.dropzone_error_file-invalid-type": "{fileName, select, undefined{File} other{{fileName}}} has invalid type{allowedTypes, select, undefined{} other{. Allowed types are ({allowedTypes})}}",
+    "sulu_admin.dropzone_error_file-invalid-type": "{fileName, select, undefined{File} other{{fileName}}} has invalid type \"{fileType}\". {allowedTypes, select, undefined{} other{Allowed types are ({allowedTypes})}}",
     "sulu_admin.dropzone_error_file-too-large": "{fileName, select, undefined{File} other{{fileName}}} is {maxSize, select, undefined{too large} other{larger than {maxSize}}}",
     "sulu_admin.dropzone_error_file-too-small": "{fileName, select, undefined{File} other{{fileName}}} is {minSize, select, undefined{too small} other{smaller than {minSize}}}",
     "sulu_admin.dropzone_error_too-many-files": "Too many files{maxFiles, select, undefined{} other{. Maximum allowed files: {maxFiles}}}",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | sulu/sulu#8721
| License | MIT
| Documentation PR | -

#### What's in this PR?
Improving the error message when an uploaded file doesn't match the allowed file types.

#### Why?
Before the message would show: "Invalid file type" + allowed file types but never the file type the js thought this file was. Now it gives more information on what the library thinks the type of file this is:

<img width="628" height="35" alt="swappy-20260408_181848" src="https://github.com/user-attachments/assets/1863af7c-a289-4224-95f1-e839634394f2" />
