### PR TITLE
Fix php doc for LinkConfigurationBuilder setTarget

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfiguration.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfiguration.php
@@ -58,7 +58,7 @@ class LinkConfiguration
     private $icon;
 
     /**
-     * @var string[]
+     * @var list<string>
      */
     #[Groups(['frontend'])]
     private $targets = [
@@ -69,7 +69,7 @@ class LinkConfiguration
     ];
 
     /**
-     * @param array<string>|null $targets
+     * @param list<string>|null $targets
      */
     public function __construct(
         string $title,

--- a/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfigurationBuilder.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/Link/LinkConfigurationBuilder.php
@@ -49,7 +49,7 @@ class LinkConfigurationBuilder
     private $icon;
 
     /**
-     * @var ?array<string, string>
+     * @var list<string>|null
      */
     private $targets = null;
 
@@ -114,7 +114,7 @@ class LinkConfigurationBuilder
     }
 
     /**
-     * @param array<string, string> $targets
+     * @param list<string> $targets
      */
     public function setTargets(array $targets): self
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Noticed a small bug in the php-docs for setTarget of the LinkConfigurationBuilder while testing and updating the docs: https://github.com/sulu/sulu-docs/pull/911
