### PR TITLE
Fix unexpected container changes after migrate Service definitions from XML to PHP

### DIFF
--- a/src/Sulu/Bundle/LocationBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/LocationBundle/Resources/config/services.php
@@ -23,7 +23,7 @@ return static function(ContainerConfigurator $container) {
     // Content Types
     $services->set('sulu_location.content.type.location', '%sulu_location.content.type.location.class%')
         ->tag('sulu.content.type', ['alias' => 'location'])
-        ->tag('sulu.content.export', ['format' => '1.2.xliff', 'translate' => 'false'])
+        ->tag('sulu.content.export', ['format' => '1.2.xliff', 'translate' => false])
     ;
 
     // Controller

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.php
@@ -51,7 +51,6 @@ return static function(ContainerConfigurator $container) {
             new Reference('sulu_markup.parser.delegating_html_extractor'),
         ])
         ->tag('sulu_markup.parser', ['type' => 'html']);
-    $services->alias(MarkupParserInterface::class, 'sulu_markup.parser');
 
     $services->set('sulu_markup.response_listener', MarkupListener::class)
         ->args([new TaggedIteratorArgument('sulu_markup.parser', indexAttribute: 'type')])
@@ -59,8 +58,8 @@ return static function(ContainerConfigurator $container) {
 
     $services->set('sulu_markup.mailer_listener', MailerListener::class)
         ->args([
-            new Reference(MarkupParserInterface::class),
-            new Reference(RequestStack::class),
+            new Reference('sulu_markup.parser'),
+            new Reference('request_stack'),
             '%kernel.default_locale%',
         ])
         ->tag('kernel.event_subscriber');

--- a/src/Sulu/Bundle/MarkupBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/MarkupBundle/Resources/config/services.php
@@ -17,13 +17,11 @@ use Sulu\Bundle\MarkupBundle\Markup\HtmlTagExtractor;
 use Sulu\Bundle\MarkupBundle\Markup\Link\ExternalLinkProvider;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPool;
 use Sulu\Bundle\MarkupBundle\Markup\LinkTag;
-use Sulu\Bundle\MarkupBundle\Markup\MarkupParserInterface;
 use Sulu\Bundle\MarkupBundle\Tag\TagRegistry;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 return static function(ContainerConfigurator $container) {

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.php
@@ -73,7 +73,6 @@ return static function(ContainerConfigurator $container) {
                     : null
             '),
         ]);
-    $services->alias(PreviewRendererInterface::class, 'sulu_preview.preview.renderer');
 
     $services->set('sulu_preview.preview', Preview::class)
         ->args([

--- a/src/Sulu/Bundle/PreviewBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/config/services.php
@@ -18,7 +18,6 @@ use Sulu\Bundle\PreviewBundle\Preview\Events;
 use Sulu\Bundle\PreviewBundle\Preview\Object\PreviewObjectProviderRegistry;
 use Sulu\Bundle\PreviewBundle\Preview\Preview;
 use Sulu\Bundle\PreviewBundle\Preview\Renderer\PreviewRenderer;
-use Sulu\Bundle\PreviewBundle\Preview\Renderer\PreviewRendererInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Renderer\WebsiteKernelFactory;
 use Sulu\Bundle\PreviewBundle\UserInterface\Controller\PreviewController;
 use Sulu\Bundle\PreviewBundle\UserInterface\Controller\PreviewLinkController;
@@ -55,8 +54,7 @@ return static function(ContainerConfigurator $container) {
         ->tag('sulu.context', ['context' => 'admin']);
 
     // Preview
-    $services->set('sulu_preview.preview.kernel_factory', WebsiteKernelFactory::class)
-        ->args(['%kernel.environment%']);
+    $services->set('sulu_preview.preview.kernel_factory', WebsiteKernelFactory::class);
 
     $services->set('sulu_preview.preview.renderer', PreviewRenderer::class)
         ->args([

--- a/src/Sulu/Bundle/ReferenceBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Resources/config/services.php
@@ -61,7 +61,7 @@ return static function(ContainerConfigurator $container) {
     // Command
     $services->set('sulu_reference.refresh_command', RefreshCommand::class)
         ->args([
-            new TaggedIteratorArgument('sulu_reference.refresher', defaultIndexMethod: 'getResourceKey'),
+            new TaggedIteratorArgument('sulu_reference.refresher'),
             new Reference(ReferenceRepositoryInterface::class),
             '%sulu.context%',
         ])


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Revert accidently container changes after migrate Service definitions from XML to PHP.


#### Why?

The check script didn't include arguments check correclty and so didn't validate all. The updated script in https://github.com/sulu/skeleton/pull/329 does now.