### PR TITLE
Fix QR code tests after dependency update

### DIFF
--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -1,1 +1,6 @@
 declare var SULU_ADMIN_BUILD_VERSION: string;
+
+declare module 'util' {
+    declare export var TextDecoder: any;
+    declare export var TextEncoder: any;
+}

--- a/tests/js/testSetup.config.js
+++ b/tests/js/testSetup.config.js
@@ -1,4 +1,6 @@
 // @flow
+// eslint-disable-next-line import/no-nodejs-modules
+import {TextDecoder, TextEncoder} from 'util';
 import 'core-js/features/string/replace-all';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
@@ -6,6 +8,16 @@ import {isObservableArray, toJS} from 'mobx';
 import '@testing-library/jest-dom';
 
 Enzyme.configure({adapter: new Adapter()});
+
+Object.defineProperty(window, 'TextDecoder', {
+    writable: true,
+    value: TextDecoder,
+});
+
+Object.defineProperty(window, 'TextEncoder', {
+    writable: true,
+    value: TextEncoder,
+});
 
 function mobxAwareEqualityTester(a, b, customTesters) {
     const isAObservable = isObservableArray(a);


### PR DESCRIPTION
  | Q | A
  | --- | ---
  | Bug fix? | yes
  | New feature? | no
  | BC breaks? | no
  | Deprecations? | no
  | Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
  | Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
  | License | MIT
  | Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

  #### What's in this PR?

  The Jest setup now exposes `TextEncoder` and `TextDecoder` on the jsdom window object. The Flow globals include a declaration for the Node `util` module used by the test setup.

  #### Why?

  The updated QR code dependency uses `TextEncoder` when rendering QR codes. Browsers provide this API but the jsdom test environment does not expose it by default.