### PR TITLE
Fix permission inheritance for newly created child pages

### DIFF
--- a/packages/page/src/Domain/Model/Page.php
+++ b/packages/page/src/Domain/Model/Page.php
@@ -93,6 +93,11 @@ class Page implements PageInterface
         return $this->parent;
     }
 
+    public function getParentId(): ?string
+    {
+        return $this->parent?->getId();
+    }
+
     public function getChildren(): Collection
     {
         return $this->children;

--- a/packages/page/src/Domain/Model/PageInterface.php
+++ b/packages/page/src/Domain/Model/PageInterface.php
@@ -12,6 +12,7 @@
 namespace Sulu\Page\Domain\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sulu\Bundle\SecurityBundle\Entity\PermissionInheritanceInterface;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Security\Authorization\AccessControl\SecuredEntityInterface;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
@@ -19,7 +20,7 @@ use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 /**
  * @extends ContentRichEntityInterface<PageDimensionContentInterface>
  */
-interface PageInterface extends AuditableInterface, ContentRichEntityInterface, SecuredEntityInterface
+interface PageInterface extends AuditableInterface, ContentRichEntityInterface, SecuredEntityInterface, PermissionInheritanceInterface
 {
     public const TEMPLATE_TYPE = 'page';
     public const RESOURCE_KEY = 'pages';

--- a/packages/page/tests/Functional/Integration/PagePermissionInheritanceTest.php
+++ b/packages/page/tests/Functional/Integration/PagePermissionInheritanceTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\SecurityBundle\Entity\Permission;
+use Sulu\Bundle\SecurityBundle\Entity\Role;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+
+/**
+ * The integration test should have no impact on the coverage so we set it to coversNothing.
+ */
+#[CoversNothing]
+class PagePermissionInheritanceTest extends SuluTestCase
+{
+    use CreatePageTrait;
+
+    public function testChildPageInheritsParentPermissionsOnCreation(): void
+    {
+        self::purgeDatabase();
+
+        $entityManager = self::getEntityManager();
+
+        $role = new Role();
+        $role->setName('Child Inheritance Role');
+        $role->setSystem('Sulu');
+
+        $permission = new Permission();
+        $permission->setRole($role);
+        $permission->setPermissions(127);
+        $permission->setContext('sulu.webspaces.sulu-io');
+        $role->addPermission($permission);
+
+        $entityManager->persist($role);
+        $entityManager->persist($permission);
+        $entityManager->flush();
+
+        $roleId = $role->getId();
+
+        $homepage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Homepage',
+                    'url' => '/',
+                ],
+            ],
+        ]);
+
+        $parentPage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Parent Page',
+                    'url' => '/parent',
+                    'parentId' => $homepage->getUuid(),
+                ],
+            ],
+        ]);
+
+        /** @var AccessControlManagerInterface $accessControlManager */
+        $accessControlManager = self::getContainer()->get('sulu_security.access_control_manager');
+        $expectedPermissions = [
+            $roleId => [
+                'view' => true,
+                'add' => true,
+                'edit' => true,
+                'delete' => true,
+                'archive' => false,
+                'live' => true,
+                'security' => true,
+            ],
+        ];
+        $accessControlManager->setPermissions(Page::class, $parentPage->getUuid(), $expectedPermissions);
+
+        $childPage = $this->createPage([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Child Page',
+                    'url' => '/parent/child',
+                    'parentId' => $parentPage->getUuid(),
+                ],
+            ],
+        ]);
+
+        self::ensureKernelShutdown();
+
+        /** @var AccessControlManagerInterface $accessControlManager */
+        $accessControlManager = self::getContainer()->get('sulu_security.access_control_manager');
+        $childPermissions = $accessControlManager->getPermissions(Page::class, $childPage->getUuid());
+
+        $this->assertSame($expectedPermissions, $childPermissions);
+    }
+}


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
  | Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
  | Related issues/PRs | #8741
  | License | MIT
  | Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

  #### What's in this PR?

  This PR makes `PageInterface` implement the permission inheritance contract that is already used by the security layer. It also adds `getParentId()` to the page model so newly persisted child pages can inherit the object permissions of their parent. A functional integration test covers the creation flow and asserts that the inherited permissions are written for the new child page.

  #### Why?

  Pages already expose a permission inheritance action for existing content, but newly created child pages did not receive their parent permissions automatically. The generic security subscriber only applies this behavior to entities that implement the inheritance interface. Because pages did not implement that contract, the child page was created without object permissions even when the parent page was secured.

  #### To Do

  - [ ] Create a documentation PR
  - [ ] Add breaking changes to UPGRADE.md