### PR TITLE
Introduce PublicationRequest domain model for content approval workflow

### DIFF
--- a/packages/content/config/doctrine/PublicationRequest/PublicationRequest.orm.xml
+++ b/packages/content/config/doctrine/PublicationRequest/PublicationRequest.orm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="Sulu\Content\Domain\Model\PublicationRequest\PublicationRequest" table="pr_publication_requests">
+        <id name="id" type="string" column="id" length="36">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="resourceKey" column="resource_key" type="string"/>
+        <field name="resourceId" column="resource_id" type="string"/>
+        <field name="locale" column="locale" type="string"/>
+        <field name="status" column="status" type="string" enum-type="Sulu\Content\Domain\Model\PublicationRequest\PublicationRequestStatusEnum"/>
+        <field name="activeKey" column="active_key" type="string" nullable="true" unique="true"/>
+        <field name="requestedAt" column="requested_at" type="datetime_immutable"/>
+        <field name="created" column="created_at" type="datetime_immutable"/>
+        <field name="changed" column="changed_at" type="datetime_immutable"/>
+
+        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
+            <join-column name="creator_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
+            <join-column name="changer_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <indexes>
+            <index name="pr_publication_requests_scope_idx" columns="resource_key,resource_id,locale"/>
+        </indexes>
+
+        <one-to-many field="reviewers" target-entity="Sulu\Content\Domain\Model\PublicationRequest\PublicationRequestReviewer" mapped-by="publicationRequest" orphan-removal="true">
+            <cascade>
+                <cascade-persist/>
+            </cascade>
+        </one-to-many>
+    </entity>
+</doctrine-mapping>

--- a/packages/content/config/doctrine/PublicationRequest/PublicationRequestReviewer.orm.xml
+++ b/packages/content/config/doctrine/PublicationRequest/PublicationRequestReviewer.orm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+    <entity name="Sulu\Content\Domain\Model\PublicationRequest\PublicationRequestReviewer" table="pr_publication_request_reviewers">
+        <id name="id" type="string" column="id" length="36">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="publicationRequest" target-entity="Sulu\Content\Domain\Model\PublicationRequest\PublicationRequest" inversed-by="reviewers">
+            <join-column name="publication_request_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="status" column="status" type="string" enum-type="Sulu\Content\Domain\Model\PublicationRequest\PublicationRequestReviewerStatusEnum"/>
+        <field name="comment" column="comment" type="text" nullable="true"/>
+
+        <field name="created" column="created_at" type="datetime_immutable"/>
+        <field name="changed" column="changed_at" type="datetime_immutable"/>
+
+        <many-to-one field="creator" target-entity="Sulu\Component\Security\Authentication\UserInterface">
+            <join-column name="creator_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <many-to-one field="changer" target-entity="Sulu\Component\Security\Authentication\UserInterface">
+            <join-column name="changer_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <unique-constraints>
+            <unique-constraint name="pr_publication_request_reviewers_unique" columns="publication_request_id,creator_id"/>
+        </unique-constraints>
+
+    </entity>
+</doctrine-mapping>

--- a/packages/content/config/publication-request.xml
+++ b/packages/content/config/publication-request.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu_content.publication_request_repository" class="Sulu\Content\Infrastructure\Doctrine\PublicationRequest\PublicationRequestRepository">
+            <argument type="service" id="doctrine.orm.entity_manager"/>
+        </service>
+
+        <service id="Sulu\Content\Domain\Repository\PublicationRequestRepositoryInterface" alias="sulu_content.publication_request_repository"/>
+    </services>
+</container>

--- a/packages/content/src/Domain/Exception/DuplicateActivePublicationRequestException.php
+++ b/packages/content/src/Domain/Exception/DuplicateActivePublicationRequestException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Exception;
+
+class DuplicateActivePublicationRequestException extends \RuntimeException
+{
+    public function __construct(string $resourceKey, string $resourceId, string $locale)
+    {
+        parent::__construct(\sprintf(
+            'An active publication request already exists for "%s" "%s" in locale "%s".',
+            $resourceKey,
+            $resourceId,
+            $locale,
+        ));
+    }
+}

--- a/packages/content/src/Domain/Exception/PublicationRequestClosedException.php
+++ b/packages/content/src/Domain/Exception/PublicationRequestClosedException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Exception;
+
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequest;
+
+class PublicationRequestClosedException extends \RuntimeException
+{
+    public function __construct(PublicationRequest $publicationRequest)
+    {
+        parent::__construct(\sprintf(
+            'Publication request "%s" cannot accept decisions in status "%s".',
+            $publicationRequest->getId(),
+            $publicationRequest->getStatus()->value,
+        ));
+    }
+}

--- a/packages/content/src/Domain/Exception/PublicationRequestNotFoundException.php
+++ b/packages/content/src/Domain/Exception/PublicationRequestNotFoundException.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Exception;
+
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequest;
+
+class PublicationRequestNotFoundException extends \Exception
+{
+    private string $model;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $filters;
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function __construct(array $filters, int $code = 0, ?\Throwable $previous = null)
+    {
+        $this->model = PublicationRequest::class;
+
+        $criteriaMessages = [];
+        foreach ($filters as $key => $value) {
+            if (\is_object($value)) {
+                $value = \get_debug_type($value);
+            } else {
+                $value = \json_encode($value);
+            }
+
+            $criteriaMessages[] = \sprintf('"%s" %s', $key, $value);
+        }
+
+        $message = \sprintf(
+            'Model "%s" with %s not found',
+            $this->model,
+            \implode(' and ', $criteriaMessages)
+        );
+
+        parent::__construct($message, $code, $previous);
+
+        $this->filters = $filters;
+    }
+
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getFilters(): array
+    {
+        return $this->filters;
+    }
+}

--- a/packages/content/src/Domain/Model/PublicationRequest/PublicationRequest.php
+++ b/packages/content/src/Domain/Model/PublicationRequest/PublicationRequest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Model\PublicationRequest;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Sulu\Component\Persistence\Model\AuditableInterface;
+use Sulu\Component\Persistence\Model\AuditableTrait;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Content\Domain\Exception\PublicationRequestClosedException;
+use Symfony\Component\Uid\Uuid;
+
+class PublicationRequest implements AuditableInterface
+{
+    use AuditableTrait;
+
+    private string $id;
+
+    private PublicationRequestStatusEnum $status = PublicationRequestStatusEnum::PENDING;
+
+    private ?string $activeKey = null;
+
+    private \DateTimeImmutable $requestedAt;
+
+    /**
+     * @var Collection<int, PublicationRequestReviewer>
+     */
+    private Collection $reviewers;
+
+    public function __construct(
+        private readonly string $resourceKey,
+        private readonly string $resourceId,
+        private readonly string $locale,
+    ) {
+        $this->id = Uuid::v7()->toRfc4122();
+        $this->requestedAt = new \DateTimeImmutable();
+        $this->reviewers = new ArrayCollection();
+        $this->syncActiveKey();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getResourceKey(): string
+    {
+        return $this->resourceKey;
+    }
+
+    public function getResourceId(): string
+    {
+        return $this->resourceId;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getStatus(): PublicationRequestStatusEnum
+    {
+        return $this->status;
+    }
+
+    public function getActiveKey(): ?string
+    {
+        return $this->activeKey;
+    }
+
+    public function getRequestedAt(): \DateTimeImmutable
+    {
+        return $this->requestedAt;
+    }
+
+    /**
+     * @return list<PublicationRequestReviewer>
+     */
+    public function getReviewers(): array
+    {
+        return \array_values($this->reviewers->toArray());
+    }
+
+    public function addApproval(UserInterface $user, ?string $comment = null): void
+    {
+        if ($this->status->isClosed()) {
+            throw new PublicationRequestClosedException($this);
+        }
+
+        $this->updateOrAddReviewer($user, PublicationRequestReviewerStatusEnum::APPROVED, $comment);
+        $this->synchronizeStatus();
+    }
+
+    public function addRejection(UserInterface $user, ?string $comment = null): void
+    {
+        if ($this->status->isClosed()) {
+            throw new PublicationRequestClosedException($this);
+        }
+
+        $this->updateOrAddReviewer($user, PublicationRequestReviewerStatusEnum::REJECTED, $comment);
+        $this->synchronizeStatus();
+    }
+
+    public function cancel(): void
+    {
+        $this->transitionTo(PublicationRequestStatusEnum::CANCELLED);
+    }
+
+    public function publish(): void
+    {
+        $this->transitionTo(PublicationRequestStatusEnum::PUBLISHED);
+    }
+
+    private function updateOrAddReviewer(UserInterface $user, PublicationRequestReviewerStatusEnum $status, ?string $comment): void
+    {
+        foreach ($this->reviewers as $reviewer) {
+            if ($reviewer->getCreator() === $user) {
+                $reviewer->update($status, $comment);
+
+                return;
+            }
+        }
+
+        $reviewer = new PublicationRequestReviewer($user, $status, $comment);
+        $reviewer->setPublicationRequest($this);
+        $this->reviewers->add($reviewer);
+    }
+
+    private function synchronizeStatus(): void
+    {
+        if ($this->hasRejectedReviewer()) {
+            $this->transitionTo(PublicationRequestStatusEnum::REJECTED);
+
+            return;
+        }
+
+        if ($this->reviewers->count() > 0) {
+            $this->transitionTo(PublicationRequestStatusEnum::APPROVED);
+        }
+    }
+
+    private function hasRejectedReviewer(): bool
+    {
+        foreach ($this->reviewers as $reviewer) {
+            if (PublicationRequestReviewerStatusEnum::REJECTED === $reviewer->getStatus()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function transitionTo(PublicationRequestStatusEnum $toStatus): void
+    {
+        if ($this->status === $toStatus) {
+            return;
+        }
+
+        $this->status = $toStatus;
+        $this->syncActiveKey();
+    }
+
+    private function syncActiveKey(): void
+    {
+        $this->activeKey = $this->status->isActive()
+            ? \sprintf('%s:%s:%s', $this->resourceKey, $this->resourceId, $this->locale)
+            : null;
+    }
+}

--- a/packages/content/src/Domain/Model/PublicationRequest/PublicationRequestReviewer.php
+++ b/packages/content/src/Domain/Model/PublicationRequest/PublicationRequestReviewer.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Model\PublicationRequest;
+
+use Sulu\Component\Persistence\Model\AuditableInterface;
+use Sulu\Component\Persistence\Model\AuditableTrait;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\Uid\Uuid;
+
+class PublicationRequestReviewer implements AuditableInterface
+{
+    use AuditableTrait;
+
+    private string $id;
+
+    private PublicationRequest $publicationRequest;
+
+    private PublicationRequestReviewerStatusEnum $status;
+
+    private ?string $comment;
+
+    public function __construct(
+        UserInterface $user,
+        PublicationRequestReviewerStatusEnum $status,
+        ?string $comment = null,
+    ) {
+        $this->id = Uuid::v7()->toRfc4122();
+        $this->status = $status;
+        $this->comment = $comment;
+        $this->setCreator($user);
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getPublicationRequest(): PublicationRequest
+    {
+        return $this->publicationRequest;
+    }
+
+    public function setPublicationRequest(PublicationRequest $publicationRequest): void
+    {
+        $this->publicationRequest = $publicationRequest;
+    }
+
+    public function getStatus(): PublicationRequestReviewerStatusEnum
+    {
+        return $this->status;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function update(PublicationRequestReviewerStatusEnum $status, ?string $comment = null): void
+    {
+        $this->status = $status;
+        $this->comment = $comment;
+    }
+}

--- a/packages/content/src/Domain/Model/PublicationRequest/PublicationRequestReviewerStatusEnum.php
+++ b/packages/content/src/Domain/Model/PublicationRequest/PublicationRequestReviewerStatusEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Model\PublicationRequest;
+
+enum PublicationRequestReviewerStatusEnum: string
+{
+    case APPROVED = 'approved';
+    case REJECTED = 'rejected';
+}

--- a/packages/content/src/Domain/Model/PublicationRequest/PublicationRequestStatusEnum.php
+++ b/packages/content/src/Domain/Model/PublicationRequest/PublicationRequestStatusEnum.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Model\PublicationRequest;
+
+enum PublicationRequestStatusEnum: string
+{
+    case PENDING = 'pending';
+    case APPROVED = 'approved';
+    case REJECTED = 'rejected';
+    case CANCELLED = 'cancelled';
+    case PUBLISHED = 'published';
+
+    public function isActive(): bool
+    {
+        return \in_array($this, [self::PENDING, self::APPROVED], true);
+    }
+
+    public function isClosed(): bool
+    {
+        return \in_array($this, [self::CANCELLED, self::PUBLISHED], true);
+    }
+}

--- a/packages/content/src/Domain/Repository/PublicationRequestRepositoryInterface.php
+++ b/packages/content/src/Domain/Repository/PublicationRequestRepositoryInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Repository;
+
+use Sulu\Content\Domain\Exception\PublicationRequestNotFoundException;
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequest;
+
+interface PublicationRequestRepositoryInterface
+{
+    /**
+     * @param array{
+     *     id?: string,
+     *     ids?: string[],
+     *     resourceKey?: string,
+     *     resourceId?: string,
+     *     locale?: string,
+     *     active?: bool,
+     * } $filters
+     *
+     * @throws PublicationRequestNotFoundException
+     */
+    public function getOneBy(array $filters): PublicationRequest;
+
+    /**
+     * @param array{
+     *     id?: string,
+     *     ids?: string[],
+     *     resourceKey?: string,
+     *     resourceId?: string,
+     *     locale?: string,
+     *     active?: bool,
+     * } $filters
+     */
+    public function findOneBy(array $filters): ?PublicationRequest;
+
+    /**
+     * @param array{
+     *     id?: string,
+     *     ids?: string[],
+     *     resourceKey?: string,
+     *     resourceId?: string,
+     *     locale?: string,
+     *     active?: bool,
+     *     page?: int,
+     *     limit?: int,
+     * } $filters
+     * @param array{
+     *     requestedAt?: 'asc'|'desc',
+     * } $sortBy
+     *
+     * @return iterable<PublicationRequest>
+     */
+    public function findBy(array $filters = [], array $sortBy = []): iterable;
+
+    /**
+     * @param array{
+     *     id?: string,
+     *     ids?: string[],
+     *     resourceKey?: string,
+     *     resourceId?: string,
+     *     locale?: string,
+     *     active?: bool,
+     * } $filters
+     */
+    public function countBy(array $filters = []): int;
+
+    public function add(PublicationRequest $publicationRequest): void;
+
+    public function remove(PublicationRequest $publicationRequest): void;
+}

--- a/packages/content/src/Infrastructure/Doctrine/PublicationRequest/PublicationRequestRepository.php
+++ b/packages/content/src/Infrastructure/Doctrine/PublicationRequest/PublicationRequestRepository.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Doctrine\PublicationRequest;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\QueryBuilder;
+use Sulu\Content\Domain\Exception\PublicationRequestNotFoundException;
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequest;
+use Sulu\Content\Domain\Repository\PublicationRequestRepositoryInterface;
+
+final class PublicationRequestRepository implements PublicationRequestRepositoryInterface
+{
+    /**
+     * @var EntityRepository<PublicationRequest>
+     */
+    private readonly EntityRepository $entityRepository;
+
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+        $this->entityRepository = $entityManager->getRepository(PublicationRequest::class);
+    }
+
+    public function getOneBy(array $filters): PublicationRequest
+    {
+        try {
+            /** @var PublicationRequest $publicationRequest */
+            $publicationRequest = $this->createQueryBuilder($filters)->getQuery()->getSingleResult();
+        } catch (NoResultException $e) {
+            throw new PublicationRequestNotFoundException($filters, 0, $e);
+        }
+
+        return $publicationRequest;
+    }
+
+    public function findOneBy(array $filters): ?PublicationRequest
+    {
+        try {
+            /** @var PublicationRequest $publicationRequest */
+            $publicationRequest = $this->createQueryBuilder($filters)->getQuery()->getSingleResult();
+        } catch (NoResultException) {
+            return null;
+        }
+
+        return $publicationRequest;
+    }
+
+    public function findBy(array $filters = [], array $sortBy = []): \Generator
+    {
+        $queryBuilder = $this->createQueryBuilder($filters, $sortBy);
+
+        /** @var iterable<PublicationRequest> $results */
+        $results = $queryBuilder->getQuery()->getResult();
+
+        foreach ($results as $result) {
+            yield $result;
+        }
+    }
+
+    public function countBy(array $filters = []): int
+    {
+        unset($filters['page']); // @phpstan-ignore-line
+        unset($filters['limit']); // @phpstan-ignore-line
+
+        $queryBuilder = $this->createQueryBuilder($filters);
+        $queryBuilder->select('COUNT(DISTINCT publicationRequest.id)');
+
+        return (int) $queryBuilder->getQuery()->getSingleScalarResult();
+    }
+
+    public function add(PublicationRequest $publicationRequest): void
+    {
+        $this->entityManager->persist($publicationRequest);
+    }
+
+    public function remove(PublicationRequest $publicationRequest): void
+    {
+        $this->entityManager->remove($publicationRequest);
+    }
+
+    /**
+     * @param array{
+     *     id?: string,
+     *     ids?: string[],
+     *     resourceKey?: string,
+     *     resourceId?: string,
+     *     locale?: string,
+     *     active?: bool,
+     *     page?: int,
+     *     limit?: int,
+     * } $filters
+     * @param array{
+     *     requestedAt?: 'asc'|'desc',
+     * } $sortBy
+     */
+    private function createQueryBuilder(array $filters, array $sortBy = []): QueryBuilder
+    {
+        $queryBuilder = $this->entityRepository->createQueryBuilder('publicationRequest');
+
+        $id = $filters['id'] ?? null;
+        if (null !== $id) {
+            $queryBuilder->andWhere('publicationRequest.id = :id')
+                ->setParameter('id', $id);
+        }
+
+        $ids = $filters['ids'] ?? null;
+        if (null !== $ids) {
+            $queryBuilder->andWhere('publicationRequest.id IN (:ids)')
+                ->setParameter('ids', $ids);
+        }
+
+        $resourceKey = $filters['resourceKey'] ?? null;
+        if (null !== $resourceKey) {
+            $queryBuilder->andWhere('publicationRequest.resourceKey = :resourceKey')
+                ->setParameter('resourceKey', $resourceKey);
+        }
+
+        $resourceId = $filters['resourceId'] ?? null;
+        if (null !== $resourceId) {
+            $queryBuilder->andWhere('publicationRequest.resourceId = :resourceId')
+                ->setParameter('resourceId', $resourceId);
+        }
+
+        $locale = $filters['locale'] ?? null;
+        if (null !== $locale) {
+            $queryBuilder->andWhere('publicationRequest.locale = :locale')
+                ->setParameter('locale', $locale);
+        }
+
+        $active = $filters['active'] ?? null;
+        if (null !== $active) {
+            if ($active) {
+                $queryBuilder->andWhere('publicationRequest.activeKey IS NOT NULL');
+            } else {
+                $queryBuilder->andWhere('publicationRequest.activeKey IS NULL');
+            }
+        }
+
+        $page = $filters['page'] ?? null;
+        $limit = $filters['limit'] ?? null;
+        if (null !== $limit) {
+            $queryBuilder->setMaxResults($limit);
+            if (null !== $page) {
+                $queryBuilder->setFirstResult(($page - 1) * $limit);
+            }
+        }
+
+        $requestedAtSort = $sortBy['requestedAt'] ?? null;
+        if (null !== $requestedAtSort) {
+            $queryBuilder->addOrderBy('publicationRequest.requestedAt', $requestedAtSort);
+        }
+
+        return $queryBuilder;
+    }
+}

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
@@ -59,6 +59,7 @@ final class SuluContentBundle extends AbstractBundle
     {
         // TODO refactor to PHP based service definitions
         $loader = new XmlFileLoader($builder, new FileLocator(\dirname(__DIR__, 4) . '/config'));
+        $loader->load('publication-request.xml');
         $loader->load('data-mapper.xml');
         $loader->load('merger.xml');
         $loader->load('normalizer.xml');
@@ -90,6 +91,26 @@ final class SuluContentBundle extends AbstractBundle
      */
     public function prependExtension(ContainerConfigurator $container, ContainerBuilder $builder): void
     {
+        if ($builder->hasExtension('doctrine')) {
+            $builder->prependExtensionConfig(
+                'doctrine',
+                [
+                    'orm' => [
+                        'mappings' => [
+                            'SuluContentPublicationRequest' => [
+                                'type' => 'xml',
+                                'prefix' => 'Sulu\Content\Domain\Model\PublicationRequest',
+                                'dir' => \dirname(__DIR__, 4) . '/config/doctrine/PublicationRequest',
+                                'alias' => 'SuluContentPublicationRequest',
+                                'is_bundle' => false,
+                                'mapping' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            );
+        }
+
         if ($builder->hasExtension('sulu_admin')) {
             $builder->prependExtensionConfig(
                 'sulu_admin',

--- a/packages/content/tests/Unit/Content/Domain/Model/PublicationRequestReviewerTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Model/PublicationRequestReviewerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Domain\Model;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequestReviewer;
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequestReviewerStatusEnum;
+
+#[CoversClass(PublicationRequestReviewer::class)]
+#[CoversClass(PublicationRequestReviewerStatusEnum::class)]
+class PublicationRequestReviewerTest extends TestCase
+{
+    public function testConstructCreatesApprovedReviewer(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $reviewer = new PublicationRequestReviewer($user, PublicationRequestReviewerStatusEnum::APPROVED, 'Looks good');
+
+        $this->assertNotSame('', $reviewer->getId());
+        $this->assertSame(PublicationRequestReviewerStatusEnum::APPROVED, $reviewer->getStatus());
+        $this->assertSame('Looks good', $reviewer->getComment());
+        $this->assertSame($user, $reviewer->getCreator());
+    }
+
+    public function testConstructCreatesRejectedReviewer(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $reviewer = new PublicationRequestReviewer($user, PublicationRequestReviewerStatusEnum::REJECTED, 'Needs changes');
+
+        $this->assertSame(PublicationRequestReviewerStatusEnum::REJECTED, $reviewer->getStatus());
+        $this->assertSame('Needs changes', $reviewer->getComment());
+    }
+
+    public function testConstructWithNullCommentDefaultsToNull(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $reviewer = new PublicationRequestReviewer($user, PublicationRequestReviewerStatusEnum::APPROVED);
+
+        $this->assertSame(PublicationRequestReviewerStatusEnum::APPROVED, $reviewer->getStatus());
+        $this->assertNull($reviewer->getComment());
+    }
+
+    public function testUpdateChangesStatusAndComment(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $reviewer = new PublicationRequestReviewer($user, PublicationRequestReviewerStatusEnum::REJECTED, 'Needs changes');
+
+        $reviewer->update(PublicationRequestReviewerStatusEnum::APPROVED, 'Changed mind');
+
+        $this->assertSame(PublicationRequestReviewerStatusEnum::APPROVED, $reviewer->getStatus());
+        $this->assertSame('Changed mind', $reviewer->getComment());
+    }
+
+    public function testUpdateClearsCommentWhenNull(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $reviewer = new PublicationRequestReviewer($user, PublicationRequestReviewerStatusEnum::REJECTED, 'Needs changes');
+
+        $reviewer->update(PublicationRequestReviewerStatusEnum::APPROVED);
+
+        $this->assertNull($reviewer->getComment());
+    }
+}

--- a/packages/content/tests/Unit/Content/Domain/Model/PublicationRequestTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Model/PublicationRequestTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Domain\Model;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Content\Domain\Exception\PublicationRequestClosedException;
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequest;
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequestReviewerStatusEnum;
+use Sulu\Content\Domain\Model\PublicationRequest\PublicationRequestStatusEnum;
+
+#[CoversClass(PublicationRequest::class)]
+#[CoversClass(PublicationRequestStatusEnum::class)]
+class PublicationRequestTest extends TestCase
+{
+    public function testConstructInitializesOpenRequest(): void
+    {
+        $request = $this->createRequest();
+
+        $this->assertNotSame('', $request->getId());
+        $this->assertSame(PublicationRequestStatusEnum::PENDING, $request->getStatus());
+        $this->assertSame('pages:4d3e0d90-4cc8-46c4-a6dc-9f0ad643f5a0:en', $request->getActiveKey());
+        $this->assertEqualsWithDelta(new \DateTimeImmutable(), $request->getRequestedAt(), 5);
+    }
+
+    public function testAddApprovalTransitionsToApproved(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $request = $this->createRequest();
+
+        $request->addApproval($user, 'Looks good');
+
+        $this->assertSame(PublicationRequestStatusEnum::APPROVED, $request->getStatus());
+        $this->assertSame('pages:4d3e0d90-4cc8-46c4-a6dc-9f0ad643f5a0:en', $request->getActiveKey());
+        $this->assertCount(1, $request->getReviewers());
+        $this->assertSame('Looks good', $request->getReviewers()[0]->getComment());
+    }
+
+    public function testAddRejectionTransitionsToRejected(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $request = $this->createRequest();
+
+        $request->addRejection($user, 'Needs changes');
+
+        $this->assertSame(PublicationRequestStatusEnum::REJECTED, $request->getStatus());
+        $this->assertNull($request->getActiveKey());
+        $this->assertCount(1, $request->getReviewers());
+        $this->assertSame('Needs changes', $request->getReviewers()[0]->getComment());
+    }
+
+    public function testSameUserChangingMindUpdatesExistingReviewer(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $request = $this->createRequest();
+
+        $request->addRejection($user, 'Needs changes');
+        $request->addApproval($user, 'Changed mind');
+
+        $this->assertSame(PublicationRequestStatusEnum::APPROVED, $request->getStatus());
+        $this->assertCount(1, $request->getReviewers());
+        $this->assertSame(PublicationRequestReviewerStatusEnum::APPROVED, $request->getReviewers()[0]->getStatus());
+        $this->assertSame('Changed mind', $request->getReviewers()[0]->getComment());
+    }
+
+    public function testDifferentUsersCreateSeparateReviewers(): void
+    {
+        $userA = $this->createStub(UserInterface::class);
+        $userB = $this->createStub(UserInterface::class);
+        $request = $this->createRequest();
+
+        $request->addApproval($userA);
+        $request->addApproval($userB);
+
+        $this->assertCount(2, $request->getReviewers());
+        $this->assertSame(PublicationRequestStatusEnum::APPROVED, $request->getStatus());
+    }
+
+    public function testRejectionByOneUserOverridesOtherApprovalsInStatus(): void
+    {
+        $userA = $this->createStub(UserInterface::class);
+        $userB = $this->createStub(UserInterface::class);
+        $request = $this->createRequest();
+
+        $request->addApproval($userA);
+        $request->addRejection($userB, 'Needs changes');
+
+        $this->assertSame(PublicationRequestStatusEnum::REJECTED, $request->getStatus());
+        $this->assertNull($request->getActiveKey());
+    }
+
+    public function testClosedRequestThrowsOnApproval(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $request = $this->createRequest();
+        $request->cancel();
+
+        $this->expectException(PublicationRequestClosedException::class);
+        $request->addApproval($user);
+    }
+
+    public function testClosedRequestThrowsOnRejection(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $request = $this->createRequest();
+        $request->cancel();
+
+        $this->expectException(PublicationRequestClosedException::class);
+        $request->addRejection($user);
+    }
+
+    public function testCancelTransitionsToTerminalStateAndClearsActiveKey(): void
+    {
+        $request = $this->createRequest();
+        $request->cancel();
+
+        $this->assertSame(PublicationRequestStatusEnum::CANCELLED, $request->getStatus());
+        $this->assertNull($request->getActiveKey());
+    }
+
+    public function testCancelOnAlreadyCancelledRequestIsNoOp(): void
+    {
+        $request = $this->createRequest();
+        $request->cancel();
+        $request->cancel();
+
+        $this->assertSame(PublicationRequestStatusEnum::CANCELLED, $request->getStatus());
+    }
+
+    public function testMarkPublishedTransitionsApprovedRequestToPublished(): void
+    {
+        $user = $this->createStub(UserInterface::class);
+        $request = $this->createRequest();
+        $request->addApproval($user);
+
+        $request->publish();
+
+        $this->assertSame(PublicationRequestStatusEnum::PUBLISHED, $request->getStatus());
+        $this->assertNull($request->getActiveKey());
+    }
+
+    private function createRequest(): PublicationRequest
+    {
+        return new PublicationRequest(
+            resourceKey: 'pages',
+            resourceId: '4d3e0d90-4cc8-46c4-a6dc-9f0ad643f5a0',
+            locale: 'en',
+        );
+    }
+}

--- a/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
@@ -23,7 +23,9 @@ use Sulu\Content\Application\ContentNormalizer\ContentNormalizerInterface;
 use Sulu\Content\Application\ContentPersister\ContentPersisterInterface;
 use Sulu\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Content\Domain\Factory\DimensionContentCollectionFactoryInterface;
+use Sulu\Content\Domain\Repository\PublicationRequestRepositoryInterface;
 use Sulu\Content\Infrastructure\Doctrine\MetadataLoader;
+use Sulu\Content\Infrastructure\Doctrine\PublicationRequest\PublicationRequestRepository;
 use Sulu\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -33,6 +35,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 
 class SuluContentBundleTest extends AbstractExtensionTestCase
 {
@@ -108,6 +111,7 @@ class SuluContentBundleTest extends AbstractExtensionTestCase
         $this->load();
 
         $this->assertContainerBuilderHasService('sulu_content.metadata_loader', MetadataLoader::class);
+        $this->assertContainerBuilderHasService('sulu_content.publication_request_repository', PublicationRequestRepository::class);
 
         // Main services aliases
         $this->assertContainerBuilderHasAlias(ContentManagerInterface::class, 'sulu_content.content_manager');
@@ -120,6 +124,11 @@ class SuluContentBundleTest extends AbstractExtensionTestCase
         // Additional services aliases
         $this->assertContainerBuilderHasAlias(ContentViewBuilderFactoryInterface::class, 'sulu_content.content_view_builder_factory');
         $this->assertContainerBuilderHasAlias(DimensionContentCollectionFactoryInterface::class, 'sulu_content.dimension_content_collection_factory');
+        $this->assertContainerBuilderHasAlias(PublicationRequestRepositoryInterface::class, 'sulu_content.publication_request_repository');
+
+        $repositoryDefinition = $this->container->getDefinition('sulu_content.publication_request_repository');
+        $this->assertSame(PublicationRequestRepository::class, $repositoryDefinition->getClass());
+        $this->assertEquals(new Reference('doctrine.orm.entity_manager'), $repositoryDefinition->getArgument(0));
     }
 
     public function testPrepend(): void
@@ -141,9 +150,26 @@ class SuluContentBundleTest extends AbstractExtensionTestCase
         $doctrineExtension = new DoctrineExtension();
         $containerBuilder->registerExtension($doctrineExtension);
 
-        $doctrineExtension = new SuluAdminExtension();
-        $containerBuilder->registerExtension($doctrineExtension);
+        $adminExtension = new SuluAdminExtension();
+        $containerBuilder->registerExtension($adminExtension);
         $extension->prependExtension($containerConfigurator, $containerBuilder);
+
+        $this->assertSame([
+            [
+                'orm' => [
+                    'mappings' => [
+                        'SuluContentPublicationRequest' => [
+                            'type' => 'xml',
+                            'prefix' => 'Sulu\\Content\\Domain\\Model\\PublicationRequest',
+                            'dir' => \dirname(__DIR__, 5) . '/config/doctrine/PublicationRequest',
+                            'alias' => 'SuluContentPublicationRequest',
+                            'is_bundle' => false,
+                            'mapping' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ], $containerBuilder->getExtensionConfig('doctrine'));
 
         $this->assertSame([
             [


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | no
  | New feature? | yes
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes #
  | Related issues/PRs | #5233
  | License | MIT
  | Documentation PR | sulu/sulu-docs#

  #### What's in this PR?

  This PR introduces the `PublicationRequest` and `PublicationRequestReviewer` domain models along with their Doctrine ORM mappings, a filter-based repository, and two domain exceptions. A `PublicationRequest`
  tracks a per-resource approval lifecycle through the statuses `PENDING`, `APPROVED`, `REJECTED`, `PUBLISHED` and `CANCELLED`. A `PublicationRequestReviewer` is one record per user per request and is updated in
  place when the reviewer changes their decision.

  #### Why?

  Content editors need a formal review step before content can go live, as described in issue #5233. This PR delivers the domain foundation.