### PR TITLE
Expose block type in block settings form via __parent.blockType

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -470,7 +470,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
         this.blockSettingsFormStore?.destroy();
         this.blockSettingsFormStore = memoryFormStoreFactory.createFromFormKey(
             settingsFormKey,
-            {...this.value[index][SETTINGS_KEY]},
+            {...this.value[index][SETTINGS_KEY], blockType: this.value[index]?.type},
             this.props.formInspector.locale,
             undefined,
             this.props.formInspector.options
@@ -512,7 +512,7 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
         const newValue = [
             ...oldValues.slice(0, openedBlockSettingsIndex),
-            {...oldValues[openedBlockSettingsIndex], [SETTINGS_KEY]: blockSettingsFormStore.data},
+            {...oldValues[openedBlockSettingsIndex], [SETTINGS_KEY]: (({blockType: _b, ...rest}) => rest)(blockSettingsFormStore.data)},
             ...oldValues.slice(openedBlockSettingsIndex + 1),
         ];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/FieldBlocks.js
@@ -512,7 +512,10 @@ class FieldBlocks extends React.Component<FieldTypeProps<Array<BlockEntry>>> {
 
         const newValue = [
             ...oldValues.slice(0, openedBlockSettingsIndex),
-            {...oldValues[openedBlockSettingsIndex], [SETTINGS_KEY]: (({blockType: _b, ...rest}) => rest)(blockSettingsFormStore.data)},
+            {
+                ...oldValues[openedBlockSettingsIndex],
+                [SETTINGS_KEY]: (({blockType: _b, ...rest}) => rest)(blockSettingsFormStore.data),
+            },
             ...oldValues.slice(openedBlockSettingsIndex + 1),
         ];
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js
@@ -2145,3 +2145,60 @@ test('Throw error if passed block_id_generator schema option is not a boolean', 
         />
     )).toThrow('The "block" field types only accepts booleans as "block_id_generator" schema option!');
 });
+
+test('Should inject blockType of clicked block into settings form data and strip it on save', () => {
+    const changeSpy = jest.fn();
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+    const types = {
+        default: {
+            title: 'Default',
+            form: {},
+        },
+    };
+    const value = [
+        {type: 'content-images', settings: {}},
+        {type: 'content-text', settings: {}},
+    ];
+    formInspector.getSchemaEntryByPath.mockReturnValue({types});
+
+    const schemaPromise = Promise.resolve({});
+    const jsonSchemaPromise = Promise.resolve({});
+    metadataStore.getSchema.mockReturnValue(schemaPromise);
+    metadataStore.getJsonSchema.mockReturnValue(jsonSchemaPromise);
+
+    const fieldBlocks = mount(
+        <FieldBlocks
+            {...fieldTypeDefaultProps}
+            defaultType="default"
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaOptions={{settings_form_key: {name: 'settings_form_key', value: 'content_block_settings'}}}
+            types={types}
+            value={value}
+        />
+    );
+
+    fieldBlocks.find('Block').at(1).simulate('click');
+    fieldBlocks.find('Block').at(1).find('Icon[name="su-cog"]').simulate('click');
+
+    // blockType is available in form store data so __parent.blockType works in visibleCondition
+    expect(fieldBlocks.instance().blockSettingsFormStore.data.blockType).toEqual('content-text');
+
+    // blockType is not passed via metadataOptions
+    expect(metadataStore.getSchema).toBeCalledWith('content_block_settings', undefined, undefined);
+    expect(metadataStore.getJsonSchema).toBeCalledWith('content_block_settings', undefined, undefined);
+
+    return Promise.all([schemaPromise, jsonSchemaPromise]).then(() => {
+        fieldBlocks.update();
+        fieldBlocks.find('FormOverlay Button[children="sulu_admin.apply"]').simulate('click');
+
+        // blockType is stripped from saved settings so it is not persisted in the database
+        expect(changeSpy).toBeCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    settings: expect.not.objectContaining({blockType: expect.anything()}),
+                }),
+            ])
+        );
+    });
+});


### PR DESCRIPTION
| Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | License | MIT

  #### What's in this PR?

  When a block's settings form is opened, the current block type is injected into
  the settings form store data as `blockType` at the root level. This makes it
  accessible in `visibleCondition` expressions as `__parent.blockType` via the
  existing `parentConditionDataProvider` mechanism.

  `blockType` is stripped from the form data before saving to avoid persisting
  it in the database.

  #### Why?

  In complex content structures it is useful to show/hide sections or fields in
  the block settings overlay depending on which block type is currently being
  edited. Without this change there was no way to access the block type from
  within a `visibleCondition` in the settings form.

  #### Example Usage

```
<!-- In a block settings XML form -->
<section name="headline-options" visibleCondition="__parent.blockType == 'property-headline'">
    <property name="headline_level" type="single_select">
        ...
    </property>
</section>
```

  To Do

  - Create a documentation PR
  - Add breaking changes to UPGRADE.md