### PR TITLE
Fix phpstan errors in WebspaceCollectionBuilder portal information sort

### DIFF
--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -106,16 +106,15 @@ class WebspaceCollectionBuilder
             }
         );
 
-        $environments = \array_keys($this->portalInformations);
-
-        foreach ($environments as $environment) {
-            // sort all portal informations by length
+        // sort all portal informations by length
+        foreach ($this->portalInformations as $environment => $environmentPortalInformations) {
             \uksort(
-                $this->portalInformations[$environment],
-                function($a, $b) {
+                $environmentPortalInformations,
+                function(string $a, string $b) {
                     return \strlen($a) < \strlen($b) ? 1 : -1;
                 }
             );
+            $this->portalInformations[$environment] = $environmentPortalInformations;
         }
 
         $collection->setWebspaces($this->webspaces);

--- a/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
+++ b/src/Sulu/Component/Webspace/Manager/WebspaceCollectionBuilder.php
@@ -107,15 +107,16 @@ class WebspaceCollectionBuilder
         );
 
         // sort all portal informations by length
-        foreach ($this->portalInformations as $environment => $environmentPortalInformations) {
+        $environmentPortalInformations = [];
+        foreach ($this->portalInformations as &$environmentPortalInformations) {
             \uksort(
                 $environmentPortalInformations,
                 function(string $a, string $b) {
                     return \strlen($a) < \strlen($b) ? 1 : -1;
                 }
             );
-            $this->portalInformations[$environment] = $environmentPortalInformations;
         }
+        unset($environmentPortalInformations);
 
         $collection->setWebspaces($this->webspaces);
         $collection->setPortals($this->portals);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The portal information sort loop in `WebspaceCollectionBuilder::build()` now iterates over the property directly with key and value. The local value is sorted with `uksort()` and written back to the property under the original key. The sort callback parameters are typed as `string` to match the URL address keys used by `strlen()`.

#### Why?

After the recent PHPStan upgrade, the previous loop produced four errors at max level. PHPStan inferred `mixed` for the nested array access and lost the string key type required by the comparison callback. Iterating with key and value preserves the inferred type and removes the type errors without suppressing them.