### PR TITLE
Add missing bundles to SuluTestKernel

### DIFF
--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -72,6 +72,8 @@ class SuluTestKernel extends SuluKernel
             new \Sulu\Content\Infrastructure\Symfony\HttpKernel\SuluContentBundle(),
             new \Sulu\Page\Infrastructure\Symfony\HttpKernel\SuluPageBundle(),
             new \Sulu\Search\Infrastructure\Symfony\HttpKernel\SuluSearchBundle(),
+            new \Sulu\Snippet\Infrastructure\Symfony\HttpKernel\SuluSnippetBundle(),
+            new \Sulu\Article\Infrastructure\Symfony\HttpKernel\SuluArticleBundle(),
         ];
 
         if (\class_exists(\Symfony\Bundle\MonologBundle\MonologBundle::class)) {

--- a/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
+++ b/src/Sulu/Bundle/TestBundle/Kernel/SuluTestKernel.php
@@ -73,7 +73,6 @@ class SuluTestKernel extends SuluKernel
             new \Sulu\Page\Infrastructure\Symfony\HttpKernel\SuluPageBundle(),
             new \Sulu\Search\Infrastructure\Symfony\HttpKernel\SuluSearchBundle(),
             new \Sulu\Snippet\Infrastructure\Symfony\HttpKernel\SuluSnippetBundle(),
-            new \Sulu\Article\Infrastructure\Symfony\HttpKernel\SuluArticleBundle(),
         ];
 
         if (\class_exists(\Symfony\Bundle\MonologBundle\MonologBundle::class)) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | #8816
| Related issues/PRs | #8816
| License | MIT
| Documentation PR | 

#### What's in this PR?

This PR adds the SuluSnippetBundle as well as the SuluArticleBundle into the SuluTestKernel, so that applications automatically can run their tests in "real world" environments, without the need to add the bundles manually to their own TestKernels.

#### Why?

It is nearer to the real world, when those bundles are automatically present in the test environment. 
As pointed out in the issue, these bundles might have been forgotten during migration.


