### PR TITLE
Throw exception when portal key is not unique

### DIFF
--- a/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
+++ b/src/Sulu/Component/Webspace/Resources/skeleton/WebspaceCollectionClass.php.twig
@@ -119,6 +119,9 @@ class {{ cache_class }} extends {{ base_class }}
 
         $portal->addEnvironment($environment);
 {% endfor %}
+        if (isset($portalRefs['{{ portal.key }}'])) {
+            throw new \InvalidArgumentException('Portal with key "{{ portal.key }}" already exists in webspace "' . $portalRefs['{{ portal.key }}']->getWebspace()->getKey() . '" and conflicts with webspace "{{ webspace.key }}". Portal keys must be unique across all webspaces.');
+        }
         $portalRefs['{{ portal.key }}'] = $portal;
         $webspace->addPortal($portal);
 


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
  | Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
  | Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
  | License | MIT
  | Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

  #### What's in this PR?

  - Added a duplicate portal key check in the generated `WebspaceCollectionClass` cache file
  - Throws an `\InvalidArgumentException` when two portals across different webspaces share the same key

  #### Why?

  The `$portalRefs` array in the generated webspace cache class was silently overwriting portals that shared the same key. When two webspaces defined portals with identical keys, the first portal would be lost
  without any warning, leading to incorrect portal resolution at runtime. This fix catches the misconfiguration at cache generation time with a clear error message.

<img width="1249" height="75" alt="image" src="https://github.com/user-attachments/assets/ae334b1c-3e42-49e9-9d0e-2306439db39c" />
