### PR TITLE
Navigation extension merge properties

### DIFF
--- a/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
+++ b/packages/page/src/Infrastructure/Symfony/Twig/Extension/NavigationTwigExtension.php
@@ -70,7 +70,7 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $segment?->getKey(),
             $depth,
-            $properties ?? $this->getDefaultProperties(),
+            \array_merge($this->getDefaultProperties(), $properties ?? []),
         );
     }
 
@@ -99,7 +99,7 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $segment?->getKey(),
             $depth,
-            $properties ?? $this->getDefaultProperties()
+            \array_merge($this->getDefaultProperties(), $properties ?? []),
         );
     }
 
@@ -131,7 +131,7 @@ class NavigationTwigExtension extends AbstractExtension
                 $uuid,
                 $locale,
                 $webspaceKey,
-                $properties ?? $this->getDefaultProperties()
+                \array_merge($this->getDefaultProperties(), $properties ?? []),
             );
 
             if (!isset($breadcrumb[$level])) {
@@ -152,7 +152,7 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $depth,
             $context,
-            $properties ?? $this->getDefaultProperties()
+            \array_merge($this->getDefaultProperties(), $properties ?? []),
         );
     }
 
@@ -184,7 +184,7 @@ class NavigationTwigExtension extends AbstractExtension
                 $uuid,
                 $locale,
                 $webspaceKey,
-                $properties ?? $this->getDefaultProperties()
+                \array_merge($this->getDefaultProperties(), $properties ?? []),
             );
 
             if (!isset($breadcrumb[$level])) {
@@ -205,7 +205,7 @@ class NavigationTwigExtension extends AbstractExtension
             $webspaceKey,
             $depth,
             $context,
-            $properties ?? $this->getDefaultProperties()
+            \array_merge($this->getDefaultProperties(), $properties ?? []),
         );
     }
 
@@ -230,7 +230,7 @@ class NavigationTwigExtension extends AbstractExtension
             $uuid,
             $locale,
             $webspaceKey,
-            $properties ?? $this->getDefaultProperties()
+            \array_merge($this->getDefaultProperties(), $properties ?? []),
         );
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Merge Navigation extension properties.

#### Why?

So the default properties are not overwritten if there are custom properties. Otherwise the targetType would be always `page` and not working properly.
