### PR TITLE
Fix some found issues in service definitions during XML to PHP migration

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -84,7 +84,6 @@ return $config
         [
             'guzzlehttp/promises', // required for faster fos http cache clearing
             'nyholm/psr7', // required for faster fos http cache clearing
-            'symfony/http-client', // required and used via symfony/http-client-contracts
             'symfony/css-selector', // kept for future usage
         ],
         [ErrorType::UNUSED_DEPENDENCY],

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/cache.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/cache.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use ProxyManager\Configuration;
-use ProxyManager\FileLocator\FileLocator;
-use ProxyManager\GeneratorStrategy\FileWriterGeneratorStrategy;
 use Sulu\Component\Cache\Memoize;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\DependencyInjection\Reference;
@@ -29,17 +26,4 @@ return static function(ContainerConfigurator $container) {
             '%sulu_core.cache.memoize.default_lifetime%',
         ])
         ->tag('kernel.reset', ['method' => 'reset']);
-
-    $services->set('sulu_core.proxy_manager.configuration', Configuration::class)
-        ->private()
-        ->call('setProxiesTargetDir', ['%sulu_core.proxy_cache_dir%'])
-        ->call('setGeneratorStrategy', [new Reference('sulu_core.proxy_manager.file_writer_generator_strategy')]);
-
-    $services->set('sulu_core.proxy_manager.file_writer_generator_strategy', FileWriterGeneratorStrategy::class)
-        ->private()
-        ->args([new Reference('sulu_core.proxy_manager.file_locator')]);
-
-    $services->set('sulu_core.proxy_manager.file_locator', FileLocator::class)
-        ->private()
-        ->args([expr('service(\'sulu_core.proxy_manager.configuration\').getProxiesTargetDir()')]);
 };

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/services.php
@@ -500,8 +500,6 @@ return static function(ContainerConfigurator $container) {
         ])
         ->tag('sulu_media.file_inspector');
 
-    $services->alias('Sulu\Bundle\MediaBundle\FileInspector\SvgSafetyInspectorInterface', 'sulu_media.file_inspector.svg_inspector');
-
     $services->set('sulu_media.file_inspector.subscriber', UploadFileSubscriber::class)
         ->args([tagged_iterator('sulu_media.file_inspector')])
         ->tag('kernel.event_subscriber');

--- a/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
+++ b/src/Sulu/Bundle/TagBundle/DependencyInjection/SuluTagExtension.php
@@ -89,7 +89,6 @@ class SuluTagExtension extends Extension implements PrependExtensionInterface
 
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.php');
-        $loader->load('services_content.php');
 
         if (\array_key_exists('SuluTrashBundle', $bundles)) {
             $loader->load('services_trash.php');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

 - The usage of symfony/http-client is now correctly detected in composer dependency analser. 
 - some classes listed in are unused core cache.php service definitions just don't exists
 - duplicated loading of services_content in tag bundle
 - remove alias to none existing interface

#### Why?

Fix some found issues in service definitions during XML to PHP migration.