### PR TITLE
Only add request parameters to existing views

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -217,19 +217,17 @@ class ArticleAdmin extends Admin
             $viewCollection->add($viewBuilder);
         }
 
-        $editView = $viewCollection->get(static::EDIT_TABS_VIEW . '_' . $groupIdentifier . '.content');
-        if (\method_exists($editView, 'addMetadataRequestParameters')) {
-            $editView->addMetadataRequestParameters([
-                'templates' => \implode(',', $group->templates),
-            ]);
-        }
+        $this->addRequestParameters(
+            $viewCollection,
+            static::EDIT_TABS_VIEW . '_' . $groupIdentifier . '.content',
+            ['templates' => \implode(',', $group->templates)]
+        );
 
-        $addView = $viewCollection->get(static::ADD_TABS_VIEW . '_' . $groupIdentifier . '.content');
-        if (\method_exists($addView, 'addMetadataRequestParameters')) {
-            $addView->addMetadataRequestParameters([
-                'templates' => \implode(',', $group->templates),
-            ]);
-        }
+        $this->addRequestParameters(
+            $viewCollection,
+            static::ADD_TABS_VIEW . '_' . $groupIdentifier . '.content',
+            ['templates' => \implode(',', $group->templates)]
+        );
 
         $insightsResourceTabViewName = self::EDIT_TABS_VIEW . '_' . $groupIdentifier . '.insights';
         if ($viewCollection->has($insightsResourceTabViewName) && $this->activityViewBuilderFactory->hasActivityListPermission()) {
@@ -242,6 +240,21 @@ class ArticleAdmin extends Admin
                     )
                     ->setParent($insightsResourceTabViewName),
             );
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function addRequestParameters(ViewCollection $viewCollection, string $viewName, array $metadata): void
+    {
+        if (!$viewCollection->has($viewName)) {
+            return;
+        }
+
+        $view = $viewCollection->get($viewName);
+        if (\method_exists($view, 'addMetadataRequestParameters')) {
+            $view->addMetadataRequestParameters($metadata);
         }
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8725
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Only call `addMetadataRequestParameters` on views that actually exists.

#### Why?
Otherwise it's going to crash.

The user might not have permissions to all views and therefore some views might not be added. So we need to check first if the view exists.