### PR TITLE
Adopt postTriggerAction to use action query parameter

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49897,12 +49897,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Controller/RoleSettingController.php
 
 		-
-			message: '#^Binary operation "\." between ''Unrecognized action…'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
-
-		-
 			message: '#^Call to an undefined method Doctrine\\ORM\\EntityRepository\<object\>\:\:findUserByContact\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\CategoryBundle\Category\CategoryManagerInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryRepositoryInterface;
 use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
@@ -116,7 +117,7 @@ class CategoryController extends AbstractRestController implements ClassResource
 
     public function postTriggerAction($id, Request $request)
     {
-        $action = $this->getRequestParameter($request, 'action', true);
+        $action = $request->query->get('action') ?: throw new MissingParameterException(self::class, 'action');
 
         try {
             return match ($action) {

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -22,6 +22,7 @@ use Sulu\Bundle\MediaBundle\Media\Exception\CollectionNotFoundException;
 use Sulu\Component\Media\SystemCollections\SystemCollectionManagerInterface;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\ListBuilder\ListRepresentation;
@@ -306,7 +307,7 @@ class CollectionController extends AbstractRestController implements ClassResour
      */
     public function postTriggerAction($id, Request $request)
     {
-        $action = $this->getRequestParameter($request, 'action', true);
+        $action = $request->query->get('action') ?: throw new MissingParameterException(self::class, 'action');
 
         try {
             return match ($action) {

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -409,7 +409,7 @@ class MediaController extends AbstractMediaController implements
      */
     public function postTriggerAction($id, Request $request)
     {
-        $action = $this->getRequestParameter($request, 'action', true);
+        $action = $request->query->get('action') ?: throw new MissingParameterException(self::class, 'action');
 
         try {
             return match ($action) {

--- a/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewLinkController.php
+++ b/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewLinkController.php
@@ -17,6 +17,7 @@ use HandcraftedInTheAlps\RestRoutingBundle\Routing\ClassResourceInterface;
 use Sulu\Bundle\PreviewBundle\Application\Manager\PreviewLinkManagerInterface;
 use Sulu\Bundle\PreviewBundle\Domain\Repository\PreviewLinkRepositoryInterface;
 use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\RequestParametersTrait;
 use Symfony\Component\HttpFoundation\Request;
@@ -54,7 +55,7 @@ class PreviewLinkController extends AbstractRestController implements ClassResou
 
     public function postTriggerAction(Request $request, string $resourceId): Response
     {
-        $action = $this->getRequestParameter($request, 'action', true);
+        $action = $request->query->get('action') ?: throw new MissingParameterException(self::class, 'action');
 
         try {
             switch ($action) {

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -166,7 +166,7 @@ class UserController extends AbstractRestController implements ClassResourceInte
      */
     public function postTriggerAction($id, Request $request)
     {
-        $action = $request->get('action');
+        $action = $request->query->get('action');
 
         try {
             $user = match ($action) {

--- a/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
+++ b/src/Sulu/Bundle/TrashBundle/Tests/Functional/UserInterface/Controller/Admin/TrashItemControllerTest.php
@@ -199,7 +199,7 @@ class TrashItemControllerTest extends SuluTestCase
         $trashItem = static::createTrashItem();
         $id = $trashItem->getId();
 
-        $this->client->jsonRequest('POST', '/api/trash-items/' . $id, ['action' => 'restore']);
+        $this->client->jsonRequest('POST', '/api/trash-items/' . $id . '?action=restore');
         static::assertHttpStatusCode(200, $this->client->getResponse());
 
         $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
@@ -222,10 +222,14 @@ class TrashItemControllerTest extends SuluTestCase
         $trashItem = static::createTrashItem();
         $id = $trashItem->getId();
 
-        $this->client->jsonRequest('POST', '/api/trash-items/' . $id, ['action' => 'restore'], [
-            'PHP_AUTH_USER' => self::ALT_USER_USERNAME,
-            'PHP_AUTH_PW' => 'test',
-        ]);
+        $this->client->jsonRequest(
+            'POST',
+            '/api/trash-items/' . $id . '?action=restore',
+            [
+                'PHP_AUTH_USER' => self::ALT_USER_USERNAME,
+                'PHP_AUTH_PW' => 'test',
+            ]
+        );
         static::assertHttpStatusCode(200, $this->client->getResponse());
     }
 

--- a/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
+++ b/src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\TrashBundle\Domain\Model\TrashItemInterface;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
 use Sulu\Bundle\TrashBundle\Infrastructure\Sulu\Admin\TrashAdmin;
 use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
@@ -199,7 +200,7 @@ class TrashItemController extends AbstractRestController implements ClassResourc
 
     public function postTriggerAction(int $id, Request $request): Response
     {
-        $action = $this->getRequestParameter($request, 'action', true);
+        $action = $request->query->get('action') ?: throw new MissingParameterException(self::class, 'action');
 
         try {
             return match ($action) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | maybe
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #8656 #8216 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Rebasing #8656 down to 2.6

* `action` parameter is a query parameter (and not in the body)
* Replacing the `RequestParametersTrait` with it's implementation (will also be removed some day)

#### Why?
The `$request->get(...)` is deprecated and will be removed in Symfony 8