### PR TITLE
Temporarily hide created date for route history

### DIFF
--- a/packages/route/assets/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
+++ b/packages/route/assets/js/containers/ResourceLocatorHistory/ResourceLocatorHistory.js
@@ -92,13 +92,11 @@ class ResourceLocatorHistory extends React.Component<Props> {
                             <Table buttons={[{icon: 'su-trash-alt', onClick: this.handleDeleteClick}]}>
                                 <Table.Header>
                                     <Table.HeaderCell>{translate('sulu_admin.url')}</Table.HeaderCell>
-                                    <Table.HeaderCell>{translate('sulu_admin.created')}</Table.HeaderCell>
                                 </Table.Header>
                                 <Table.Body>
                                     {historyRoutes.map((historyRoute) => (
                                         <Table.Row id={historyRoute.id} key={historyRoute.id}>
                                             <Table.Cell>{historyRoute.slug}</Table.Cell>
-                                            <Table.Cell>{(new Date(historyRoute.created)).toLocaleString()}</Table.Cell>
                                         </Table.Row>
                                     ))}
                                 </Table.Body>

--- a/packages/route/assets/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
+++ b/packages/route/assets/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js
@@ -79,12 +79,10 @@ test('Show history routes in overlay', () => {
         {
             id: 3,
             slug: '/test',
-            created: '2019-04-10T13:06:16',
         },
         {
             id: 6,
             slug: '/testing',
-            created: '2019-04-10T16:01:12',
         },
     ];
 
@@ -145,7 +143,6 @@ test('Do not delete if confirmation dialog is cancelled', () => {
         {
             id: 3,
             slug: '/test',
-            created: '2019-04-10T13:06:16',
         },
     ];
 
@@ -179,7 +176,6 @@ test('Delete if confirmation dialog is confirmed', () => {
         {
             id: 3,
             slug: 'sulu.io/test',
-            created: '2019-04-10T13:06:16',
         },
     ];
 

--- a/packages/route/assets/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
+++ b/packages/route/assets/js/containers/ResourceLocatorHistory/tests/__snapshots__/ResourceLocatorHistory.test.js.snap
@@ -62,13 +62,6 @@ Array [
                         sulu_admin.url
                       </span>
                     </th>
-                    <th
-                      class="headerCell"
-                    >
-                      <span>
-                        sulu_admin.created
-                      </span>
-                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -100,15 +93,6 @@ Array [
                         /test
                       </div>
                     </td>
-                    <td
-                      class="cell"
-                    >
-                      <div
-                        class="cellContent"
-                      >
-                        4/10/2019, 1:06:16 PM
-                      </div>
-                    </td>
                   </tr>
                   <tr
                     class="row"
@@ -136,15 +120,6 @@ Array [
                         class="cellContent"
                       >
                         /testing
-                      </div>
-                    </td>
-                    <td
-                      class="cell"
-                    >
-                      <div
-                        class="cellContent"
-                      >
-                        4/10/2019, 4:01:12 PM
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Hide created date for route history.

#### Why?

Because at the moment routes do not have a created date, so we hide the field till it's implemented.

See also https://github.com/sulu/sulu/issues/8750

