### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/README.md
+++ b/src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/README.md
@@ -11,7 +11,7 @@ handleChange = (value) => {
     <ImageFocusPoint
         value={value}
         onChange={handleChange}
-        image="https://source.unsplash.com/random/600x400"
+        image="https://picsum.photos/600/400"
     />
     <div>Selection: {JSON.stringify(value)}</div>
 </div>


### PR DESCRIPTION
`src/Sulu/Bundle/MediaBundle/Resources/js/components/ImageFocusPoint/README.md` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` (and the related `source.unsplash.com/featured`) was deprecated by Unsplash in mid-2024 and the endpoint now returns HTTP 503 instead of an image. Browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600?office | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Updates the `ImageFocusPoint` component README example so the usage snippet renders an image instead of a 503 when developers test the focus-point picker.

#### Replacement details

Docs-only. Same dimensions. The `ImageFocusPoint` component needs an actual image rendered under the crosshair to demonstrate focus-point behaviour — a 503 here defeats the purpose of the example.

#### Background

I'm tracking the deprecated `source.unsplash.com/random` endpoint across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. But if you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights this same broken-URL pattern in any landing page — useful for verifying the fix lands and for finding other places `source.unsplash.com/random` slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
