### PR TITLE
Prevent exception when trying to cache null as key

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/Twig/ContactTwigExtension.php
@@ -40,7 +40,7 @@ class ContactTwigExtension extends AbstractExtension
     }
 
     /**
-     * @param string|int $id id to resolve
+     * @param mixed $id id to resolve
      *
      * @return ContactInterface|null
      *
@@ -48,6 +48,10 @@ class ContactTwigExtension extends AbstractExtension
      */
     public function resolveContactFunction($id)
     {
+        if (!\is_string($id) && !\is_int($id)) {
+            return null;
+        }
+
         return $this->cache->get((string) $id, function() use ($id) {
             return $this->contactRepository->find($id);
         });

--- a/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
+++ b/src/Sulu/Bundle/SecurityBundle/Twig/UserTwigExtension.php
@@ -39,12 +39,16 @@ class UserTwigExtension extends AbstractExtension
     /**
      * resolves user id to user data.
      *
-     * @param int $id id to resolve
+     * @param mixed $id id to resolve
      *
      * @return UserInterface|null
      */
     public function resolveUserFunction($id)
     {
+        if (!\is_int($id)) {
+            return null;
+        }
+
         return $this->cache->get((string) $id, function() use ($id) {
             return $this->userRepository->findUserById($id);
         });


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #8720
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Added null/type guard in `ContactTwigExtension::resolveContactFunction()` to prevent passing non-string/int values to the cache
  - Added null/type guard in `UserTwigExtension::resolveUserFunction()` to prevent passing non-string/int values to the cache
  - Returns `null` early when `$id` is not a string or integer, avoiding an exception when the cache adapter receives an invalid key

  #### Why?

  When the given `id` is null, calling `$this->cache->get((string) $id, ...)` would throw an exception because the cache key becomes invalid.