### PR TITLE
Update page routes when pages are moved or copied and use primarily the slug in the RouteChangedUpdater

### DIFF
--- a/packages/page/src/Application/MessageHandler/CopyPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/CopyPageMessageHandler.php
@@ -218,7 +218,9 @@ final class CopyPageMessageHandler
     }
 
     /**
-     * Slug relative to the old parent, or the full slug when there is no old parent route.
+     * Slug relative to the old parent, or the full slug when there is no old parent route. The
+     * parent path must be followed by a "/" to count as a prefix, so a sibling slug that merely
+     * shares a string prefix is not stripped.
      */
     private function relativeSlug(string $slug, ?PageInterface $parent, string $locale): string
     {
@@ -234,7 +236,7 @@ final class CopyPageMessageHandler
 
         $parentPath = \rtrim($parentRoute?->getSlug() ?? '', '/');
 
-        if ('' !== $parentPath && \str_starts_with($slug, $parentPath)) {
+        if ('' !== $parentPath && \str_starts_with($slug, $parentPath . '/')) {
             return \substr($slug, \strlen($parentPath));
         }
 

--- a/packages/page/src/Application/MessageHandler/CopyPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/CopyPageMessageHandler.php
@@ -22,6 +22,10 @@ use Sulu\Page\Domain\Event\PageCopiedEvent;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorGeneratorInterface;
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorRequest;
+use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 
 /**
  * @internal This class should not be instantiated by a project.
@@ -33,6 +37,8 @@ final class CopyPageMessageHandler
         private PageRepositoryInterface $pageRepository,
         private ContentCopierInterface $contentCopier,
         private LocalizationManagerInterface $localizationManager,
+        private RouteRepositoryInterface $routeRepository,
+        private ResourceLocatorGeneratorInterface $resourceLocatorGenerator,
         private DomainEventCollectorInterface $domainEventCollector,
     ) {
     }
@@ -80,6 +86,7 @@ final class CopyPageMessageHandler
             PageDimensionContent::class
         );
 
+        $copiedLocales = [];
         foreach ($allLocales as $locale) {
             $sourceDimensionContent = $dimensionContentCollection->getDimensionContent([
                 'locale' => $locale,
@@ -103,12 +110,20 @@ final class CopyPageMessageHandler
                     'locale' => $locale,
                 ],
                 [
-                    'ignoredAttributes' => [
-                        'url', // TODO remove this once the route resolving is implemented on duplicates
-                    ],
+                    // url is re-resolved per-locale below against the new parent
+                    'ignoredAttributes' => ['url'],
                 ]
             );
+
+            $copiedLocales[] = $locale;
         }
+
+        $this->createRoutesForCopiedPage(
+            $sourcePage,
+            $targetPage,
+            $targetParentPage,
+            $copiedLocales,
+        );
 
         /** @var PageDimensionContent $localizedDimensionContent */
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent([
@@ -119,5 +134,110 @@ final class CopyPageMessageHandler
         $this->domainEventCollector->collect(new PageCopiedEvent($sourcePage, $sourcePage->getId(), $sourcePage->getWebspaceKey(), $localizedDimensionContent->getTitle(), $message->getLocale()));
 
         return $targetPage;
+    }
+
+    /**
+     * Creates the copied page's route(s) under the target parent, reusing the source slug
+     * relative to its old parent.
+     *
+     * @param array<string> $copiedLocales
+     */
+    private function createRoutesForCopiedPage(
+        PageInterface $sourcePage,
+        PageInterface $targetPage,
+        PageInterface $targetParentPage,
+        array $copiedLocales,
+    ): void {
+        if ([] === $copiedLocales) {
+            return;
+        }
+
+        $sourceParent = $sourcePage->getParent();
+
+        $targetCollection = new DimensionContentCollection(
+            $targetPage->getDimensionContents(),
+            [],
+            PageDimensionContent::class
+        );
+
+        foreach ($copiedLocales as $locale) {
+            /** @var PageDimensionContent|null $targetDimensionContent */
+            $targetDimensionContent = $targetCollection->getDimensionContent([
+                'locale' => $locale,
+                'stage' => DimensionContentInterface::STAGE_DRAFT,
+            ]);
+
+            if (null === $targetDimensionContent || $targetDimensionContent->getLocale() !== $locale) {
+                continue;
+            }
+
+            $sourceRoute = $this->routeRepository->findOneBy([
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $sourcePage->getUuid(),
+                'locale' => $locale,
+            ]);
+
+            if (null === $sourceRoute || $sourceRoute->isHistory()) {
+                continue;
+            }
+
+            $targetParentRoute = $this->routeRepository->findOneBy([
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $targetParentPage->getUuid(),
+                'locale' => $locale,
+            ]);
+
+            if (null === $targetParentRoute) {
+                // target parent not routable in this locale → copy keeps no route
+                continue;
+            }
+
+            $slug = $this->resourceLocatorGenerator->generate(new ResourceLocatorRequest(
+                parts: [],
+                locale: $locale,
+                webspace: $targetPage->getWebspaceKey(),
+                resourceKey: PageInterface::RESOURCE_KEY,
+                resourceId: $targetPage->getUuid(),
+                parentResourceId: $targetParentPage->getUuid(),
+                parentResourceKey: PageInterface::RESOURCE_KEY,
+                routeSchema: $this->relativeSlug($sourceRoute->getSlug(), $sourceParent, $locale),
+            ));
+
+            // parent_id stays null like normal page routes; cascade is slug-based
+            $route = new Route(
+                PageInterface::RESOURCE_KEY,
+                $targetPage->getUuid(),
+                $locale,
+                $slug,
+                $targetPage->getWebspaceKey(),
+            );
+            $this->routeRepository->add($route);
+
+            $targetDimensionContent->setRoute($route);
+        }
+    }
+
+    /**
+     * Slug relative to the old parent, or the full slug when there is no old parent route.
+     */
+    private function relativeSlug(string $slug, ?PageInterface $parent, string $locale): string
+    {
+        if (null === $parent) {
+            return $slug;
+        }
+
+        $parentRoute = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $parent->getUuid(),
+            'locale' => $locale,
+        ]);
+
+        $parentPath = \rtrim($parentRoute?->getSlug() ?? '', '/');
+
+        if ('' !== $parentPath && \str_starts_with($slug, $parentPath)) {
+            return \substr($slug, \strlen($parentPath));
+        }
+
+        return $slug;
     }
 }

--- a/packages/page/src/Application/MessageHandler/CopyPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/CopyPageMessageHandler.php
@@ -218,9 +218,9 @@ final class CopyPageMessageHandler
     }
 
     /**
-     * Slug relative to the old parent, or the full slug when there is no old parent route. The
-     * parent path must be followed by a "/" to count as a prefix, so a sibling slug that merely
-     * shares a string prefix is not stripped.
+     * The page's own slug segment relative to the given parent, or the trailing segment when the
+     * parent has no route in this locale. The parent path must be followed by a "/", so a sibling
+     * that merely shares a string prefix is not stripped.
      */
     private function relativeSlug(string $slug, ?PageInterface $parent, string $locale): string
     {
@@ -234,7 +234,11 @@ final class CopyPageMessageHandler
             'locale' => $locale,
         ]);
 
-        $parentPath = \rtrim($parentRoute?->getSlug() ?? '', '/');
+        if (null === $parentRoute) {
+            return \substr($slug, (int) \strrpos($slug, '/'));
+        }
+
+        $parentPath = \rtrim($parentRoute->getSlug(), '/');
 
         if ('' !== $parentPath && \str_starts_with($slug, $parentPath . '/')) {
             return \substr($slug, \strlen($parentPath));

--- a/packages/page/src/Application/MessageHandler/MovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/MovePageMessageHandler.php
@@ -94,17 +94,6 @@ class MovePageMessageHandler
             }
 
             $locale = $route->getLocale();
-
-            $newParentRoute = $this->routeRepository->findOneBy([
-                'resourceKey' => PageInterface::RESOURCE_KEY,
-                'resourceId' => $newParent->getUuid(),
-                'locale' => $locale,
-            ]);
-
-            if (null === $newParentRoute) {
-                continue;
-            }
-
             $oldSlug = $route->getSlug();
             $newSlug = $this->resourceLocatorGenerator->generate(new ResourceLocatorRequest(
                 parts: [],
@@ -124,9 +113,9 @@ class MovePageMessageHandler
     }
 
     /**
-     * Slug relative to the old parent, or the full slug when there is no old parent route. The
-     * parent path must be followed by a "/" to count as a prefix, so a sibling slug that merely
-     * shares a string prefix is not stripped.
+     * The page's own slug segment relative to its previous parent, or the trailing segment when the
+     * previous parent has no route in this locale. The parent path must be followed by a "/", so a
+     * sibling that merely shares a string prefix is not stripped.
      */
     private function relativeSlug(string $slug, ?PageInterface $previousParent, string $locale): string
     {
@@ -140,7 +129,11 @@ class MovePageMessageHandler
             'locale' => $locale,
         ]);
 
-        $previousParentPath = \rtrim($previousParentRoute?->getSlug() ?? '', '/');
+        if (null === $previousParentRoute) {
+            return \substr($slug, (int) \strrpos($slug, '/'));
+        }
+
+        $previousParentPath = \rtrim($previousParentRoute->getSlug(), '/');
 
         if ('' !== $previousParentPath && \str_starts_with($slug, $previousParentPath . '/')) {
             return \substr($slug, \strlen($previousParentPath));

--- a/packages/page/src/Application/MessageHandler/MovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/MovePageMessageHandler.php
@@ -87,6 +87,12 @@ class MovePageMessageHandler
         ]);
 
         foreach ($routes as $route) {
+            if (null !== $route->getParentRoute()) {
+                // route is anchored to an external page (e.g. via a page_tree_route field),
+                // not to the page tree, so moving the page must not re-anchor it
+                continue;
+            }
+
             $locale = $route->getLocale();
 
             $newParentRoute = $this->routeRepository->findOneBy([
@@ -118,7 +124,9 @@ class MovePageMessageHandler
     }
 
     /**
-     * Slug relative to the old parent, or the full slug when there is no old parent route.
+     * Slug relative to the old parent, or the full slug when there is no old parent route. The
+     * parent path must be followed by a "/" to count as a prefix, so a sibling slug that merely
+     * shares a string prefix is not stripped.
      */
     private function relativeSlug(string $slug, ?PageInterface $previousParent, string $locale): string
     {
@@ -134,7 +142,7 @@ class MovePageMessageHandler
 
         $previousParentPath = \rtrim($previousParentRoute?->getSlug() ?? '', '/');
 
-        if ('' !== $previousParentPath && \str_starts_with($slug, $previousParentPath)) {
+        if ('' !== $previousParentPath && \str_starts_with($slug, $previousParentPath . '/')) {
             return \substr($slug, \strlen($previousParentPath));
         }
 

--- a/packages/page/src/Application/MessageHandler/MovePageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/MovePageMessageHandler.php
@@ -18,6 +18,9 @@ use Sulu\Page\Domain\Event\PageMovedEvent;
 use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorGeneratorInterface;
+use Sulu\Route\Application\ResourceLocator\ResourceLocatorRequest;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 
 /**
  * @internal This class should not be instantiated by a project.
@@ -27,6 +30,8 @@ class MovePageMessageHandler
 {
     public function __construct(
         private PageRepositoryInterface $pageRepository,
+        private RouteRepositoryInterface $routeRepository,
+        private ResourceLocatorGeneratorInterface $resourceLocatorGenerator,
         private DomainEventCollectorInterface $domainEventCollector,
     ) {
     }
@@ -37,6 +42,11 @@ class MovePageMessageHandler
         $previousParent = $page->getParent();
 
         $this->pageRepository->moveOneBy($message->getIdentifier(), $message->getTargetParentIdentifier());
+
+        $newParent = $page->getParent();
+        if (null !== $newParent && $newParent !== $previousParent) {
+            $this->moveRoutes($page, $previousParent, $newParent);
+        }
 
         if (null === $previousParent) {
             $this->domainEventCollector->collect(new PageMovedEvent(
@@ -63,5 +73,71 @@ class MovePageMessageHandler
         ));
 
         return $page;
+    }
+
+    /**
+     * Re-anchors the page's route(s) under the new parent; the RouteChangedUpdater cascades
+     * descendants and history on flush.
+     */
+    private function moveRoutes(PageInterface $page, ?PageInterface $previousParent, PageInterface $newParent): void
+    {
+        $routes = $this->routeRepository->findBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $page->getUuid(),
+        ]);
+
+        foreach ($routes as $route) {
+            $locale = $route->getLocale();
+
+            $newParentRoute = $this->routeRepository->findOneBy([
+                'resourceKey' => PageInterface::RESOURCE_KEY,
+                'resourceId' => $newParent->getUuid(),
+                'locale' => $locale,
+            ]);
+
+            if (null === $newParentRoute) {
+                continue;
+            }
+
+            $oldSlug = $route->getSlug();
+            $newSlug = $this->resourceLocatorGenerator->generate(new ResourceLocatorRequest(
+                parts: [],
+                locale: $locale,
+                webspace: $route->getWebspace(),
+                resourceKey: PageInterface::RESOURCE_KEY,
+                resourceId: $page->getUuid(),
+                parentResourceId: $newParent->getUuid(),
+                parentResourceKey: PageInterface::RESOURCE_KEY,
+                routeSchema: $this->relativeSlug($oldSlug, $previousParent, $locale),
+            ));
+
+            if ($oldSlug !== $newSlug) {
+                $route->setSlug($newSlug);
+            }
+        }
+    }
+
+    /**
+     * Slug relative to the old parent, or the full slug when there is no old parent route.
+     */
+    private function relativeSlug(string $slug, ?PageInterface $previousParent, string $locale): string
+    {
+        if (null === $previousParent) {
+            return $slug;
+        }
+
+        $previousParentRoute = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $previousParent->getUuid(),
+            'locale' => $locale,
+        ]);
+
+        $previousParentPath = \rtrim($previousParentRoute?->getSlug() ?? '', '/');
+
+        if ('' !== $previousParentPath && \str_starts_with($slug, $previousParentPath)) {
+            return \substr($slug, \strlen($previousParentPath));
+        }
+
+        return $slug;
     }
 }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -230,6 +230,8 @@ final class SuluPageBundle extends AbstractBundle
             ->class(MovePageMessageHandler::class)
             ->args([
                 new Reference('sulu_page.page_repository'),
+                new Reference('sulu_route.route_repository'),
+                new Reference('sulu_route.resource_locator_generator'),
                 new Reference('sulu_activity.domain_event_collector'),
             ])
             ->tag('messenger.message_handler');
@@ -240,6 +242,8 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_content.content_copier'),
                 new Reference('sulu.core.localization_manager'),
+                new Reference('sulu_route.route_repository'),
+                new Reference('sulu_route.resource_locator_generator'),
                 new Reference('sulu_activity.domain_event_collector'),
             ])
             ->tag('messenger.message_handler');

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -795,7 +795,7 @@ class PageControllerTest extends SuluTestCase
         $copiedPageId = $content['_embedded']['pages'][0]['_embedded']['pages'][1]['_embedded']['pages'][0]['id']; // @phpstan-ignore-line
 
         $routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
-        $this->assertCount(10, $routeRepository->findBy([]));
+        $this->assertCount(11, $routeRepository->findBy([]));
 
         return $copiedPageId;
     }

--- a/packages/page/tests/Functional/Integration/PageMoveCopyRoutingTest.php
+++ b/packages/page/tests/Functional/Integration/PageMoveCopyRoutingTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Page\Application\Message\CopyPageMessage;
+use Sulu\Page\Application\Message\CreatePageMessage;
+use Sulu\Page\Application\Message\MovePageMessage;
+use Sulu\Page\Application\MessageHandler\CopyPageMessageHandler;
+use Sulu\Page\Application\MessageHandler\CreatePageMessageHandler;
+use Sulu\Page\Application\MessageHandler\MovePageMessageHandler;
+use Sulu\Page\Domain\Model\PageInterface;
+use Sulu\Page\Domain\Repository\PageRepositoryInterface;
+use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+#[CoversNothing]
+class PageMoveCopyRoutingTest extends SuluTestCase
+{
+    private PageRepositoryInterface $pageRepository;
+
+    private RouteRepositoryInterface $routeRepository;
+
+    protected function setUp(): void
+    {
+        self::purgeDatabase();
+
+        self::assertInstanceOf(KernelInterface::class, self::$kernel);
+        $application = new Application(self::$kernel);
+        $command = $application->find('sulu:page:initialize');
+        (new CommandTester($command))->execute([]);
+
+        $this->pageRepository = $this->getContainer()->get('sulu_page.page_repository');
+        $this->routeRepository = $this->getContainer()->get(RouteRepositoryInterface::class);
+    }
+
+    public function testMoveUpdatesUrlToNewParentPath(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-b/child', $child->getUuid(), 'en');
+    }
+
+    public function testMoveToRootUsesHomepageSlug(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->move($child->getUuid(), $homepage->getUuid());
+
+        $this->assertRouteSlug('/child', $child->getUuid(), 'en');
+    }
+
+    public function testMoveCascadesDescendantSlugs(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+        $grandchild = $this->createPage($child->getUuid(), ['title' => 'Grandchild', 'url' => '/parent-a/child/grandchild']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-b/child', $child->getUuid(), 'en');
+        $this->assertRouteSlug('/parent-b/child/grandchild', $grandchild->getUuid(), 'en');
+    }
+
+    public function testMoveAppendsSuffixWhenDestinationSlugIsTaken(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $this->createPage($parentB->getUuid(), ['title' => 'Existing', 'url' => '/parent-b/child']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-b/child-1', $child->getUuid(), 'en');
+    }
+
+    public function testMoveCreatesHistoryRoute(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        $historyRoute = $this->routeRepository->findOneBy([
+            'webspace' => 'sulu-io',
+            'locale' => 'en',
+            'slug' => '/parent-a/child',
+        ]);
+
+        self::assertNotNull($historyRoute, 'A history route should be created at the old slug.');
+        self::assertTrue($historyRoute->isHistory());
+    }
+
+    public function testMoveDoesNothingWhenParentIsUnchanged(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->move($child->getUuid(), $parentA->getUuid());
+
+        $this->assertRouteSlug('/parent-a/child', $child->getUuid(), 'en');
+        self::assertNull($this->routeRepository->findOneBy([
+            'webspace' => 'sulu-io',
+            'locale' => 'en',
+            'slug' => '/parent-a/child',
+            'resourceKey' => Route::HISTORY_RESOURCE_KEY,
+        ]));
+    }
+
+    public function testMoveReanchorsRouteSoLaterParentRenameCascades(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+        $this->assertRouteSlug('/parent-b/child', $child->getUuid(), 'en');
+
+        // Renaming the new parent must cascade to the moved child, which only works if the moved
+        // route's parent_id FK was re-pointed at parent B.
+        $this->renameRoute($parentB->getUuid(), 'en', '/parent-b-renamed');
+
+        $this->assertRouteSlug('/parent-b-renamed/child', $child->getUuid(), 'en');
+    }
+
+    public function testCopyCreatesRouteSoLaterParentRenameCascades(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $source = $this->createPage($parentA->getUuid(), ['title' => 'Source', 'url' => '/parent-a/source']);
+
+        $target = $this->copy($source->getUuid(), $parentB->getUuid());
+        $this->assertRouteSlug('/parent-b/source', $target->getUuid(), 'en');
+
+        // Renaming the parent must cascade to the copied route, which only works if the copied
+        // route's parent_id FK was set to parent B.
+        $this->renameRoute($parentB->getUuid(), 'en', '/parent-b-renamed');
+
+        $this->assertRouteSlug('/parent-b-renamed/source', $target->getUuid(), 'en');
+    }
+
+    public function testCopyCreatesRouteWithUniqueSlug(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $source = $this->createPage($parentA->getUuid(), ['title' => 'Source', 'url' => '/parent-a/source']);
+
+        $target = $this->copy($source->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-b/source', $target->getUuid(), 'en');
+    }
+
+    public function testCopyToSameParentAppendsSuffix(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $source = $this->createPage($parentA->getUuid(), ['title' => 'Source', 'url' => '/parent-a/source']);
+
+        $target = $this->copy($source->getUuid(), $parentA->getUuid());
+
+        $this->assertRouteSlug('/parent-a/source-1', $target->getUuid(), 'en');
+    }
+
+    public function testCopyIncrementsSuffixWhenFirstCandidateIsTaken(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $this->createPage($parentA->getUuid(), ['title' => 'Existing', 'url' => '/parent-a/source-1']);
+        $source = $this->createPage($parentA->getUuid(), ['title' => 'Source', 'url' => '/parent-a/source']);
+
+        $target = $this->copy($source->getUuid(), $parentA->getUuid());
+
+        $this->assertRouteSlug('/parent-a/source-2', $target->getUuid(), 'en');
+    }
+
+    public function testCopyUnderHomepageCollapsesParentSlash(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $source = $this->createPage($parentA->getUuid(), ['title' => 'Source', 'url' => '/parent-a/source']);
+
+        $target = $this->copy($source->getUuid(), $homepage->getUuid());
+
+        $this->assertRouteSlug('/source', $target->getUuid(), 'en');
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function createPage(string $parentId, array $data): PageInterface
+    {
+        $data = \array_merge(['locale' => 'en', 'template' => 'default'], $data);
+
+        /** @var CreatePageMessageHandler $handler */
+        $handler = self::getContainer()->get('sulu_page.create_page_handler');
+        $page = $handler(new CreatePageMessage('sulu-io', $parentId, $data));
+        self::getEntityManager()->flush();
+        self::getEntityManager()->clear();
+
+        return $this->pageRepository->getOneBy(['uuid' => $page->getUuid()]);
+    }
+
+    private function move(string $uuid, string $destinationParentUuid): void
+    {
+        /** @var MovePageMessageHandler $handler */
+        $handler = self::getContainer()->get('sulu_page.move_page_handler');
+        $handler(new MovePageMessage(['uuid' => $uuid], ['uuid' => $destinationParentUuid], 'en'));
+        self::getEntityManager()->flush();
+        self::getEntityManager()->clear();
+    }
+
+    private function copy(string $sourceUuid, string $destinationParentUuid): PageInterface
+    {
+        /** @var CopyPageMessageHandler $handler */
+        $handler = self::getContainer()->get('sulu_page.copy_page_handler');
+        $target = $handler(new CopyPageMessage(['uuid' => $sourceUuid], ['uuid' => $destinationParentUuid], 'en'));
+        $targetUuid = $target->getUuid();
+        self::getEntityManager()->flush();
+        self::getEntityManager()->clear();
+
+        return $this->pageRepository->getOneBy(['uuid' => $targetUuid]);
+    }
+
+    private function renameRoute(string $resourceId, string $locale, string $newSlug): void
+    {
+        $route = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $resourceId,
+            'locale' => $locale,
+        ]);
+        self::assertNotNull($route, \sprintf('Expected a route for page %s in locale %s.', $resourceId, $locale));
+
+        $route->setSlug($newSlug);
+        self::getEntityManager()->flush();
+        self::getEntityManager()->clear();
+    }
+
+    private function getHomepage(): PageInterface
+    {
+        $homepage = $this->pageRepository->findOneBy([
+            'webspaceKey' => 'sulu-io',
+            'parentId' => null,
+            'locale' => 'en',
+            'stage' => DimensionContentInterface::STAGE_DRAFT,
+        ]);
+        self::assertNotNull($homepage, 'Homepage should be initialized in setUp.');
+
+        return $homepage;
+    }
+
+    private function assertRouteSlug(string $expectedSlug, string $resourceId, string $locale): void
+    {
+        $route = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $resourceId,
+            'locale' => $locale,
+        ]);
+
+        self::assertNotNull($route, \sprintf('Expected a route for page %s in locale %s.', $resourceId, $locale));
+        self::assertSame($expectedSlug, $route->getSlug());
+    }
+}

--- a/packages/page/tests/Functional/Integration/PageMoveCopyRoutingTest.php
+++ b/packages/page/tests/Functional/Integration/PageMoveCopyRoutingTest.php
@@ -18,9 +18,11 @@ use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Page\Application\Message\CopyPageMessage;
 use Sulu\Page\Application\Message\CreatePageMessage;
+use Sulu\Page\Application\Message\ModifyPageMessage;
 use Sulu\Page\Application\Message\MovePageMessage;
 use Sulu\Page\Application\MessageHandler\CopyPageMessageHandler;
 use Sulu\Page\Application\MessageHandler\CreatePageMessageHandler;
+use Sulu\Page\Application\MessageHandler\ModifyPageMessageHandler;
 use Sulu\Page\Application\MessageHandler\MovePageMessageHandler;
 use Sulu\Page\Domain\Model\PageInterface;
 use Sulu\Page\Domain\Repository\PageRepositoryInterface;
@@ -259,6 +261,155 @@ class PageMoveCopyRoutingTest extends SuluTestCase
         $this->assertRouteSlug('/parent-a/child', $child->getUuid(), 'en');
     }
 
+    public function testMoveThenOldParentRenameMustNotDragMovedChildInUntranslatedLocale(): void
+    {
+        // Multi-locale move where the destination (parent B) is not translated in "de". createPage()
+        // creates only the "en" locale, so "de" is added to parent A and the child via translatePage().
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->translatePage($parentA->getUuid(), ['title' => 'Eltern A', 'url' => '/eltern-a']);
+        $this->translatePage($child->getUuid(), ['title' => 'Kind', 'url' => '/eltern-a/kind']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        // The "en" route is correctly re-anchored under the new parent.
+        $this->assertRouteSlug('/parent-b/child', $child->getUuid(), 'en');
+
+        // The child has moved out of parent A, so a later rename of parent A in "de" must not drag
+        // the moved-away child's "de" route along.
+        $this->renameRoute($parentA->getUuid(), 'de', '/eltern-a-neu');
+
+        $childDeRoute = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $child->getUuid(),
+            'locale' => 'de',
+        ]);
+        self::assertNotNull($childDeRoute, 'Expected a "de" route for the moved child.');
+        self::assertStringStartsNotWith(
+            '/eltern-a-neu/',
+            $childDeRoute->getSlug(),
+            'A page moved out of parent A must not be re-parented under it when parent A is later renamed.',
+        );
+    }
+
+    public function testMoveReanchorsRouteRootRelativeWhenNewParentUntranslatedInLocale(): void
+    {
+        // Parent B is not translated in "de", so the moved child's "de" URL cannot sit under it. The
+        // route must be re-generated root-relative ("/kind") instead of being left stale under parent A.
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->translatePage($parentA->getUuid(), ['title' => 'Eltern A', 'url' => '/eltern-a']);
+        $this->translatePage($child->getUuid(), ['title' => 'Kind', 'url' => '/eltern-a/kind']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-b/child', $child->getUuid(), 'en');
+        $this->assertRouteSlug('/kind', $child->getUuid(), 'de');
+    }
+
+    public function testMoveReanchorsRouteRootRelativeWhenPreviousParentUntranslatedInLocale(): void
+    {
+        // Edge: the child was given a "de" URL nested under parent A even though parent A itself is not
+        // translated in "de" (a manually typed URL). On move, the slug cannot be resolved relative to
+        // the untranslated previous parent, so it falls back to the child's own segment ("/child").
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->translatePage($child->getUuid(), ['title' => 'Kind', 'url' => '/parent-a/child']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/child', $child->getUuid(), 'de');
+    }
+
+    public function testMoveAnchorPageCascadesToAnchoredPageTreeRouteArticle(): void
+    {
+        // An article using a page_tree_route field is stored as a webspace-NULL route whose slug sits
+        // under its anchor page and whose parent_id points at the anchor page's route. When the anchor
+        // page is moved (its own slug changes), the article URL must follow via the slug-prefix cascade.
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $anchor = $this->createPage($parentA->getUuid(), ['title' => 'Anchor', 'url' => '/parent-a/anchor']);
+
+        $this->createArticleRoute('article-1', $anchor->getUuid(), 'en', '/parent-a/anchor/my-article');
+
+        $this->move($anchor->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-b/anchor', $anchor->getUuid(), 'en');
+        $this->assertArticleRouteSlug('/parent-b/anchor/my-article', 'article-1', 'en');
+    }
+
+    public function testMoveUpdatesRoutesInAllTranslatedLocales(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->translatePage($parentA->getUuid(), ['title' => 'Eltern A', 'url' => '/eltern-a']);
+        $this->translatePage($parentB->getUuid(), ['title' => 'Eltern B', 'url' => '/eltern-b']);
+        $this->translatePage($child->getUuid(), ['title' => 'Kind', 'url' => '/eltern-a/kind']);
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-b/child', $child->getUuid(), 'en');
+        $this->assertRouteSlug('/eltern-b/kind', $child->getUuid(), 'de');
+    }
+
+    public function testCopyCreatesRoutesInAllTranslatedLocales(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $source = $this->createPage($parentA->getUuid(), ['title' => 'Source', 'url' => '/parent-a/source']);
+
+        $this->translatePage($parentA->getUuid(), ['title' => 'Eltern A', 'url' => '/eltern-a']);
+        $this->translatePage($parentB->getUuid(), ['title' => 'Eltern B', 'url' => '/eltern-b']);
+        $this->translatePage($source->getUuid(), ['title' => 'Quelle', 'url' => '/eltern-a/quelle']);
+
+        $target = $this->copy($source->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-b/source', $target->getUuid(), 'en');
+        $this->assertRouteSlug('/eltern-b/quelle', $target->getUuid(), 'de');
+    }
+
+    public function testCopyCreatesParentlessRouteWithoutHistory(): void
+    {
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $source = $this->createPage($parentA->getUuid(), ['title' => 'Source', 'url' => '/parent-a/source']);
+
+        $target = $this->copy($source->getUuid(), $parentA->getUuid());
+
+        $targetRoute = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $target->getUuid(),
+            'locale' => 'en',
+        ]);
+        self::assertNotNull($targetRoute, 'Expected a route for the copied page.');
+        self::assertNull(
+            $targetRoute->getParentRoute(),
+            'A copied page route must stay anchored to the tree (parent_id null), like a normal page route.',
+        );
+
+        // Copy is a fresh INSERT (not a slug change), so it must not create a history route.
+        $historyRoute = $this->routeRepository->findOneBy([
+            'resourceKey' => Route::HISTORY_RESOURCE_KEY,
+            'locale' => 'en',
+            'slug' => $targetRoute->getSlug(),
+        ]);
+        self::assertNull($historyRoute, 'Copying a page must not create a history route for the new slug.');
+    }
+
     /**
      * @param array<string, mixed> $data
      */
@@ -273,6 +424,22 @@ class PageMoveCopyRoutingTest extends SuluTestCase
         self::getEntityManager()->clear();
 
         return $this->pageRepository->getOneBy(['uuid' => $page->getUuid()]);
+    }
+
+    /**
+     * Adds a translation (and its route) in an additional locale to an existing page.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function translatePage(string $uuid, array $data): void
+    {
+        $data = \array_merge(['locale' => 'de', 'template' => 'default'], $data);
+
+        /** @var ModifyPageMessageHandler $handler */
+        $handler = self::getContainer()->get('sulu_page.modify_page_handler');
+        $handler(new ModifyPageMessage(['uuid' => $uuid], $data));
+        self::getEntityManager()->flush();
+        self::getEntityManager()->clear();
     }
 
     private function move(string $uuid, string $destinationParentUuid): void
@@ -353,6 +520,37 @@ class PageMoveCopyRoutingTest extends SuluTestCase
         ]);
 
         self::assertNotNull($route, \sprintf('Expected a route for page %s in locale %s.', $resourceId, $locale));
+        self::assertSame($expectedSlug, $route->getSlug());
+    }
+
+    /**
+     * Creates a route the way a page_tree_route article field does: webspace NULL, anchored to the
+     * given page's route via parent_id.
+     */
+    private function createArticleRoute(string $resourceId, string $anchorResourceId, string $locale, string $slug): void
+    {
+        $anchorRoute = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $anchorResourceId,
+            'locale' => $locale,
+        ]);
+        self::assertNotNull($anchorRoute, \sprintf('Expected a route for anchor page %s in locale %s.', $anchorResourceId, $locale));
+
+        $route = new Route('articles', $resourceId, $locale, $slug, null, $anchorRoute);
+        $this->routeRepository->add($route);
+        self::getEntityManager()->flush();
+        self::getEntityManager()->clear();
+    }
+
+    private function assertArticleRouteSlug(string $expectedSlug, string $resourceId, string $locale): void
+    {
+        $route = $this->routeRepository->findOneBy([
+            'resourceKey' => 'articles',
+            'resourceId' => $resourceId,
+            'locale' => $locale,
+        ]);
+
+        self::assertNotNull($route, \sprintf('Expected an article route %s in locale %s.', $resourceId, $locale));
         self::assertSame($expectedSlug, $route->getSlug());
     }
 }

--- a/packages/page/tests/Functional/Integration/PageMoveCopyRoutingTest.php
+++ b/packages/page/tests/Functional/Integration/PageMoveCopyRoutingTest.php
@@ -147,7 +147,7 @@ class PageMoveCopyRoutingTest extends SuluTestCase
         $this->assertRouteSlug('/parent-b/child', $child->getUuid(), 'en');
 
         // Renaming the new parent must cascade to the moved child, which only works if the moved
-        // route's parent_id FK was re-pointed at parent B.
+        // route's slug now sits under parent B's slug (the cascade matches by slug prefix).
         $this->renameRoute($parentB->getUuid(), 'en', '/parent-b-renamed');
 
         $this->assertRouteSlug('/parent-b-renamed/child', $child->getUuid(), 'en');
@@ -164,7 +164,7 @@ class PageMoveCopyRoutingTest extends SuluTestCase
         $this->assertRouteSlug('/parent-b/source', $target->getUuid(), 'en');
 
         // Renaming the parent must cascade to the copied route, which only works if the copied
-        // route's parent_id FK was set to parent B.
+        // route's slug sits under parent B's slug (the cascade matches by slug prefix).
         $this->renameRoute($parentB->getUuid(), 'en', '/parent-b-renamed');
 
         $this->assertRouteSlug('/parent-b-renamed/source', $target->getUuid(), 'en');
@@ -216,6 +216,49 @@ class PageMoveCopyRoutingTest extends SuluTestCase
         $this->assertRouteSlug('/source', $target->getUuid(), 'en');
     }
 
+    public function testMoveKeepsSlugWhenChildSlugSharesParentPrefixWithoutBoundary(): void
+    {
+        // The child's slug ("/sportswear") shares a string prefix with the parent ("/sport") but
+        // is not actually nested under it. Re-anchoring must not strip a partial segment.
+        $homepage = $this->getHomepage();
+        $sport = $this->createPage($homepage->getUuid(), ['title' => 'Sport', 'url' => '/sport']);
+        $leisure = $this->createPage($homepage->getUuid(), ['title' => 'Leisure', 'url' => '/leisure']);
+        $child = $this->createPage($sport->getUuid(), ['title' => 'Sportswear', 'url' => '/sportswear']);
+
+        $this->move($child->getUuid(), $leisure->getUuid());
+
+        $this->assertRouteSlug('/leisure/sportswear', $child->getUuid(), 'en');
+    }
+
+    public function testCopyKeepsSlugWhenSourceSlugSharesParentPrefixWithoutBoundary(): void
+    {
+        $homepage = $this->getHomepage();
+        $sport = $this->createPage($homepage->getUuid(), ['title' => 'Sport', 'url' => '/sport']);
+        $leisure = $this->createPage($homepage->getUuid(), ['title' => 'Leisure', 'url' => '/leisure']);
+        $source = $this->createPage($sport->getUuid(), ['title' => 'Sportswear', 'url' => '/sportswear']);
+
+        $target = $this->copy($source->getUuid(), $leisure->getUuid());
+
+        $this->assertRouteSlug('/leisure/sportswear', $target->getUuid(), 'en');
+    }
+
+    public function testMoveDoesNotReanchorRouteAnchoredToExternalParentRoute(): void
+    {
+        // A route with a parentRoute (e.g. from a page_tree_route field) is anchored to an external
+        // page, not to the page tree, so moving the page in the tree must leave its slug untouched.
+        $homepage = $this->getHomepage();
+        $parentA = $this->createPage($homepage->getUuid(), ['title' => 'Parent A', 'url' => '/parent-a']);
+        $parentB = $this->createPage($homepage->getUuid(), ['title' => 'Parent B', 'url' => '/parent-b']);
+        $anchor = $this->createPage($homepage->getUuid(), ['title' => 'Anchor', 'url' => '/anchor']);
+        $child = $this->createPage($parentA->getUuid(), ['title' => 'Child', 'url' => '/parent-a/child']);
+
+        $this->anchorRouteToParent($child->getUuid(), $anchor->getUuid(), 'en');
+
+        $this->move($child->getUuid(), $parentB->getUuid());
+
+        $this->assertRouteSlug('/parent-a/child', $child->getUuid(), 'en');
+    }
+
     /**
      * @param array<string, mixed> $data
      */
@@ -263,6 +306,27 @@ class PageMoveCopyRoutingTest extends SuluTestCase
         self::assertNotNull($route, \sprintf('Expected a route for page %s in locale %s.', $resourceId, $locale));
 
         $route->setSlug($newSlug);
+        self::getEntityManager()->flush();
+        self::getEntityManager()->clear();
+    }
+
+    private function anchorRouteToParent(string $resourceId, string $parentResourceId, string $locale): void
+    {
+        $route = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $resourceId,
+            'locale' => $locale,
+        ]);
+        self::assertNotNull($route, \sprintf('Expected a route for page %s in locale %s.', $resourceId, $locale));
+
+        $parentRoute = $this->routeRepository->findOneBy([
+            'resourceKey' => PageInterface::RESOURCE_KEY,
+            'resourceId' => $parentResourceId,
+            'locale' => $locale,
+        ]);
+        self::assertNotNull($parentRoute, \sprintf('Expected a route for page %s in locale %s.', $parentResourceId, $locale));
+
+        $route->setParentRoute($parentRoute);
         self::getEntityManager()->flush();
         self::getEntityManager()->clear();
     }

--- a/packages/page/tests/Functional/Integration/responses/page_post_copy.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_copy.json
@@ -59,7 +59,7 @@
     "stage" : "draft",
     "template" : "default",
     "title" : "Test page for copy",
-    "url" : null,
+    "url" : "/test-page-for-copy/test-page-for-copy",
     "version" : 0,
     "webspace": "sulu-io",
     "workflowPlace" : "unpublished"

--- a/packages/page/tests/Functional/Integration/responses/page_post_move.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_move.json
@@ -59,7 +59,7 @@
     "stage" : "draft",
     "template" : "default",
     "title" : "Test page for copy",
-    "url" : "/test-page-for-copy/test-page-for-copy",
+    "url" : "/test-page-for-copy-1",
     "version" : 0,
     "webspace": "sulu-io",
     "workflowPlace" : "unpublished"

--- a/packages/page/tests/Functional/Integration/responses/page_post_move.json
+++ b/packages/page/tests/Functional/Integration/responses/page_post_move.json
@@ -59,7 +59,7 @@
     "stage" : "draft",
     "template" : "default",
     "title" : "Test page for copy",
-    "url" : null,
+    "url" : "/test-page-for-copy/test-page-for-copy",
     "version" : 0,
     "webspace": "sulu-io",
     "workflowPlace" : "unpublished"

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Route\Infrastructure\Doctrine\EventListener;
 
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
@@ -128,22 +127,28 @@ class RouteChangedUpdater implements ResetInterface
             $locale = $route->getLocale();
             $webspace = $route->getWebspace();
 
+            // match descendants by slug prefix, not the parent_id FK (unset for "route" fields);
+            // OR-NULL keeps cross-site children attached
+            $webspaceCondition = \is_string($webspace)
+                ? '(webspace = :webspace OR webspace IS NULL)'
+                : 'webspace IS NULL';
+
             // select all child and grand routes of oldSlug
             $selectQueryBuilder = $connection->createQueryBuilder()
-                ->from($routesTableName, 'parent')
-                ->select('parent.id AS parent_id')
-                ->addSelect('child.webspace')
-                ->addSelect('child.slug')
-                ->addSelect('child.resource_key')
-                ->addSelect('child.resource_id')
-                ->innerJoin('parent', $routesTableName, 'child', 'child.parent_id = parent.id')
-                ->andWhere(\is_string($webspace) ? 'parent.webspace = :webspace' : 'parent.webspace IS NULL')
-                ->andWhere('parent.locale = :locale')
-                ->andWhere('(parent.slug = :newSlug OR parent.slug LIKE :oldSlugSlash)') // direct child is using newSlug already updated as we are in PostFlush, grand child use oldSlugWithSlash as not yet updated
-                ->andWhere('(child.slug LIKE :oldSlugSlash)') // ignore disconnected child routes in case of full tree edit
-                ->setParameter('newSlug', $newSlug, ParameterType::STRING)
+                ->from($routesTableName)
+                ->select('webspace')
+                ->addSelect('slug')
+                ->addSelect('resource_key')
+                ->addSelect('resource_id')
+                ->andWhere($webspaceCondition)
+                ->andWhere('locale = :locale')
+                ->andWhere('slug LIKE :oldSlugSlash')
+                ->andWhere('resource_key != :historyResourceKey') // never rewrite or re-historize history routes
+                ->andWhere('id != :changedRouteId') // never re-process the changed route itself
                 ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
-                ->setParameter('locale', $locale, ParameterType::STRING);
+                ->setParameter('locale', $locale, ParameterType::STRING)
+                ->setParameter('historyResourceKey', Route::HISTORY_RESOURCE_KEY, ParameterType::STRING)
+                ->setParameter('changedRouteId', $route->getId(), ParameterType::INTEGER);
 
             if (\is_string($webspace)) {
                 $selectQueryBuilder->setParameter('webspace', $webspace, ParameterType::STRING);
@@ -151,7 +156,6 @@ class RouteChangedUpdater implements ResetInterface
 
             /**
              * @var array<int, array{
-             *     parent_id: int,
              *     webspace: string|null,
              *     slug: string,
              *     resource_key: string,
@@ -159,10 +163,8 @@ class RouteChangedUpdater implements ResetInterface
              * }> $childAndGrandChildResult
              */
             $childAndGrandChildResult = $selectQueryBuilder->executeQuery()->iterateAssociative();
-            $parentIds = [];
             $childAndGrandChildHistoryRoutes = [];
             foreach ($childAndGrandChildResult as $childAndGrandChildRow) {
-                $parentIds[] = $childAndGrandChildRow['parent_id'];
                 $childAndGrandChildHistoryRoutes[] = new Route(
                     Route::HISTORY_RESOURCE_KEY,
                     $childAndGrandChildRow['resource_key'] . '::' . $childAndGrandChildRow['resource_id'],
@@ -172,9 +174,6 @@ class RouteChangedUpdater implements ResetInterface
                     null, // history never has parents as they never will be updated
                 );
             }
-
-            $parentIds = \array_filter($parentIds);
-            $parentIds = \array_unique($parentIds); // DISTINCT and GROUP BY is a lot slower as make it unique in PHP itself
 
             $historyRoute = new Route(
                 Route::HISTORY_RESOURCE_KEY,
@@ -187,7 +186,7 @@ class RouteChangedUpdater implements ResetInterface
 
             $this->createHistoryRoute($objectManager, $classMetadata, $historyRoute);
 
-            if (0 !== \count($parentIds)) {
+            if (0 !== \count($childAndGrandChildHistoryRoutes)) {
                 $newSlugCast = '';
                 if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
                     $newSlugCast = '::text'; // concat seems not directly supported by dbal and parameter $1 (newSlug) is not cast to text correctly. So manually cast it here: https://github.com/sulu/sulu/pull/7726#discussion_r1930324013
@@ -198,10 +197,19 @@ class RouteChangedUpdater implements ResetInterface
                     ->update($routesTableName)
                     ->set('slug', 'CONCAT(:newSlug' . $newSlugCast . ', SUBSTRING(slug, ' . (\strlen($oldSlug) + 1) . '))')
                     ->setParameter('newSlug', $newSlug, ParameterType::STRING)
-                    ->where('parent_id IN (:parentIds)')
-                    ->andWhere('slug LIKE :oldSlugSlash') // ignore disconnected child routes in case of full tree edit
+                    ->andWhere($webspaceCondition)
+                    ->andWhere('locale = :locale')
+                    ->andWhere('slug LIKE :oldSlugSlash')
+                    ->andWhere('resource_key != :historyResourceKey')
+                    ->andWhere('id != :changedRouteId')
                     ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
-                    ->setParameter('parentIds', $parentIds, ArrayParameterType::INTEGER);
+                    ->setParameter('locale', $locale, ParameterType::STRING)
+                    ->setParameter('historyResourceKey', Route::HISTORY_RESOURCE_KEY, ParameterType::STRING)
+                    ->setParameter('changedRouteId', $route->getId(), ParameterType::INTEGER);
+
+                if (\is_string($webspace)) {
+                    $updateQueryBuilder->setParameter('webspace', $webspace, ParameterType::STRING);
+                }
 
                 $updateQueryBuilder->executeStatement();
             }

--- a/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
+++ b/packages/route/src/Infrastructure/Doctrine/EventListener/RouteChangedUpdater.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Route\Infrastructure\Doctrine\EventListener;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
@@ -127,24 +128,27 @@ class RouteChangedUpdater implements ResetInterface
             $locale = $route->getLocale();
             $webspace = $route->getWebspace();
 
-            // match descendants by slug prefix, not the parent_id FK (unset for "route" fields);
-            // OR-NULL keeps cross-site children attached
+            // Same-webspace descendants are matched by slug prefix (plain page routes have no
+            // parent_id). A webspace-NULL route (e.g. a page_tree_route article) is matched only
+            // when its parent_id resolves into this webspace, so it follows just its real anchor.
             $webspaceCondition = \is_string($webspace)
-                ? '(webspace = :webspace OR webspace IS NULL)'
-                : 'webspace IS NULL';
+                ? '(child.webspace = :webspace OR (child.webspace IS NULL AND parent.webspace = :webspace))'
+                : 'child.webspace IS NULL';
 
             // select all child and grand routes of oldSlug
             $selectQueryBuilder = $connection->createQueryBuilder()
-                ->from($routesTableName)
-                ->select('webspace')
-                ->addSelect('slug')
-                ->addSelect('resource_key')
-                ->addSelect('resource_id')
+                ->from($routesTableName, 'child')
+                ->leftJoin('child', $routesTableName, 'parent', 'parent.id = child.parent_id')
+                ->select('child.id AS id')
+                ->addSelect('child.webspace AS webspace')
+                ->addSelect('child.slug AS slug')
+                ->addSelect('child.resource_key AS resource_key')
+                ->addSelect('child.resource_id AS resource_id')
                 ->andWhere($webspaceCondition)
-                ->andWhere('locale = :locale')
-                ->andWhere('slug LIKE :oldSlugSlash')
-                ->andWhere('resource_key != :historyResourceKey') // never rewrite or re-historize history routes
-                ->andWhere('id != :changedRouteId') // never re-process the changed route itself
+                ->andWhere('child.locale = :locale')
+                ->andWhere('child.slug LIKE :oldSlugSlash')
+                ->andWhere('child.resource_key != :historyResourceKey') // never rewrite or re-historize history routes
+                ->andWhere('child.id != :changedRouteId') // never re-process the changed route itself
                 ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
                 ->setParameter('locale', $locale, ParameterType::STRING)
                 ->setParameter('historyResourceKey', Route::HISTORY_RESOURCE_KEY, ParameterType::STRING)
@@ -156,6 +160,7 @@ class RouteChangedUpdater implements ResetInterface
 
             /**
              * @var array<int, array{
+             *     id: int,
              *     webspace: string|null,
              *     slug: string,
              *     resource_key: string,
@@ -163,8 +168,10 @@ class RouteChangedUpdater implements ResetInterface
              * }> $childAndGrandChildResult
              */
             $childAndGrandChildResult = $selectQueryBuilder->executeQuery()->iterateAssociative();
+            $childAndGrandChildIds = [];
             $childAndGrandChildHistoryRoutes = [];
             foreach ($childAndGrandChildResult as $childAndGrandChildRow) {
+                $childAndGrandChildIds[] = $childAndGrandChildRow['id'];
                 $childAndGrandChildHistoryRoutes[] = new Route(
                     Route::HISTORY_RESOURCE_KEY,
                     $childAndGrandChildRow['resource_key'] . '::' . $childAndGrandChildRow['resource_id'],
@@ -186,30 +193,19 @@ class RouteChangedUpdater implements ResetInterface
 
             $this->createHistoryRoute($objectManager, $classMetadata, $historyRoute);
 
-            if (0 !== \count($childAndGrandChildHistoryRoutes)) {
+            if (0 !== \count($childAndGrandChildIds)) {
                 $newSlugCast = '';
                 if ($connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
                     $newSlugCast = '::text'; // concat seems not directly supported by dbal and parameter $1 (newSlug) is not cast to text correctly. So manually cast it here: https://github.com/sulu/sulu/pull/7726#discussion_r1930324013
                 }
 
-                // update child and grand routes
+                // update exactly the routes the select matched, by id
                 $updateQueryBuilder = $connection->createQueryBuilder()
                     ->update($routesTableName)
                     ->set('slug', 'CONCAT(:newSlug' . $newSlugCast . ', SUBSTRING(slug, ' . (\strlen($oldSlug) + 1) . '))')
                     ->setParameter('newSlug', $newSlug, ParameterType::STRING)
-                    ->andWhere($webspaceCondition)
-                    ->andWhere('locale = :locale')
-                    ->andWhere('slug LIKE :oldSlugSlash')
-                    ->andWhere('resource_key != :historyResourceKey')
-                    ->andWhere('id != :changedRouteId')
-                    ->setParameter('oldSlugSlash', $oldSlug . '/%', ParameterType::STRING)
-                    ->setParameter('locale', $locale, ParameterType::STRING)
-                    ->setParameter('historyResourceKey', Route::HISTORY_RESOURCE_KEY, ParameterType::STRING)
-                    ->setParameter('changedRouteId', $route->getId(), ParameterType::INTEGER);
-
-                if (\is_string($webspace)) {
-                    $updateQueryBuilder->setParameter('webspace', $webspace, ParameterType::STRING);
-                }
+                    ->where('id IN (:childAndGrandChildIds)')
+                    ->setParameter('childAndGrandChildIds', $childAndGrandChildIds, ArrayParameterType::INTEGER);
 
                 $updateQueryBuilder->executeStatement();
             }

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
@@ -825,7 +825,9 @@ class RouteChangedUpdaterTest extends KernelTestCase
             'expectedChangedRoutes' => 2,
         ];
 
-        yield 'tree_full_edit_disconnected_unrelated_child_not_updated' => [
+        // The cascade matches by slug prefix, so a child sharing the slug path is updated even
+        // without a parent_id link (e.g. plain "route" page fields never set parent_id).
+        yield 'tree_full_edit_disconnected_child_updated_by_slug' => [
             'routes' => [
                 [
                     'resourceId' => '1',
@@ -849,13 +851,13 @@ class RouteChangedUpdaterTest extends KernelTestCase
                 ],
                 [
                     'resourceId' => '2',
-                    'slug' => '/test/child-a',
+                    'slug' => '/test-article/child-a',
                     'webspace' => 'website',
                     'parentSlug' => null,
                     'parentWebspace' => null,
                 ],
             ],
-            'expectedChangedRoutes' => 1,
+            'expectedChangedRoutes' => 2,
         ];
 
         yield 'tree_full_edit_update_child_not_directly_connected' => [

--- a/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
+++ b/packages/route/tests/Functional/Infrastructure/Doctrine/EventListener/RouteChangedUpdaterTest.php
@@ -712,6 +712,57 @@ class RouteChangedUpdaterTest extends KernelTestCase
             'expectedChangedRoutes' => 4,
         ];
 
+        // A webspace-NULL route (e.g. a page_tree_route article) is anchored to its page via
+        // parent_id. Two webspaces may share a slug ("/blog"), so renaming one webspace's "/blog"
+        // must not sweep in an article anchored to the other webspace's "/blog".
+        yield 'cross_webspace_null_child_not_touched_by_other_webspace' => [
+            'routes' => [
+                // First entry is the route that gets renamed: intranet "/blog" -> "/news".
+                [
+                    'resourceId' => '1',
+                    'slug' => '/blog',
+                    'webspace' => 'intranet',
+                ],
+                // A different webspace that happens to share the same slug.
+                [
+                    'resourceId' => '2',
+                    'slug' => '/blog',
+                    'webspace' => 'website',
+                ],
+                // page_tree_route article anchored to WEBSITE's "/blog" (webspace NULL, parent_id
+                // -> website "/blog"). It has nothing to do with the intranet page.
+                [
+                    'resourceId' => '3',
+                    'slug' => '/blog/my-post',
+                    'webspace' => null,
+                    'parentSlug' => '/blog',
+                    'parentWebspace' => 'website',
+                ],
+            ],
+            'changeRoute' => '/news',
+            'expectedRoutes' => [
+                [
+                    'resourceId' => '1',
+                    'slug' => '/news',
+                    'webspace' => 'intranet',
+                ],
+                [
+                    'resourceId' => '2',
+                    'slug' => '/blog',
+                    'webspace' => 'website',
+                ],
+                // Must stay put: the intranet rename must not touch the website-anchored article.
+                [
+                    'resourceId' => '3',
+                    'slug' => '/blog/my-post',
+                    'webspace' => null,
+                    'parentSlug' => '/blog',
+                    'parentWebspace' => 'website',
+                ],
+            ],
+            'expectedChangedRoutes' => 1,
+        ];
+
         yield 'tree_full_edit_last_part_changes_keep_parent' => [
             'routes' => [
                 [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Moving a page now re-anchors its route under the new parent and keeps a history redirect at the old path. Copying a page now creates a route under the target parent instead of leaving the copy without a URL. Descendant routes cascade to the new path in both cases. The cascade in the route changed updater now matches descendants by slug prefix rather than the parent route foreign key, so it also covers moved and copied routes whose parent reference is not set.

#### Why?

Previously a moved page kept its original URL and a copied page received no route at all. This left pages reachable under the wrong path or not reachable by their expected URL. Routes now follow the page tree so the published URL matches the page position after a move or copy.
