### PR TITLE
Fix snippet locale fallback for shadow locale entities

### DIFF
--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -24,6 +24,8 @@ use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableInterface;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\ShadowInterface;
+use Sulu\Content\Domain\Model\TemplateInterface;
 use Webmozart\Assert\Assert;
 
 readonly class ContentResolver implements ContentResolverInterface
@@ -45,6 +47,12 @@ readonly class ContentResolver implements ContentResolverInterface
         $locale = $dimensionContent->getLocale();
         Assert::string($locale, 'Locale must be a string');
 
+        // Pass shadow base locale as context for resource loader fallback.
+        $context = [];
+        if ($dimensionContent instanceof ShadowInterface && null !== $dimensionContent->getShadowLocale()) {
+            $context['_shadowLocale'] = $dimensionContent->getShadowLocale();
+        }
+
         // Initial resolution to gather ResolvableResources
         /** @var array<int, array<string, array<int, array<int|string, array<string, ResolvableInterface>>>>> $priorityQueue */
         $priorityQueue = [];
@@ -64,7 +72,7 @@ readonly class ContentResolver implements ContentResolverInterface
             $loaderIdDepths = $extractedResources['loaderIdDepths'];
 
             // Load resources at this priority level
-            $loadedResources = $this->resolvableResourceLoader->loadResources($resourcesToLoad, $locale);
+            $loadedResources = $this->resolvableResourceLoader->loadResources($resourcesToLoad, $locale, $context);
 
             // Process loaded resources
             foreach ($loadedResources as $loaderKey => $resources) {
@@ -77,6 +85,18 @@ readonly class ContentResolver implements ContentResolverInterface
                                 'locale' => $locale,
                                 'stage' => DimensionContentInterface::STAGE_LIVE,
                             ]);
+
+                            // Retry with shadow base locale if child has no content in page locale.
+                            $shadowLocale = $context['_shadowLocale'] ?? null;
+                            if ($childContent instanceof TemplateInterface
+                                && (null === $childContent->getTemplateKey() || '' === $childContent->getTemplateKey())
+                                && \is_string($shadowLocale)
+                            ) {
+                                $childContent = $this->contentAggregator->aggregate($resource, [
+                                    'locale' => $shadowLocale,
+                                    'stage' => DimensionContentInterface::STAGE_LIVE,
+                                ]);
+                            }
 
                             /** @var ResolvableInterface $resolvableResource */
                             $resolvableResource = $resourcesToLoad[$loaderKey][$id][$metadataIdentifier];

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoader.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoader.php
@@ -30,7 +30,7 @@ class ResolvableResourceLoader implements ResolvableResourceLoaderInterface
     ) {
     }
 
-    public function loadResources(array $resourcesPerLoader, ?string $locale): array
+    public function loadResources(array $resourcesPerLoader, ?string $locale, array $context = []): array
     {
         $loadedResources = [];
         foreach ($resourcesPerLoader as $loaderKey => $resourcesToLoad) {
@@ -64,7 +64,7 @@ class ResolvableResourceLoader implements ResolvableResourceLoaderInterface
             }
 
             if (\count($resolvableResources) > 0) {
-                $result = $this->loadResolvableResources($resolvableResources, $loaderKey, $locale);
+                $result = $this->loadResolvableResources($resolvableResources, $loaderKey, $locale, $context);
                 foreach ($result as $id => $loadedResource) {
                     foreach ($metadataIdentifiersPerResourceId[$id] as $metadataIdentifier) {
                         $loadedResources[$loaderKey][$id][$metadataIdentifier] = $loadedResource;
@@ -100,10 +100,11 @@ class ResolvableResourceLoader implements ResolvableResourceLoaderInterface
 
     /**
      * @param array<ResolvableResource> $resolvableResources
+     * @param array<string, mixed> $context
      *
      * @return array<string|int, mixed>
      */
-    private function loadResolvableResources(array $resolvableResources, string $loaderKey, ?string $locale): array
+    private function loadResolvableResources(array $resolvableResources, string $loaderKey, ?string $locale, array $context = []): array
     {
         $resourceLoader = $this->resourceLoaderProvider->getResourceLoader($loaderKey);
         if (!$resourceLoader) {
@@ -119,7 +120,7 @@ class ResolvableResourceLoader implements ResolvableResourceLoaderInterface
         return $resourceLoader->load(
             $resourceIds,
             $locale,
-            $params
+            \array_merge($params, $context),
         );
     }
 }

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoaderInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoaderInterface.php
@@ -25,8 +25,9 @@ interface ResolvableResourceLoaderInterface
      * Loads and resolves resources from various resource loaders.
      *
      * @param array<string, array<string|int, array<string, ResolvableInterface>>> $resourcesPerLoader Resource loaders and their associated resources to load
+     * @param array<string, mixed> $context Additional context passed to resource loaders (e.g. _shadowLocale)
      *
      * @return array<string, array<string|int, array<string, mixed>>> Resolved resources organized by resource loader key
      */
-    public function loadResources(array $resourcesPerLoader, ?string $locale): array;
+    public function loadResources(array $resourcesPerLoader, ?string $locale, array $context = []): array;
 }

--- a/packages/content/tests/Application/config/templates/examples/default-snippet-selection.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-snippet-selection.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>default-snippet-selection</key>
+
+    <meta>
+        <title lang="en">Default Snippet Selection</title>
+        <title lang="de">Standard Schnipsel Auswahl</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <tag name="sulu.node.name"/>
+        </property>
+
+        <property name="url" type="route">
+            <meta>
+                <title lang="en">URL</title>
+                <title lang="de">URL</title>
+            </meta>
+        </property>
+
+        <property name="snippet" type="single_snippet_selection">
+            <meta>
+                <title lang="en">Snippet</title>
+                <title lang="de">Schnipsel</title>
+            </meta>
+            <params>
+                <param name="properties" type="collection">
+                    <param name="description" value="description"/>
+                </param>
+            </params>
+        </property>
+    </properties>
+</template>

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverShadowLocaleTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverShadowLocaleTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Functional\Application\ContentResolver;
+
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
+use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
+use Sulu\Content\Tests\Traits\CreateExampleTrait;
+use Sulu\Snippet\Tests\Traits\CreateSnippetTrait;
+
+class ContentResolverShadowLocaleTest extends SuluTestCase
+{
+    use CreateExampleTrait;
+    use CreateSnippetTrait;
+
+    private ContentResolverInterface $contentResolver;
+    private ContentAggregatorInterface $contentAggregator;
+
+    protected function setUp(): void
+    {
+        self::purgeDatabase();
+
+        $this->contentResolver = self::getContainer()->get('sulu_content.content_resolver');
+        $this->contentAggregator = self::getContainer()->get('sulu_content.content_aggregator');
+    }
+
+    public function testResolveSnippetWithShadowLocaleFallback(): void
+    {
+        $snippet = static::createSnippet([
+            'de' => [
+                'live' => [
+                    'template' => 'snippet-1',
+                    'title' => 'Test Snippet DE',
+                    'description' => '<p>Snippet description DE</p>',
+                ],
+            ],
+        ]);
+
+        $snippetUuid = $snippet->getUuid();
+
+        $example = static::createExample([
+            'de' => [
+                'live' => [
+                    'template' => 'default-snippet-selection',
+                    'title' => 'Test Page DE',
+                    'snippet' => $snippetUuid,
+                ],
+            ],
+            'de_li' => [
+                'live' => [
+                    'template' => 'default-snippet-selection',
+                    'title' => 'Test Page DE_LI',
+                    'snippet' => $snippetUuid,
+                ],
+            ],
+        ]);
+
+        foreach ($example->getDimensionContents() as $existingDimensionContent) {
+            if ('de_li' === $existingDimensionContent->getLocale()) {
+                $existingDimensionContent->setShadowLocale('de');
+            }
+        }
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($example, [
+            'locale' => 'de_li',
+            'stage' => 'live',
+        ]);
+
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertArrayHasKey('snippet', $result['content']);
+        self::assertIsArray($result['content']['snippet']);
+        self::assertSame('<p>Snippet description DE</p>', $result['content']['snippet']['description'] ?? null);
+    }
+
+    public function testResolveSnippetWithoutShadowLocaleNoFallback(): void
+    {
+        $snippet = static::createSnippet([
+            'de' => [
+                'live' => [
+                    'template' => 'snippet-1',
+                    'title' => 'Test Snippet DE',
+                    'description' => '<p>Snippet description DE</p>',
+                ],
+            ],
+        ]);
+
+        $snippetUuid = $snippet->getUuid();
+
+        // de_li page without shadow — snippet doesn't exist in de_li, so it should be empty.
+        $example = static::createExample([
+            'de_li' => [
+                'live' => [
+                    'template' => 'default-snippet-selection',
+                    'title' => 'Test Page DE_LI',
+                    'snippet' => $snippetUuid,
+                ],
+            ],
+        ]);
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($example, [
+            'locale' => 'de_li',
+            'stage' => 'live',
+        ]);
+
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertFalse(\is_array($result['content']['snippet']), 'Snippet should not be resolved without shadow fallback');
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentResolverTest.php
@@ -173,12 +173,14 @@ class ContentResolverTest extends TestCase
 
         $this->resolvableResourceLoader->loadResources(
             ['example' => ['333' => [$highPriorityResource->getMetadataIdentifier() => $highPriorityResource]]],
-            'en'
+            'en',
+            []
         )->willReturn(['example' => ['333' => [$highPriorityResource->getMetadataIdentifier() => 'High Priority Result']]]);
 
         $this->resolvableResourceLoader->loadResources(
             ['example' => ['444' => [$lowPriorityResource->getMetadataIdentifier() => $lowPriorityResource]]],
-            'en'
+            'en',
+            []
         )->willReturn(['example' => ['444' => [$lowPriorityResource->getMetadataIdentifier() => 'Low Priority Result']]]);
 
         $result = $this->contentResolver->resolve($dimensionContent);

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoaderTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceLoader/ResolvableResourceLoaderTest.php
@@ -213,6 +213,40 @@ class ResolvableResourceLoaderTest extends TestCase
         ], $result['example']['123'][$metadata2]);
     }
 
+    public function testLoadResourcesWithContext(): void
+    {
+        $contextAwareLoader = new class() implements ResourceLoaderInterface {
+            /** @var array<mixed> */
+            public array $lastParams = [];
+
+            public function load(array $ids, ?string $locale, array $params = []): array
+            {
+                $this->lastParams = $params;
+
+                return ['1' => ['title' => 'test']];
+            }
+
+            public static function getKey(): string
+            {
+                return 'context_test';
+            }
+        };
+
+        $provider = new ResourceLoaderProvider(['context_test' => $contextAwareLoader]);
+        $loader = new ResolvableResourceLoader($provider, $this->smartResolverProvider);
+
+        $resolvable = new ResolvableResource('1', 'context_test', 1);
+        $resourcesPerLoader = [
+            'context_test' => [
+                '1' => [$resolvable->getMetadataIdentifier() => $resolvable],
+            ],
+        ];
+
+        $loader->loadResources($resourcesPerLoader, 'de_li', ['_shadowLocale' => 'de']);
+
+        self::assertSame('de', $contextAwareLoader->lastParams['_shadowLocale']);
+    }
+
     public function testLoadResourcesWithInvalidLoaderKey(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoader.php
@@ -15,6 +15,7 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader;
 
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
 
 /**
@@ -40,6 +41,26 @@ class SnippetResourceLoader implements ResourceLoaderInterface
             return [];
         }
 
+        $mappedResult = $this->loadForLocale($ids, $locale);
+
+        // Fall back to shadow base locale for missing snippets.
+        $missingIds = \array_values(\array_diff($ids, \array_keys($mappedResult)));
+        $shadowLocale = $params['_shadowLocale'] ?? null;
+        if ([] !== $missingIds && \is_string($shadowLocale)) {
+            $fallbackResult = $this->loadForLocale($missingIds, $shadowLocale);
+            $mappedResult += $fallbackResult;
+        }
+
+        return $mappedResult;
+    }
+
+    /**
+     * @param string[] $ids
+     *
+     * @return array<string, SnippetInterface>
+     */
+    private function loadForLocale(array $ids, string $locale): array
+    {
         $result = $this->snippetRepository->findBy(
             [
                 'uuids' => $ids,

--- a/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoaderTest.php
+++ b/packages/snippet/tests/Unit/Infrastructure/Sulu/Content/ResourceLoader/SnippetResourceLoaderTest.php
@@ -70,6 +70,92 @@ class SnippetResourceLoaderTest extends TestCase
         ], $result);
     }
 
+    public function testLoadWithShadowLocaleFallback(): void
+    {
+        $snippet1 = $this->createSnippet('1');
+
+        // First query: de_li finds snippet 1 but not snippet 2.
+        $this->snippetRepository->findBy(
+            [
+                'uuids' => ['1', '2'],
+                'locale' => 'de_li',
+                'stage' => DimensionContentInterface::STAGE_LIVE,
+            ],
+            [],
+            [SnippetRepositoryInterface::GROUP_SELECT_SNIPPET_WEBSITE => true]
+        )->willReturn([$snippet1])
+            ->shouldBeCalled();
+
+        $snippet2 = $this->createSnippet('2');
+
+        // Second query: shadow base locale de finds snippet 2.
+        $this->snippetRepository->findBy(
+            [
+                'uuids' => ['2'],
+                'locale' => 'de',
+                'stage' => DimensionContentInterface::STAGE_LIVE,
+            ],
+            [],
+            [SnippetRepositoryInterface::GROUP_SELECT_SNIPPET_WEBSITE => true]
+        )->willReturn([$snippet2])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load(['1', '2'], 'de_li', ['_shadowLocale' => 'de']);
+
+        $this->assertSame([
+            '1' => $snippet1,
+            '2' => $snippet2,
+        ], $result);
+    }
+
+    public function testLoadWithShadowLocaleNotTriggeredWhenAllFound(): void
+    {
+        $snippet1 = $this->createSnippet('1');
+        $snippet2 = $this->createSnippet('2');
+
+        // All snippets found in page locale — no fallback query.
+        $this->snippetRepository->findBy(
+            [
+                'uuids' => ['1', '2'],
+                'locale' => 'de_li',
+                'stage' => DimensionContentInterface::STAGE_LIVE,
+            ],
+            [],
+            [SnippetRepositoryInterface::GROUP_SELECT_SNIPPET_WEBSITE => true]
+        )->willReturn([$snippet1, $snippet2])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load(['1', '2'], 'de_li', ['_shadowLocale' => 'de']);
+
+        $this->assertSame([
+            '1' => $snippet1,
+            '2' => $snippet2,
+        ], $result);
+    }
+
+    public function testLoadWithoutShadowLocaleNoFallback(): void
+    {
+        $snippet1 = $this->createSnippet('1');
+
+        // No _shadowLocale in params — no fallback for missing snippet 2.
+        $this->snippetRepository->findBy(
+            [
+                'uuids' => ['1', '2'],
+                'locale' => 'de_li',
+                'stage' => DimensionContentInterface::STAGE_LIVE,
+            ],
+            [],
+            [SnippetRepositoryInterface::GROUP_SELECT_SNIPPET_WEBSITE => true]
+        )->willReturn([$snippet1])
+            ->shouldBeCalled();
+
+        $result = $this->loader->load(['1', '2'], 'de_li');
+
+        $this->assertSame([
+            '1' => $snippet1,
+        ], $result);
+    }
+
     private static function createSnippet(string $uuid): Snippet
     {
         return new Snippet($uuid);


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Pass `shadowLocale` context from `ContentResolver` through `ResolvableResourceLoader` to individual resource loaders
  - Add fallback logic in `SnippetResourceLoader` to retry loading missing snippets using the shadow base locale
  - Add retry logic in `ContentResolver` to re-aggregate child content with shadow locale when template key is empty
  - Add unit tests for context passing and all fallback scenarios (fallback triggered, all found, no shadow locale)

  #### Why?

  When a page uses a shadow locale (e.g. `de_li` shadowing `de`), snippets referenced on that page may only exist in the shadow base locale (`de`), not in the page's own locale (`de_li`). Without this fix, those
  snippets silently fail to load and appear empty on the website. This PR ensures snippets fall back to the shadow base locale when they cannot be found in the page's locale.