### PR TITLE
Fix admin search security context for single article group setups

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -2,6 +2,30 @@
 
 ## 3.0.7
 
+### Article admin now gates the navigation and views on per-group permissions
+
+The `ArticleAdmin` previously gated its navigation item, per-group views, and toolbar actions (Add, Delete, Export) on the
+umbrella `sulu.article.articles` EDIT permission, with per-group `sulu.article.articles_<group>` checks layered on top. The
+umbrella check has been removed from those code paths, and the per-group permission is now the sole gate for the admin UI
+(see #8830).
+
+The umbrella `sulu.article.articles` permission is still required: `ArticleController` reports it as its security context, so
+every article REST endpoint (list, get, create, update, delete, workflow) continues to check it. Roles need both the umbrella
+permission for API access and the per-group permission for the matching navigation item and views to render.
+
+After upgrading, re-run the reindex command for both kernels so the admin search index reflects the current security contexts:
+
+```bash
+bin/console cmsig:seal:reindex
+```
+
+#### Role updates
+
+After upgrading, review every role with article permissions and adjust the grants accordingly:
+
+- `sulu.article.articles`: always required, because the article REST controllers depend on it.
+- `sulu.article.articles_<group>`: required for each group the role should manage.
+
 ### Selection view structure changed (snippet, page, article)
 
 The `view` data emitted by `*_selection` and `single_*_selection` property resolvers now exposes the loaded entity's metadata and field-level view directly, restoring the Sulu 2.6 shape for multi-selections.

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -59,24 +59,16 @@ class ArticleAdmin extends Admin
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
     {
-        if (!$this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            return;
-        }
-
         $hasArticleTypeWithEditPermissions = false;
-        if (1 === \count($this->groupProvider->getGroups())) {
-            $hasArticleTypeWithEditPermissions = true;
-        } else {
-            foreach ($this->groupProvider->getGroups() as $group) {
-                $securityContext = static::getArticleSecurityContext($group->identifier);
-                if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
-                    continue;
-                }
-
-                $hasArticleTypeWithEditPermissions = true;
-
-                break;
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
+        foreach ($groups as $group) {
+            $securityContext = static::getArticleSecurityContext($group->identifier);
+            if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
+                continue;
             }
+
+            $hasArticleTypeWithEditPermissions = true;
+            break;
         }
 
         if (!$hasArticleTypeWithEditPermissions) {
@@ -93,10 +85,6 @@ class ArticleAdmin extends Admin
 
     public function configureViews(ViewCollection $viewCollection): void
     {
-        if (!$this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            return;
-        }
-
         $locales = $this->localizationManager->getLocales();
         $resourceKey = ArticleInterface::RESOURCE_KEY;
 
@@ -105,7 +93,7 @@ class ArticleAdmin extends Admin
                 ->addRouterAttributesToBlacklist(['active', 'filter', 'limit', 'page', 'search', 'sortColumn', 'sortOrder']),
         );
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         foreach ($groups as $group) {
             $securityContext = static::getArticleSecurityContext($group->identifier);
             if (1 === \count($groups)) {
@@ -118,8 +106,7 @@ class ArticleAdmin extends Admin
 
     private function hasPermission(string $groupIdentifier, string $permission, bool $checkGroup): bool
     {
-        return $this->securityChecker->hasPermission(static::SECURITY_CONTEXT, $permission)
-            && (false === $checkGroup || $this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), $permission));
+        return $this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), $permission);
     }
 
     /**
@@ -135,15 +122,15 @@ class ArticleAdmin extends Admin
 
         $listToolbarActions = [];
 
-        if ($this->hasPermission($groupIdentifier, PermissionTypes::ADD, $securityContext !== static::SECURITY_CONTEXT)) {
+        if ($this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), PermissionTypes::ADD)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
-        if ($this->hasPermission($groupIdentifier, PermissionTypes::DELETE, $securityContext !== static::SECURITY_CONTEXT)) {
+        if ($this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), PermissionTypes::DELETE)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
-        if ($this->hasPermission($groupIdentifier, PermissionTypes::VIEW, $securityContext !== static::SECURITY_CONTEXT)) {
+        if ($this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), PermissionTypes::VIEW)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
@@ -170,7 +157,7 @@ class ArticleAdmin extends Admin
         );
         $viewCollection->add(
             $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_TABS_VIEW . '_' . $groupIdentifier, '/:locale/' . $groupIdentifier . '/:id') // TODO should be uuid
-                ->setResourceKey($resourceKey)
+            ->setResourceKey($resourceKey)
                 ->addLocales($locales)
                 ->setBackView(static::LIST_VIEW . '_' . $groupIdentifier)
                 ->setTitleProperty('title'),
@@ -261,9 +248,9 @@ class ArticleAdmin extends Admin
     public function getSecurityContexts()
     {
         $securityContext = [];
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         if (1 !== \count($groups)) {
-            foreach ($this->groupProvider->getGroups() as $group) {
+            foreach ($groups as $group) {
                 $securityContext[static::getArticleSecurityContext($group->identifier)] = [
                     PermissionTypes::VIEW,
                     PermissionTypes::ADD,

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -132,7 +132,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
                         'type' => $group->identifier,
                     ];
                 },
-                $this->groupProvider->getGroups(),
+                $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE),
             )))
             ->enableProperties([
                 'title' => 'title',
@@ -326,7 +326,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
     private function expandGroupsToTemplates(array $identifiers): array
     {
         $templates = [];
-        foreach ($this->groupProvider->getGroups() as $group) {
+        foreach ($this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE) as $group) {
             if (\in_array($group->identifier, $identifiers, true)) {
                 $templates = \array_merge($templates, \array_filter($group->templates, 'is_string'));
             }

--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
@@ -66,7 +66,7 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
     {
         $articles = $this->loadArticles($reindexConfig->getIdentifiers());
         /** @var FormGroup[] $groups */
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
 
         /** @var Article $article */
         foreach ($articles as $article) {
@@ -90,7 +90,7 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
                 'metadata' => [
                     'group' => $groupIdentifier,
                 ],
-                'securityContext' => ArticleAdmin::getArticleSecurityContext($groupIdentifier ?? 'default'),
+                'securityContext' => ArticleAdmin::getArticleSecurityContext($groupIdentifier ?? GroupProviderInterface::DEFAULT_GROUP),
             ];
 
             foreach ($this->enhancers as $enhancer) {

--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
@@ -79,6 +79,11 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
                 }
             }
 
+            $securityContext = ArticleAdmin::getArticleSecurityContext($groupIdentifier ?? GroupProviderInterface::DEFAULT_GROUP);
+            if (1 === \count($groups)) {
+                $securityContext = ArticleAdmin::SECURITY_CONTEXT;
+            }
+
             $data = [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . ((string) $article['articleId']) . '__' . $article['locale'],
                 'resourceKey' => ArticleInterface::RESOURCE_KEY,
@@ -90,7 +95,7 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
                 'metadata' => [
                     'group' => $groupIdentifier,
                 ],
-                'securityContext' => ArticleAdmin::getArticleSecurityContext($groupIdentifier ?? GroupProviderInterface::DEFAULT_GROUP),
+                'securityContext' => $securityContext,
             ];
 
             foreach ($this->enhancers as $enhancer) {

--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -73,7 +73,7 @@ final class ArticleController implements SecuredControllerInterface
         $types = \array_filter(\explode(',', \is_string($typesParam) ? $typesParam : ''));
 
         $groupTemplates = [];
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         foreach ($groups as $group) {
             if (\in_array($group->identifier, $types)) {
                 $groupTemplates = \array_merge($groupTemplates, $group->templates);

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
@@ -19,6 +19,7 @@ use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Admin\ArticleAdmin;
 use Sulu\Article\Infrastructure\Sulu\Search\AdminArticleReindexProvider;
 use Sulu\Article\Tests\Traits\CreateArticleTrait;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
 use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -165,6 +166,40 @@ class AdminArticleReindexProviderTest extends SuluTestCase
             $expectedResult,
             $results,
         );
+    }
+
+    public function testProvideEmitsBroadSecurityContextWithSingleGroup(): void
+    {
+        $singleGroupProvider = new class() implements GroupProviderInterface {
+            public function getGroups(string $key): array
+            {
+                return [GroupProviderInterface::DEFAULT_GROUP => new FormGroup(GroupProviderInterface::DEFAULT_GROUP, 'Default', ['article'])];
+            }
+        };
+
+        $provider = new AdminArticleReindexProvider($this->entityManager, $singleGroupProvider);
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Admin search regression',
+                    'url' => '/admin-search-regression',
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([
+                ArticleInterface::RESOURCE_KEY . '__' . $article->getUuid() . '__en',
+            ]);
+
+        /** @var array<array{securityContext: string}> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+        $this->assertSame(ArticleAdmin::SECURITY_CONTEXT, $results[0]['securityContext']);
     }
 
     public function testProvideWithSpecificIdentifiers(): void

--- a/src/Sulu/Bundle/AdminBundle/Metadata/GroupProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/GroupProvider.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Bundle\AdminBundle\Metadata;
 
-use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -24,21 +23,21 @@ final readonly class GroupProvider implements GroupProviderInterface
     ) {
     }
 
-    public function getGroups(): array
+    public function getGroups(string $key): array
     {
         /** @var TypedFormMetadata $metadata */
         $metadata = $this->metadataProviderRegistry->getMetadataProvider('form')
-            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', []);
+            ->getMetadata($key, '', []);
 
         $groups = [];
 
-        foreach ($metadata->getForms() as $articleForm) {
-            $group = $articleForm->getGroup() ?: 'default';
+        foreach ($metadata->getForms() as $form) {
+            $group = $form->getGroup() ?: GroupProviderInterface::DEFAULT_GROUP;
 
             if (!\array_key_exists($group, $groups)) {
                 $groups[$group] = new FormGroup($group, $this->getGroupTitle($group));
             }
-            $groups[$group] = $groups[$group]->withTemplate($articleForm->getKey());
+            $groups[$group] = $groups[$group]->withTemplate($form->getKey());
         }
 
         return $groups;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/GroupProviderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/GroupProviderInterface.php
@@ -15,8 +15,10 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
 
 interface GroupProviderInterface
 {
+    public const DEFAULT_GROUP = 'default';
+
     /**
      * @return array<string, FormGroup>
      */
-    public function getGroups(): array;
+    public function getGroups(string $key): array;
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
@@ -81,7 +81,7 @@ class GroupProviderTest extends TestCase
         $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
             ->willReturnArgument(0);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(1, $groups);
         $this->assertArrayHasKey('content', $groups);
@@ -120,7 +120,7 @@ class GroupProviderTest extends TestCase
         $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
             ->willReturnArgument(0);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(3, $groups);
         $this->assertArrayHasKey('content', $groups);
@@ -159,7 +159,7 @@ class GroupProviderTest extends TestCase
         $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
             ->willReturnArgument(0);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(1, $groups);
         $this->assertArrayHasKey('default', $groups);
@@ -179,7 +179,7 @@ class GroupProviderTest extends TestCase
             ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
             ->willReturn($typedFormMetadata);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(0, $groups);
         $this->assertEmpty($groups);
@@ -214,7 +214,7 @@ class GroupProviderTest extends TestCase
         $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
             ->willReturnArgument(0);
 
-        $groups = $this->groupProvider->getGroups();
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
 
         $this->assertCount(2, $groups);
         $this->assertArrayHasKey('content', $groups);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #8830 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The `AdminArticleReindexProvider` now emits the broad `ArticleAdmin::SECURITY_CONTEXT` when only a single article template group exists. When multiple groups are configured, the provider keeps emitting the per group context as before. A functional regression test covers the single group case by injecting a stub group provider.

#### Why?

`ArticleAdmin::getSecurityContexts()` only registers the broad context for single group setups, while the indexer always wrote the per group context into the admin search index. The `SearchController` filters results by the contexts granted to the user, so articles were hidden from admin search whenever exactly one template group was configured. Mirroring the existing toggle from `ArticleAdmin::configureViews()` keeps the indexer aligned with the security context registration.