### PR TITLE
Restore optimistic locking via content hash for new content architecture

### DIFF
--- a/packages/article/src/Application/MessageHandler/ModifyArticleMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/ModifyArticleMessageHandler.php
@@ -17,6 +17,7 @@ use Sulu\Article\Domain\Event\ArticleModifiedEvent;
 use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Content\Application\ContentHash\ContentHashChecker;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 
@@ -30,7 +31,8 @@ final class ModifyArticleMessageHandler
         private ArticleRepositoryInterface $articleRepository,
         /** @var iterable<ArticleMapperInterface> */
         private iterable $articleMappers,
-        private DomainEventCollectorInterface $domainEventCollector
+        private DomainEventCollectorInterface $domainEventCollector,
+        private ContentHashChecker $contentHashChecker,
     ) {
     }
 
@@ -55,6 +57,13 @@ final class ModifyArticleMessageHandler
                     ],
                 ],
             ]
+        );
+
+        $this->contentHashChecker->checkHash(
+            $data,
+            $article,
+            ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_DRAFT],
+            $article->getId(),
         );
 
         foreach ($this->articleMappers as $articleMapper) {

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -181,6 +181,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_article.article_repository'),
                 tagged_iterator('sulu_article.article_mapper'),
                 new Reference('sulu_activity.domain_event_collector'),
+                new Reference('sulu_content.content_hash_checker'),
             ])
             ->tag('messenger.message_handler');
 

--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -269,12 +269,18 @@ final class ArticleController implements SecuredControllerInterface
      */
     private function getData(Request $request): array
     {
-        return \array_replace(
+        $data = \array_replace(
             $request->request->all(),
             [
                 'locale' => $this->getLocale($request),
             ],
         );
+
+        if ($request->query->getBoolean('force', false)) {
+            unset($data['_hash']);
+        }
+
+        return $data;
     }
 
     public function getLocale(Request $request): string

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -17,6 +17,7 @@ use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
+use Sulu\Component\Rest\Exception\RestExceptionInterface;
 use Sulu\Content\Tests\Traits\CreateTagTrait;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
@@ -409,6 +410,26 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertCount(4, $routeRepository->findBy([]));
 
         $this->assertResponseSnapshot('article_put.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
+    public function testPutWithInvalidHashReturnsConflict(string $id): void
+    {
+        $this->client->request('PUT', '/admin/api/articles/' . $id . '?locale=en', [], [], [], \json_encode([
+            '_hash' => 'invalid-hash',
+            'template' => 'article',
+            'title' => 'Test Article 2',
+            'url' => '/my-article-2',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(409, $response);
+
+        /** @var array{code: int, message: string} $responseData */
+        $responseData = \json_decode((string) $response->getContent(), true);
+
+        $this->assertEquals(RestExceptionInterface::EXCEPTION_CODE_INVALID_HASH, $responseData['code']);
     }
 
     #[Depends('testPost')]

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -433,6 +433,21 @@ class ArticleControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testPutWithForceIgnoresHash(string $id): void
+    {
+        $this->client->request('PUT', '/admin/api/articles/' . $id . '?locale=en&force=true', [], [], [], \json_encode([
+            '_hash' => 'invalid-hash',
+            'template' => 'article',
+            'title' => 'Test Article 2',
+            'url' => '/my-article-2',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(200, $response);
+    }
+
+    #[Depends('testPost')]
     #[Depends('testPut')]
     public function testGetList(): void
     {

--- a/packages/article/tests/Functional/Integration/responses/article_get.json
+++ b/packages/article/tests/Functional/Integration/responses/article_get.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": "@integer@",
     "authored": "2020-05-08T00:00:00+00:00",
     "availableLocales": [

--- a/packages/article/tests/Functional/Integration/responses/article_get_after_restore.json
+++ b/packages/article/tests/Functional/Integration/responses/article_get_after_restore.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "@datetime@",
     "availableLocales": [

--- a/packages/article/tests/Functional/Integration/responses/article_get_ghost_locale.json
+++ b/packages/article/tests/Functional/Integration/responses/article_get_ghost_locale.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": null,
     "availableLocales": ["en"],

--- a/packages/article/tests/Functional/Integration/responses/article_get_shadow_locale.json
+++ b/packages/article/tests/Functional/Integration/responses/article_get_shadow_locale.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": null,
     "availableLocales": [

--- a/packages/article/tests/Functional/Integration/responses/article_post.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "additionalWebspaces": [],
     "author": "@integer@",
     "authored": "2020-05-08T00:00:00+00:00",

--- a/packages/article/tests/Functional/Integration/responses/article_post_publish.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post_publish.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "additionalWebspaces": [],
     "author": null,
     "authored": "2020-05-08T00:00:00+00:00",

--- a/packages/article/tests/Functional/Integration/responses/article_post_restore.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post_restore.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": "@integer@",
     "authored": "2020-06-09T00:00:00+00:00",
     "availableLocales": [

--- a/packages/article/tests/Functional/Integration/responses/article_post_trigger_copy_locale.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post_trigger_copy_locale.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": "@integer@",
     "authored": "2020-05-08T00:00:00+00:00",
     "availableLocales": [

--- a/packages/article/tests/Functional/Integration/responses/article_post_trigger_unpublish.json
+++ b/packages/article/tests/Functional/Integration/responses/article_post_trigger_unpublish.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "2020-05-08T00:00:00+00:00",
     "availableLocales": [

--- a/packages/article/tests/Functional/Integration/responses/article_put.json
+++ b/packages/article/tests/Functional/Integration/responses/article_put.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": "@integer@",
     "authored": "2020-06-09T00:00:00+00:00",
     "availableLocales": [

--- a/packages/content/config/normalizer.xml
+++ b/packages/content/config/normalizer.xml
@@ -46,6 +46,12 @@
             <tag name="sulu_content.normalizer" priority="4"/>
         </service>
 
+        <service id="sulu_content.content_hash_normalizer" class="Sulu\Content\Application\ContentNormalizer\Normalizer\ContentHashNormalizer">
+            <argument type="service" id="sulu_hash.auditable_hasher"/>
+
+            <tag name="sulu_content.normalizer" priority="3"/>
+        </service>
+
         <service id="sulu_content.auditable_normalizer" class="Sulu\Content\Application\ContentNormalizer\Normalizer\AuditableNormalizer">
             <tag name="sulu_content.normalizer" priority="2"/>
         </service>

--- a/packages/content/config/services.xml
+++ b/packages/content/config/services.xml
@@ -145,6 +145,10 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="sulu_content.content_hash_checker" class="Sulu\Content\Application\ContentHash\ContentHashChecker">
+            <argument type="service" id="sulu_hash.auditable_hasher"/>
+        </service>
+
         <!-- Cache Tag Subscriber -->
         <service id="sulu_content.dimension_content_tag_subscriber" class="Sulu\Content\Infrastructure\Sulu\HttpCache\EventSubscriber\DimensionContentTagSubscriber">
             <argument type="service" id="sulu_http_cache.reference_store"/>

--- a/packages/content/src/Application/ContentHash/ContentHashChecker.php
+++ b/packages/content/src/Application/ContentHash/ContentHashChecker.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentHash;
+
+use Sulu\Component\Hash\HasherInterface;
+use Sulu\Component\Rest\Exception\InvalidHashException;
+use Sulu\Content\Domain\Model\ContentRichEntityInterface;
+use Sulu\Content\Domain\Model\DimensionContentCollection;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+
+class ContentHashChecker
+{
+    public function __construct(
+        private HasherInterface $hasher,
+    ) {
+    }
+
+    /**
+     * @template T of DimensionContentInterface
+     *
+     * @param mixed[] $data
+     * @param ContentRichEntityInterface<T> $contentRichEntity
+     * @param mixed[] $dimensionAttributes
+     * @param int|string $identifier
+     */
+    public function checkHash(array $data, ContentRichEntityInterface $contentRichEntity, array $dimensionAttributes, $identifier): void
+    {
+        $expectedHash = $data['_hash'] ?? null;
+        if (!\is_string($expectedHash)) {
+            return;
+        }
+
+        /** @var class-string<T>&literal-string $dimensionContentClass */
+        $dimensionContentClass = $contentRichEntity->createDimensionContent()::class;
+        $dimensionAttributes = $dimensionContentClass::getEffectiveDimensionAttributes($dimensionAttributes);
+        $dimensionContent = (new DimensionContentCollection(
+            $contentRichEntity->getDimensionContents(),
+            $dimensionAttributes,
+            $dimensionContentClass,
+        ))->getDimensionContent($dimensionAttributes);
+
+        if (!$dimensionContent instanceof DimensionContentInterface
+            || $expectedHash !== $this->hasher->hash($dimensionContent)
+        ) {
+            throw new InvalidHashException($contentRichEntity::class, $identifier);
+        }
+    }
+}

--- a/packages/content/src/Application/ContentHash/ContentHashChecker.php
+++ b/packages/content/src/Application/ContentHash/ContentHashChecker.php
@@ -37,6 +37,7 @@ class ContentHashChecker
     public function checkHash(array $data, ContentRichEntityInterface $contentRichEntity, array $dimensionAttributes, $identifier): void
     {
         $expectedHash = $data['_hash'] ?? null;
+        // No hash in the request means the check is skipped (e.g. when ?force=true strips _hash from data).
         if (!\is_string($expectedHash)) {
             return;
         }

--- a/packages/content/src/Application/ContentNormalizer/Normalizer/ContentHashNormalizer.php
+++ b/packages/content/src/Application/ContentNormalizer/Normalizer/ContentHashNormalizer.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentNormalizer\Normalizer;
+
+use Sulu\Component\Hash\HasherInterface;
+use Sulu\Content\Domain\Model\AuditableInterface;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+
+class ContentHashNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        private HasherInterface $hasher,
+    ) {
+    }
+
+    public function enhance(object $object, array $normalizedData): array
+    {
+        if (!$object instanceof DimensionContentInterface || !$object instanceof AuditableInterface) {
+            return $normalizedData;
+        }
+
+        $normalizedData['_hash'] = $this->hasher->hash($object);
+
+        return $normalizedData;
+    }
+
+    public function getIgnoredAttributes(object $object): array
+    {
+        return [];
+    }
+}

--- a/packages/content/tests/Functional/Integration/responses/example_get.json
+++ b/packages/content/tests/Functional/Integration/responses/example_get.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "2020-05-08T00:00:00+00:00",
     "changer" : "@integer@",

--- a/packages/content/tests/Functional/Integration/responses/example_get_after_restore.json
+++ b/packages/content/tests/Functional/Integration/responses/example_get_after_restore.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "@dateTime@",
     "availableLocales": [

--- a/packages/content/tests/Functional/Integration/responses/example_get_ghost_locale.json
+++ b/packages/content/tests/Functional/Integration/responses/example_get_ghost_locale.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": null,
     "availableLocales": ["en"],

--- a/packages/content/tests/Functional/Integration/responses/example_post.json
+++ b/packages/content/tests/Functional/Integration/responses/example_post.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "2020-05-08T00:00:00+00:00",
     "changer" : null,

--- a/packages/content/tests/Functional/Integration/responses/example_post_publish.json
+++ b/packages/content/tests/Functional/Integration/responses/example_post_publish.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "2020-05-08T00:00:00+00:00",
     "changer" : "@integer@",

--- a/packages/content/tests/Functional/Integration/responses/example_post_trigger_copy_locale.json
+++ b/packages/content/tests/Functional/Integration/responses/example_post_trigger_copy_locale.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "2020-05-08T00:00:00+00:00",
     "changer" : "@integer@",

--- a/packages/content/tests/Functional/Integration/responses/example_post_trigger_unpublish.json
+++ b/packages/content/tests/Functional/Integration/responses/example_post_trigger_unpublish.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "2020-05-08T00:00:00+00:00",
     "changer" : "@integer@",

--- a/packages/content/tests/Functional/Integration/responses/example_put.json
+++ b/packages/content/tests/Functional/Integration/responses/example_put.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "author": null,
     "authored": "2020-06-09T00:00:00+00:00",
     "changer" : "@integer@",

--- a/packages/page/src/Application/MessageHandler/ModifyPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/ModifyPageMessageHandler.php
@@ -12,6 +12,7 @@
 namespace Sulu\Page\Application\MessageHandler;
 
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Content\Application\ContentHash\ContentHashChecker;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Application\Mapper\PageMapperInterface;
@@ -34,6 +35,7 @@ final class ModifyPageMessageHandler
         /** @var iterable<PageMapperInterface> */
         private iterable $pageMappers,
         private DomainEventCollectorInterface $domainEventCollector,
+        private ContentHashChecker $contentHashChecker,
     ) {
     }
 
@@ -58,6 +60,13 @@ final class ModifyPageMessageHandler
                     ],
                 ],
             ]
+        );
+
+        $this->contentHashChecker->checkHash(
+            $data,
+            $page,
+            ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_DRAFT],
+            $page->getId(),
         );
 
         foreach ($this->pageMappers as $pageMapper) {

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -176,6 +176,7 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_page.page_repository'),
                 tagged_iterator('sulu_page.page_mapper'),
                 new Reference('sulu_activity.domain_event_collector'),
+                new Reference('sulu_content.content_hash_checker'),
             ])
             ->tag('messenger.message_handler');
 

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -268,12 +268,18 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
      */
     private function getData(Request $request): array
     {
-        return \array_replace(
+        $data = \array_replace(
             $request->request->all(),
             [
                 'locale' => $this->getLocale($request),
             ],
         );
+
+        if ($request->query->getBoolean('force', false)) {
+            unset($data['_hash']);
+        }
+
+        return $data;
     }
 
     public function getLocale(Request $request): string

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -633,6 +633,21 @@ class PageControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testPutWithForceIgnoresHash(string $id): void
+    {
+        $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=en&force=true', [], [], [], \json_encode([
+            '_hash' => 'invalid-hash',
+            'template' => 'default',
+            'title' => 'Test Page 2',
+            'url' => '/my-page-2',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(200, $response);
+    }
+
+    #[Depends('testPost')]
     #[Depends('testPut')]
     public function testGetList(string $id): void
     {

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -19,6 +19,7 @@ use Sulu\Bundle\AudienceTargetingBundle\Entity\TargetGroup;
 use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
+use Sulu\Component\Rest\Exception\RestExceptionInterface;
 use Sulu\Content\Tests\Traits\CreateTagTrait;
 use Sulu\Page\Application\Message\CreatePageMessage;
 use Sulu\Page\Application\Message\ModifyPageMessage;
@@ -609,6 +610,26 @@ class PageControllerTest extends SuluTestCase
         $this->assertCount(4, $routeRepository->findBy([]));
 
         $this->assertResponseSnapshot('page_put.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
+    public function testPutWithInvalidHashReturnsConflict(string $id): void
+    {
+        $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=en', [], [], [], \json_encode([
+            '_hash' => 'invalid-hash',
+            'template' => 'default',
+            'title' => 'Test Page 2',
+            'url' => '/my-page-2',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(409, $response);
+
+        /** @var array{code: int, message: string} $responseData */
+        $responseData = \json_decode((string) $response->getContent(), true);
+
+        $this->assertEquals(RestExceptionInterface::EXCEPTION_CODE_INVALID_HASH, $responseData['code']);
     }
 
     #[Depends('testPost')]

--- a/packages/page/tests/Functional/Integration/responses/page_get.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_get_after_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get_after_restore.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_get_ghost_locale.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get_ghost_locale.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post_copy.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_copy.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post_move.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_move.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post_order.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_order.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post_publish.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_publish.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post_publish_blog.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_publish_blog.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post_restore.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_restore.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post_trigger_copy_locale.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_trigger_copy_locale.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_post_trigger_unpublish.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_trigger_unpublish.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/page/tests/Functional/Integration/responses/page_put.json
+++ b/packages/page/tests/Functional/Integration/responses/page_put.json
@@ -1,5 +1,6 @@
 {
     "_hasPermissions": false,
+    "_hash": "@string@",
     "_permissions": {
         "add": false,
         "archive": false,

--- a/packages/snippet/src/Application/MessageHandler/ModifySnippetMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/ModifySnippetMessageHandler.php
@@ -12,6 +12,7 @@
 namespace Sulu\Snippet\Application\MessageHandler;
 
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Content\Application\ContentHash\ContentHashChecker;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Snippet\Application\Mapper\SnippetMapperInterface;
@@ -30,7 +31,8 @@ final class ModifySnippetMessageHandler
         private SnippetRepositoryInterface $snippetRepository,
         /** @var iterable<SnippetMapperInterface> */
         private iterable $snippetMappers,
-        private DomainEventCollectorInterface $domainEventCollector
+        private DomainEventCollectorInterface $domainEventCollector,
+        private ContentHashChecker $contentHashChecker,
     ) {
     }
 
@@ -55,6 +57,13 @@ final class ModifySnippetMessageHandler
                     ],
                 ],
             ]
+        );
+
+        $this->contentHashChecker->checkHash(
+            $data,
+            $snippet,
+            ['locale' => $locale, 'stage' => DimensionContentInterface::STAGE_DRAFT],
+            $snippet->getId(),
         );
 
         foreach ($this->snippetMappers as $snippetMapper) {

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -148,6 +148,7 @@ final class SuluSnippetBundle extends AbstractBundle
                 new Reference('sulu_snippet.snippet_repository'),
                 tagged_iterator('sulu_snippet.snippet_mapper'),
                 new Reference('sulu_activity.domain_event_collector'),
+                new Reference('sulu_content.content_hash_checker'),
             ])
             ->tag('messenger.message_handler');
 

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -283,12 +283,18 @@ final class SnippetController implements SecuredControllerInterface
      */
     private function getData(Request $request): array
     {
-        return \array_replace(
+        $data = \array_replace(
             $request->request->all(),
             [
                 'locale' => $this->getLocale($request),
             ]
         );
+
+        if ($request->query->getBoolean('force', false)) {
+            unset($data['_hash']);
+        }
+
+        return $data;
     }
 
     public function getLocale(Request $request): string

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Depends;
 use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Bundle\TrashBundle\Domain\Repository\TrashItemRepositoryInterface;
+use Sulu\Component\Rest\Exception\RestExceptionInterface;
 use Sulu\Content\Tests\Traits\CreateTagTrait;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\UserInterface\Controller\Admin\SnippetController;
@@ -229,6 +230,25 @@ class SnippetControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
 
         $this->assertResponseSnapshot('snippet_put.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
+    public function testPutWithInvalidHashReturnsConflict(string $id): void
+    {
+        $this->client->request('PUT', '/admin/api/snippets/' . $id . '?locale=en', [], [], [], \json_encode([
+            '_hash' => 'invalid-hash',
+            'template' => 'snippet',
+            'title' => 'Test Snippet 2',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(409, $response);
+
+        /** @var array{code: int, message: string} $responseData */
+        $responseData = \json_decode((string) $response->getContent(), true);
+
+        $this->assertEquals(RestExceptionInterface::EXCEPTION_CODE_INVALID_HASH, $responseData['code']);
     }
 
     #[Depends('testPost')]

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -252,6 +252,20 @@ class SnippetControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testPutWithForceIgnoresHash(string $id): void
+    {
+        $this->client->request('PUT', '/admin/api/snippets/' . $id . '?locale=en&force=true', [], [], [], \json_encode([
+            '_hash' => 'invalid-hash',
+            'template' => 'snippet',
+            'title' => 'Test Snippet 2',
+        ]) ?: null);
+
+        $response = $this->client->getResponse();
+
+        $this->assertHttpStatusCode(200, $response);
+    }
+
+    #[Depends('testPost')]
     #[Depends('testPut')]
     public function testGetList(): void
     {

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_get.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_get.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_get_after_restore.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_get_after_restore.json
@@ -1,11 +1,12 @@
 {
+    "_hash": "@string@",
+    "availableLocales": [
+        "en"
+    ],
     "changed": "@datetime@",
     "changer" : "@integer@",
     "created": "@datetime@",
     "creator" : "@integer@",
-    "availableLocales": [
-        "en"
-    ],
     "description": null,
     "excerptCategories": [],
     "excerptTags": [

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_get_ghost_locale.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_get_ghost_locale.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "availableLocales": ["en"],
     "changed": "@datetime@",
     "changer" : "@integer@",

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_publish.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_publish.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "availableLocales": [
         "en",
         "de"

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_trigger_copy_locale.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_trigger_copy_locale.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "availableLocales": [
         "en",
         "de"

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_trigger_unpublish.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_trigger_unpublish.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_put.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_put.json
@@ -1,4 +1,5 @@
 {
+    "_hash": "@string@",
     "availableLocales": [
         "en",
         "de"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32343,19 +32343,25 @@ parameters:
 		-
 			message: '#^Call to an undefined method DateTimeImmutable\:\:willReturn\(\)\.$#'
 			identifier: method.notFound
-			count: 4
+			count: 7
 			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
 
 		-
 			message: '#^Call to an undefined method Sulu\\Component\\Persistence\\Model\\AuditableInterface\:\:reveal\(\)\.$#'
 			identifier: method.notFound
-			count: 5
+			count: 6
+			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
+
+		-
+			message: '#^Call to an undefined method Sulu\\Content\\Domain\\Model\\AuditableInterface\:\:reveal\(\)\.$#'
+			identifier: method.notFound
+			count: 3
 			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
 
 		-
 			message: '#^Call to an undefined method Sulu\\Component\\Security\\Authentication\\UserInterface\:\:reveal\(\)\.$#'
 			identifier: method.notFound
-			count: 3
+			count: 6
 			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
 
 		-
@@ -32367,13 +32373,13 @@ parameters:
 		-
 			message: '#^Cannot call method willReturn\(\) on Sulu\\Component\\Security\\Authentication\\UserInterface\|null\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 7
 			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
 
 		-
 			message: '#^Cannot call method willReturn\(\) on int\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 6
 			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
 
 		-
@@ -32409,19 +32415,25 @@ parameters:
 		-
 			message: '#^PHPDoc tag @var with type Sulu\\Component\\Persistence\\Model\\AuditableInterface is not subtype of native type Prophecy\\Prophecy\\ObjectProphecy\.$#'
 			identifier: varTag.nativeType
-			count: 4
+			count: 5
 			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
 
 		-
 			message: '#^PHPDoc tag @var with type Sulu\\Component\\Security\\Authentication\\UserInterface is not subtype of native type Prophecy\\Prophecy\\ObjectProphecy\.$#'
 			identifier: varTag.nativeType
-			count: 3
+			count: 6
+			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
+
+		-
+			message: '#^PHPDoc tag @var with type Sulu\\Content\\Domain\\Model\\AuditableInterface is not subtype of native type Prophecy\\Prophecy\\ObjectProphecy\.$#'
+			identifier: varTag.nativeType
+			count: 2
 			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
 
 		-
 			message: '#^Parameter \#1 \$object of method Sulu\\Component\\Hash\\AuditableHasher\:\:hash\(\) expects object, mixed given\.$#'
 			identifier: argument.type
-			count: 5
+			count: 9
 			path: src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
 
 		-

--- a/src/Sulu/Component/Hash/AuditableHasher.php
+++ b/src/Sulu/Component/Hash/AuditableHasher.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Hash;
 
 use Sulu\Component\Persistence\Model\AuditableInterface;
+use Sulu\Content\Domain\Model\AuditableInterface as ContentAuditableInterface;
 
 /**
  * Hashes objects by serializing and hashing them using the internal PHP functions.
@@ -20,7 +21,7 @@ class AuditableHasher implements HasherInterface
 {
     public function hash($object)
     {
-        if ($object instanceof AuditableInterface) {
+        if ($object instanceof AuditableInterface || $object instanceof ContentAuditableInterface) {
             return \md5(
                 ($object->getChanger() ? $object->getChanger()->getId() : '')
                 . ($object->getChanged() ? $object->getChanged()->getTimestamp() : '')

--- a/src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
+++ b/src/Sulu/Component/Hash/Tests/AuditableHasherTest.php
@@ -16,6 +16,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Hash\AuditableHasher;
 use Sulu\Component\Persistence\Model\AuditableInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Sulu\Content\Domain\Model\AuditableInterface as ContentAuditableInterface;
 
 class AuditableHasherTest extends TestCase
 {
@@ -89,5 +90,41 @@ class AuditableHasherTest extends TestCase
         $object->getChanged()->willReturn(new \DateTimeImmutable('2016-02-05'));
 
         $this->assertIsString($this->hasher->hash($object->reveal()));
+    }
+
+    public function testHashSameContentObject(): void
+    {
+        /** @var ContentAuditableInterface $object */
+        $object = $this->prophesize(ContentAuditableInterface::class);
+        /** @var UserInterface $user */
+        $user = $this->prophesize(UserInterface::class);
+        $user->getId()->willReturn(1);
+        $object->getChanger()->willReturn($user->reveal());
+        $object->getChanged()->willReturn(new \DateTimeImmutable('2016-02-05'));
+
+        $this->assertSame($this->hasher->hash($object->reveal()), $this->hasher->hash($object->reveal()));
+    }
+
+    public function testHashContentObjectProducesSameResultAsClassicObject(): void
+    {
+        $changed = new \DateTimeImmutable('2016-02-05');
+
+        /** @var AuditableInterface $classic */
+        $classic = $this->prophesize(AuditableInterface::class);
+        /** @var UserInterface $user1 */
+        $user1 = $this->prophesize(UserInterface::class);
+        $user1->getId()->willReturn(1);
+        $classic->getChanger()->willReturn($user1->reveal());
+        $classic->getChanged()->willReturn($changed);
+
+        /** @var ContentAuditableInterface $content */
+        $content = $this->prophesize(ContentAuditableInterface::class);
+        /** @var UserInterface $user2 */
+        $user2 = $this->prophesize(UserInterface::class);
+        $user2->getId()->willReturn(1);
+        $content->getChanger()->willReturn($user2->reveal());
+        $content->getChanged()->willReturn($changed);
+
+        $this->assertSame($this->hasher->hash($classic->reveal()), $this->hasher->hash($content->reveal()));
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

A `_hash` field is now included in every content API response for pages, articles, and snippets using the new content architecture. The `ContentHashChecker` validates that hash on write operations, rejecting the request with an `InvalidHashException` if the content has been modified since the client last loaded it. The `AuditableHasher` is extended to also support the content-package `AuditableInterface` so the same hashing strategy applies across the architectures.

#### Why?

Optimistic locking via `_hash` was already present in Sulu 2.6 but was not carried over when the new content architecture was introduced in 3.0. This PR restores the behavior so concurrent edits to pages, articles, and snippets built on the new architecture are detected and rejected in the same way as they were before.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md