### PR TITLE
Clean live workspace orphans for unpublished locales

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -296,11 +296,15 @@ class PHPCRCleanupSingleNodeCommand extends Command
                 $defaultSessionModified = false;
             }
 
-            if ($wasPublished) {
-                $liveNode = $this->liveSession->getNode($node->getPath());
+            // Sweep live workspace whenever it holds data for the locale, not only
+            // when currently published; otherwise schema leftovers survive in live.
+            $liveNodeForCleanup = $this->getLiveNodeByPathOrNull($node->getPath());
+            if (null !== $liveNodeForCleanup && $this->hasLocalizedProperties($liveNodeForCleanup, $locale)) {
                 /** @var string[] $writtenProperties */
-                $writtenProperties = $liveCleanupNode->getWrittenPropertyKeys();
-                foreach ($this->cleanupNode($liveNode, $locale, $writtenProperties, $dryRun) as $result) {
+                $writtenProperties = null !== $liveCleanupNode
+                    ? $liveCleanupNode->getWrittenPropertyKeys()
+                    : $defaultCleanupNode->getWrittenPropertyKeys();
+                foreach ($this->cleanupNode($liveNodeForCleanup, $locale, $writtenProperties, $dryRun) as $result) {
                     ++$stats['properties'];
                     $stats['removedProperties'] += $result ? 1 : 0;
                 }
@@ -518,6 +522,21 @@ class PHPCRCleanupSingleNodeCommand extends Command
         $this->cachedLocalesByWebspaces ??= $this->webspaceManager->getAllLocalesByWebspaces();
 
         return \array_keys($this->cachedLocalesByWebspaces[$key] ?? []);
+    }
+
+    /**
+     * Returns true if the node has at least one property localized for the given locale.
+     */
+    public function hasLocalizedProperties(NodeInterface $node, string $locale): bool
+    {
+        $prefix = $this->languagePrefix . ':' . $locale . '-';
+        foreach ($node->getProperties() as $property) {
+            if (\str_starts_with($property->getName(), $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Command/PHPCRCleanupSingleNodeCommand.php
@@ -529,11 +529,8 @@ class PHPCRCleanupSingleNodeCommand extends Command
      */
     public function hasLocalizedProperties(NodeInterface $node, string $locale): bool
     {
-        $prefix = $this->languagePrefix . ':' . $locale . '-';
-        foreach ($node->getProperties() as $property) {
-            if (\str_starts_with($property->getName(), $prefix)) {
-                return true;
-            }
+        foreach ($node->getProperties($this->languagePrefix . ':' . $locale . '-*') as $property) {
+            return true;
         }
 
         return false;

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
@@ -23,6 +23,8 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Command\PHPCRCleanupSingleNodeCommand;
+use Sulu\Component\Content\Document\Behavior\WorkflowStageBehavior;
+use Sulu\Component\Content\Document\WorkflowStage;
 use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
 use Sulu\Component\DocumentManager\Behavior\Mapping\UuidBehavior;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
@@ -263,6 +265,158 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
         $node->hasProperty('i18n:de-shadow-on')->willReturn(false);
 
         $result = $this->command->cleanInvalidShadowReferences($node->reveal(), ['en', 'de'], false);
+
+        $this->assertSame(0, $result);
+    }
+
+    public function testHasLocalizedPropertiesReturnsTrueWhenLocaleMatches(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        $matching = $this->prophesize(PropertyInterface::class);
+        $matching->getName()->willReturn('i18n:de-content-blocks#0-description#2');
+
+        $otherLocale = $this->prophesize(PropertyInterface::class);
+        $otherLocale->getName()->willReturn('i18n:en-template');
+
+        $node->getProperties()->willReturn([
+            $otherLocale->reveal(),
+            $matching->reveal(),
+        ]);
+
+        $this->assertTrue($this->command->hasLocalizedProperties($node->reveal(), 'de'));
+    }
+
+    public function testHasLocalizedPropertiesReturnsFalseWhenNoMatch(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+
+        $otherLocale = $this->prophesize(PropertyInterface::class);
+        $otherLocale->getName()->willReturn('i18n:en-template');
+
+        $unlocalized = $this->prophesize(PropertyInterface::class);
+        $unlocalized->getName()->willReturn('sulu:order');
+
+        $node->getProperties()->willReturn([
+            $otherLocale->reveal(),
+            $unlocalized->reveal(),
+        ]);
+
+        $this->assertFalse($this->command->hasLocalizedProperties($node->reveal(), 'de'));
+    }
+
+    public function testHasLocalizedPropertiesReturnsFalseForEmptyNode(): void
+    {
+        $node = $this->prophesize(NodeInterface::class);
+        $node->getProperties()->willReturn([]);
+
+        $this->assertFalse($this->command->hasLocalizedProperties($node->reveal(), 'de'));
+    }
+
+    public function testExecuteCleansLiveWorkspaceForUnpublishedDocument(): void
+    {
+        $path = '/cmf/sulu_io/contents/page-1';
+
+        $defaultNode = $this->prophesize(NodeInterface::class);
+        $defaultNode->getPath()->willReturn($path);
+
+        $nodeType = $this->prophesize(NodeTypeInterface::class);
+        $nodeType->getName()->willReturn('sulu:page');
+        $defaultNode->getMixinNodeTypes()->willReturn([$nodeType->reveal()]);
+
+        $defaultTemplateProp = $this->prophesize(PropertyInterface::class);
+        $defaultTemplateProp->getName()->willReturn('i18n:en-template');
+        $defaultTemplateProp->remove()->shouldBeCalled();
+        $defaultNode->getProperties()->willReturn([$defaultTemplateProp->reveal()]);
+
+        $defaultWorkspace = $this->prophesize(WorkspaceInterface::class);
+        $defaultWorkspace->getName()->willReturn('default');
+        $this->session->getWorkspace()->willReturn($defaultWorkspace->reveal());
+        $defaultNode->getSession()->willReturn($this->session->reveal());
+
+        $liveNode = $this->prophesize(NodeInterface::class);
+        $liveNode->getPath()->willReturn($path);
+
+        $liveTemplateProp = $this->prophesize(PropertyInterface::class);
+        $liveTemplateProp->getName()->willReturn('i18n:en-template');
+        $liveTemplateProp->remove()->shouldBeCalled();
+
+        // Orphan from a previous schema; live sweep must remove it even though unpublished.
+        $liveOrphanProp = $this->prophesize(PropertyInterface::class);
+        $liveOrphanProp->getName()->willReturn('i18n:en-content-blocks#0-description#2');
+        $liveOrphanProp->remove()->shouldBeCalled();
+
+        $liveNode->getProperties()->willReturn([
+            $liveTemplateProp->reveal(),
+            $liveOrphanProp->reveal(),
+        ]);
+
+        $liveWorkspace = $this->prophesize(WorkspaceInterface::class);
+        $liveWorkspace->getName()->willReturn('default_live');
+        $this->liveSession->getWorkspace()->willReturn($liveWorkspace->reveal());
+        $liveNode->getSession()->willReturn($this->liveSession->reveal());
+
+        $this->session->getNodeByIdentifier('uuid-1')->willReturn($defaultNode->reveal());
+        $this->liveSession->getNode($path)->willReturn($liveNode->reveal());
+        $this->session->save()->shouldBeCalled();
+        $this->liveSession->save()->shouldBeCalled();
+
+        $this->structureMetadataFactory->hasStructuresFor('page')->willReturn(true);
+        $this->webspaceManager->getAllLocalesByWebspaces()->willReturn([
+            'sulu_io' => ['en' => new Localization('en')],
+        ]);
+
+        $document = new class() implements UuidBehavior, WorkflowStageBehavior {
+            public function getUuid()
+            {
+                return 'uuid-1';
+            }
+
+            public function getWorkflowStage()
+            {
+                return WorkflowStage::TEST;
+            }
+
+            public function setWorkflowStage($workflowStage)
+            {
+                return $this;
+            }
+
+            public function getPublished()
+            {
+                return null;
+            }
+        };
+        $this->documentManager->find('uuid-1', 'en')->willReturn($document);
+
+        $command = new class(
+            $this->liveSession->reveal(),
+            $this->session->reveal(),
+            $this->structureMetadataFactory->reveal(),
+            $this->namespaceRegistry->reveal(),
+            $this->eventDispatcher->reveal(),
+            $this->documentManager->reveal(),
+            [['phpcr_type' => 'sulu:page', 'alias' => 'page']],
+            $this->webspaceManager->reveal(),
+        ) extends PHPCRCleanupSingleNodeCommand {
+            // Stub out stale-locale and shadow handling; covered by their own tests.
+            public function removeStaleLocaleProperties(NodeInterface $node, array $staleLocales, bool $dryRun): int
+            {
+                return 0;
+            }
+
+            /**
+             * @param string[] $validLocales
+             */
+            public function cleanInvalidShadowReferences(NodeInterface $node, array $validLocales, bool $dryRun): int
+            {
+                return 0;
+            }
+        };
+
+        $result = $command->run(new ArrayInput([
+            'node' => ['uuid-1'],
+        ]), new BufferedOutput());
 
         $this->assertSame(0, $result);
     }

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Command/PHPCRCleanupSingleNodeCommandTest.php
@@ -274,15 +274,8 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
         $node = $this->prophesize(NodeInterface::class);
 
         $matching = $this->prophesize(PropertyInterface::class);
-        $matching->getName()->willReturn('i18n:de-content-blocks#0-description#2');
 
-        $otherLocale = $this->prophesize(PropertyInterface::class);
-        $otherLocale->getName()->willReturn('i18n:en-template');
-
-        $node->getProperties()->willReturn([
-            $otherLocale->reveal(),
-            $matching->reveal(),
-        ]);
+        $node->getProperties('i18n:de-*')->willReturn([$matching->reveal()]);
 
         $this->assertTrue($this->command->hasLocalizedProperties($node->reveal(), 'de'));
     }
@@ -290,17 +283,7 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
     public function testHasLocalizedPropertiesReturnsFalseWhenNoMatch(): void
     {
         $node = $this->prophesize(NodeInterface::class);
-
-        $otherLocale = $this->prophesize(PropertyInterface::class);
-        $otherLocale->getName()->willReturn('i18n:en-template');
-
-        $unlocalized = $this->prophesize(PropertyInterface::class);
-        $unlocalized->getName()->willReturn('sulu:order');
-
-        $node->getProperties()->willReturn([
-            $otherLocale->reveal(),
-            $unlocalized->reveal(),
-        ]);
+        $node->getProperties('i18n:de-*')->willReturn([]);
 
         $this->assertFalse($this->command->hasLocalizedProperties($node->reveal(), 'de'));
     }
@@ -308,7 +291,7 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
     public function testHasLocalizedPropertiesReturnsFalseForEmptyNode(): void
     {
         $node = $this->prophesize(NodeInterface::class);
-        $node->getProperties()->willReturn([]);
+        $node->getProperties('i18n:de-*')->willReturn([]);
 
         $this->assertFalse($this->command->hasLocalizedProperties($node->reveal(), 'de'));
     }
@@ -350,6 +333,10 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
             $liveTemplateProp->reveal(),
             $liveOrphanProp->reveal(),
         ]);
+        $liveNode->getProperties('i18n:en-*')->willReturn([
+            $liveTemplateProp->reveal(),
+            $liveOrphanProp->reveal(),
+        ]);
 
         $liveWorkspace = $this->prophesize(WorkspaceInterface::class);
         $liveWorkspace->getName()->willReturn('default_live');
@@ -372,12 +359,12 @@ class PHPCRCleanupSingleNodeCommandTest extends TestCase
                 return 'uuid-1';
             }
 
-            public function getWorkflowStage()
+            public function getWorkflowStage(): int
             {
                 return WorkflowStage::TEST;
             }
 
-            public function setWorkflowStage($workflowStage)
+            public function setWorkflowStage($workflowStage): self
             {
                 return $this;
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The PHPCR cleanup command now sweeps orphan localized properties from the live workspace whenever it still holds data for a locale, not only when the document is currently published. A new helper `hasLocalizedProperties` detects that condition. When the document is unpublished, the live sweep reuses the draft persist's `writtenProperties` set as the truth reference. Tests cover the helper directly and the full processNode flow for an unpublished document with live workspace orphans.

#### Why?

The previous code only ran the cleanup on the live workspace when the document's current workflow stage was PUBLISHED. Documents that were once published and then unpublished, or had a schema change while published, kept stale localized data in the live workspace that the cleanup never reached. This caused downstream consumers like the PHPCR migration bundle to trip over leftover scalar values where a block subtree was now expected.