### PR TITLE
Fix permission inheritance overlay not shown and not applied for pages

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Content/Normalizer/PageNormalizer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/Normalizer/PageNormalizer.php
@@ -33,6 +33,7 @@ class PageNormalizer implements NormalizerInterface
 
         $normalizedData['webspace'] = $page->getWebspaceKey();
         $normalizedData['parentUuid'] = $page->getParent()?->getUuid();
+        $normalizedData['hasSub'] = ($page->getLft() + 1) !== $page->getRgt();
 
         return $normalizedData;
     }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -382,7 +382,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_content.dimension_content_query_enhancer'),
                 new Reference('sulu_security.access_control_query_enhancer'),
             ])
-            ->tag('sulu.descendant_provider');
+            ->tag('sulu_security.access_control_descendant_provider');
 
         $services->alias(PageRepositoryInterface::class, 'sulu_page.page_repository');
         $services->alias(PageRepository::class, 'sulu_page.page_repository');

--- a/packages/page/tests/Functional/Integration/PagePermissionInheritanceTest.php
+++ b/packages/page/tests/Functional/Integration/PagePermissionInheritanceTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**
  * The integration test should have no impact on the coverage so we set it to coversNothing.
@@ -29,7 +30,104 @@ class PagePermissionInheritanceTest extends SuluTestCase
 {
     use CreatePageTrait;
 
-    public function testChildPageInheritsParentPermissionsOnCreation(): void
+    protected KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient(
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+        );
+    }
+
+    public function testGetPageReturnsHasSubFalseForLeafPage(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ]);
+
+        $leafPage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Leaf Page',
+                    'url' => '/leaf',
+                    'parentId' => $homepage->getUuid(),
+                ],
+            ],
+        ]);
+
+        self::ensureKernelShutdown();
+
+        $this->client->request('GET', '/admin/api/pages/' . $leafPage->getUuid() . '?locale=en');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+
+        $this->assertArrayHasKey('hasSub', $content);
+        $this->assertFalse($content['hasSub']);
+    }
+
+    public function testGetPageReturnsHasSubTrueForPageWithChildren(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ]);
+
+        $parentPage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Parent Page',
+                    'url' => '/parent',
+                    'parentId' => $homepage->getUuid(),
+                ],
+            ],
+        ]);
+
+        $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Child Page',
+                    'url' => '/parent/child',
+                    'parentId' => $parentPage->getUuid(),
+                ],
+            ],
+        ]);
+
+        self::ensureKernelShutdown();
+
+        $this->client->request('GET', '/admin/api/pages/' . $parentPage->getUuid() . '?locale=en');
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+
+        $this->assertArrayHasKey('hasSub', $content);
+        $this->assertTrue($content['hasSub']);
+    }
+
+    public function testPermissionInheritanceSetsPermissionsOnChildPages(): void
     {
         self::purgeDatabase();
 
@@ -104,6 +202,16 @@ class PagePermissionInheritanceTest extends SuluTestCase
         $accessControlManager = self::getContainer()->get('sulu_security.access_control_manager');
         $childPermissions = $accessControlManager->getPermissions(Page::class, $childPage->getUuid());
 
+        // Must not throw AccessControlDescendantProviderNotFoundException for Page type
+        $accessControlManager->setPermissions(
+            Page::class,
+            $parentPage->getUuid(),
+            [$roleId => ['view' => true, 'add' => true, 'edit' => true, 'delete' => true, 'live' => true, 'security' => true]],
+            true,
+        );
+
+        $childPermissions = $accessControlManager->getPermissions(Page::class, $parentPage->getUuid());
+        $this->assertArrayHasKey($roleId, $childPermissions);
         $this->assertSame($expectedPermissions, $childPermissions);
     }
 }

--- a/packages/page/tests/Functional/Integration/responses/page_get.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get.json
@@ -42,6 +42,7 @@
         "sulu-io": "@string@"
     },
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/page/tests/Functional/Integration/responses/page_get_after_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get_after_restore.json
@@ -34,6 +34,7 @@
     ],
     "excerptSegment" : { "sulu-io" : "@string@" },
     "ghostLocale" : "en",
+    "hasSub" : false,
     "id" : "@string@",
     "image" : null,
     "lastModified" : "@dateTime@",

--- a/packages/page/tests/Functional/Integration/responses/page_get_ghost_locale.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get_ghost_locale.json
@@ -25,6 +25,7 @@
     "excerptAudienceTargetGroups": [],
     "excerptSegment": null,
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "lastModified": null,
     "lastModifiedEnabled": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post.json
@@ -43,6 +43,7 @@
         "sulu-io": "@string@"
     },
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/page/tests/Functional/Integration/responses/page_post_copy.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_copy.json
@@ -33,6 +33,7 @@
     "excerptAudienceTargetGroups" : [ "@integer@", "@integer@" ],
     "excerptSegment" : { "sulu-io" : "copy-segment" },
     "ghostLocale" : "en",
+    "hasSub" : false,
     "id" : "@string@",
     "image" : null,
     "lastModified" : "@datetime@",

--- a/packages/page/tests/Functional/Integration/responses/page_post_move.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_move.json
@@ -33,6 +33,7 @@
     "excerptAudienceTargetGroups" : [ "@integer@", "@integer@" ],
     "excerptSegment" : { "sulu-io" : "@string@" },
     "ghostLocale" : "en",
+    "hasSub" : false,
     "id" : "@string@",
     "image" : null,
     "lastModified" : "@datetime@",

--- a/packages/page/tests/Functional/Integration/responses/page_post_order.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_order.json
@@ -30,6 +30,7 @@
     "excerptAudienceTargetGroups": [],
     "excerptSegment": null,
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "image": null,
     "lastModified": null,

--- a/packages/page/tests/Functional/Integration/responses/page_post_publish.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_publish.json
@@ -43,6 +43,7 @@
         "sulu-io": "@string@"
     },
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/page/tests/Functional/Integration/responses/page_post_publish_blog.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_publish_blog.json
@@ -43,6 +43,7 @@
         "blog": "@string@"
     },
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/page/tests/Functional/Integration/responses/page_post_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_restore.json
@@ -44,6 +44,7 @@
         "Tag 4"
     ],
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@uuid@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/page/tests/Functional/Integration/responses/page_post_trigger_copy_locale.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_trigger_copy_locale.json
@@ -45,6 +45,7 @@
         "sulu-io": "@string@"
     },
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/page/tests/Functional/Integration/responses/page_post_trigger_unpublish.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_trigger_unpublish.json
@@ -43,6 +43,7 @@
         "sulu-io": "@string@"
     },
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",

--- a/packages/page/tests/Functional/Integration/responses/page_put.json
+++ b/packages/page/tests/Functional/Integration/responses/page_put.json
@@ -45,6 +45,7 @@
         "sulu-io": "@string@"
     },
     "ghostLocale": "en",
+    "hasSub": false,
     "id": "@string@",
     "image": null,
     "lastModified": "2022-05-08T00:00:00+00:00",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

- `PageNormalizer` now includes `hasSub` in the page API response so the toolbar condition `__parent.hasSub` can evaluate correctly and show the "Inherit permissions" overlay
- The `PageRepository` service tag was corrected from `sulu.descendant_provider` to `sulu_security.access_control_descendant_provider` so the `AccessControlManager` can resolve child pages when applying inherited permissions
- Added functional tests for `hasSub` values and permission inheritance via the `AccessControlManager`
- Updated existing snapshot tests to include the new `hasSub` field

#### Why?

In Sulu 2.x a JMS Serializer subscriber automatically added `hasSub` to every serialized page document. When Sulu 3.0 moved to Doctrine entities this subscriber was removed and never replaced in `PageNormalizer`, so the "Inherit permissions" overlay never appeared for pages.