### PR TITLE
Fix Doctrine / Gedmo compatibility issues with custom page model subclasses

### DIFF
--- a/packages/content/src/Infrastructure/Doctrine/MetadataLoader.php
+++ b/packages/content/src/Infrastructure/Doctrine/MetadataLoader.php
@@ -17,6 +17,7 @@ use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\InverseSideMapping;
 use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroupInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\ContactBundle\Entity\ContactInterface;
@@ -141,6 +142,18 @@ final class MetadataLoader
 
             $this->addIndex($metadata, 'link_provider', ['linkProvider']);
         }
+
+        // Doctrine leaves `declared` null on inverse-side associations (OneToMany, inverse
+        // OneToOne, inverse ManyToMany) that a concrete entity inherits from a mapped-superclass.
+        // Doctrine then builds reflection against the concrete child class, where the inherited
+        // private property does not exist, and throws `ReflectionException: Property X::$y does
+        // not exist`. Owning-side associations are populated correctly and are skipped here.
+        // ORM 3.x stores mappings as `InverseSideMapping` objects; ORM 2.x stores them as arrays.
+        if (!$metadata->isMappedSuperclass) {
+            foreach ($metadata->associationMappings as $key => $mapping) {
+                $this->backfillInverseSideDeclared($metadata, $key, $mapping);
+            }
+        }
     }
 
     /**
@@ -255,6 +268,53 @@ final class MetadataLoader
         $tableName = $metadata->getTableName();
 
         $builder->addIndex($fields, 'idx_' . $tableName . '_' . $name);
+    }
+
+    /**
+     * @param ClassMetadata<object> $metadata
+     * @param mixed $mapping object on ORM 3.x, array on ORM 2.x
+     */
+    private function backfillInverseSideDeclared(ClassMetadata $metadata, string $key, mixed $mapping): void
+    {
+        if (\is_array($mapping)) {
+            $fieldName = $mapping['fieldName'] ?? null;
+
+            if (!\is_string($fieldName) || ($mapping['isOwningSide'] ?? true) || isset($mapping['declared'])) {
+                return;
+            }
+
+            $mapping['declared'] = $this->findDeclaringClass($metadata->getName(), $fieldName);
+            /* @phpstan-ignore assign.propertyType */
+            $metadata->associationMappings[$key] = $mapping;
+
+            return;
+        }
+
+        if (!$mapping instanceof InverseSideMapping || null !== $mapping->declared) {
+            return;
+        }
+
+        $mapping->declared = $this->findDeclaringClass($metadata->getName(), $mapping->fieldName);
+    }
+
+    /**
+     * @param class-string $className
+     *
+     * @return class-string
+     */
+    private function findDeclaringClass(string $className, string $propertyName): string
+    {
+        foreach (\class_parents($className) as $parent) {
+            $parentReflection = new \ReflectionClass($parent);
+
+            foreach ($parentReflection->getProperties() as $property) {
+                if ($property->getName() === $propertyName) {
+                    return $parentReflection->getName();
+                }
+            }
+        }
+
+        return $className;
     }
 
     /**

--- a/packages/page/src/Infrastructure/Doctrine/Hydrator/SafeTreeObjectHydrator.php
+++ b/packages/page/src/Infrastructure/Doctrine/Hydrator/SafeTreeObjectHydrator.php
@@ -26,6 +26,8 @@ use Gedmo\Tree\Hydrator\ORM\TreeObjectHydrator;
  * Upstream issue: https://github.com/doctrine-extensions/DoctrineExtensions/issues/2921
  * Upstream fix (open PR): https://github.com/doctrine-extensions/DoctrineExtensions/pull/3041
  *
+ * @internal
+ *
  * @phpstan-ignore class.extendsFinalByPhpDoc
  */
 final class SafeTreeObjectHydrator extends TreeObjectHydrator

--- a/packages/page/src/Infrastructure/Doctrine/Hydrator/SafeTreeObjectHydrator.php
+++ b/packages/page/src/Infrastructure/Doctrine/Hydrator/SafeTreeObjectHydrator.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Doctrine\Hydrator;
+
+use Doctrine\ORM\Mapping\InverseSideMapping;
+use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tree\Hydrator\ORM\TreeObjectHydrator;
+
+/**
+ * Works around Gedmo's TreeObjectHydrator crashing on ORM 3.x. When the tree entity is
+ * a concrete subclass of a mapped-superclass, Gedmo iterates `getReflectionProperties()`
+ * and reads `mappedBy` on owning-side associations (which throw `OutOfRangeException`
+ * because the property only exists on inverse-side mappings).
+ *
+ * Upstream issue: https://github.com/doctrine-extensions/DoctrineExtensions/issues/2921
+ * Upstream fix (open PR): https://github.com/doctrine-extensions/DoctrineExtensions/pull/3041
+ *
+ * @phpstan-ignore class.extendsFinalByPhpDoc
+ */
+final class SafeTreeObjectHydrator extends TreeObjectHydrator
+{
+    protected function getChildrenField($entityClass): string
+    {
+        $meta = $this->getClassMetadata($entityClass);
+
+        foreach ($meta->getReflectionProperties() as $property) {
+            $name = $property->getName();
+
+            if (!$meta->hasAssociation($name)) {
+                continue;
+            }
+
+            $fieldName = $this->resolveChildrenField($meta->getAssociationMapping($name));
+
+            if (null !== $fieldName) {
+                return $fieldName;
+            }
+        }
+
+        throw new InvalidMappingException(
+            'The children property could not be found. It is identified through the `mappedBy` annotation to your parent property.'
+        );
+    }
+
+    /**
+     * @param mixed $mapping object on ORM 3.x, array on ORM 2.x
+     */
+    private function resolveChildrenField(mixed $mapping): ?string
+    {
+        if (\is_array($mapping)) {
+            if (($mapping['isOwningSide'] ?? true) || ($mapping['mappedBy'] ?? null) !== $this->getParentField()) {
+                return null;
+            }
+
+            return \is_string($mapping['fieldName'] ?? null) ? $mapping['fieldName'] : null;
+        }
+
+        if (!$mapping instanceof InverseSideMapping || $mapping->mappedBy !== $this->getParentField()) {
+            return null;
+        }
+
+        return $mapping->fieldName;
+    }
+}

--- a/packages/page/src/Infrastructure/Doctrine/Tree/SuluPageAwareTreeListener.php
+++ b/packages/page/src/Infrastructure/Doctrine/Tree/SuluPageAwareTreeListener.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Doctrine\Tree;
+
+use Doctrine\Persistence\ObjectManager;
+use Gedmo\Tree\Strategy;
+use Gedmo\Tree\TreeListener;
+use Sulu\Page\Domain\Model\Page as SuluPage;
+
+/**
+ * Works around Gedmo's ExtensionMetadataFactory returning an empty configuration for
+ * mapped-superclasses (`if ($meta->isMappedSuperclass) return [];`). When a project uses
+ * a concrete subclass of Sulu's `Page` mapped-superclass, we redirect lookups for the
+ * parent class to the concrete class so the tree strategy can resolve its configuration.
+ *
+ * Upstream issue (closed without fix since 2016): https://github.com/doctrine-extensions/DoctrineExtensions/issues/1696
+ */
+final class SuluPageAwareTreeListener extends TreeListener
+{
+    /**
+     * @var class-string
+     */
+    private string $concretePageClass = SuluPage::class;
+
+    /**
+     * Reentry guard: Gedmo walks parent classes during metadata loading, which would
+     * otherwise cause `SuluPage -> concretePageClass -> SuluPage` redirect recursion.
+     */
+    private bool $redirecting = false;
+
+    /**
+     * @param class-string $class
+     */
+    public function setConcretePageClass(string $class): void
+    {
+        $this->concretePageClass = $class;
+    }
+
+    public function getConfiguration(ObjectManager $objectManager, $class): array
+    {
+        if (SuluPage::class === $class && !$this->redirecting) {
+            $this->redirecting = true;
+            try {
+                return parent::getConfiguration($objectManager, $this->concretePageClass);
+            } finally {
+                $this->redirecting = false;
+            }
+        }
+
+        return parent::getConfiguration($objectManager, $class);
+    }
+
+    public function getStrategy(ObjectManager $objectManager, $class): Strategy
+    {
+        if (SuluPage::class === $class && !$this->redirecting) {
+            $this->redirecting = true;
+            try {
+                return parent::getStrategy($objectManager, $this->concretePageClass);
+            } finally {
+                $this->redirecting = false;
+            }
+        }
+
+        return parent::getStrategy($objectManager, $class);
+    }
+}

--- a/packages/page/src/Infrastructure/Doctrine/Tree/SuluPageAwareTreeListener.php
+++ b/packages/page/src/Infrastructure/Doctrine/Tree/SuluPageAwareTreeListener.php
@@ -25,6 +25,8 @@ use Sulu\Page\Domain\Model\Page as SuluPage;
  * parent class to the concrete class so the tree strategy can resolve its configuration.
  *
  * Upstream issue (closed without fix since 2016): https://github.com/doctrine-extensions/DoctrineExtensions/issues/1696
+ *
+ * @internal
  */
 final class SuluPageAwareTreeListener extends TreeListener
 {

--- a/packages/page/src/Infrastructure/Symfony/DependencyInjection/Compiler/OverrideTreeListenerPass.php
+++ b/packages/page/src/Infrastructure/Symfony/DependencyInjection/Compiler/OverrideTreeListenerPass.php
@@ -18,6 +18,9 @@ use Sulu\Page\Infrastructure\Doctrine\Tree\SuluPageAwareTreeListener;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @internal
+ */
 final class OverrideTreeListenerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void

--- a/packages/page/src/Infrastructure/Symfony/DependencyInjection/Compiler/OverrideTreeListenerPass.php
+++ b/packages/page/src/Infrastructure/Symfony/DependencyInjection/Compiler/OverrideTreeListenerPass.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Symfony\DependencyInjection\Compiler;
+
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Infrastructure\Doctrine\Tree\SuluPageAwareTreeListener;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class OverrideTreeListenerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('stof_doctrine_extensions.listener.tree')) {
+            return;
+        }
+
+        /** @var class-string $pageClass */
+        $pageClass = $container->getParameter('sulu.model.page.class');
+
+        if (Page::class === $pageClass) {
+            return;
+        }
+
+        $container->getDefinition('stof_doctrine_extensions.listener.tree')
+            ->setClass(SuluPageAwareTreeListener::class)
+            ->addMethodCall('setConcretePageClass', [$pageClass]);
+    }
+}

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Infrastructure\Symfony\HttpKernel;
 
-use Gedmo\Tree\Hydrator\ORM\TreeObjectHydrator;
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Content\Infrastructure\Sulu\Preview\ContentObjectProvider;
@@ -42,6 +41,7 @@ use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Infrastructure\Doctrine\Hydrator\SafeTreeObjectHydrator;
 use Sulu\Page\Infrastructure\Doctrine\Repository\NavigationRepository;
 use Sulu\Page\Infrastructure\Doctrine\Repository\PageRepository;
 use Sulu\Page\Infrastructure\JMS\Serializer\WebspaceSerializeEventSubscriber;
@@ -83,6 +83,7 @@ use Sulu\Page\Infrastructure\Sulu\Security\PageDescendantSecurityListener;
 use Sulu\Page\Infrastructure\Sulu\Security\PageSecurityListener;
 use Sulu\Page\Infrastructure\Sulu\Sitemap\PagesSitemapProvider;
 use Sulu\Page\Infrastructure\Sulu\Trash\PageTrashItemHandler;
+use Sulu\Page\Infrastructure\Symfony\DependencyInjection\Compiler\OverrideTreeListenerPass;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\ContentPathTwigExtension;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\PageTwigExtension;
@@ -786,7 +787,7 @@ final class SuluPageBundle extends AbstractBundle
                             ],
                         ],
                         'hydrators' => [
-                            'sulu_page_tree' => TreeObjectHydrator::class,
+                            'sulu_page_tree' => SafeTreeObjectHydrator::class,
                         ],
                     ],
                 ],
@@ -853,5 +854,6 @@ final class SuluPageBundle extends AbstractBundle
             PageInterface::class => 'sulu.model.page.class',
             PageDimensionContentInterface::class => 'sulu.model.page_content.class',
         ], $container);
+        $container->addCompilerPass(new OverrideTreeListenerPass());
     }
 }

--- a/packages/page/tests/Application/Entity/Page.php
+++ b/packages/page/tests/Application/Entity/Page.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Application\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Tree\Entity\Repository\NestedTreeRepository;
+use Sulu\Page\Domain\Model\Page as SuluPage;
+
+#[ORM\Entity(repositoryClass: NestedTreeRepository::class)]
+#[ORM\Table(name: 'pa_pages')]
+class Page extends SuluPage
+{
+    #[ORM\Column(name: 'custom_text', type: 'string', length: 255, nullable: true)]
+    private ?string $customText = null;
+
+    public function getCustomText(): ?string
+    {
+        return $this->customText;
+    }
+
+    public function setCustomText(?string $customText): void
+    {
+        $this->customText = $customText;
+    }
+}

--- a/packages/page/tests/Application/config/config_custom_page_model.yml
+++ b/packages/page/tests/Application/config/config_custom_page_model.yml
@@ -1,0 +1,15 @@
+doctrine:
+    orm:
+        mappings:
+            PageTestsApplication:
+                type: attribute
+                prefix: Sulu\Page\Tests\Application\Entity
+                dir: "%kernel.project_dir%/Entity"
+                alias: PageTestsApplication
+                is_bundle: false
+                mapping: true
+
+sulu_page:
+    objects:
+        page:
+            model: Sulu\Page\Tests\Application\Entity\Page

--- a/packages/page/tests/Functional/Integration/CustomPageModelTreeTest.php
+++ b/packages/page/tests/Functional/Integration/CustomPageModelTreeTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page as SuluPage;
+use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Page\Tests\Application\Entity\Page as CustomPage;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+
+/**
+ * The test boots a second kernel (`test_custom_page_model`) in addition to the default
+ * one. Sulu's `adminWebspaceCollectionCache` uses a hardcoded class name and would clash
+ * in the same PHP process, so the test runs in isolation.
+ */
+#[RunTestsInSeparateProcesses]
+class CustomPageModelTreeTest extends SuluTestCase
+{
+    use CreatePageTrait;
+
+    private EntityManagerInterface $entityManager;
+    private NavigationRepositoryInterface $navigationRepository;
+    private PageRepositoryInterface $pageRepository;
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function getKernelConfiguration(): array
+    {
+        return ['environment' => 'test_custom_page_model'];
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        self::purgeDatabase();
+
+        $this->entityManager = self::getEntityManager();
+        $this->navigationRepository = self::getContainer()->get('sulu_page.navigation_repository');
+        $this->pageRepository = self::getContainer()->get('sulu_page.page_repository');
+
+        $this->ensureCustomTextColumn();
+    }
+
+    private function ensureCustomTextColumn(): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $columns = $connection->createSchemaManager()->listTableColumns('pa_pages');
+
+        if (isset($columns['custom_text'])) {
+            return;
+        }
+
+        $connection->executeStatement('ALTER TABLE pa_pages ADD COLUMN custom_text VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function testCustomConcretePageModelSupportsTreeOperationsAndTreeHydration(): void
+    {
+        self::assertSame(CustomPage::class, self::getContainer()->getParameter('sulu.model.page.class'));
+
+        $parent = self::createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Parent Page',
+                    'url' => '/parent',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        $child1 = self::createPage([
+            'en' => [
+                'live' => [
+                    'parentId' => $parent->getUuid(),
+                    'template' => 'default',
+                    'title' => 'Child 1',
+                    'url' => '/parent/child-1',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        $child2 = self::createPage([
+            'en' => [
+                'live' => [
+                    'parentId' => $parent->getUuid(),
+                    'template' => 'default',
+                    'title' => 'Child 2',
+                    'url' => '/parent/child-2',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        $grandchild = self::createPage([
+            'en' => [
+                'live' => [
+                    'parentId' => $child1->getUuid(),
+                    'template' => 'default',
+                    'title' => 'Grandchild 1',
+                    'url' => '/parent/child-1/grandchild-1',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        $this->entityManager->clear();
+
+        $reloadedParent = $this->entityManager->find(CustomPage::class, $parent->getUuid());
+        $reloadedChild1 = $this->entityManager->find(CustomPage::class, $child1->getUuid());
+        $reloadedChild2 = $this->entityManager->find(CustomPage::class, $child2->getUuid());
+        $reloadedGrandchild = $this->entityManager->find(CustomPage::class, $grandchild->getUuid());
+
+        self::assertInstanceOf(CustomPage::class, $reloadedParent);
+        self::assertInstanceOf(CustomPage::class, $reloadedChild1);
+        self::assertInstanceOf(CustomPage::class, $reloadedChild2);
+        self::assertInstanceOf(CustomPage::class, $reloadedGrandchild);
+
+        self::assertSame($reloadedParent->getUuid(), $reloadedChild1->getParent()?->getUuid());
+        self::assertSame($reloadedParent->getUuid(), $reloadedChild2->getParent()?->getUuid());
+        self::assertSame($reloadedChild1->getUuid(), $reloadedGrandchild->getParent()?->getUuid());
+        self::assertLessThan($reloadedChild2->getLft(), $reloadedChild1->getLft());
+        self::assertGreaterThan($reloadedChild1->getLft(), $reloadedGrandchild->getLft());
+        self::assertLessThan($reloadedChild1->getRgt(), $reloadedGrandchild->getRgt());
+
+        $navigation = $this->navigationRepository->getNavigationTreeByUuid(
+            $parent->getUuid(),
+            'en',
+            'sulu-io',
+            2,
+            'main',
+            $this->getDefaultProperties()
+        );
+
+        self::assertCount(2, $navigation);
+        self::assertSame('Child 1', $navigation[0]['title']);
+        self::assertSame('Child 2', $navigation[1]['title']);
+
+        self::assertIsArray($navigation[0]['children']);
+        self::assertCount(1, $navigation[0]['children']);
+        $grandchildNav = $navigation[0]['children'][0];
+        self::assertIsArray($grandchildNav);
+        self::assertSame('Grandchild 1', $grandchildNav['title']);
+        self::assertGreaterThan($navigation[0]['lft'], $grandchildNav['lft']);
+        self::assertLessThan($navigation[0]['rgt'], $grandchildNav['rgt']);
+
+        $reloadedParent->setCustomText('persisted-custom-value');
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $withCustomField = $this->entityManager->find(CustomPage::class, $parent->getUuid());
+        self::assertInstanceOf(CustomPage::class, $withCustomField);
+        self::assertSame('persisted-custom-value', $withCustomField->getCustomText());
+
+        $metadata = $this->entityManager->getClassMetadata(CustomPage::class);
+        self::assertSame(CustomPage::class, self::mappingDeclared($metadata->fieldMappings['customText']) ?? CustomPage::class);
+        self::assertSame(SuluPage::class, self::mappingDeclared($metadata->associationMappings['parent']));
+        self::assertSame(SuluPage::class, self::mappingDeclared($metadata->associationMappings['children']));
+
+        // Exercises Gedmo's `sulu_page_tree` hydrator (the code path guarded by SafeTreeObjectHydrator).
+        $treeRoots = \iterator_to_array($this->pageRepository->findByAsTree([
+            'webspaceKey' => 'sulu-io',
+            'locale' => 'en',
+        ]));
+        self::assertNotEmpty($treeRoots);
+    }
+
+    /**
+     * Reads the `declared` metadata key from a mapping, supporting both
+     * ORM 3.x (object mappings) and ORM 2.x (array mappings).
+     */
+    private static function mappingDeclared(mixed $mapping): ?string
+    {
+        if (\is_array($mapping)) {
+            $value = $mapping['declared'] ?? null;
+        } else {
+            $value = \is_object($mapping) && \property_exists($mapping, 'declared') ? $mapping->declared : null;
+        }
+
+        return \is_string($value) ? $value : null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getDefaultProperties(): array
+    {
+        return [
+            'uuid' => 'object.resource.id',
+            'title' => 'title',
+            'url' => 'url',
+            'webspaceKey' => 'object.resource.webspaceKey',
+            'depth' => 'object.resource.depth',
+            'lft' => 'object.resource.lft',
+            'rgt' => 'object.resource.rgt',
+        ];
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | doctrine-extensions/DoctrineExtensions#2921, doctrine-extensions/DoctrineExtensions#1696, doctrine-extensions/DoctrineExtensions#3041
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Three workarounds that make the `sulu_page.objects.page.model` override point usable on Doctrine ORM 3.x with attribute mapping, plus a functional test.

1. `SafeTreeObjectHydrator` overrides Gedmo's `TreeObjectHydrator::getChildrenField()`. It filters associations to `InverseSideMapping` before reading `mappedBy`, which stops the `OutOfRangeException: Unknown property "mappedBy" on class ManyToOneAssociationMapping` crash on ORM 3.x.

2. `SuluPageAwareTreeListener` plus `OverrideTreeListenerPass` kick in only when a project overrides the page model. The compiler pass swaps `stof_doctrine_extensions.listener.tree` for our subclass, which transparently redirects `getConfiguration()` and `getStrategy()` calls from the mapped-superclass to the concrete class so Gedmo does not bail out on its `isMappedSuperclass` guard.

3. `MetadataLoader` now backfills `$declared` on inverse-side associations. ORM 3.x populates `$declared` correctly for owning-side mappings inherited from a mapped-superclass but leaves it null on inverse-side mappings. Without the backfill `ClassMetadata::wakeupReflection()` throws `ReflectionException: Property X::$children does not exist`.

#### Why?

Sulu 3.0 ships `Sulu\Page\Domain\Model\Page` as a Doctrine mapped-superclass. Projects that need custom columns, associations, or behavior on pages are supposed to override `sulu_page.objects.page.model` with a concrete subclass. On ORM 3.x with attribute mapping, three independent upstream bugs make that override impossible to use.

The first is Gedmo's `TreeObjectHydrator` crashing on ORM 3.x because it treats `AssociationMapping` objects like arrays and hits a property that only exists on inverse-side mappings. Tracked upstream at [DoctrineExtensions#2921](https://github.com/doctrine-extensions/DoctrineExtensions/issues/2921) with an open fix in [#3041](https://github.com/doctrine-extensions/DoctrineExtensions/pull/3041).

The second is Gedmo's `ExtensionMetadataFactory::getExtensionMetadata()` returning an empty config for mapped-superclasses (`if ($meta->isMappedSuperclass) return []`). Nested-tree lft/rgt maintenance silently stops working. Reported in 2016 as [DoctrineExtensions#1696](https://github.com/doctrine-extensions/DoctrineExtensions/issues/1696) and never fixed.

The third is an ORM 3.x gap. `ClassMetadataFactory::addMappingInheritanceInformation()` populates `$declared` on inherited associations, but empirically only for the owning side. Inverse-side mappings (OneToMany, inverse OneToOne, inverse ManyToMany) inherited from an XML-mapped mapped-superclass into an attribute-mapped child end up with `$declared = null`. `ClassMetadata::wakeupReflection()` then tries to resolve the inherited private property on the concrete child class, where it does not exist.
