### PR TITLE
Add resolvable smart content view tags and categories to make Tag Names accessible like in Sulu 2.6

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -2,35 +2,21 @@
 
 ## 3.0.7
 
-### Smart content view: tags and categories restored to Sulu 2.6 shape
+### Smart content tag and category resolving is opt-in
 
-The `view.<smart_content_field>.tags` and `view.<smart_content_field>.categories` keys
-were regressed in 3.0.6 to expose raw ID arrays (reported as #8812). They are now
-restored to the Sulu 2.6 shape:
+`view.<smart_content_field>.tags` and `view.<smart_content_field>.categories` now expose the raw filter ids by default. To resolve the ids through a resource loader (for example to receive tag names or `Sulu\Bundle\CategoryBundle\Api\Category` API objects, as in Sulu 2.6), opt in via the new `tagResourceLoader` and `categoryResourceLoader` smart content `<param>` entries:
 
-- `view.<field>.tags` → list of plain tag name strings, e.g. `['Beach', 'City']`
-- `view.<field>.categories` → list of `Sulu\Bundle\CategoryBundle\Api\Category` API objects,
-  exposing `getId()`, `getKey()`, `getName()`, and the other 2.6 category fields
-
-```twig
-{# 3.0.6 (broken — printed ids, ?tags=<id> didn't match the name-based filter) #}
-{% for tagId in view.examples.tags %}
-    <a href="?tags={{ tagId }}">{{ tagId }}</a>
-{% endfor %}
-
-{# 3.0.7 — same code as 2.6 again #}
-{% for tag in view.examples.tags %}
-    <a href="?tags={{ tag }}">{{ tag }}</a>
-{% endfor %}
-
-{# 3.0.7 categories #}
-{% for category in view.examples.categories %}
-    <a href="?categories={{ category.id }}">{{ category.name }}</a>
-{% endfor %}
+```xml
+<property name="my_smart_content" type="smart_content">
+    <params>
+        <param name="provider" value="pages"/>
+        <param name="tagResourceLoader" value="tag"/>
+        <param name="categoryResourceLoader" value="category"/>
+    </params>
+</property>
 ```
 
-The URL filter handlers are unchanged: `?tags=<name>` matches tags by name and
-`?categories=<id>` matches categories by id.
+Without these params, the new `raw` resource loader is used, which keeps the ids unchanged. The HTTP cache reference store is still populated for the tag and category ids regardless of the loader choice, so renaming or removing a referenced tag or category continues to invalidate the affected pages.
 
 ### Article admin now gates the navigation and views on per-group permissions
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -2,6 +2,36 @@
 
 ## 3.0.7
 
+### Smart content view: tags and categories restored to Sulu 2.6 shape
+
+The `view.<smart_content_field>.tags` and `view.<smart_content_field>.categories` keys
+were regressed in 3.0.6 to expose raw ID arrays (reported as #8812). They are now
+restored to the Sulu 2.6 shape:
+
+- `view.<field>.tags` → list of plain tag name strings, e.g. `['Beach', 'City']`
+- `view.<field>.categories` → list of `Sulu\Bundle\CategoryBundle\Api\Category` API objects,
+  exposing `getId()`, `getKey()`, `getName()`, and the other 2.6 category fields
+
+```twig
+{# 3.0.6 (broken — printed ids, ?tags=<id> didn't match the name-based filter) #}
+{% for tagId in view.examples.tags %}
+    <a href="?tags={{ tagId }}">{{ tagId }}</a>
+{% endfor %}
+
+{# 3.0.7 — same code as 2.6 again #}
+{% for tag in view.examples.tags %}
+    <a href="?tags={{ tag }}">{{ tag }}</a>
+{% endfor %}
+
+{# 3.0.7 categories #}
+{% for category in view.examples.categories %}
+    <a href="?categories={{ category.id }}">{{ category.name }}</a>
+{% endfor %}
+```
+
+The URL filter handlers are unchanged: `?tags=<name>` matches tags by name and
+`?categories=<id>` matches categories by id.
+
 ### Article admin now gates the navigation and views on per-group permissions
 
 The `ArticleAdmin` previously gated its navigation item, per-group views, and toolbar actions (Add, Delete, Export) on the

--- a/packages/content/config/resolvers.php
+++ b/packages/content/config/resolvers.php
@@ -178,7 +178,6 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_content.smart_content_smart_resolver', SmartContentSmartResolver::class)
         ->args([
             tagged_locator('sulu_content.smart_content_provider', indexAttribute: 'type', defaultIndexMethod: 'getType'),
-            new Reference('sulu_audience_targeting.target_group_store', ContainerInterface::NULL_ON_INVALID_REFERENCE),
         ])
         ->tag('sulu_content.smart_resolver', ['type' => 'smart_content']);
 };

--- a/packages/content/config/resource-loader.php
+++ b/packages/content/config/resource-loader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sulu\Content\Application\ResourceLoader\Loader\LinkResourceLoader;
+use Sulu\Content\Application\ResourceLoader\Loader\RawResourceLoader;
 use Sulu\Content\Application\ResourceLoader\Loader\TeaserResourceLoader;
 use Sulu\Content\Application\ResourceLoader\ResourceLoaderProvider;
 use Symfony\Component\DependencyInjection\Reference;
@@ -29,4 +30,7 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_content.teaser_resource_loader', TeaserResourceLoader::class)
         ->args([new Reference('sulu_admin.teaser_manager')])
         ->tag('sulu_content.resource_loader', ['key' => 'teaser']);
+
+    $services->set('sulu_content.raw_resource_loader', RawResourceLoader::class)
+        ->tag('sulu_content.resource_loader', ['key' => RawResourceLoader::RESOURCE_LOADER_KEY]);
 };

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -324,6 +324,13 @@ readonly class ContentResolver implements ContentResolverInterface
         /** @var array<string, mixed> $viewData */
         $viewData = $resolvedContent['view'];
 
+        // view resolvables run after viewEnhancements so enhancement merges can layer on top of resolved view values
+        /** @var array<string, mixed> $viewData */
+        $viewData = $this->resolvableResourceReplacer->replaceResolvableResourcesInView(
+            $viewData,
+            $resolvedResources,
+        );
+
         $normalizedContentData = $this->contentViewDataNormalizer->normalizeContentViewData(
             $finalContent,
             $viewData,

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -325,10 +325,11 @@ readonly class ContentResolver implements ContentResolverInterface
         $viewData = $resolvedContent['view'];
 
         // view resolvables run after viewEnhancements so enhancement merges can layer on top of resolved view values
-        /** @var array<string, mixed> $viewData */
         $viewData = $this->resolvableResourceReplacer->replaceResolvableResourcesInView(
             $viewData,
             $resolvedResources,
+            1,
+            $this->maxDepth,
         );
 
         $normalizedContentData = $this->contentViewDataNormalizer->normalizeContentViewData(

--- a/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentViewResolver/ContentViewResolver.php
@@ -119,6 +119,19 @@ class ContentViewResolver implements ContentViewResolverInterface
                 // resolve array of content views
                 $resolvedContentViews = $this->resolveContentViews($content, $depth, $priorityQueue);
                 $result['content'][$name] = $resolvedContentViews['content'];
+
+                // when content is empty (e.g. smart content with zero matches) keep the outer
+                // view so filter metadata such as tags/categories/total stays exposed; otherwise
+                // the per-item resolved views take over (selection lists)
+                if ([] === $content) {
+                    $result['view'][$name] = $view;
+                    $resolvableResources = $resolvedContentViews['resolvableResources'];
+                    $this->collectViewResolvables($result['view'][$name], $depth, $resolvableResources);
+                    $result['resolvableResources'] = $resolvableResources;
+
+                    return $result;
+                }
+
                 $result['view'][$name] = $resolvedContentViews['view'];
                 $result['resolvableResources'] = $this->resolvableResourceQueueProcessor->mergeResolvableResources(
                     $result['resolvableResources'],
@@ -156,6 +169,8 @@ class ContentViewResolver implements ContentViewResolverInterface
             // Root view provides the base; per-key sub-item views take precedence on collision
             $result['view'][$name] = \array_merge($view, $result['view'][$name] ?? []);
 
+            $this->collectViewResolvables($result['view'][$name], $depth, $resolvableResources);
+
             $result['resolvableResources'] = $resolvableResources;
 
             return $result;
@@ -169,6 +184,29 @@ class ContentViewResolver implements ContentViewResolverInterface
         $result['content'][$name] = $content;
         $result['view'][$name] = $view;
 
+        $this->collectViewResolvables($result['view'][$name], $depth, $result['resolvableResources']);
+
         return $result;
+    }
+
+    /**
+     * @param array<int, array<string, array<int, array<string|int, array<string, ResolvableInterface>>>>> &$resolvableResources
+     */
+    private function collectViewResolvables(mixed $view, int $depth, array &$resolvableResources): void
+    {
+        if (!\is_array($view)) {
+            return;
+        }
+
+        foreach ($view as $entry) {
+            if ($entry instanceof ResolvableInterface) {
+                $resolvableResources[$entry->getPriority()][$entry->getResourceLoaderKey()][$depth][$entry->getId()][$entry->getMetadataIdentifier()] = $entry;
+                continue;
+            }
+
+            if (\is_array($entry)) {
+                $this->collectViewResolvables($entry, $depth, $resolvableResources);
+            }
+        }
     }
 }

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -222,4 +222,38 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
     {
         $this->referenceStore->add((string) $resourceId, $resourceKey);
     }
+
+    public function replaceResolvableResourcesInView(
+        array $view,
+        array $resolvedResources
+    ): array {
+        if (0 === \count($resolvedResources)) {
+            return $view;
+        }
+
+        return $this->replaceInViewRecursively($view, $resolvedResources);
+    }
+
+    /**
+     * @param array<int|string, mixed> $view
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentViewEnhancement: ContentView}>>> $resolvedResources
+     *
+     * @return array<int|string, mixed>
+     */
+    private function replaceInViewRecursively(array $view, array $resolvedResources): array
+    {
+        foreach ($view as $key => $value) {
+            if ($value instanceof ResolvableInterface) {
+                $resolveResult = $this->resolveValue($value, $resolvedResources);
+                $view[$key] = $resolveResult['resolved'];
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $view[$key] = $this->replaceInViewRecursively($value, $resolvedResources);
+            }
+        }
+
+        return $view;
+    }
 }

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -255,16 +255,26 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
             return $this->replaceUnresolvedWithNull($view);
         }
 
+        $onlyResolvableResources = true;
         foreach ($view as $key => $value) {
             if ($value instanceof ResolvableInterface) {
                 $resolveResult = $this->resolveValue($value, $resolvedResources);
                 $view[$key] = $resolveResult['resolved'];
                 continue;
             }
+            $onlyResolvableResources = false;
 
             if (\is_array($value)) {
                 // only increase depth for ResolvableInterface, matching replaceRecursively
                 $view[$key] = $this->replaceInViewRecursively($value, $resolvedResources, $depth, $maxDepth);
+            }
+        }
+
+        if ($onlyResolvableResources) {
+            $isList = \array_is_list($view);
+            $view = \array_filter($view, static fn ($value) => null !== $value);
+            if ($isList) {
+                $view = \array_values($view);
             }
         }
 

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -225,13 +225,18 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
 
     public function replaceResolvableResourcesInView(
         array $view,
-        array $resolvedResources
+        array $resolvedResources,
+        int $depth,
+        int $maxDepth
     ): array {
         if (0 === \count($resolvedResources)) {
             return $view;
         }
 
-        return $this->replaceInViewRecursively($view, $resolvedResources);
+        /** @var array<string, mixed> $result */
+        $result = $this->replaceInViewRecursively($view, $resolvedResources, $depth, $maxDepth);
+
+        return $result;
     }
 
     /**
@@ -240,8 +245,16 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
      *
      * @return array<int|string, mixed>
      */
-    private function replaceInViewRecursively(array $view, array $resolvedResources): array
-    {
+    private function replaceInViewRecursively(
+        array $view,
+        array $resolvedResources,
+        int $depth,
+        int $maxDepth
+    ): array {
+        if ($depth > $maxDepth) {
+            return $this->replaceUnresolvedWithNull($view);
+        }
+
         foreach ($view as $key => $value) {
             if ($value instanceof ResolvableInterface) {
                 $resolveResult = $this->resolveValue($value, $resolvedResources);
@@ -250,7 +263,8 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
             }
 
             if (\is_array($value)) {
-                $view[$key] = $this->replaceInViewRecursively($value, $resolvedResources);
+                // only increase depth for ResolvableInterface, matching replaceRecursively
+                $view[$key] = $this->replaceInViewRecursively($value, $resolvedResources, $depth, $maxDepth);
             }
         }
 

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
@@ -36,4 +36,15 @@ interface ResolvableResourceReplacerInterface
         int $depth,
         int $maxDepth
     ): array;
+
+    /**
+     * @param array<int|string, mixed> $view
+     * @param array<string, array<string|int, array<string, array{resolved: mixed, contentViewEnhancement: ContentView}>>> $resolvedResources
+     *
+     * @return array<int|string, mixed>
+     */
+    public function replaceResolvableResourcesInView(
+        array $view,
+        array $resolvedResources
+    ): array;
 }

--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerInterface.php
@@ -38,13 +38,15 @@ interface ResolvableResourceReplacerInterface
     ): array;
 
     /**
-     * @param array<int|string, mixed> $view
+     * @param array<string, mixed> $view
      * @param array<string, array<string|int, array<string, array{resolved: mixed, contentViewEnhancement: ContentView}>>> $resolvedResources
      *
-     * @return array<int|string, mixed>
+     * @return array<string, mixed>
      */
     public function replaceResolvableResourcesInView(
         array $view,
-        array $resolvedResources
+        array $resolvedResources,
+        int $depth,
+        int $maxDepth
     ): array;
 }

--- a/packages/content/src/Application/ResourceLoader/Loader/RawResourceLoader.php
+++ b/packages/content/src/Application/ResourceLoader/Loader/RawResourceLoader.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ResourceLoader\Loader;
+
+/**
+ * Returns the given ids unchanged.
+ *
+ * Useful as a default loader for properties that wrap ids in `ResolvableResource`
+ * purely to participate in the HTTP cache reference store, without resolving the
+ * id to a richer representation.
+ */
+class RawResourceLoader implements ResourceLoaderInterface
+{
+    public const RESOURCE_LOADER_KEY = 'raw';
+
+    public function load(array $ids, ?string $locale, array $params = []): array
+    {
+        return \array_combine($ids, $ids);
+    }
+
+    public static function getKey(): string
+    {
+        return self::RESOURCE_LOADER_KEY;
+    }
+}

--- a/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
+++ b/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
@@ -119,13 +119,15 @@ class SmartContentSmartResolver implements SmartResolverInterface
         $fullTotal = $smartContentProvider->countBy($countByFilters, $params);
         $total = $limit ? \min($limit, $fullTotal) : $fullTotal;
 
+        /** @var array<int|string> $valueTags */
+        $valueTags = $value['tags'] ?? [];
+
         $view = [
             'dataSource' => $filters['dataSource'],
             'includeSubFolders' => $filters['includeSubFolders'],
-            // match Sulu 2.6 shape: tags as plain name strings, categories as full CategoryWrapper API objects
-            'categories' => $this->buildCategoryResolvables($filters['categories'] ?? []),
+            'categories' => $this->buildCategoryResolvables($filters['categories']),
             'categoryOperator' => $filters['categoryOperator'],
-            'tags' => $this->buildTagResolvables($value['tags'] ?? []),
+            'tags' => $this->buildTagResolvables($valueTags),
             'tagOperator' => $filters['tagOperator'],
             'types' => $filters['types'],
             'templateKeys' => $filters['templateKeys'] ?? [],
@@ -175,17 +177,15 @@ class SmartContentSmartResolver implements SmartResolverInterface
     }
 
     /**
-     * @param mixed[] $tagIds
+     * @param array<int|string> $tagIds
      *
      * @return ResolvableResource[]
      */
     private function buildTagResolvables(array $tagIds): array
     {
-        // TagResourceLoader returns the tag name string. We pass it through unchanged
-        // so view.tags is a list of name strings (Sulu 2.6 shape, ready for ?tags=<name> URLs).
         return \array_map(
-            static fn (mixed $id): ResolvableResource => new ResolvableResource(
-                id: \is_int($id) || \is_string($id) ? $id : (string) $id,
+            static fn (int|string $id): ResolvableResource => new ResolvableResource(
+                id: $id,
                 resourceLoaderKey: TagResourceLoader::RESOURCE_LOADER_KEY,
                 priority: 0,
                 resourceKey: TagInterface::RESOURCE_KEY,
@@ -195,17 +195,15 @@ class SmartContentSmartResolver implements SmartResolverInterface
     }
 
     /**
-     * @param mixed[] $categoryIds
+     * @param int[] $categoryIds
      *
      * @return ResolvableResource[]
      */
     private function buildCategoryResolvables(array $categoryIds): array
     {
-        // CategoryResourceLoader returns the full CategoryWrapper API object (Sulu 2.6 shape).
-        // Templates access .id (for ?categories=<id> URLs) and .name, .key, etc. via the wrapper.
         return \array_map(
-            static fn (mixed $id): ResolvableResource => new ResolvableResource(
-                id: \is_int($id) || \is_string($id) ? $id : (string) $id,
+            static fn (int $id): ResolvableResource => new ResolvableResource(
+                id: $id,
                 resourceLoaderKey: CategoryResourceLoader::RESOURCE_LOADER_KEY,
                 priority: 0,
                 resourceKey: CategoryInterface::RESOURCE_KEY,

--- a/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
+++ b/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
@@ -15,12 +15,11 @@ namespace Sulu\Content\Application\SmartResolver\Resolver;
 
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
-use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader;
-use Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader\TagResourceLoader;
 use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
 use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
+use Sulu\Content\Application\ResourceLoader\Loader\RawResourceLoader;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
 /**
@@ -125,9 +124,9 @@ class SmartContentSmartResolver implements SmartResolverInterface
         $view = [
             'dataSource' => $filters['dataSource'],
             'includeSubFolders' => $filters['includeSubFolders'],
-            'categories' => $this->buildCategoryResolvables($filters['categories']),
+            'categories' => $this->buildCategoryResolvables($filters['categories'], $parameters['categoryResourceLoader'] ?? null),
             'categoryOperator' => $filters['categoryOperator'],
-            'tags' => $this->buildTagResolvables($valueTags),
+            'tags' => $this->buildTagResolvables($valueTags, $parameters['tagResourceLoader'] ?? null),
             'tagOperator' => $filters['tagOperator'],
             'types' => $filters['types'],
             'templateKeys' => $filters['templateKeys'] ?? [],
@@ -181,12 +180,14 @@ class SmartContentSmartResolver implements SmartResolverInterface
      *
      * @return ResolvableResource[]
      */
-    private function buildTagResolvables(array $tagIds): array
+    private function buildTagResolvables(array $tagIds, mixed $resourceLoaderKey): array
     {
+        $resourceLoaderKey = \is_string($resourceLoaderKey) ? $resourceLoaderKey : RawResourceLoader::RESOURCE_LOADER_KEY;
+
         return \array_map(
             static fn (int|string $id): ResolvableResource => new ResolvableResource(
                 id: $id,
-                resourceLoaderKey: TagResourceLoader::RESOURCE_LOADER_KEY,
+                resourceLoaderKey: $resourceLoaderKey,
                 priority: 0,
                 resourceKey: TagInterface::RESOURCE_KEY,
             ),
@@ -199,12 +200,14 @@ class SmartContentSmartResolver implements SmartResolverInterface
      *
      * @return ResolvableResource[]
      */
-    private function buildCategoryResolvables(array $categoryIds): array
+    private function buildCategoryResolvables(array $categoryIds, mixed $resourceLoaderKey): array
     {
+        $resourceLoaderKey = \is_string($resourceLoaderKey) ? $resourceLoaderKey : RawResourceLoader::RESOURCE_LOADER_KEY;
+
         return \array_map(
             static fn (int $id): ResolvableResource => new ResolvableResource(
                 id: $id,
-                resourceLoaderKey: CategoryResourceLoader::RESOURCE_LOADER_KEY,
+                resourceLoaderKey: $resourceLoaderKey,
                 priority: 0,
                 resourceKey: CategoryInterface::RESOURCE_KEY,
             ),

--- a/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
+++ b/packages/content/src/Application/SmartResolver/Resolver/SmartContentSmartResolver.php
@@ -14,7 +14,12 @@ declare(strict_types=1);
 namespace Sulu\Content\Application\SmartResolver\Resolver;
 
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
+use Sulu\Bundle\CategoryBundle\Infrastructure\Sulu\Content\ResourceLoader\CategoryResourceLoader;
+use Sulu\Bundle\TagBundle\Infrastructure\Sulu\Content\ResourceLoader\TagResourceLoader;
+use Sulu\Bundle\TagBundle\Tag\TagInterface;
 use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Application\ContentResolver\Value\ResolvableResource;
 use Sulu\Content\Application\ContentResolver\Value\SmartResolvable;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
@@ -117,9 +122,10 @@ class SmartContentSmartResolver implements SmartResolverInterface
         $view = [
             'dataSource' => $filters['dataSource'],
             'includeSubFolders' => $filters['includeSubFolders'],
-            'categories' => $filters['categories'],
+            // match Sulu 2.6 shape: tags as plain name strings, categories as full CategoryWrapper API objects
+            'categories' => $this->buildCategoryResolvables($filters['categories'] ?? []),
             'categoryOperator' => $filters['categoryOperator'],
-            'tags' => $value['tags'] ?? [],
+            'tags' => $this->buildTagResolvables($value['tags'] ?? []),
             'tagOperator' => $filters['tagOperator'],
             'types' => $filters['types'],
             'templateKeys' => $filters['templateKeys'] ?? [],
@@ -166,5 +172,45 @@ class SmartContentSmartResolver implements SmartResolverInterface
     public static function getType(): string
     {
         return 'smart_content';
+    }
+
+    /**
+     * @param mixed[] $tagIds
+     *
+     * @return ResolvableResource[]
+     */
+    private function buildTagResolvables(array $tagIds): array
+    {
+        // TagResourceLoader returns the tag name string. We pass it through unchanged
+        // so view.tags is a list of name strings (Sulu 2.6 shape, ready for ?tags=<name> URLs).
+        return \array_map(
+            static fn (mixed $id): ResolvableResource => new ResolvableResource(
+                id: \is_int($id) || \is_string($id) ? $id : (string) $id,
+                resourceLoaderKey: TagResourceLoader::RESOURCE_LOADER_KEY,
+                priority: 0,
+                resourceKey: TagInterface::RESOURCE_KEY,
+            ),
+            $tagIds,
+        );
+    }
+
+    /**
+     * @param mixed[] $categoryIds
+     *
+     * @return ResolvableResource[]
+     */
+    private function buildCategoryResolvables(array $categoryIds): array
+    {
+        // CategoryResourceLoader returns the full CategoryWrapper API object (Sulu 2.6 shape).
+        // Templates access .id (for ?categories=<id> URLs) and .name, .key, etc. via the wrapper.
+        return \array_map(
+            static fn (mixed $id): ResolvableResource => new ResolvableResource(
+                id: \is_int($id) || \is_string($id) ? $id : (string) $id,
+                resourceLoaderKey: CategoryResourceLoader::RESOURCE_LOADER_KEY,
+                priority: 0,
+                resourceKey: CategoryInterface::RESOURCE_KEY,
+            ),
+            $categoryIds,
+        );
     }
 }

--- a/packages/content/tests/Application/config/templates/examples/default-example-smart-content.xml
+++ b/packages/content/tests/Application/config/templates/examples/default-example-smart-content.xml
@@ -56,6 +56,8 @@
 
             <params>
                 <param name="provider" value="examples"/>
+                <param name="tagResourceLoader" value="tag"/>
+                <param name="categoryResourceLoader" value="category"/>
             </params>
         </property>
 

--- a/packages/content/tests/Application/config/templates/examples/smart-content-tag-selection.xml
+++ b/packages/content/tests/Application/config/templates/examples/smart-content-tag-selection.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>smart-content-tag-selection</key>
+
+    <view>@ExampleTest/examples/default</view>
+    <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Smart Content with Tag Selection</title>
+        <title lang="de">Smart Content mit Tag Selection</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+            </meta>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="route">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="examples" type="smart_content">
+            <meta>
+                <title lang="en">Examples</title>
+            </meta>
+
+            <params>
+                <param name="provider" value="examples"/>
+            </params>
+        </property>
+
+        <property name="featured_tags" type="tag_selection">
+            <meta>
+                <title lang="en">Featured Tags</title>
+            </meta>
+        </property>
+    </properties>
+</template>

--- a/packages/content/tests/Application/config/templates/examples/smart-content-tag-selection.xml
+++ b/packages/content/tests/Application/config/templates/examples/smart-content-tag-selection.xml
@@ -38,6 +38,8 @@
 
             <params>
                 <param name="provider" value="examples"/>
+                <param name="tagResourceLoader" value="tag"/>
+                <param name="categoryResourceLoader" value="category"/>
             </params>
         </property>
 

--- a/packages/content/tests/Functional/Application/ContentResolver/SmartContentContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/SmartContentContentResolverTest.php
@@ -901,11 +901,9 @@ class SmartContentContentResolverTest extends SuluTestCase
         /** @var array{categories: array<int, CategoryWrapper>, categoryOperator: string} $view */
         $view = $result['view']['examples'];
         self::assertCount(2, $view['categories']);
-        self::assertInstanceOf(CategoryWrapper::class, $view['categories'][0]);
         self::assertSame($catA->getId(), $view['categories'][0]->getId());
         self::assertSame('cat-a', $view['categories'][0]->getKey());
         self::assertSame('Category A', $view['categories'][0]->getName());
-        self::assertInstanceOf(CategoryWrapper::class, $view['categories'][1]);
         self::assertSame($catB->getId(), $view['categories'][1]->getId());
         self::assertSame('OR', $view['categoryOperator']);
     }
@@ -968,7 +966,6 @@ class SmartContentContentResolverTest extends SuluTestCase
 
         /** @var array{categories: array<int, CategoryWrapper>} $view */
         $view = $result['view']['examples'];
-        self::assertInstanceOf(CategoryWrapper::class, $view['categories'][0]);
         self::assertSame($catA->getId(), $view['categories'][0]->getId());
         self::assertSame($catB->getId(), $view['categories'][1]->getId());
 

--- a/packages/content/tests/Functional/Application/ContentResolver/SmartContentContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/SmartContentContentResolverTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Functional\Application\ContentResolver;
 
+use Sulu\Bundle\CategoryBundle\Api\Category as CategoryWrapper;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
@@ -301,6 +302,36 @@ class SmartContentContentResolverTest extends SuluTestCase
         self::assertNull($view['maxPage']);
         self::assertSame(2, $view['limit']);
         self::assertNull($view['maxPerPage']);
+    }
+
+    public function testResolveSmartContentExposesTagNamesInView(): void
+    {
+        $beach = self::createTag(['name' => 'Beach']);
+        $city = self::createTag(['name' => 'City']);
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-smart-content',
+                    'title' => 'Listing',
+                    'url' => '/listing',
+                    'examples' => [
+                        'tags' => [$beach->getId(), $city->getId()],
+                        'tagOperator' => 'OR',
+                    ],
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $this->pushWebsiteRequest();
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array{tags: array<int, string>} $view */
+        $view = $result['view']['examples'];
+        self::assertSame(['Beach', 'City'], $view['tags']);
     }
 
     public function testResolveExampleSmartContentFilterByCategoriesAndTagsWithOperators(): void
@@ -712,5 +743,265 @@ class SmartContentContentResolverTest extends SuluTestCase
         $finalNext = $current['examples'] ?? null;
         $first = \is_array($finalNext) ? ($finalNext[0] ?? null) : null;
         self::assertNull($first);
+    }
+
+    public function testSmartContentViewTagsAreUsableAsUrlFilterParameter(): void
+    {
+        $beach = self::createTag(['name' => 'Beach']);
+        $city = self::createTag(['name' => 'City']);
+        static::getEntityManager()->flush();
+
+        static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Beach Article',
+                    'url' => '/beach-article',
+                    'excerptTags' => [$beach->getId()],
+                ],
+            ],
+        ]);
+        static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'City Article',
+                    'url' => '/city-article',
+                    'excerptTags' => [$city->getId()],
+                ],
+            ],
+        ]);
+        static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Untagged Article',
+                    'url' => '/untagged',
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $listing = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-smart-content',
+                    'title' => 'Listing',
+                    'url' => '/listing',
+                    'examples' => [
+                        'tags' => [$beach->getId(), $city->getId()],
+                        'tagOperator' => 'OR',
+                    ],
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $this->pushWebsiteRequest();
+        $dimensionContent = $this->contentAggregator->aggregate($listing, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array{tags: array<int, string>} $view */
+        $view = $result['view']['examples'];
+        self::assertSame(['Beach', 'City'], $view['tags']);
+
+        $tagParam = \implode(',', $view['tags']);
+
+        $detailPage = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-smart-content',
+                    'title' => 'Detail',
+                    'url' => '/detail',
+                    'examples' => [
+                        'types' => ['default'],
+                    ],
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        self::getContainer()->get('request_stack')->pop();
+        $this->pushWebsiteRequest(['tags' => $tagParam]);
+        $detailDimension = $this->contentAggregator->aggregate($detailPage, ['locale' => 'en', 'stage' => 'live']);
+        $filtered = $this->contentResolver->resolve($detailDimension);
+
+        /** @var array<int, array<string, mixed>> $items */
+        $items = $filtered['content']['examples'];
+        $titles = \array_map(static fn (array $item) => $item['title'], $items);
+        self::assertContains('Beach Article', $titles);
+        self::assertContains('City Article', $titles);
+        self::assertNotContains('Untagged Article', $titles);
+    }
+
+    public function testViewTagsAndTagSelectionContentResolveTogether(): void
+    {
+        $beach = self::createTag(['name' => 'Beach']);
+        $city = self::createTag(['name' => 'City']);
+        $mountain = self::createTag(['name' => 'Mountain']);
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'smart-content-tag-selection',
+                    'title' => 'Combo',
+                    'url' => '/combo',
+                    'examples' => [
+                        'tags' => [$beach->getId(), $city->getId()],
+                    ],
+                    'featured_tags' => [$mountain->getId(), $beach->getId()],
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $this->pushWebsiteRequest();
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        // smart_content view.tags exposes plain name strings (Sulu 2.6 shape)
+        /** @var array{tags: array<int, string>} $view */
+        $view = $result['view']['examples'];
+        self::assertSame(['Beach', 'City'], $view['tags']);
+
+        // tag_selection also resolves to plain name strings
+        /** @var array<int, string> $featured */
+        $featured = $result['content']['featured_tags'];
+        self::assertEqualsCanonicalizing(['Mountain', 'Beach'], \array_values($featured));
+    }
+
+    public function testResolveSmartContentExposesCategoryWrappersInView(): void
+    {
+        $catA = self::createCategory(['key' => 'cat-a']);
+        self::createCategoryTranslation($catA, ['title' => 'Category A']);
+        $catB = self::createCategory(['key' => 'cat-b']);
+        self::createCategoryTranslation($catB, ['title' => 'Category B']);
+        static::getEntityManager()->flush();
+
+        $page = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-smart-content',
+                    'title' => 'Listing',
+                    'url' => '/listing',
+                    'examples' => [
+                        'categories' => [$catA->getId(), $catB->getId()],
+                        'categoryOperator' => 'OR',
+                    ],
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $this->pushWebsiteRequest();
+        $dimensionContent = $this->contentAggregator->aggregate($page, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array{categories: array<int, CategoryWrapper>, categoryOperator: string} $view */
+        $view = $result['view']['examples'];
+        self::assertCount(2, $view['categories']);
+        self::assertInstanceOf(CategoryWrapper::class, $view['categories'][0]);
+        self::assertSame($catA->getId(), $view['categories'][0]->getId());
+        self::assertSame('cat-a', $view['categories'][0]->getKey());
+        self::assertSame('Category A', $view['categories'][0]->getName());
+        self::assertInstanceOf(CategoryWrapper::class, $view['categories'][1]);
+        self::assertSame($catB->getId(), $view['categories'][1]->getId());
+        self::assertSame('OR', $view['categoryOperator']);
+    }
+
+    public function testSmartContentViewCategoriesAreUsableAsUrlFilterParameter(): void
+    {
+        $catA = self::createCategory(['key' => 'cat-a']);
+        $catB = self::createCategory(['key' => 'cat-b']);
+        static::getEntityManager()->flush();
+
+        static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Cat A Article',
+                    'url' => '/cat-a-article',
+                    'excerptCategories' => [$catA->getId()],
+                ],
+            ],
+        ]);
+        static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Cat B Article',
+                    'url' => '/cat-b-article',
+                    'excerptCategories' => [$catB->getId()],
+                ],
+            ],
+        ]);
+        static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default',
+                    'title' => 'Uncategorized Article',
+                    'url' => '/uncategorized',
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $listing = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-smart-content',
+                    'title' => 'Listing',
+                    'url' => '/listing',
+                    'examples' => [
+                        'categories' => [$catA->getId(), $catB->getId()],
+                        'categoryOperator' => 'OR',
+                    ],
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        $this->pushWebsiteRequest();
+        $dimensionContent = $this->contentAggregator->aggregate($listing, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        /** @var array{categories: array<int, CategoryWrapper>} $view */
+        $view = $result['view']['examples'];
+        self::assertInstanceOf(CategoryWrapper::class, $view['categories'][0]);
+        self::assertSame($catA->getId(), $view['categories'][0]->getId());
+        self::assertSame($catB->getId(), $view['categories'][1]->getId());
+
+        // mimic the typical template pattern: build ?categories=... from the resolved wrappers
+        $categoryParam = \implode(',', \array_map(
+            static fn (CategoryWrapper $cat) => (string) $cat->getId(),
+            $view['categories'],
+        ));
+
+        $detailPage = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'default-example-smart-content',
+                    'title' => 'Detail',
+                    'url' => '/detail',
+                    'examples' => [
+                        'types' => ['default'],
+                    ],
+                ],
+            ],
+        ]);
+        static::getEntityManager()->flush();
+
+        self::getContainer()->get('request_stack')->pop();
+        $this->pushWebsiteRequest(['categories' => $categoryParam]);
+        $detailDimension = $this->contentAggregator->aggregate($detailPage, ['locale' => 'en', 'stage' => 'live']);
+        $filtered = $this->contentResolver->resolve($detailDimension);
+
+        /** @var array<int, array<string, mixed>> $items */
+        $items = $filtered['content']['examples'];
+        $titles = \array_map(static fn (array $item) => $item['title'], $items);
+        self::assertContains('Cat A Article', $titles);
+        self::assertContains('Cat B Article', $titles);
+        self::assertNotContains('Uncategorized Article', $titles);
     }
 }

--- a/packages/content/tests/Unit/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
+++ b/packages/content/tests/Unit/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Content\Tests\Unit\Application\SmartResolver\Resolver;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfiguration;
@@ -214,5 +215,62 @@ class SmartContentSmartResolverTest extends TestCase
         $view = $result->getView();
         $this->assertArrayHasKey('total', $view);
         $this->assertSame(3, $view['total']); // Since result count equals limit, total equals count
+    }
+
+    public function testResolveExposesTagsAndCategoriesAsResolvablesInView(): void
+    {
+        $smartResolvable = $this->prophesize(SmartResolvable::class);
+        $smartContentProvider = $this->prophesize(SmartContentProviderInterface::class);
+
+        $data = [
+            'value' => ['tags' => [3, 4]],
+            'filters' => [
+                'dataSource' => null,
+                'includeSubFolders' => false,
+                'categories' => [10, 11],
+                'categoryOperator' => 'OR',
+                'tagOperator' => 'OR',
+                'types' => [],
+                'typesOperator' => 'OR',
+                'websiteCategories' => [],
+                'websiteCategoryOperator' => 'OR',
+                'websiteTags' => [],
+                'websiteTagOperator' => 'OR',
+                'limit' => null,
+                'page' => 1,
+            ],
+            'sortBys' => [],
+            'parameters' => ['provider' => 'articles'],
+        ];
+
+        $smartResolvable->getData()->willReturn($data);
+
+        $this->serviceLocator->has('articles')->willReturn(true);
+        $this->serviceLocator->get('articles')->willReturn($smartContentProvider->reveal());
+
+        $smartContentProvider->findFlatBy(Argument::cetera())->willReturn([]);
+        $smartContentProvider->countBy(Argument::cetera())->willReturn(0);
+        $smartContentProvider->getResourceLoaderKey()->willReturn('articles');
+        $smartContentProvider->getConfiguration()->willReturn(new ProviderConfiguration());
+
+        $result = $this->smartResolver->resolve($smartResolvable->reveal(), 'en');
+
+        $view = $result->getView();
+
+        $this->assertCount(2, $view['tags']);
+        $this->assertInstanceOf(ResolvableResource::class, $view['tags'][0]);
+        $this->assertSame(3, $view['tags'][0]->getId());
+        $this->assertSame('tag', $view['tags'][0]->getResourceLoaderKey());
+        // no callback: the loader output (tag name string) is forwarded unchanged to the view
+        $this->assertSame('Beach', $view['tags'][0]->executeResourceCallback('Beach'));
+        $this->assertInstanceOf(ResolvableResource::class, $view['tags'][1]);
+        $this->assertSame(4, $view['tags'][1]->getId());
+
+        $this->assertCount(2, $view['categories']);
+        $this->assertInstanceOf(ResolvableResource::class, $view['categories'][0]);
+        $this->assertSame(10, $view['categories'][0]->getId());
+        $this->assertSame('category', $view['categories'][0]->getResourceLoaderKey());
+        $this->assertInstanceOf(ResolvableResource::class, $view['categories'][1]);
+        $this->assertSame(11, $view['categories'][1]->getId());
     }
 }

--- a/packages/content/tests/Unit/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
+++ b/packages/content/tests/Unit/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
@@ -255,22 +255,19 @@ class SmartContentSmartResolverTest extends TestCase
 
         $result = $this->smartResolver->resolve($smartResolvable->reveal(), 'en');
 
+        /** @var array{tags: list<ResolvableResource>, categories: list<ResolvableResource>} $view */
         $view = $result->getView();
 
         $this->assertCount(2, $view['tags']);
-        $this->assertInstanceOf(ResolvableResource::class, $view['tags'][0]);
         $this->assertSame(3, $view['tags'][0]->getId());
         $this->assertSame('tag', $view['tags'][0]->getResourceLoaderKey());
         // no callback: the loader output (tag name string) is forwarded unchanged to the view
         $this->assertSame('Beach', $view['tags'][0]->executeResourceCallback('Beach'));
-        $this->assertInstanceOf(ResolvableResource::class, $view['tags'][1]);
         $this->assertSame(4, $view['tags'][1]->getId());
 
         $this->assertCount(2, $view['categories']);
-        $this->assertInstanceOf(ResolvableResource::class, $view['categories'][0]);
         $this->assertSame(10, $view['categories'][0]->getId());
         $this->assertSame('category', $view['categories'][0]->getResourceLoaderKey());
-        $this->assertInstanceOf(ResolvableResource::class, $view['categories'][1]);
         $this->assertSame(11, $view['categories'][1]->getId());
     }
 }

--- a/packages/content/tests/Unit/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
+++ b/packages/content/tests/Unit/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
@@ -260,14 +260,69 @@ class SmartContentSmartResolverTest extends TestCase
 
         $this->assertCount(2, $view['tags']);
         $this->assertSame(3, $view['tags'][0]->getId());
-        $this->assertSame('tag', $view['tags'][0]->getResourceLoaderKey());
-        // no callback: the loader output (tag name string) is forwarded unchanged to the view
-        $this->assertSame('Beach', $view['tags'][0]->executeResourceCallback('Beach'));
+        $this->assertSame('raw', $view['tags'][0]->getResourceLoaderKey());
+        // default raw loader returns ids unchanged; resourceKey stays set for cache invalidation
+        $this->assertSame('tags', $view['tags'][0]->getResourceKey());
         $this->assertSame(4, $view['tags'][1]->getId());
 
         $this->assertCount(2, $view['categories']);
         $this->assertSame(10, $view['categories'][0]->getId());
-        $this->assertSame('category', $view['categories'][0]->getResourceLoaderKey());
+        $this->assertSame('raw', $view['categories'][0]->getResourceLoaderKey());
+        $this->assertSame('categories', $view['categories'][0]->getResourceKey());
         $this->assertSame(11, $view['categories'][1]->getId());
+    }
+
+    public function testResolveUsesExplicitTagAndCategoryResourceLoadersFromParameters(): void
+    {
+        $smartResolvable = $this->prophesize(SmartResolvable::class);
+        $smartContentProvider = $this->prophesize(SmartContentProviderInterface::class);
+
+        $data = [
+            'value' => ['tags' => [3, 4]],
+            'filters' => [
+                'dataSource' => null,
+                'includeSubFolders' => false,
+                'categories' => [10, 11],
+                'categoryOperator' => 'OR',
+                'tagOperator' => 'OR',
+                'types' => [],
+                'typesOperator' => 'OR',
+                'websiteCategories' => [],
+                'websiteCategoryOperator' => 'OR',
+                'websiteTags' => [],
+                'websiteTagOperator' => 'OR',
+                'limit' => null,
+                'page' => 1,
+            ],
+            'sortBys' => [],
+            'parameters' => [
+                'provider' => 'articles',
+                'tagResourceLoader' => 'tag',
+                'categoryResourceLoader' => 'category',
+            ],
+        ];
+
+        $smartResolvable->getData()->willReturn($data);
+
+        $this->serviceLocator->has('articles')->willReturn(true);
+        $this->serviceLocator->get('articles')->willReturn($smartContentProvider->reveal());
+
+        $smartContentProvider->findFlatBy(Argument::cetera())->willReturn([]);
+        $smartContentProvider->countBy(Argument::cetera())->willReturn(0);
+        $smartContentProvider->getResourceLoaderKey()->willReturn('articles');
+        $smartContentProvider->getConfiguration()->willReturn(new ProviderConfiguration());
+
+        $result = $this->smartResolver->resolve($smartResolvable->reveal(), 'en');
+
+        /** @var array{tags: list<ResolvableResource>, categories: list<ResolvableResource>} $view */
+        $view = $result->getView();
+
+        $this->assertCount(2, $view['tags']);
+        $this->assertSame('tag', $view['tags'][0]->getResourceLoaderKey());
+        $this->assertSame('tag', $view['tags'][1]->getResourceLoaderKey());
+
+        $this->assertCount(2, $view['categories']);
+        $this->assertSame('category', $view['categories'][0]->getResourceLoaderKey());
+        $this->assertSame('category', $view['categories'][1]->getResourceLoaderKey());
     }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentViewResolver/ContentViewResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentViewResolver/ContentViewResolverTest.php
@@ -277,4 +277,96 @@ class ContentViewResolverTest extends TestCase
         self::assertArrayHasKey('snippet-1', $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][$initialDepth]);
         self::assertArrayHasKey('snippet-2', $result['resolvableResources'][$expectedPriority][$expectedLoaderKey][$initialDepth]);
     }
+
+    public function testResolveContentViewCollectsResolvablesFromView(): void
+    {
+        $tag = new ResolvableResource(3, 'tag', 0);
+        $contentView = ContentView::create(
+            ['title' => 'Article'],
+            ['tags' => [$tag]],
+        );
+
+        $priorityQueue = [];
+        $result = $this->contentViewResolver->resolveContentView($contentView, 'test', 0, $priorityQueue);
+
+        self::assertArrayHasKey(0, $result['resolvableResources']);
+        self::assertArrayHasKey('tag', $result['resolvableResources'][0]);
+        self::assertSame($tag, $result['resolvableResources'][0]['tag'][0][3][$tag->getMetadataIdentifier()]);
+        self::assertSame([$tag], $result['view']['test']['tags']);
+    }
+
+    public function testResolveContentViewCollectsResolvablesFromNestedView(): void
+    {
+        $tag = new ResolvableResource(7, 'tag', 0);
+        $contentView = ContentView::create(
+            ['something' => 'plain'],
+            ['filters' => ['nested' => ['tags' => [$tag]]]],
+        );
+
+        $priorityQueue = [];
+        $result = $this->contentViewResolver->resolveContentView($contentView, 'block', 0, $priorityQueue);
+
+        self::assertArrayHasKey(0, $result['resolvableResources']);
+        self::assertArrayHasKey('tag', $result['resolvableResources'][0]);
+        self::assertArrayHasKey(7, $result['resolvableResources'][0]['tag'][0]);
+    }
+
+    public function testResolveContentViewIgnoresNonResolvableViewValues(): void
+    {
+        $contentView = ContentView::create(
+            ['title' => 'plain'],
+            [
+                'tags' => ['Beach', 'City'],
+                'count' => 42,
+                'meta' => ['key' => 'value'],
+                'flag' => true,
+            ],
+        );
+
+        $priorityQueue = [];
+        $result = $this->contentViewResolver->resolveContentView($contentView, 'block', 0, $priorityQueue);
+
+        self::assertSame([], $result['resolvableResources']);
+        self::assertSame(['Beach', 'City'], $result['view']['block']['tags']);
+        self::assertSame(42, $result['view']['block']['count']);
+    }
+
+    public function testResolveContentViewPreservesPriorityAndDepthForViewResolvables(): void
+    {
+        $highPriorityTag = new ResolvableResource(1, 'tag', 5);
+        $lowPriorityTag = new ResolvableResource(2, 'tag', 1);
+        $contentView = ContentView::create(
+            ['title' => 'Article'],
+            ['tags' => [$highPriorityTag, $lowPriorityTag]],
+        );
+
+        $priorityQueue = [];
+        $depth = 3;
+        $result = $this->contentViewResolver->resolveContentView($contentView, 'test', $depth, $priorityQueue);
+
+        self::assertArrayHasKey(5, $result['resolvableResources']);
+        self::assertArrayHasKey(1, $result['resolvableResources']);
+        self::assertArrayHasKey($depth, $result['resolvableResources'][5]['tag']);
+        self::assertArrayHasKey($depth, $result['resolvableResources'][1]['tag']);
+    }
+
+    public function testResolveContentViewQueuesContentAndViewResolvablesUnderSameLoaderKey(): void
+    {
+        $contentTag = new ResolvableResource(10, 'tag', 0);
+        $viewTag = new ResolvableResource(20, 'tag', 0);
+
+        $contentView = ContentView::create(
+            ['selected_tag' => $contentTag],
+            ['tags' => [$viewTag]],
+        );
+
+        $priorityQueue = [];
+        $result = $this->contentViewResolver->resolveContentView($contentView, 'block', 0, $priorityQueue);
+
+        self::assertArrayHasKey(0, $result['resolvableResources']);
+        self::assertArrayHasKey('tag', $result['resolvableResources'][0]);
+        self::assertArrayHasKey(0, $result['resolvableResources'][0]['tag']);
+        self::assertArrayHasKey(10, $result['resolvableResources'][0]['tag'][0]);
+        self::assertArrayHasKey(20, $result['resolvableResources'][0]['tag'][0]);
+    }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ContentViewResolver/ContentViewResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ContentViewResolver/ContentViewResolverTest.php
@@ -292,7 +292,9 @@ class ContentViewResolverTest extends TestCase
         self::assertArrayHasKey(0, $result['resolvableResources']);
         self::assertArrayHasKey('tag', $result['resolvableResources'][0]);
         self::assertSame($tag, $result['resolvableResources'][0]['tag'][0][3][$tag->getMetadataIdentifier()]);
-        self::assertSame([$tag], $result['view']['test']['tags']);
+        /** @var array{tags: list<ResolvableResource>} $testView */
+        $testView = $result['view']['test'];
+        self::assertSame([$tag], $testView['tags']);
     }
 
     public function testResolveContentViewCollectsResolvablesFromNestedView(): void
@@ -327,8 +329,10 @@ class ContentViewResolverTest extends TestCase
         $result = $this->contentViewResolver->resolveContentView($contentView, 'block', 0, $priorityQueue);
 
         self::assertSame([], $result['resolvableResources']);
-        self::assertSame(['Beach', 'City'], $result['view']['block']['tags']);
-        self::assertSame(42, $result['view']['block']['count']);
+        /** @var array{tags: list<string>, count: int} $blockView */
+        $blockView = $result['view']['block'];
+        self::assertSame(['Beach', 'City'], $blockView['tags']);
+        self::assertSame(42, $blockView['count']);
     }
 
     public function testResolveContentViewPreservesPriorityAndDepthForViewResolvables(): void

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
@@ -924,4 +924,45 @@ class ResolvableResourceReplacerTest extends TestCase
         self::assertSame('2024-06-01T00:00:00+00:00', $pages[1]['authored']);
         self::assertSame('2024-09-01T00:00:00+00:00', $pages[1]['lastModified']);
     }
+
+    public function testReplaceResolvableResourcesInViewReplacesNestedResolvables(): void
+    {
+        $tagA = new ResolvableResource(3, 'tag', 0, null, null, 'tags');
+        $tagB = new ResolvableResource(4, 'tag', 0, null, null, 'tags');
+
+        $view = [
+            'tags' => [$tagA, $tagB],
+            'plain' => 'untouched',
+            'nested' => [
+                'tag' => $tagA,
+            ],
+        ];
+
+        $resolvedResources = [
+            'tag' => [
+                3 => [$tagA->getMetadataIdentifier() => $this->createResolvedEntry('Beach')],
+                4 => [$tagB->getMetadataIdentifier() => $this->createResolvedEntry('City')],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesInView($view, $resolvedResources);
+
+        self::assertSame(['Beach', 'City'], $result['tags']);
+        self::assertSame('untouched', $result['plain']);
+        self::assertSame('Beach', $result['nested']['tag']);
+
+        $refs = $this->referenceStore->getAll();
+        self::assertContains('tags-3', $refs);
+        self::assertContains('tags-4', $refs);
+    }
+
+    public function testReplaceResolvableResourcesInViewReturnsEarlyWithNoResolvedResources(): void
+    {
+        $tag = new ResolvableResource(3, 'tag', 0);
+        $view = ['tags' => [$tag]];
+
+        $result = $this->replacer->replaceResolvableResourcesInView($view, []);
+
+        self::assertSame($view, $result);
+    }
 }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
@@ -945,11 +945,13 @@ class ResolvableResourceReplacerTest extends TestCase
             ],
         ];
 
-        $result = $this->replacer->replaceResolvableResourcesInView($view, $resolvedResources);
+        $result = $this->replacer->replaceResolvableResourcesInView($view, $resolvedResources, 1, 10);
 
         self::assertSame(['Beach', 'City'], $result['tags']);
         self::assertSame('untouched', $result['plain']);
-        self::assertSame('Beach', $result['nested']['tag']);
+        /** @var array{tag: string} $nested */
+        $nested = $result['nested'];
+        self::assertSame('Beach', $nested['tag']);
 
         $refs = $this->referenceStore->getAll();
         self::assertContains('tags-3', $refs);
@@ -961,7 +963,7 @@ class ResolvableResourceReplacerTest extends TestCase
         $tag = new ResolvableResource(3, 'tag', 0);
         $view = ['tags' => [$tag]];
 
-        $result = $this->replacer->replaceResolvableResourcesInView($view, []);
+        $result = $this->replacer->replaceResolvableResourcesInView($view, [], 1, 10);
 
         self::assertSame($view, $result);
     }

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
@@ -967,4 +967,49 @@ class ResolvableResourceReplacerTest extends TestCase
 
         self::assertSame($view, $result);
     }
+
+    public function testReplaceResolvableResourcesInViewFiltersUnresolvedListEntries(): void
+    {
+        $tagA = new ResolvableResource(3, 'tag', 0, null, null, 'tags');
+        $tagMissing = new ResolvableResource(4, 'tag', 0, null, null, 'tags');
+        $tagC = new ResolvableResource(5, 'tag', 0, null, null, 'tags');
+
+        $view = [
+            'tags' => [$tagA, $tagMissing, $tagC],
+        ];
+
+        $resolvedResources = [
+            'tag' => [
+                3 => [$tagA->getMetadataIdentifier() => $this->createResolvedEntry('Beach')],
+                5 => [$tagC->getMetadataIdentifier() => $this->createResolvedEntry('Mountain')],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesInView($view, $resolvedResources, 1, 10);
+
+        self::assertSame(['Beach', 'Mountain'], $result['tags']);
+    }
+
+    public function testReplaceResolvableResourcesInViewKeepsAssociativeKeysWhenFiltering(): void
+    {
+        $tagA = new ResolvableResource(3, 'tag', 0, null, null, 'tags');
+        $tagMissing = new ResolvableResource(4, 'tag', 0, null, null, 'tags');
+
+        $view = [
+            'tags' => [
+                'first' => $tagA,
+                'second' => $tagMissing,
+            ],
+        ];
+
+        $resolvedResources = [
+            'tag' => [
+                3 => [$tagA->getMetadataIdentifier() => $this->createResolvedEntry('Beach')],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesInView($view, $resolvedResources, 1, 10);
+
+        self::assertSame(['first' => 'Beach'], $result['tags']);
+    }
 }

--- a/packages/content/tests/Unit/Content/Application/ResourceLoader/RawResourceLoaderTest.php
+++ b/packages/content/tests/Unit/Content/Application/ResourceLoader/RawResourceLoaderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\ResourceLoader;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Application\ResourceLoader\Loader\RawResourceLoader;
+
+class RawResourceLoaderTest extends TestCase
+{
+    public function testGetKey(): void
+    {
+        $this->assertSame('raw', RawResourceLoader::getKey());
+    }
+
+    public function testLoadReturnsIdsKeyedByThemselves(): void
+    {
+        $loader = new RawResourceLoader();
+
+        $this->assertSame([1 => 1, 2 => 2, 3 => 3], $loader->load([1, 2, 3], 'en'));
+    }
+
+    public function testLoadHandlesStringIds(): void
+    {
+        $loader = new RawResourceLoader();
+
+        $this->assertSame(['a' => 'a', 'b' => 'b'], $loader->load(['a', 'b'], 'en'));
+    }
+
+    public function testLoadReturnsEmptyForEmptyInput(): void
+    {
+        $loader = new RawResourceLoader();
+
+        $this->assertSame([], $loader->load([], 'en'));
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/SmartResolver/Resolver/SmartContentSmartResolverTest.php
@@ -50,7 +50,9 @@ class SmartContentSmartResolverTest extends TestCase
         $this->serviceLocator->has('test_provider')->willReturn(true);
         $this->serviceLocator->get('test_provider')->willReturn($this->smartContentProvider->reveal());
 
-        $this->resolver = new SmartContentSmartResolver($this->serviceLocator->reveal());
+        $this->resolver = new SmartContentSmartResolver(
+            $this->serviceLocator->reveal(),
+        );
     }
 
     public function testResolveUsingMaxPerPage(): void
@@ -258,7 +260,9 @@ class SmartContentSmartResolverTest extends TestCase
         $serviceLocator->getProvidedServices()->willReturn([]);
         $serviceLocator->has('invalid_provider')->willReturn(false);
 
-        $resolver = new SmartContentSmartResolver($serviceLocator->reveal());
+        $resolver = new SmartContentSmartResolver(
+            $serviceLocator->reveal(),
+        );
 
         $data = [
             'value' => ['presentAs' => 'grid'],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #8812
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The `view.<smart_content_field>.tags` key now resolves to a list of plain tag name strings and `view.<smart_content_field>.categories` resolves to a list of `Sulu\Bundle\CategoryBundle\Api\Category` API objects. The smart content resolver wraps tag and category ids in `ResolvableResource` instances so the existing resource loader pipeline can replace them after content resolution. The `ContentViewResolver` collects view side resolvables and keeps the outer view when the matched content set is empty, so filter metadata such as tags, categories and total stays exposed. The `ResolvableResourceReplacer` walks the view tree once more to swap resolvables for resolved values and now honors a depth limit.

#### Why?

The view shape regressed in 3.0.6 to expose raw id arrays, which broke templates that mirrored the Sulu 2.6 markup and relied on `?tags=<name>` and `?categories=<id>` URL filters. Restoring the name based shape for tags and the API wrapper for categories realigns the contract with Sulu 2.6 so existing twig templates keep working after the upgrade. As a documented side effect of going through the resource loaders, the smart content filter ids now register in the HTTP cache reference store, so renaming a tag or category invalidates pages whose smart content filter references it.