### PR TITLE
Migrate Sidebar and ViewRenderer enzyme tests to react testing library

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/Sidebar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/Sidebar.test.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import {render} from 'enzyme';
+import {render} from '@testing-library/react';
 import Sidebar from '../Sidebar';
 import sidebarStore from '../stores/sidebarStore';
 import sidebarRegistry from '../registries/sidebarRegistry';
@@ -19,7 +19,8 @@ test('Render correct sidebar view', () => {
     sidebarRegistry.get.mockReturnValue(component);
     sidebarRegistry.isDisabled.mockReturnValue(false);
 
-    expect(render(<Sidebar />)).toMatchSnapshot();
+    const {container} = render(<Sidebar />);
+    expect(container).toMatchSnapshot();
 });
 
 test('Render correct sidebar view with props', () => {
@@ -28,16 +29,16 @@ test('Render correct sidebar view with props', () => {
     sidebarRegistry.get.mockReturnValue(component);
     sidebarRegistry.isDisabled.mockReturnValue(false);
 
-    const view = render(<Sidebar />);
-    expect(view).toMatchSnapshot();
+    const {container} = render(<Sidebar />);
+    expect(container).toMatchSnapshot();
 });
 
 test('Return null if view is not set', () => {
     sidebarStore.view = null;
     sidebarStore.props = {};
 
-    const view = render(<Sidebar />);
-    expect(view).toMatchSnapshot();
+    const {container} = render(<Sidebar />);
+    expect(container).toMatchSnapshot();
 });
 
 test('Return null if view is disabled', () => {
@@ -45,5 +46,6 @@ test('Return null if view is disabled', () => {
     sidebarStore.props = {};
     sidebarRegistry.isDisabled.mockReturnValue(true);
 
-    expect(render(<Sidebar />)).toMatchSnapshot();
+    const {container} = render(<Sidebar />);
+    expect(container).toMatchSnapshot();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/__snapshots__/Sidebar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/__snapshots__/Sidebar.test.js.snap
@@ -1,23 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render correct sidebar view 1`] = `
-<aside
-  class="sidebar"
->
-  <h1 />
-</aside>
+<div>
+  <aside
+    class="sidebar"
+  >
+    <h1 />
+  </aside>
+</div>
 `;
 
 exports[`Render correct sidebar view with props 1`] = `
-<aside
-  class="sidebar"
->
-  <h1>
-    Hello world
-  </h1>
-</aside>
+<div>
+  <aside
+    class="sidebar"
+  >
+    <h1>
+      Hello world
+    </h1>
+  </aside>
+</div>
 `;
 
-exports[`Return null if view is disabled 1`] = `null`;
+exports[`Return null if view is disabled 1`] = `<div />`;
 
-exports[`Return null if view is not set 1`] = `null`;
+exports[`Return null if view is not set 1`] = `<div />`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/__snapshots__/withSidebar.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/__snapshots__/withSidebar.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Pass props to rendered component 1`] = `
-<h1>
-  Test
-</h1>
+<div>
+  <h1>
+    Test
+  </h1>
+</div>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/withSidebar.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/withSidebar.test.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import {extendObservable, observable} from 'mobx';
-import {mount, render} from 'enzyme';
+import {render} from '@testing-library/react';
 import sidebarStore from '../stores/sidebarStore';
 import withSidebar from '../withSidebar';
 
@@ -21,7 +21,12 @@ test('Pass props to rendered component', () => {
         return null;
     });
 
-    expect(render(<ComponentWithSidebar title="Test" />)).toMatchSnapshot();
+    const router = {
+        addUpdateRouteHook: jest.fn().mockReturnValue(jest.fn()),
+    };
+
+    const {container} = render(<ComponentWithSidebar router={router} title="Test" />);
+    expect(container).toMatchSnapshot();
 });
 
 test('Bind sidebar method to component instance', () => {
@@ -40,19 +45,29 @@ test('Bind sidebar method to component instance', () => {
     });
 
     const router = {
-        addUpdateRouteHook: jest.fn(),
+        addUpdateRouteHook: jest.fn().mockReturnValue(jest.fn()),
     };
 
-    mount(<ComponentWithSidebar router={router} />);
+    render(<ComponentWithSidebar router={router} />);
     expect(sidebarStore.setConfig).toBeCalledWith({
         view: 'preview',
     });
 });
 
 test('Call life-cycle events of rendered component', () => {
+    const renderSpy = jest.fn();
+    const componentWillUnmountSpy = jest.fn();
+
     const Component = class Component extends React.Component<*> {
-        componentWillUnmount = jest.fn();
-        render = jest.fn();
+        componentWillUnmount() {
+            componentWillUnmountSpy();
+        }
+
+        render() {
+            renderSpy();
+
+            return <h1>Test</h1>;
+        }
     };
 
     const ComponentWithSidebar = withSidebar(Component, () => {
@@ -60,20 +75,21 @@ test('Call life-cycle events of rendered component', () => {
     });
 
     const router = {
-        addUpdateRouteHook: jest.fn(),
+        addUpdateRouteHook: jest.fn().mockReturnValue(jest.fn()),
     };
 
-    const component = mount(<ComponentWithSidebar router={router} />);
-    expect(component.instance().render).toBeCalled();
+    const {unmount} = render(<ComponentWithSidebar router={router} />);
+    expect(renderSpy).toBeCalled();
 
-    const componentWillUnmount = component.instance().componentWillUnmount;
-    component.unmount();
-    expect(componentWillUnmount).toBeCalled();
+    unmount();
+    expect(componentWillUnmountSpy).toBeCalled();
 });
 
 test('Reset config of toolbarStore when component is unmounted', () => {
     const Component = class Component extends React.Component<*> {
-        render = jest.fn();
+        render() {
+            return <h1>Test</h1>;
+        }
     };
 
     const ComponentWithToolbar = withSidebar(Component, () => ({view: 'test1'}));
@@ -83,17 +99,19 @@ test('Reset config of toolbarStore when component is unmounted', () => {
         addUpdateRouteHook: jest.fn().mockReturnValue(updateRouteHookDisposer),
     };
 
-    const component = mount(<ComponentWithToolbar router={router} />);
+    const {unmount} = render(<ComponentWithToolbar router={router} />);
     expect(sidebarStore.setConfig).toBeCalledWith({view: 'test1'});
 
-    component.unmount();
+    unmount();
     expect(updateRouteHookDisposer).toBeCalledWith();
     expect(sidebarStore.clearConfig).toBeCalledWith();
 });
 
 test('Dispose toolbar when a new view is rendered', () => {
     const Component = class Component extends React.Component<*> {
-        render = jest.fn();
+        render() {
+            return <h1>Test</h1>;
+        }
     };
 
     const config = {};
@@ -101,13 +119,13 @@ test('Dispose toolbar when a new view is rendered', () => {
     const ComponentWithSidebar = withSidebar(Component, () => ({view: config.view}));
 
     const router = {
-        addUpdateRouteHook: jest.fn(),
+        addUpdateRouteHook: jest.fn().mockReturnValue(jest.fn()),
         route: {
             name: 'route1',
         },
     };
 
-    mount(<ComponentWithSidebar router={router} />);
+    render(<ComponentWithSidebar router={router} />);
     expect(sidebarStore.setConfig).toHaveBeenLastCalledWith({view: 'test1'});
 
     config.view = 'test2';
@@ -119,6 +137,8 @@ test('Dispose toolbar when a new view is rendered', () => {
 });
 
 test('Recall sidebar-function when changing observable', () => {
+    const ref = React.createRef();
+
     const Component = class Component extends React.Component<*> {
         @observable sidebarView = 'preview';
 
@@ -132,16 +152,16 @@ test('Recall sidebar-function when changing observable', () => {
     });
 
     const router = {
-        addUpdateRouteHook: jest.fn(),
+        addUpdateRouteHook: jest.fn().mockReturnValue(jest.fn()),
     };
 
-    const component = mount(<ComponentWithSidebar router={router} />);
+    render(<ComponentWithSidebar ref={ref} router={router} />);
 
     expect(sidebarStore.setConfig).toBeCalledWith({
         view: 'preview',
     });
 
-    component.instance().sidebarView = 'test';
+    ref.current.sidebarView = 'test';
     expect(sidebarStore.setConfig).toBeCalledWith({
         view: 'test',
     });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import React from 'react';
-import {mount, render, shallow} from 'enzyme';
+import {render} from '@testing-library/react';
 import ViewRenderer from '../ViewRenderer';
 import viewRegistry from '../registries/viewRegistry';
 
@@ -16,8 +16,8 @@ test('Render view returned from ViewRegistry', () => {
     };
     viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
     viewRegistry.getConfig.mockReturnValue({});
-    const view = mount(<ViewRenderer router={router} />);
-    expect(render(view)).toMatchSnapshot();
+    const {container} = render(<ViewRenderer router={router} />);
+    expect(container).toMatchSnapshot();
     expect(viewRegistry.get).toBeCalledWith('test');
 });
 
@@ -28,13 +28,14 @@ test('Render view returned from ViewRegistry with disableDefaultSpacing true', (
     };
     viewRegistry.get.mockReturnValue(() => (<h1>Test</h1>));
     viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
-    const view = mount(<ViewRenderer router={router} />);
-    expect(render(view)).toMatchSnapshot();
+    const {container} = render(<ViewRenderer router={router} />);
+    expect(container).toMatchSnapshot();
     expect(viewRegistry.get).toBeCalledWith('test');
 });
 
 test('Render view returned from ViewRegistry with passed router', () => {
     const router = {
+        addUpdateRouteHook: jest.fn(),
         route: {
             type: 'test',
         },
@@ -45,13 +46,14 @@ test('Render view returned from ViewRegistry with passed router', () => {
 
     viewRegistry.get.mockReturnValue((props) => (<h1>{props.router.attributes.value}</h1>));
     viewRegistry.getConfig.mockReturnValue({});
-    const view = render(<ViewRenderer router={router} />);
-    expect(view).toMatchSnapshot();
+    const {container} = render(<ViewRenderer router={router} />);
+    expect(container).toMatchSnapshot();
     expect(viewRegistry.get).toBeCalledWith('test');
 });
 
 test('Render view with parents should nest rendered views', () => {
     const router = {
+        addUpdateRouteHook: jest.fn(),
         route: {
             name: 'sulu_admin.form_tab',
             type: 'form_tab',
@@ -101,11 +103,13 @@ test('Render view with parents should nest rendered views', () => {
     });
     viewRegistry.getConfig.mockReturnValue({});
 
-    expect(render(<ViewRenderer router={router} />)).toMatchSnapshot();
+    const {container} = render(<ViewRenderer router={router} />);
+    expect(container).toMatchSnapshot();
 });
 
 test('Render view with parents should nest rendered views and correctly pass children arguments', () => {
     const router = {
+        addUpdateRouteHook: jest.fn(),
         route: {
             name: 'sulu_admin.form_tab',
             type: 'form_tab',
@@ -157,10 +161,13 @@ test('Render view with parents should nest rendered views and correctly pass chi
     });
     viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
 
-    expect(render(<ViewRenderer router={router} />)).toMatchSnapshot();
+    const {container} = render(<ViewRenderer router={router} />);
+    expect(container).toMatchSnapshot();
 });
 
 test('Render view with route that has no rerenderAttributes', () => {
+    const mountSpy = jest.fn();
+
     const router = {
         addUpdateRouteHook: jest.fn(),
         route: {
@@ -172,25 +179,27 @@ test('Render view with route that has no rerenderAttributes', () => {
         },
     };
 
-    viewRegistry.get.mockImplementation((view) => {
-        switch (view) {
-            case 'webspaceOverview':
-                return function WebspaceOverview() {
-                    return (
-                        <div>
-                            <h3>Webspace</h3>
-                        </div>
-                    );
-                };
-        }
+    viewRegistry.get.mockImplementation(() => {
+        return function WebspaceOverview() {
+            React.useEffect(() => { mountSpy(); }, []);
+
+            return (
+                <div>
+                    <h3>Webspace</h3>
+                </div>
+            );
+        };
     });
     viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
 
-    const viewRenderer = shallow(<ViewRenderer router={router} />);
-    expect(viewRenderer.key()).toBe('route');
+    const {container} = render(<ViewRenderer router={router} />);
+    expect(container).toMatchSnapshot();
+    expect(mountSpy).toHaveBeenCalledTimes(1);
 });
 
 test('Render view with route that has rerenderAttributes', () => {
+    const mountSpy = jest.fn();
+
     const router = {
         addUpdateRouteHook: jest.fn(),
         route: {
@@ -205,25 +214,27 @@ test('Render view with route that has rerenderAttributes', () => {
         },
     };
 
-    viewRegistry.get.mockImplementation((view) => {
-        switch (view) {
-            case 'webspaceOverview':
-                return function WebspaceOverview() {
-                    return (
-                        <div>
-                            <h3>Webspace</h3>
-                        </div>
-                    );
-                };
-        }
+    viewRegistry.get.mockImplementation(() => {
+        return function WebspaceOverview() {
+            React.useEffect(() => { mountSpy(); }, []);
+
+            return (
+                <div>
+                    <h3>Webspace</h3>
+                </div>
+            );
+        };
     });
     viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
 
-    const viewRenderer = shallow(<ViewRenderer router={router} />);
-    expect(viewRenderer.key()).toBe('route-test');
+    const {container} = render(<ViewRenderer router={router} />);
+    expect(container).toMatchSnapshot();
+    expect(mountSpy).toHaveBeenCalledTimes(1);
 });
 
 test('Render view with route that has more than one rerenderAttributes', () => {
+    const mountSpy = jest.fn();
+
     const router = {
         addUpdateRouteHook: jest.fn(),
         route: {
@@ -240,22 +251,22 @@ test('Render view with route that has more than one rerenderAttributes', () => {
         },
     };
 
-    viewRegistry.get.mockImplementation((view) => {
-        switch (view) {
-            case 'webspaceOverview':
-                return function WebspaceOverview() {
-                    return (
-                        <div>
-                            <h3>Webspace</h3>
-                        </div>
-                    );
-                };
-        }
+    viewRegistry.get.mockImplementation(() => {
+        return function WebspaceOverview() {
+            React.useEffect(() => { mountSpy(); }, []);
+
+            return (
+                <div>
+                    <h3>Webspace</h3>
+                </div>
+            );
+        };
     });
     viewRegistry.getConfig.mockReturnValue({disableDefaultSpacing: true});
 
-    const viewRenderer = shallow(<ViewRenderer router={router} />);
-    expect(viewRenderer.key()).toBe('route-test__de');
+    const {container} = render(<ViewRenderer router={router} />);
+    expect(container).toMatchSnapshot();
+    expect(mountSpy).toHaveBeenCalledTimes(1);
 });
 
 test('Clear bindings of router everytime a new view is rendered', () => {
@@ -278,7 +289,7 @@ test('Clear bindings of router everytime a new view is rendered', () => {
         route: route1,
     };
 
-    shallow(<ViewRenderer router={router} />);
+    render(<ViewRenderer router={router} />);
     expect(router.addUpdateRouteHook).toBeCalledWith(expect.anything(), 1024);
 
     const updateRouteHook = router.addUpdateRouteHook.mock.calls[0][0];
@@ -310,7 +321,7 @@ test('Clear bindings of router when same view with a different rerender attribut
         route,
     };
 
-    shallow(<ViewRenderer router={router} />);
+    render(<ViewRenderer router={router} />);
     expect(router.addUpdateRouteHook).toBeCalledWith(expect.anything(), 1024);
 
     const updateRouteHook = router.addUpdateRouteHook.mock.calls[0][0];

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/__snapshots__/ViewRenderer.test.js.snap
@@ -1,50 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Render view returned from ViewRegistry 1`] = `
-<div
-  class="view"
->
+<div>
+  <div
+    class="view"
+  >
+    <h1>
+      Test
+    </h1>
+  </div>
+</div>
+`;
+
+exports[`Render view returned from ViewRegistry with disableDefaultSpacing true 1`] = `
+<div>
   <h1>
     Test
   </h1>
 </div>
 `;
 
-exports[`Render view returned from ViewRegistry with disableDefaultSpacing true 1`] = `
-<h1>
-  Test
-</h1>
-`;
-
 exports[`Render view returned from ViewRegistry with passed router 1`] = `
-<div
-  class="view"
->
-  <h1>
-    Test attribute
-  </h1>
+<div>
+  <div
+    class="view"
+  >
+    <h1>
+      Test attribute
+    </h1>
+  </div>
 </div>
 `;
 
 exports[`Render view with parents should nest rendered views 1`] = `
-<div
-  class="view"
->
-  <div>
-    <h1>
-      App
-    </h1>
-    sulu_admin.app
+<div>
+  <div
+    class="view"
+  >
     <div>
-      <h2>
-        Form
-      </h2>
-      sulu_admin.form
+      <h1>
+        App
+      </h1>
+      sulu_admin.app
       <div>
-        <h3>
-          Form Tab
-        </h3>
-        sulu_admin.form_tab
+        <h2>
+          Form
+        </h2>
+        sulu_admin.form
+        <div>
+          <h3>
+            Form Tab
+          </h3>
+          sulu_admin.form_tab
+        </div>
       </div>
     </div>
   </div>
@@ -53,33 +61,65 @@ exports[`Render view with parents should nest rendered views 1`] = `
 
 exports[`Render view with parents should nest rendered views and correctly pass children arguments 1`] = `
 <div>
-  <h1>
-    App
-  </h1>
-  <p>
-    sulu_admin.app
-  </p>
   <div>
-    <h2>
-      Form
-    </h2>
-    <p>
-      sulu_admin.form
-    </p>
-    <p>
+    <h1>
       App
+    </h1>
+    <p>
+      sulu_admin.app
     </p>
     <div>
-      <h3>
-        Form Tab
-      </h3>
-      <p>
-        sulu_admin.form_tab
-      </p>
-      <p>
+      <h2>
         Form
+      </h2>
+      <p>
+        sulu_admin.form
       </p>
+      <p>
+        App
+      </p>
+      <div>
+        <h3>
+          Form Tab
+        </h3>
+        <p>
+          sulu_admin.form_tab
+        </p>
+        <p>
+          Form
+        </p>
+      </div>
     </div>
+  </div>
+</div>
+`;
+
+exports[`Render view with route that has more than one rerenderAttributes 1`] = `
+<div>
+  <div>
+    <h3>
+      Webspace
+    </h3>
+  </div>
+</div>
+`;
+
+exports[`Render view with route that has no rerenderAttributes 1`] = `
+<div>
+  <div>
+    <h3>
+      Webspace
+    </h3>
+  </div>
+</div>
+`;
+
+exports[`Render view with route that has rerenderAttributes 1`] = `
+<div>
+  <div>
+    <h3>
+      Webspace
+    </h3>
   </div>
 </div>
 `;


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | parts of #6799
| License | MIT
| Documentation PR | ---

#### What's in this PR?

Migrate enzyme tests to `@testing-library/react` for the `Sidebar` and `ViewRenderer` containers:

- `Sidebar.test.js` (4 tests)
- `withSidebar.test.js` (6 tests)
- `ViewRenderer.test.js` (10 tests)

#### Why?

Enzyme is no longer maintained and incompatible with React 18. These containers were not covered by the existing migration PRs (#8661, #8671, #8727).