### PR TITLE
Fix internal link pages leaking target identity into navigation and content resolution

### DIFF
--- a/packages/page/src/Domain/Model/PageDimensionContent.php
+++ b/packages/page/src/Domain/Model/PageDimensionContent.php
@@ -74,6 +74,17 @@ class PageDimensionContent implements PageDimensionContentInterface
         return $this->page;
     }
 
+    /**
+     * @internal the returned clone is detached from Doctrine's unit of work and must not be persisted
+     */
+    public function withPage(PageInterface $page): static
+    {
+        $clone = clone $this;
+        $clone->page = $page;
+
+        return $clone;
+    }
+
     public function getTitle(): ?string
     {
         return $this->title;

--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -18,10 +18,12 @@ use Sulu\Bundle\MarkupBundle\Markup\Link\LinkUrlTrait;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentEnhancer\DimensionContentEnhancerInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
 use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal This class should not be instantiated by a project.
@@ -112,23 +114,26 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
         /** @var PageDimensionContentInterface $targetDimensionContent */
         $targetDimensionContent = $this->contentAggregator->aggregate($page, $dimensionAttributes);
 
-        $route = $targetDimensionContent->getRoute();
+        Assert::isInstanceOf($targetDimensionContent, PageDimensionContent::class);
+        $enhancedDimensionContent = $targetDimensionContent->withPage($pageDimensionContent->getResource());
+
+        $route = $enhancedDimensionContent->getRoute();
         $url = $route?->getSlug();
 
         if (null !== $url && null !== $linkData) {
             $url = $this->appendQueryAndAnchor($url, $linkData);
         }
 
-        $targetDimensionContent->setTemplateData([
-            ...$targetDimensionContent->getTemplateData(),
+        $enhancedDimensionContent->setTemplateData([
+            ...$enhancedDimensionContent->getTemplateData(),
             ...[
                 'title' => $pageDimensionContent->getTitle(),
                 'url' => $url,
             ],
         ]);
-        $targetDimensionContent->setLinkData($linkData);
+        $enhancedDimensionContent->setLinkData($linkData);
 
-        return $targetDimensionContent; // @phpstan-ignore-line return.type
+        return $enhancedDimensionContent; // @phpstan-ignore-line return.type
     }
 
     /**

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -27,6 +27,10 @@ class NavigationRepositoryLinkTest extends SuluTestCase
 
     private NavigationRepositoryInterface $navigationRepository;
 
+    private static string $targetPageUuid;
+
+    private static string $internalLinkPageUuid;
+
     /**
      * @return array<string, string>
      */
@@ -119,8 +123,9 @@ class NavigationRepositoryLinkTest extends SuluTestCase
                 ],
             ],
         ]);
+        self::$targetPageUuid = $targetPage->getUuid();
 
-        self::createPage([
+        $internalLinkPage = self::createPage([
             'en' => [
                 'live' => [
                     'title' => 'Internal Link Page',
@@ -139,6 +144,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
                 ],
             ],
         ]);
+        self::$internalLinkPageUuid = $internalLinkPage->getUuid();
 
         self::createPage([
             'en' => [
@@ -184,6 +190,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $this->assertSame('/target-page', $internalLinkNav['url']);
         $this->assertSame('sulu-io', $internalLinkNav['webspaceKey']);
         $this->assertSame('page', $internalLinkNav['linkProvider']);
+        $this->assertSame(self::$internalLinkPageUuid, $internalLinkNav['uuid']);
 
         // Test external link resolve url
         /** @var array<string, mixed> $externalLinkNav */
@@ -249,6 +256,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
         $this->assertSame('/target-page', $internalLinkNav['url']);
         $this->assertSame('page', $internalLinkNav['linkProvider']);
+        $this->assertSame(self::$internalLinkPageUuid, $internalLinkNav['uuid']);
         $this->assertArrayHasKey('children', $internalLinkNav);
 
         // Test external link resolve url
@@ -260,7 +268,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $this->assertArrayHasKey('children', $externalLinkNav);
     }
 
-    public function testGetNavigationTreeResolvesTargetPositionMetadataForInternalLinks(): void
+    public function testGetNavigationTreeResolvesSourcePositionMetadataForInternalLinks(): void
     {
         $properties = [
             ...$this->getDefaultProperties(),
@@ -286,13 +294,15 @@ class NavigationRepositoryLinkTest extends SuluTestCase
         $contentPageNav = $homepageChildren[0];
         /** @var array<string, mixed> $internalLinkNav */
         $internalLinkNav = $homepageChildren[1];
-        /** @var array<string, mixed> $externalLinkNav */
-        $externalLinkNav = $homepageChildren[2];
 
         $this->assertSame('Internal Link Page', $internalLinkNav['title']);
         $this->assertSame('/target-page', $internalLinkNav['url']);
-        $this->assertSame(2, $internalLinkNav['depth']);
-        $this->assertGreaterThan($contentPageNav['lft'], $internalLinkNav['lft']);
-        $this->assertLessThan($contentPageNav['rgt'], $internalLinkNav['rgt']);
+
+        $this->assertSame(self::$internalLinkPageUuid, $internalLinkNav['uuid']);
+        $this->assertNotSame(self::$targetPageUuid, $internalLinkNav['uuid']);
+        $this->assertSame($contentPageNav['depth'], $internalLinkNav['depth']);
+        // source is a sibling of the content page, so its lft sits after the content page's subtree
+        $this->assertGreaterThan($contentPageNav['rgt'], $internalLinkNav['lft']);
+        $this->assertGreaterThan($internalLinkNav['lft'], $internalLinkNav['rgt']);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancerTest.php
@@ -129,7 +129,7 @@ class PageLinkDimensionContentEnhancerTest extends TestCase
         $this->assertSame($pageDimensionContent->reveal(), $result);
     }
 
-    public function testEnhancePreservesSourceLinkDataWhenResolvingPageLink(): void
+    public function testEnhanceInternalPageLinkReportsSourceIdentityWithTargetContent(): void
     {
         $sourcePage = $this->prophesize(PageInterface::class);
         $sourcePage->getId()->willReturn('uuid-link');
@@ -147,20 +147,12 @@ class PageLinkDimensionContentEnhancerTest extends TestCase
         $targetPage = $this->prophesize(PageInterface::class);
         $targetPage->getWebspaceKey()->willReturn('sulu-io');
 
-        $targetDimensionContent = $this->prophesize(PageDimensionContentInterface::class);
-        $targetDimensionContent->getRoute()->willReturn(new Route('pages', 'uuid-target', 'en', '/target-page'));
-        $targetDimensionContent->getLocale()->willReturn('en');
-        $targetDimensionContent->getResource()->willReturn($targetPage->reveal());
-        $targetDimensionContent->getTemplateData()->willReturn(['existing' => 'value']);
-        $targetDimensionContent->setTemplateData([
-            'existing' => 'value',
-            'title' => 'Link Page',
-            'url' => '/target-page',
-        ])->shouldBeCalled();
-        $targetDimensionContent->setLinkData([
-            'provider' => 'page',
-            'href' => 'uuid-target',
-        ])->shouldBeCalled();
+        $targetDimensionContent = new PageDimensionContent($targetPage->reveal());
+        $targetDimensionContent->setLocale('en');
+        $targetDimensionContent->setStage(DimensionContentInterface::STAGE_LIVE);
+        $targetDimensionContent->setVersion(DimensionContentInterface::CURRENT_VERSION);
+        $targetDimensionContent->setTemplateData(['existing' => 'value', 'title' => 'Target Page']);
+        $targetDimensionContent->setRoute(new Route('pages', 'uuid-target', 'en', '/target-page'));
 
         $this->pageRepository->findOneBy(
             ['uuid' => 'uuid-target'],
@@ -171,10 +163,29 @@ class PageLinkDimensionContentEnhancerTest extends TestCase
             'locale' => 'en',
             'stage' => DimensionContentInterface::STAGE_LIVE,
             'version' => DimensionContentInterface::CURRENT_VERSION,
-        ])->willReturn($targetDimensionContent->reveal())->shouldBeCalled();
+        ])->willReturn($targetDimensionContent)->shouldBeCalled();
 
         $result = $this->enhancer->enhance($pageDimensionContent);
 
-        $this->assertSame($targetDimensionContent->reveal(), $result);
+        $this->assertNotSame($targetDimensionContent, $result);
+        $this->assertSame($sourcePage->reveal(), $result->getResource());
+        $this->assertSame([
+            'existing' => 'value',
+            'title' => 'Link Page',
+            'url' => '/target-page',
+        ], $result->getTemplateData());
+        $this->assertSame('Link Page', $result->getTitle());
+        $this->assertSame([
+            'provider' => 'page',
+            'href' => 'uuid-target',
+        ], $result->getLinkData());
+
+        // the clone took all writes so the aggregator's instance stays unmodified
+        $this->assertSame($targetPage->reveal(), $targetDimensionContent->getResource());
+        $this->assertSame(
+            ['existing' => 'value', 'title' => 'Target Page'],
+            $targetDimensionContent->getTemplateData(),
+        );
+        $this->assertNull($targetDimensionContent->getLinkData());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

* Added an `@internal` `withPage()` method on `PageDimensionContent`. It returns a clone of the dimension content with a different source page attached. The clone is intentionally detached from Doctrine's unit of work.
* Reworked `PageLinkDimensionContentEnhancer::resolvePage()` to call `withPage()` on the aggregated target. The returned `DimensionContent` now reports the source `Page` via `getResource()` while keeping the target's template data, excerpt, SEO, route and other extension fields.
* Updated `NavigationRepositoryLinkTest` so the internal link navigation items assert source identity (uuid, depth, lft, rgt). The existing title, url and excerpt assertions stay pointed at the target resolution.
* Rewrote the corresponding unit test in `PageLinkDimensionContentEnhancerTest` against real `PageDimensionContent` instances. It verifies that the clone took all writes and that the aggregator's target instance stays unmodified.

#### Why?

When a page uses an internal page link, `PageLinkDimensionContentEnhancer` was replacing the whole source `DimensionContent` with the target's aggregated `DimensionContent`. Every `object.resource.*` property path then resolved against the target page, so `uuid`, `depth`, `lft` and `rgt` in `treeRootNavigationFunction` and `treeNavigationFunction` returned the link target instead of the internal link page itself. Recursive Twig menus could no longer tell a source page apart from the page it linked to and the wrong item was shown.

Sulu 2 returned the source identity together with the target URL. This PR restores that contract by keeping the target's content but flipping `getResource()` back to the source via a cheap clone. The same fix also resolves the identical issue in breadcrumbs and every other consumer of the ContentResolver pipeline.

#### To Do

* [ ] Create a documentation PR
* [ ] Add breaking changes to UPGRADE.md
