### PR TITLE
Add stricter validation for sort columns in ListRestHelper

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -6,7 +6,10 @@ For every update follow the [Upgrade Documentation](https://docs.sulu.io/2.x/upg
 
 ### Disallow function calls in sort columns
 
-Sulu no longer allows any string in the `sortBy` query parameters. The only allowed pattern is letters, `.` and `_`. To
+Sulu no longer allows arbitrary strings in the `sortBy` query parameters. The allowed pattern is word characters
+(letters, digits, and `_`) plus `.`. If you need to change this behavior, replace or decorate the
+`sulu_core.list_rest_helper` service (aliased to `Sulu\Component\Rest\ListBuilder\ListRestHelperInterface`) instead of
+overriding `Sulu\Component\Rest\ListBuilder\ListRestHelper::getSortColumn` directly.
 change this override the `Sulu\Component\Rest\ListBuilder\ListRestHelper::getSortColumn` function.
 
 ## 2.6.23

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -2,6 +2,13 @@
 
 For every update follow the [Upgrade Documentation](https://docs.sulu.io/2.x/upgrades/upgrade-2.x.html) steps.
 
+## 2.6.24
+
+### Disallow function calls in sort columns
+
+Sulu no longer allows any string in the `sortBy` query parameters. The only allowed pattern is letters, `.` and `_`. To
+change this override the `Sulu\Component\Rest\ListBuilder\ListRestHelper::getSortColumn` function.
+
 ## 2.6.23
 
 ### CKEditor upgrade to 47

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -74,7 +74,7 @@ class ListRestHelper implements ListRestHelperInterface
         }
 
         // Only allow sort columns like id, otherEntity.id and no function calls (empty strings are also invalid)
-        if (!\preg_match('#^(\w|\.)+$#', $sortColumn)) {
+        if (!\preg_match('#^\w+(\.\w+)*$#', $sortColumn)) {
             return null;
         }
 

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -66,14 +66,19 @@ class ListRestHelper implements ListRestHelperInterface
         return (null !== $excludedIdsString) ? \array_filter(\explode(',', $excludedIdsString)) : [];
     }
 
-    /**
-     * Returns the desired sort column.
-     *
-     * @return string
-     */
     public function getSortColumn()
     {
-        return $this->getRequest()->get('sortBy', null);
+        $sortColumn = $this->getRequest()->get('sortBy', null);
+        if (null === $sortColumn || !\is_string($sortColumn)) {
+            return null;
+        }
+
+        // Only allow sort columns like id, otherEntity.id and no function calls (empty strings are also invalid)
+        if (!\preg_match('#^(\w|\.)+$#', $sortColumn)) {
+            return null;
+        }
+
+        return $sortColumn;
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelperInterface.php
@@ -34,7 +34,7 @@ interface ListRestHelperInterface
     /**
      * Returns the desired sort column.
      *
-     * @return string
+     * @return string|null
      */
     public function getSortColumn();
 

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/ListRestHelperTest.php
@@ -27,11 +27,17 @@ class ListRestHelperTest extends TestCase
      */
     protected $requestStack;
 
+    protected ListRestHelper $helper;
+
     public function setUp(): void
     {
         $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->helper = new ListRestHelper($this->requestStack->reveal());
     }
 
+    /**
+     * @return array<int,array<int,mixed>>
+     */
     public static function dataFieldsProvider()
     {
         return [
@@ -149,17 +155,65 @@ class ListRestHelperTest extends TestCase
     public function testGetFields($request, $expected): void
     {
         $this->requestStack->getCurrentRequest()->willReturn($request);
-        $helper = new ListRestHelper($this->requestStack->reveal());
 
-        $this->assertEquals($expected['fields'], $helper->getFields());
-        $this->assertEquals($expected['sortColumn'], $helper->getSortColumn());
-        $this->assertEquals($expected['sortOrder'], $helper->getSortOrder());
-        $this->assertEquals($expected['searchPattern'], $helper->getSearchPattern());
-        $this->assertEquals($expected['searchFields'], $helper->getSearchFields());
-        $this->assertEquals($expected['limit'], $helper->getLimit());
-        $this->assertEquals($expected['offset'], $helper->getOffset());
-        $this->assertEquals($expected['ids'], $helper->getIds());
-        $this->assertEquals($expected['excludedIds'], $helper->getExcludedIds());
-        $this->assertEquals($expected['filters'], $helper->getFilter());
+        $this->assertEquals($expected['fields'], $this->helper->getFields());
+        $this->assertEquals($expected['sortColumn'], $this->helper->getSortColumn());
+        $this->assertEquals($expected['sortOrder'], $this->helper->getSortOrder());
+        $this->assertEquals($expected['searchPattern'], $this->helper->getSearchPattern());
+        $this->assertEquals($expected['searchFields'], $this->helper->getSearchFields());
+        $this->assertEquals($expected['limit'], $this->helper->getLimit());
+        $this->assertEquals($expected['offset'], $this->helper->getOffset());
+        $this->assertEquals($expected['ids'], $this->helper->getIds());
+        $this->assertEquals($expected['excludedIds'], $this->helper->getExcludedIds());
+        $this->assertEquals($expected['filters'], $this->helper->getFilter());
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('dataSortColumn')]
+    public function testGetSortColumn(Request $request, ?string $expected): void
+    {
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
+        $this->assertSame($expected, $this->helper->getSortColumn());
+    }
+
+    /**
+     * @return \Generator<string,array{Request,string|null}>
+     */
+    public static function dataSortColumn(): \Generator
+    {
+        yield 'no column name' => [
+            new Request([]),
+            null,
+        ];
+
+        yield 'empty column name' => [
+            new Request(['sortBy' => '']),
+            null,
+        ];
+
+        yield 'invalid column name' => [
+            new Request(['sortBy' => 'length(somefield)']),
+            null,
+        ];
+
+        yield 'valid column name' => [
+            new Request(['sortBy' => 'somefield']),
+            'somefield',
+        ];
+
+        yield 'valid doctrine column name' => [
+            new Request(['sortBy' => 'some_field']),
+            'some_field',
+        ];
+
+        yield 'valid column name with subentity' => [
+            new Request(['sortBy' => 'someEntity.someField']),
+            'someEntity.someField',
+        ];
+
+        yield 'valid column can contain numbers' => [
+            new Request(['sortBy' => 'someEntity.field3']),
+            'someEntity.field3',
+        ];
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | kinda
| Deprecations? | -
| Fixed tickets | -
| Related issues/PRs | #8793 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Only allow FieldExpression like sort columns

#### Why?
Disallow functions and complex expressions as doctrine doesn't check column names when using the sort by.