### PR TITLE
Fix AiApplication crash when focusing fields in excerpt and seo extension tabs

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
@@ -138,17 +138,18 @@ export default class AiApplication extends Component<Props> {
     }
 
     isInsideBlock(formInspector: FormInspector, schemaPath: string) {
-        if (schemaPath.startsWith('/ext')) {
-            return false;
-        }
-
         const parts = schemaPath.split('/');
 
         for (let i = 2; i < parts.length; i++) {
             const path = '/' + parts.slice(1, i).join('/');
-            const schema = formInspector.getSchemaEntryByPath(path);
-            if (schema?.type === 'block') {
-                return true;
+
+            try {
+                const schema = formInspector.getSchemaEntryByPath(path);
+                if (schema?.type === 'block') {
+                    return true;
+                }
+            } catch (e) {
+                return false;
             }
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
@@ -349,6 +349,54 @@ describe('AiApplication', () => {
         expect(instance.hasFocus).toBe(false);
     });
 
+    test('isInsideBlock returns false when schema lookup throws on a path segment', () => {
+        const instance = new AiApplication(props);
+
+        const formInspector = {
+            getSchemaEntryByPath: jest.fn().mockImplementation(() => {
+                throw new Error('Invalid reference token: excerpt');
+            }),
+        };
+
+        // $FlowFixMe - only the methods used by isInsideBlock are relevant here
+        const result = instance.isInsideBlock(formInspector, '/excerpt/description');
+
+        expect(result).toBe(false);
+        expect(formInspector.getSchemaEntryByPath).toHaveBeenCalledWith('/excerpt');
+    });
+
+    test('isInsideBlock returns true when any ancestor in the schema path is a block', () => {
+        const instance = new AiApplication(props);
+
+        const formInspector = {
+            getSchemaEntryByPath: jest.fn().mockImplementation((path) => {
+                if (path === '/content') {
+                    return {type: 'block'};
+                }
+
+                return {type: 'text_line'};
+            }),
+        };
+
+        // $FlowFixMe - only the methods used by isInsideBlock are relevant here
+        const result = instance.isInsideBlock(formInspector, '/content/0/title');
+
+        expect(result).toBe(true);
+    });
+
+    test('isInsideBlock returns false when no ancestor is a block', () => {
+        const instance = new AiApplication(props);
+
+        const formInspector = {
+            getSchemaEntryByPath: jest.fn().mockReturnValue({type: 'section'}),
+        };
+
+        // $FlowFixMe - only the methods used by isInsideBlock are relevant here
+        const result = instance.isInsideBlock(formInspector, '/details/title');
+
+        expect(result).toBe(false);
+    });
+
     test('captures dataPath from sulu.focus event', () => {
         const instance = new AiApplication(props);
 


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  - Wrapped `getSchemaEntryByPath()` in `AiApplication.isInsideBlock()` with `try/catch` so an unresolved schema path returns `false` instead of throwing.
  - Removed the `/ext` prefix fast-path, now covered by the same `try/catch`.
  - Added unit tests for the three branches: throwing lookup, block ancestor found, no block ancestor.

  #### Why?

  Focusing a field in an extension tab (excerpt, seo) dispatches a `schemaPath` that does not resolve in the page form's schema. `json-pointer` throws `Invalid reference token`, which crashes the admin. Since
  `isInsideBlock()` is a best-effort UX hint, treating a schema miss as "not inside a block" is the correct fallback.