### PR TITLE
Splitting out Webspace Repository from the Webspace Manager

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37939,12 +37939,6 @@ parameters:
 			path: src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Manager\\WebspaceCollection\:\:getResources\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
-
-		-
 			message: '#^Method Sulu\\Component\\Webspace\\Manager\\WebspaceCollection\:\:setPortalInformations\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -37999,22 +37993,10 @@ parameters:
 			path: src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Manager\\WebspaceCollectionBuilder\:\:build\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
-
-		-
 			message: '#^Possibly invalid array key type mixed\.$#'
 			identifier: offsetAccess.invalidOffset
 			count: 1
 			path: src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
-
-		-
-			message: '#^Binary operation "\." between mixed and ''/'' results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
 		-
 			message: '#^Cannot access offset string on mixed\.$#'
@@ -38029,20 +38011,8 @@ parameters:
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
 		-
-			message: '#^Cannot call method getResources\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
-			message: '#^Method Sulu\\Component\\Webspace\\Manager\\WebspaceManager\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
@@ -38053,25 +38023,7 @@ parameters:
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
 		-
-			message: '#^Method Sulu\\Component\\Webspace\\Manager\\WebspaceManager\:\:setOptions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
 			message: '#^Parameter \#1 \$portalUrl of method Sulu\\Component\\Webspace\\Manager\\WebspaceManager\:\:createResourceLocatorUrl\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
-			message: '#^Parameter \#1 \$webspaceCollection of class Sulu\\Component\\Webspace\\Manager\\Dumper\\PhpWebspaceCollectionDumper constructor expects Sulu\\Component\\Webspace\\Manager\\WebspaceCollection, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
-			message: '#^Parameter \#2 \$debug of class Symfony\\Component\\Config\\ConfigCache constructor expects bool, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -38083,20 +38035,8 @@ parameters:
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
 		-
-			message: '#^Parameter \#2 \$metadata of method Symfony\\Component\\Config\\ResourceCheckerConfigCache\:\:write\(\) expects array\<Symfony\\Component\\Config\\Resource\\ResourceInterface\>\|null, mixed given\.$#'
+			message: '#^Parameter \#3 \$path of class Sulu\\Component\\Webspace\\Manager\\WebspaceCollectionBuilder constructor expects string, string\|null given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
-			message: '#^Parameter \#3 \$path of class Sulu\\Component\\Webspace\\Manager\\WebspaceCollectionBuilder constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
-
-		-
-			message: '#^Property Sulu\\Component\\Webspace\\Manager\\WebspaceManager\:\:\$options type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: src/Sulu/Component/Webspace/Manager/WebspaceManager.php
 
@@ -38881,200 +38821,8 @@ parameters:
 			path: src/Sulu/Component/Webspace/Tests/Unit/Loader/XmlFileLoader11Test.php
 
 		-
-			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot access offset ''austria\.sulu\.io'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot access offset ''austria\.sulu\.io/de'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot access offset ''sulu\.de'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot access offset ''sulu\.us'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot access offset ''sulu_io'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot access offset ''usa\.sulu\.io'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot access offset ''usa\.sulu\.io/en'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 14
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot access offset 1 on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 5
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getContexts\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getCustomUrls\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 7
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getEnvironment\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 6
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getKey\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getLocale\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getLocalization\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getMainUrl\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getNavigation\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getPortalInformations\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getPortals\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 7
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getPriority\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getRedirect\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getTitle\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 6
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getType\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 10
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getUrl\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 10
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getUrls\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Cannot call method getWebspaces\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Parameter \#1 \$array of function array_keys expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Parameter \#1 \$array of function array_values expects array\<T\>, mixed given\.$#'
-			identifier: argument.type
-			count: 3
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertCount\(\) expects Countable\|iterable, mixed given\.$#'
-			identifier: argument.type
-			count: 8
-			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
-
-		-
-			message: '#^Possibly invalid array key type mixed\.$#'
-			identifier: offsetAccess.invalidOffset
 			count: 1
 			path: src/Sulu/Component/Webspace/Tests/Unit/Manager/WebspaceCollectionBuilderTest.php
 

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/webspace.php
@@ -13,8 +13,10 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sulu\Component\Webspace\Loader\XmlFileLoader10;
 use Sulu\Component\Webspace\Loader\XmlFileLoader11;
+use Sulu\Component\Webspace\Manager\WebspaceCollectionBuilder;
 use Sulu\Component\Webspace\Manager\WebspaceManager;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Repository\WebspaceRepository;
 use Sulu\Component\Webspace\Url\Replacer;
 use Sulu\Component\Webspace\Url\WebspaceUrlChainProvider;
 use Sulu\Component\Webspace\Url\WebspaceUrlProvider;
@@ -42,18 +44,46 @@ return static function(ContainerConfigurator $container) {
 
     $services->set('sulu_core.webspace.webspace_manager.url_replacer', Replacer::class);
 
+    $webspaceManagerConfig = [
+        'config_dir' => '%sulu_core.webspace.config_dir%',
+        'cache_dir' => '%sulu.cache_dir%',
+        'debug' => '%kernel.debug%',
+        'cache_class' => '%sulu_core.webspace.cache_class%',
+        'base_class' => '%sulu_core.webspace.base_class%',
+    ];
+
     $services->set('sulu_core.webspace.webspace_manager', WebspaceManager::class)
         ->public()
         ->args([
             new Reference('sulu_core.webspace.loader.delegator'),
             new Reference('sulu_core.webspace.webspace_manager.url_replacer'),
             new Reference('request_stack'),
-            ['config_dir' => '%sulu_core.webspace.config_dir%', 'cache_dir' => '%sulu.cache_dir%', 'debug' => '%kernel.debug%', 'cache_class' => '%sulu_core.webspace.cache_class%', 'base_class' => '%sulu_core.webspace.base_class%'],
+            $webspaceManagerConfig,
             '%kernel.environment%',
             new Reference('router.request_context'),
             new Reference('sulu_admin.metadata_provider_registry'),
         ])
         ->tag('sulu.localization_provider');
+
+    $services->set('sulu_website.webspace_collection_builder', WebspaceCollectionBuilder::class)
+        ->args([
+            new Reference('sulu_core.webspace.loader.delegator'),
+            new Reference('sulu_core.webspace.webspace_manager.url_replacer'),
+            '%sulu_core.webspace.config_dir%',
+            [],
+        ])
+    ;
+
+    $services->set('sulu_website.webspace_repository', WebspaceRepository::class)
+        ->args([
+            new Reference('sulu_admin.metadata_provider_registry'),
+            new Reference('sulu_website.webspace_collection_builder'),
+            new Reference('request_stack'),
+            new Reference('router.request_context'),
+            '%kernel.environment%',
+            $webspaceManagerConfig,
+        ])
+    ;
 
     $services->alias(WebspaceManagerInterface::class, 'sulu_core.webspace.webspace_manager');
 

--- a/src/Sulu/Component/Webspace/Manager/Dumper/PhpWebspaceCollectionDumper.php
+++ b/src/Sulu/Component/Webspace/Manager/Dumper/PhpWebspaceCollectionDumper.php
@@ -13,6 +13,9 @@ namespace Sulu\Component\Webspace\Manager\Dumper;
 
 use Sulu\Component\Webspace\Manager\WebspaceCollection;
 
+/**
+ * @internal
+ */
 class PhpWebspaceCollectionDumper extends WebspaceCollectionDumper
 {
     public function __construct(private WebspaceCollection $webspaceCollection)

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollection.php
@@ -15,6 +15,7 @@ use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Webspace;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Config\Resource\ResourceInterface;
 
 /**
  * A collection of all webspaces and portals in a specific sulu installation.
@@ -64,7 +65,7 @@ class WebspaceCollection implements \IteratorAggregate
     /**
      * Returns the resources used to build this collection.
      *
-     * @return array The resources build to use this collection
+     * @return array<ResourceInterface> The resources build to use this collection
      */
     public function getResources()
     {

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -59,7 +59,12 @@ class WebspaceCollectionBuilder
     ) {
     }
 
-    public function build()
+    /**
+     * @param array<string>|null $availableTemplates
+     *
+     * @return WebspaceCollection
+     */
+    public function build(?array $availableTemplates = null)
     {
         $finder = new Finder();
         $finder->in($this->path)->files()->name('*.xml')->sortByName();
@@ -80,7 +85,7 @@ class WebspaceCollectionBuilder
             $webspace = $this->loader->load($file->getRealPath());
 
             foreach ($webspace->getDefaultTemplates() as $defaultTemplate) {
-                if (!\in_array($defaultTemplate, $this->availableTemplates)) {
+                if (!\in_array($defaultTemplate, $availableTemplates ?? $this->availableTemplates)) {
                     throw new InvalidTemplateException($webspace, $defaultTemplate);
                 }
 

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -454,7 +454,7 @@ class WebspaceManager implements WebspaceManagerInterface
      */
     private function getPortalInformationsPolyfill(string $environment, ?array $types = null): array
     {
-        return $this->webspaceRepository
+        return $this->webspaceRepository && $environment === $this->environment
             ? $this->webspaceRepository->findAllPortalInformations($types)
             : $this->getWebspaceCollection()->getPortalInformations($environment, $types);
     }

--- a/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceManager.php
@@ -21,6 +21,7 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\Manager\Dumper\PhpWebspaceCollectionDumper;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Repository\WebspaceRepositoryInterface;
 use Sulu\Component\Webspace\Url\ReplacerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Sulu\Page\Domain\Model\PageInterface;
@@ -40,15 +41,30 @@ class WebspaceManager implements WebspaceManagerInterface
     private $webspaceCollection;
 
     /**
-     * @var array
+     * @var array{
+     *    cache_dir: ?string,
+     *    cache_class: string,
+     *    config_dir: ?string,
+     *    base_class: string,
+     *    debug: bool,
+     * }
      */
-    private $options;
+    private array $options;
 
     /**
      * @var mixed[]
      */
     private $portalUrlCache = [];
 
+    /**
+     * @param array{
+     *    cache_class?: string,
+     *    cache_dir?: string,
+     *    config_dir?: string,
+     *    base_class?: string,
+     *    debug?: bool,
+     * } $options
+     */
     public function __construct(
         private LoaderInterface $loader,
         private ReplacerInterface $urlReplacer,
@@ -57,8 +73,10 @@ class WebspaceManager implements WebspaceManagerInterface
         private string $environment,
         private RequestContext $requestContext,
         private MetadataProviderRegistry $metadataProviderRegistry,
+        private ?WebspaceRepositoryInterface $webspaceRepository = null,
     ) {
         $this->setOptions($options);
+        $this->webspaceRepository?->setOptions($this->options);
     }
 
     public function findWebspaceByKey(?string $key): ?Webspace
@@ -67,7 +85,9 @@ class WebspaceManager implements WebspaceManagerInterface
             return null;
         }
 
-        return $this->getWebspaceCollection()->getWebspace($key);
+        return $this->webspaceRepository
+            ? $this->webspaceRepository->findWebspaceByKey($key)
+            : $this->getWebspaceCollection()->getWebspace($key);
     }
 
     public function findPortalByKey(?string $key): ?Portal
@@ -76,7 +96,9 @@ class WebspaceManager implements WebspaceManagerInterface
             return null;
         }
 
-        return $this->getWebspaceCollection()->getPortal($key);
+        return $this->webspaceRepository
+            ? $this->webspaceRepository->findPortalByKey($key)
+            : $this->getWebspaceCollection()->getPortal($key);
     }
 
     public function findPortalInformationByUrl(string $url, ?string $environment = null): ?PortalInformation
@@ -85,8 +107,7 @@ class WebspaceManager implements WebspaceManagerInterface
             $environment = $this->environment;
         }
 
-        $portalInformations = $this->getWebspaceCollection()->getPortalInformations($environment);
-        foreach ($portalInformations as $portalInformation) {
+        foreach ($this->getPortalInformations($environment) as $portalInformation) {
             if ($this->matchUrl($url, $portalInformation->getUrl())) {
                 return $portalInformation;
             }
@@ -97,12 +118,8 @@ class WebspaceManager implements WebspaceManagerInterface
 
     public function findPortalInformationsByHostIncludingSubdomains(string $host, ?string $environment = null): array
     {
-        if (null === $environment) {
-            $environment = $this->environment;
-        }
-
         return \array_filter(
-            $this->getWebspaceCollection()->getPortalInformations($environment),
+            $this->getPortalInformations($environment),
             function(PortalInformation $portalInformation) use ($host) {
                 $portalHost = $portalInformation->getHost();
 
@@ -114,12 +131,8 @@ class WebspaceManager implements WebspaceManagerInterface
 
     public function findPortalInformationsByUrl(string $url, ?string $environment = null): array
     {
-        if (null === $environment) {
-            $environment = $this->environment;
-        }
-
         return \array_filter(
-            $this->getWebspaceCollection()->getPortalInformations($environment),
+            $this->getPortalInformations($environment),
             function(PortalInformation $portalInformation) use ($url) {
                 return $this->matchUrl($url, $portalInformation->getUrl());
             }
@@ -131,12 +144,8 @@ class WebspaceManager implements WebspaceManagerInterface
         string $locale,
         ?string $environment = null
     ): array {
-        if (null === $environment) {
-            $environment = $this->environment;
-        }
-
         return \array_filter(
-            $this->getWebspaceCollection()->getPortalInformations($environment),
+            $this->getPortalInformations($environment),
             function(PortalInformation $portalInformation) use ($webspaceKey, $locale) {
                 return $portalInformation->getWebspace()->getKey() === $webspaceKey
                     && $portalInformation->getLocale() === $locale;
@@ -149,12 +158,8 @@ class WebspaceManager implements WebspaceManagerInterface
         string $locale,
         ?string $environment = null
     ): array {
-        if (null === $environment) {
-            $environment = $this->environment;
-        }
-
         return \array_filter(
-            $this->getWebspaceCollection()->getPortalInformations($environment),
+            $this->getPortalInformations($environment),
             function(PortalInformation $portalInformation) use ($portalKey, $locale) {
                 return $portalInformation->getPortal()
                     && $portalInformation->getPortal()->getKey() === $portalKey
@@ -171,17 +176,14 @@ class WebspaceManager implements WebspaceManagerInterface
         ?string $domain = null,
         ?string $scheme = null
     ): array {
-        if (null === $environment) {
-            $environment = $this->environment;
-        }
         if (null === $webspaceKey) {
             $currentWebspace = $this->getCurrentWebspace();
             $webspaceKey = $currentWebspace ? $currentWebspace->getKey() : $webspaceKey;
         }
 
         $urls = [];
-        $portals = $this->getWebspaceCollection()->getPortalInformations(
-            $environment,
+        $portals = $this->getPortalInformationsPolyfill(
+            $environment ?? $this->environment,
             [RequestAnalyzerInterface::MATCH_TYPE_FULL]
         );
         foreach ($portals as $portalInformation) {
@@ -229,11 +231,7 @@ class WebspaceManager implements WebspaceManagerInterface
         $fullMatchedUrl = null;
         $partialMatchedUrl = null;
 
-        $portals = $this->getWebspaceCollection()->getPortalInformations(
-            $environment
-        );
-
-        foreach ($portals as $portalInformation) {
+        foreach ($this->getPortalInformationsPolyfill($environment) as $portalInformation) {
             if (!\in_array($portalInformation->getType(), [
                 RequestAnalyzerInterface::MATCH_TYPE_FULL,
                 RequestAnalyzerInterface::MATCH_TYPE_PARTIAL,
@@ -302,18 +300,16 @@ class WebspaceManager implements WebspaceManagerInterface
 
     public function getPortals(): array
     {
-        return $this->getWebspaceCollection()->getPortals();
+        return $this->webspaceRepository
+            ? $this->webspaceRepository->findAllPortals()
+            : $this->getWebspaceCollection()->getPortals();
     }
 
     public function getUrls(?string $environment = null): array
     {
-        if (null === $environment) {
-            $environment = $this->environment;
-        }
-
         $urls = [];
 
-        foreach ($this->getWebspaceCollection()->getPortalInformations($environment) as $portalInformation) {
+        foreach ($this->getPortalInformations($environment) as $portalInformation) {
             $urls[] = $portalInformation->getUrl();
         }
 
@@ -322,21 +318,13 @@ class WebspaceManager implements WebspaceManagerInterface
 
     public function getPortalInformations(?string $environment = null): array
     {
-        if (null === $environment) {
-            $environment = $this->environment;
-        }
-
-        return $this->getWebspaceCollection()->getPortalInformations($environment);
+        return $this->getPortalInformationsPolyfill($environment ?? $this->environment);
     }
 
     public function getPortalInformationsByWebspaceKey(?string $environment, string $webspaceKey): array
     {
-        if (null === $environment) {
-            $environment = $this->environment;
-        }
-
         return \array_filter(
-            $this->getWebspaceCollection()->getPortalInformations($environment),
+            $this->getPortalInformations($environment),
             function(PortalInformation $portal) use ($webspaceKey) {
                 return $portal->getWebspaceKey() === $webspaceKey;
             }
@@ -347,8 +335,12 @@ class WebspaceManager implements WebspaceManagerInterface
     {
         $localizations = [];
 
-        /** @var Webspace $webspace */
-        foreach ($this->getWebspaceCollection() as $webspace) {
+        $webspaceData = $this->webspaceRepository
+            ? $this->webspaceRepository->findAllWebspaces()
+            : $this->getWebspaceCollection()->getWebspaces()
+        ;
+
+        foreach ($webspaceData as $webspace) {
             foreach ($webspace->getAllLocalizations() as $localization) {
                 $localizations[$localization->getLocale()] = $localization;
             }
@@ -361,9 +353,7 @@ class WebspaceManager implements WebspaceManagerInterface
     {
         return \array_values(
             \array_map(
-                function(Localization $localization) {
-                    return $localization->getLocale();
-                },
+                static fn (Localization $localization) => $localization->getLocale(),
                 $this->getAllLocalizations()
             )
         );
@@ -374,9 +364,13 @@ class WebspaceManager implements WebspaceManagerInterface
      */
     public function getAllLocalesByWebspaces(): array
     {
+        $webspaceData = $this->webspaceRepository
+            ? $this->webspaceRepository->findAllWebspaces()
+            : $this->getWebspaceCollection()->getWebspaces()
+        ;
+
         $webspaces = [];
-        foreach ($this->getWebspaceCollection() as $webspace) {
-            /** @var Webspace $webspace */
+        foreach ($webspaceData as $webspace) {
             $locales = [];
             $defaultLocale = $webspace->getDefaultLocalization();
             $locales[$defaultLocale->getLocale()] = $defaultLocale;
@@ -391,6 +385,9 @@ class WebspaceManager implements WebspaceManagerInterface
         return $webspaces;
     }
 
+    /**
+     * @deprecated Use Sulu\Component\Webspace\Repository\WebspaceRepository
+     */
     public function getWebspaceCollection(): WebspaceCollection
     {
         if (null === $this->webspaceCollection) {
@@ -407,9 +404,7 @@ class WebspaceManager implements WebspaceManagerInterface
                 \assert($metadata instanceof TypedFormMetadata, \sprintf('Expected TypedFormMetadata instance for "%s" metadata.', PageInterface::TEMPLATE_TYPE));
 
                 $availableTemplates = \array_map(
-                    function(FormMetadata $formMetadata) {
-                        return $formMetadata->getKey();
-                    },
+                    static fn (FormMetadata $formMetadata) => $formMetadata->getKey(),
                     $metadata->getForms()
                 );
                 $webspaceCollectionBuilder = new WebspaceCollectionBuilder(
@@ -438,7 +433,7 @@ class WebspaceManager implements WebspaceManagerInterface
             $currentRequest = $this->requestStack->getCurrentRequest();
 
             $host = $currentRequest ? $currentRequest->getHost() : $this->requestContext->getHost();
-            foreach ($this->getPortalInformations() as $portalInformation) {
+            foreach ($this->webspaceCollection->getPortalInformations($this->environment) as $portalInformation) {
                 $portalInformation->setUrl($this->urlReplacer->replaceHost($portalInformation->getUrl(), $host));
                 $portalInformation->setUrlExpression(
                     $this->urlReplacer->replaceHost($portalInformation->getUrlExpression(), $host)
@@ -453,9 +448,29 @@ class WebspaceManager implements WebspaceManagerInterface
     }
 
     /**
+     * @param array<int>|null $types Defines which type of portals are requested (null for all)
+     *
+     * @return PortalInformation[]
+     */
+    private function getPortalInformationsPolyfill(string $environment, ?array $types = null): array
+    {
+        return $this->webspaceRepository
+            ? $this->webspaceRepository->findAllPortalInformations($types)
+            : $this->getWebspaceCollection()->getPortalInformations($environment, $types);
+    }
+
+    /**
      * Sets the options for the manager.
      *
-     * @param mixed[] $options
+     * @param array{
+     *    cache_class?: string,
+     *    cache_dir?: string,
+     *    config_dir?: string,
+     *    base_class?: string,
+     *    debug?: bool,
+     * } $options
+     *
+     * @return void
      */
     public function setOptions($options)
     {
@@ -465,10 +480,8 @@ class WebspaceManager implements WebspaceManagerInterface
             'debug' => false,
             'cache_class' => 'WebspaceCollectionCache',
             'base_class' => 'WebspaceCollection',
+            ...$options,
         ];
-
-        // overwrite the default values with the given options
-        $this->options = \array_merge($this->options, $options);
     }
 
     /**

--- a/src/Sulu/Component/Webspace/Repository/WebspaceRepository.php
+++ b/src/Sulu/Component/Webspace/Repository/WebspaceRepository.php
@@ -27,7 +27,7 @@ use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RequestContext;
 
-class WebspaceRepository implements WebspaceRepositoryInterface
+final class WebspaceRepository implements WebspaceRepositoryInterface
 {
     private ?WebspaceCollection $webspaceCollection = null;
 

--- a/src/Sulu/Component/Webspace/Repository/WebspaceRepository.php
+++ b/src/Sulu/Component/Webspace/Repository/WebspaceRepository.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Repository;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
+use Sulu\Component\Webspace\Manager\Dumper\PhpWebspaceCollectionDumper;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceCollectionBuilder;
+use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\Url\ReplacerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Page\Domain\Model\PageInterface;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
+
+class WebspaceRepository implements WebspaceRepositoryInterface
+{
+    private ?WebspaceCollection $webspaceCollection = null;
+
+    /**
+     * @param array{
+     *    cache_class: string,
+     *    cache_dir: ?string,
+     *    base_class: string,
+     *    debug: bool,
+     * } $options
+     */
+    public function __construct(
+        private MetadataProviderRegistry $metadataProviderRegistry,
+        private WebspaceCollectionBuilder $webspaceCollectionBuilder,
+        private RequestStack $requestStack,
+        private RequestContext $requestContext,
+        private ReplacerInterface $urlReplacer,
+        private string $environment,
+        private array $options
+    ) {
+    }
+
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
+    }
+
+    private function getWebspaceCollection(): WebspaceCollection
+    {
+        if (null === $this->webspaceCollection) {
+            /** @var class-string<WebspaceCollection> $class */
+            $class = $this->options['cache_class'];
+            $cache = new ConfigCache(
+                $this->options['cache_dir'] . '/' . $class . '.php',
+                $this->options['debug']
+            );
+
+            if (!$cache->isFresh()) {
+                $metadataProvider = $this->metadataProviderRegistry->getMetadataProvider('form');
+                $metadata = $metadataProvider->getMetadata(PageInterface::TEMPLATE_TYPE, 'en', []);
+                \assert($metadata instanceof TypedFormMetadata, \sprintf('Expected TypedFormMetadata instance for "%s" metadata.', PageInterface::TEMPLATE_TYPE));
+
+                $availableTemplates = \array_map(
+                    static fn (FormMetadata $formMetadata) => $formMetadata->getKey(),
+                    $metadata->getForms()
+                );
+
+                $webspaceCollection = $this->webspaceCollectionBuilder->build($availableTemplates);
+
+                $dumper = new PhpWebspaceCollectionDumper($webspaceCollection);
+                $cache->write(
+                    $dumper->dump(
+                        [
+                            'cache_class' => $class,
+                            'base_class' => $this->options['base_class'],
+                        ]
+                    ),
+                    $webspaceCollection->getResources()
+                );
+            }
+
+            require_once $cache->getPath();
+
+            $this->webspaceCollection = new $class();
+
+            $currentRequest = $this->requestStack->getCurrentRequest();
+
+            $host = $currentRequest ? $currentRequest->getHost() : $this->requestContext->getHost();
+            foreach ($this->webspaceCollection->getPortalInformations($this->environment) as $portalInformation) {
+                $portalInformation->setUrl($this->urlReplacer->replaceHost($portalInformation->getUrl(), $host));
+                $portalInformation->setUrlExpression(
+                    $this->urlReplacer->replaceHost($portalInformation->getUrlExpression(), $host)
+                );
+                $portalInformation->setRedirect(
+                    $this->urlReplacer->replaceHost($portalInformation->getRedirect(), $host)
+                );
+            }
+        }
+
+        return $this->webspaceCollection;
+    }
+
+    public function findWebspaceByKey(string $key): ?Webspace
+    {
+        return $this->getWebspaceCollection()->getWebspace($key);
+    }
+
+    public function findPortalByKey(string $key): ?Portal
+    {
+        return $this->getWebspaceCollection()->getPortal($key);
+    }
+
+    public function findAllWebspaces(): array
+    {
+        return $this->getWebspaceCollection()->getWebspaces();
+    }
+
+    public function findAllPortals(): array
+    {
+        return $this->getWebspaceCollection()->getPortals();
+    }
+
+    public function findAllPortalInformations(?array $types = null): array
+    {
+        return $this->getWebspaceCollection()->getPortalInformations($this->environment, $types);
+    }
+}

--- a/src/Sulu/Component/Webspace/Repository/WebspaceRepositoryInterface.php
+++ b/src/Sulu/Component/Webspace/Repository/WebspaceRepositoryInterface.php
@@ -20,6 +20,8 @@ use Sulu\Component\Webspace\Webspace;
 interface WebspaceRepositoryInterface
 {
     /**
+     * @internal This is only here for BC reasons
+     *
      * @param array{
      *    cache_class: string,
      *    cache_dir: ?string,

--- a/src/Sulu/Component/Webspace/Repository/WebspaceRepositoryInterface.php
+++ b/src/Sulu/Component/Webspace/Repository/WebspaceRepositoryInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Component\Webspace\Repository;
+
+use Sulu\Component\Webspace\Portal;
+use Sulu\Component\Webspace\PortalInformation;
+use Sulu\Component\Webspace\Webspace;
+
+interface WebspaceRepositoryInterface
+{
+    /**
+     * @param array{
+     *    cache_class: string,
+     *    cache_dir: ?string,
+     *    base_class: string,
+     *    debug: bool,
+     * } $options
+     */
+    public function setOptions(array $options): void;
+
+    public function findWebspaceByKey(string $key): ?Webspace;
+
+    public function findPortalByKey(string $key): ?Portal;
+
+    /**
+     * @return array<string, Webspace>
+     */
+    public function findAllWebspaces(): array;
+
+    /**
+     * @return Portal[]
+     */
+    public function findAllPortals(): array;
+
+    /**
+     * @param array<int>|null $types Defines which type of portals are requested (null for all)
+     *
+     * @return PortalInformation[]
+     */
+    public function findAllPortalInformations(?array $types = null): array;
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | #7218
| License | MIT
| Documentation PR | -

#### What's in this PR?
Moving the getting of the Webspaces independent from the WebspaceManager

#### Why?
* We want to move away from Manager-God-classes
* Making it easier to extend with a smaller interface
* Allows services to be more clear with intent (manager -> complicated logic, repository -> simple find by logic)

### Example Usage

Simmilar to the WebspaceManager just with doctrine like names.
```php
class SomeClass {
    public function __construct(private WebspaceRepositoryInterface $webspaceRepository) {}

    public function printWebspace(string $key) {
        $webspace = $this->webspaceRepository->findWebspaceByKey($key);
        echo $webspace->getKey();
    }
}
```