### PR TITLE
Fix page-assigned segment switching

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Webspace/PageSegmentListener.php
+++ b/packages/page/src/Infrastructure/Sulu/Webspace/PageSegmentListener.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Webspace;
+
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Segment;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class PageSegmentListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private RequestAnalyzerInterface $requestAnalyzer,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        // Run after the routing listener (priority 32) so the matched page
+        // is available on the request as the "object" attribute, but before
+        // controller resolution and template rendering.
+        return [
+            KernelEvents::REQUEST => [['onKernelRequest', 6]],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        $object = $request->attributes->get('object');
+        if (!$object instanceof PageDimensionContentInterface) {
+            return;
+        }
+
+        $pageSegmentKey = $object->getExcerptSegment();
+        if (null === $pageSegmentKey || '' === $pageSegmentKey) {
+            return;
+        }
+
+        $requestAttributes = $request->attributes->get('_sulu');
+        if (!$requestAttributes instanceof RequestAttributes) {
+            return;
+        }
+
+        $webspace = $requestAttributes->getAttribute('webspace');
+        if (!$webspace instanceof Webspace) {
+            return;
+        }
+
+        if (null === $webspace->getSegment($pageSegmentKey)) {
+            // The page is assigned to a segment that no longer exists in the
+            // webspace configuration; do not change the active segment.
+            return;
+        }
+
+        $currentSegment = $requestAttributes->getAttribute('segment');
+        if ($currentSegment instanceof Segment && $currentSegment->getKey() === $pageSegmentKey) {
+            return;
+        }
+
+        $this->requestAnalyzer->changeSegment($pageSegmentKey);
+    }
+}

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -83,6 +83,7 @@ use Sulu\Page\Infrastructure\Sulu\Security\PageDescendantSecurityListener;
 use Sulu\Page\Infrastructure\Sulu\Security\PageSecurityListener;
 use Sulu\Page\Infrastructure\Sulu\Sitemap\PagesSitemapProvider;
 use Sulu\Page\Infrastructure\Sulu\Trash\PageTrashItemHandler;
+use Sulu\Page\Infrastructure\Sulu\Webspace\PageSegmentListener;
 use Sulu\Page\Infrastructure\Symfony\DependencyInjection\Compiler\OverrideTreeListenerPass;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\ContentPathTwigExtension;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension;
@@ -664,6 +665,13 @@ final class SuluPageBundle extends AbstractBundle
             ->class(PageSecurityListener::class)
             ->args([
                 new Reference('sulu_security.security_checker', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+            ])
+            ->tag('kernel.event_subscriber');
+
+        $services->set('sulu_page.page_segment_listener')
+            ->class(PageSegmentListener::class)
+            ->args([
+                new Reference('sulu_core.webspace.request_analyzer'),
             ])
             ->tag('kernel.event_subscriber');
 

--- a/packages/page/tests/Application/config/webspaces/sulu-segments.io.xml
+++ b/packages/page/tests/Application/config/webspaces/sulu-segments.io.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>Sulu Segments</name>
+    <key>sulu-segments-io</key>
+
+    <localizations>
+        <localization language="en" default="true"/>
+    </localizations>
+
+    <segments>
+        <segment key="business" default="true">
+            <meta>
+                <title lang="en">Business</title>
+            </meta>
+        </segment>
+        <segment key="private">
+            <meta>
+                <title lang="en">Private</title>
+            </meta>
+        </segment>
+    </segments>
+
+    <default-templates>
+        <default-template type="homepage">homepage</default-template>
+        <default-template type="page">default</default-template>
+    </default-templates>
+
+    <templates>
+        <template type="search">search/search</template>
+    </templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Main Navigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>Sulu Segments Portal</name>
+            <key>sulu_segments_portal</key>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url>{host}/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="stage">
+                    <urls>
+                        <url>{host}/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="test">
+                    <urls>
+                        <url>sulu-segments.io/{localization}</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url>sulu-segments.io/{localization}</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Admin/AdminConfigControllerTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Admin/AdminConfigControllerTest.php
@@ -42,7 +42,7 @@ class AdminConfigControllerTest extends SuluTestCase
         $this->assertSnapshot('sulu_page_admin_config.json', \json_encode($suluPageData, \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT));
 
         $this->assertSame(
-            ['blog', 'sulu-io', 'sulu-test-secure', 'aaa-sorted-io'],
+            ['blog', 'sulu-io', 'sulu-segments-io', 'sulu-test-secure', 'aaa-sorted-io'],
             \array_keys($suluPageData['webspaces']),
         );
     }

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Admin/snapshots/sulu_page_admin_config.json
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Admin/snapshots/sulu_page_admin_config.json
@@ -185,6 +185,80 @@
                 }
             ]
         },
+        "sulu-segments-io": {
+            "name": "Sulu Segments",
+            "key": "sulu-segments-io",
+            "localizations": [
+                {
+                    "locale": "en",
+                    "language": "en",
+                    "country": "",
+                    "shadow": "",
+                    "children": [],
+                    "parent": null,
+                    "default": true
+                }
+            ],
+            "theme": null,
+            "security": null,
+            "defaultTemplates": {
+                "homepage": "homepage",
+                "home": "homepage",
+                "page": "default"
+            },
+            "portalInformation": [
+                [],
+                []
+            ],
+            "urls": [
+                {
+                    "language": "",
+                    "country": "",
+                    "segment": "",
+                    "redirect": "",
+                    "main": true,
+                    "url": "sulu-segments.io\/{localization}",
+                    "environment": "test"
+                }
+            ],
+            "customUrls": [],
+            "navigations": [
+                {
+                    "key": "main",
+                    "title": "Main Navigation"
+                }
+            ],
+            "segments": [
+                {
+                    "key": "business",
+                    "title": "Business",
+                    "default": true
+                },
+                {
+                    "key": "private",
+                    "title": "Private",
+                    "default": false
+                }
+            ],
+            "resourceLocatorStrategy": {
+                "inputType": "leaf"
+            },
+            "_permissions": {
+                "view": false,
+                "add": false,
+                "edit": false,
+                "delete": false,
+                "archive": false,
+                "live": false,
+                "security": false
+            },
+            "allLocalizations": [
+                {
+                    "localization": "en",
+                    "name": "en"
+                }
+            ]
+        },
         "sulu-test-secure": {
             "name": "Sulu Test Secure",
             "key": "sulu-test-secure",

--- a/packages/page/tests/Functional/Integration/PageSegmentRoutingTest.php
+++ b/packages/page/tests/Functional/Integration/PageSegmentRoutingTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Segment;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+#[CoversNothing]
+class PageSegmentRoutingTest extends SuluTestCase
+{
+    use CreatePageTrait;
+
+    private const WEBSPACE_KEY = 'sulu-segments-io';
+    private const HOST = 'sulu-segments.io';
+
+    private KernelBrowser $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createWebsiteClient();
+        self::purgeDatabase();
+    }
+
+    public function testNoCookiePageWithoutSegmentUsesDefaultSegment(): void
+    {
+        self::createPage(
+            [
+                'en' => [
+                    'live' => [
+                        'title' => 'Plain Page',
+                        'url' => '/plain-page',
+                        'template' => 'default',
+                    ],
+                ],
+            ],
+            self::WEBSPACE_KEY,
+        );
+
+        self::getEntityManager()->clear();
+
+        $this->client->request('GET', 'http://' . self::HOST . '/en/plain-page');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSegmentKey('business');
+    }
+
+    public function testNoCookiePageAssignedToNonDefaultSegmentSwitchesSegment(): void
+    {
+        self::createPage(
+            [
+                'en' => [
+                    'live' => [
+                        'title' => 'Private Page',
+                        'url' => '/private-page',
+                        'template' => 'default',
+                        'excerptSegment' => 'private',
+                    ],
+                ],
+            ],
+            self::WEBSPACE_KEY,
+        );
+
+        self::getEntityManager()->clear();
+
+        $this->client->request('GET', 'http://' . self::HOST . '/en/private-page');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSegmentKey('private');
+        $this->assertResponseSetsSegmentCookie('private');
+    }
+
+    public function testCookieMismatchPageAssignedToDifferentSegmentOverridesCookie(): void
+    {
+        self::createPage(
+            [
+                'en' => [
+                    'live' => [
+                        'title' => 'Private Page',
+                        'url' => '/private-page',
+                        'template' => 'default',
+                        'excerptSegment' => 'private',
+                    ],
+                ],
+            ],
+            self::WEBSPACE_KEY,
+        );
+
+        self::getEntityManager()->clear();
+
+        $this->client->getCookieJar()->set(
+            new \Symfony\Component\BrowserKit\Cookie('_ss', 'business', null, '/', self::HOST)
+        );
+
+        $this->client->request('GET', 'http://' . self::HOST . '/en/private-page');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSegmentKey('private');
+        $this->assertResponseSetsSegmentCookie('private');
+    }
+
+    public function testCookieMatchesPageSegmentNoCookieRewrite(): void
+    {
+        self::createPage(
+            [
+                'en' => [
+                    'live' => [
+                        'title' => 'Private Page',
+                        'url' => '/private-page',
+                        'template' => 'default',
+                        'excerptSegment' => 'private',
+                    ],
+                ],
+            ],
+            self::WEBSPACE_KEY,
+        );
+
+        self::getEntityManager()->clear();
+
+        $this->client->getCookieJar()->set(
+            new \Symfony\Component\BrowserKit\Cookie('_ss', 'private', null, '/', self::HOST)
+        );
+
+        $this->client->request('GET', 'http://' . self::HOST . '/en/private-page');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSegmentKey('private');
+        $this->assertNoSegmentCookieRewrite();
+    }
+
+    private function assertSegmentKey(string $expectedSegmentKey): void
+    {
+        $request = $this->client->getRequest();
+        $suluAttributes = $request->attributes->get('_sulu');
+
+        $this->assertInstanceOf(
+            RequestAttributes::class,
+            $suluAttributes,
+            'Expected the request to carry the _sulu RequestAttributes set by the RequestAnalyzer.',
+        );
+
+        $segment = $suluAttributes->getAttribute('segment');
+
+        $this->assertInstanceOf(
+            Segment::class,
+            $segment,
+            \sprintf('Expected the request to be associated with the "%s" segment, got null.', $expectedSegmentKey),
+        );
+
+        $this->assertSame(
+            $expectedSegmentKey,
+            $segment->getKey(),
+            \sprintf(
+                'Expected RequestAnalyzer->getSegment() to return "%s" because the matched page is assigned to that segment, but got "%s".',
+                $expectedSegmentKey,
+                $segment->getKey(),
+            ),
+        );
+    }
+
+    private function assertResponseSetsSegmentCookie(string $expectedValue): void
+    {
+        $cookies = $this->client->getResponse()->headers->getCookies();
+
+        foreach ($cookies as $cookie) {
+            if ('_ss' === $cookie->getName()) {
+                $this->assertSame(
+                    $expectedValue,
+                    $cookie->getValue(),
+                    'Expected response to set the segment cookie to the page-assigned segment.',
+                );
+
+                return;
+            }
+        }
+
+        $this->fail(\sprintf(
+            'Expected the response to set a "_ss" cookie with value "%s" so that subsequent requests use the page-assigned segment, but no such cookie was set.',
+            $expectedValue,
+        ));
+    }
+
+    private function assertNoSegmentCookieRewrite(): void
+    {
+        $cookies = $this->client->getResponse()->headers->getCookies();
+
+        foreach ($cookies as $cookie) {
+            if ('_ss' === $cookie->getName()) {
+                $this->fail(\sprintf(
+                    'Expected no "_ss" cookie rewrite when the existing cookie already matches the page-assigned segment, but the response set "_ss=%s".',
+                    (string) $cookie->getValue(),
+                ));
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

This PR introduces `PageSegmentListener`, a `KernelEvents::REQUEST` subscriber (priority 6) that reads the `excerptSegment` assigned to the matched page and calls `RequestAnalyzer::changeSegment()` when it differs from the segment resolved by the cookie. The listener is registered as a service in `SuluPageBundle` and replaces the implicit segment switching that previously lived in the route providers. A new test webspace (`sulu-segments-io`) with `business` and `private` segments is added along with four integration test cases that cover the no-cookie, cookie-mismatch, and cookie-match scenarios.

#### Why?

In Sulu 2.6 the segment switching was handled inside `ContentRouteProvider` and `RouteBundle\RouteProvider`, which inspected the matched document's `excerpt.segments` data and called `changeSegment()` as a side effect of route resolution. When page routing was extracted into the standalone `packages/page` package in 3.0, this logic was not carried over, so pages assigned to a non-default segment via `excerptSegment` no longer switched the active segment for the request.