### PR TITLE
Make the admin user password customizable during sulu:build

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19657,12 +19657,6 @@ parameters:
 			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
 
 		-
-			message: '#^Cannot call method getOption\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
-
-		-
 			message: '#^Cannot call method getSchemaManager\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -19673,12 +19667,6 @@ parameters:
 			identifier: method.nonObject
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
-
-		-
-			message: '#^Cannot call method getOption\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/PhpcrBuilder.php
 
 		-
 			message: '#^Cannot call method initialize\(\) on mixed\.$#'
@@ -19701,7 +19689,7 @@ parameters:
 		-
 			message: '#^Cannot call method getFormatter\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 1
 			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
 
 		-
@@ -19711,21 +19699,9 @@ parameters:
 			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
 
 		-
-			message: '#^Cannot call method setIndentLevel\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
-
-		-
 			message: '#^Cannot call method setStyle\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
-			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
-
-		-
-			message: '#^Cannot call method writeln\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 4
 			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
 
 		-
@@ -19783,14 +19759,14 @@ parameters:
 			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
 
 		-
-			message: '#^Property Sulu\\Bundle\\CoreBundle\\Build\\SuluBuilder\:\:\$input has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Property Sulu\\Bundle\\CoreBundle\\Build\\SuluBuilder\:\:\$input \(Symfony\\Component\\Console\\Input\\InputInterface\) does not accept mixed\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
 
 		-
-			message: '#^Property Sulu\\Bundle\\CoreBundle\\Build\\SuluBuilder\:\:\$output has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Property Sulu\\Bundle\\CoreBundle\\Build\\SuluBuilder\:\:\$output \(Symfony\\Component\\Console\\Output\\OutputInterface\) does not accept mixed\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
 
@@ -48439,12 +48415,6 @@ parameters:
 			path: src/Sulu/Bundle/SearchBundle/Build/IndexBuilder.php
 
 		-
-			message: '#^Cannot call method getOption\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/SearchBundle/Build/InitBuilder.php
-
-		-
 			message: '#^Parameter \#1 \$query of method Massive\\Bundle\\SearchBundle\\Search\\SearchManagerInterface\:\:createSearch\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -49189,12 +49159,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
 
 		-
-			message: '#^Cannot call method getOption\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
-
-		-
 			message: '#^Cannot call method getParameter\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -49204,12 +49168,6 @@ parameters:
 			message: '#^Cannot call method remove\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
-
-		-
-			message: '#^Cannot call method writeln\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 4
 			path: src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
 
 		-

--- a/src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/SuluBuilder.php
@@ -13,9 +13,12 @@ namespace Sulu\Bundle\CoreBundle\Build;
 
 use Massive\Bundle\BuildBundle\Build\BuilderContext;
 use Massive\Bundle\BuildBundle\Build\BuilderInterface;
+use Massive\Bundle\BuildBundle\Console\MassiveOutputFormatter;
 use Massive\Bundle\BuildBundle\ContainerAwareInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -25,8 +28,14 @@ abstract class SuluBuilder implements ContainerAwareInterface, BuilderInterface
 {
     protected $container;
 
+    /**
+     * @var OutputInterface
+     */
     protected $output;
 
+    /**
+     * @var InputInterface
+     */
     protected $input;
 
     protected $application;
@@ -50,7 +59,10 @@ abstract class SuluBuilder implements ContainerAwareInterface, BuilderInterface
      */
     protected function execCommand($description, $command, $args = [''])
     {
-        $this->output->getFormatter()->setIndentLevel(1);
+        /** @var MassiveOutputFormatter $formatter */
+        $formatter = $this->output->getFormatter();
+
+        $formatter->setIndentLevel(1);
 
         if (!empty($args)) {
             $this->output->writeln(\sprintf('<comment>%s </comment> (%s)', $command, \json_encode($args)));
@@ -64,7 +76,7 @@ abstract class SuluBuilder implements ContainerAwareInterface, BuilderInterface
         $input = new ArrayInput($args);
         $input->setInteractive(false);
 
-        $this->output->getFormatter()->setIndentLevel(2);
+        $formatter->setIndentLevel(2);
         $res = $command->run($input, $this->output);
         $this->output->writeln('');
 

--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -13,6 +13,8 @@ namespace Sulu\Bundle\SecurityBundle\Build;
 
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * Builder for creating users.
@@ -32,7 +34,6 @@ class UserBuilder extends SuluBuilder
     public function build()
     {
         $user = 'admin';
-        $password = 'admin';
         $roleName = 'User';
         $system = Admin::SULU_ADMIN_SECURITY_SYSTEM;
         $locale = 'en';
@@ -52,6 +53,13 @@ class UserBuilder extends SuluBuilder
             return;
         }
 
+        // Running after the admin user check, otherwise we don't need the password.
+        $helper = new QuestionHelper();
+        $question = new Question("Please provide an admin password (default: admin)\n");
+
+        /** @var string $password */
+        $password = $helper->ask($this->input, $this->output, $question) ?: 'admin';
+
         $this->execCommand(
             'Creating role: ' . $roleName,
             'sulu:security:role:create',
@@ -64,7 +72,7 @@ class UserBuilder extends SuluBuilder
             \sprintf('Created role "<comment>%s</comment>" in system "<comment>%s</comment>"', $roleName, $system)
         );
 
-        // locale choosen doesn't exist, fallback
+        // locale chosen doesn't exist, fallback
         if (!\in_array($locale, $userLocales)) {
             $locale = \array_shift($userLocales);
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Adding an interactive prompt to ask the user for a custom admin password. When the `-n` or `--no-interaction` flag is set then it will fallback to the default admin password `"admin"`.

#### Why?
Having admin/admin hardcoded into the setup is very bad for security. At least let the user choose their password.

#### Example Usage
<img width="946" height="286" alt="image" src="https://github.com/user-attachments/assets/8796cf76-b565-4cfe-b55d-c3be854c8822" />

