### PR TITLE
Fix strip for page_tree_route for homepage

### DIFF
--- a/packages/content/src/Application/ContentNormalizer/Normalizer/RoutableNormalizer.php
+++ b/packages/content/src/Application/ContentNormalizer/Normalizer/RoutableNormalizer.php
@@ -110,8 +110,9 @@ class RoutableNormalizer implements NormalizerInterface
 
         $parentSlug = $parentRoute->getSlug();
         $slug = $route->getSlug();
-        $suffix = \str_starts_with($slug, $parentSlug)
-            ? \substr($slug, \strlen($parentSlug))
+        $parentSlugTrimmed = \rtrim($parentSlug, '/');
+        $suffix = \str_starts_with($slug, $parentSlugTrimmed)
+            ? \substr($slug, \strlen($parentSlugTrimmed))
             : '';
 
         return [

--- a/packages/content/tests/Unit/Content/Application/ContentNormalizer/Normalizer/RoutableNormalizerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentNormalizer/Normalizer/RoutableNormalizerTest.php
@@ -149,6 +149,29 @@ class RoutableNormalizerTest extends TestCase
         );
     }
 
+    public function testEnhanceFillsPageTreeRouteUrlWhenParentIsHomepage(): void
+    {
+        $parentRoute = new Route('pages', 'homepage-uuid', 'en', '/');
+        $route = new Route('pages', 'child-uuid', 'en', '/test123', null, $parentRoute);
+        $object = $this->createDimensionContent('en', 'default', $route);
+
+        $this->primeFormMetadata('example', 'en', 'default', [
+            'url' => $this->createField('url', 'page_tree_route'),
+        ]);
+
+        $result = $this->normalizer->enhance($object, []);
+
+        $this->assertSame(
+            [
+                'url' => [
+                    'page' => ['uuid' => 'homepage-uuid', 'path' => '/'],
+                    'suffix' => '/test123',
+                ],
+            ],
+            $result
+        );
+    }
+
     public function testEnhanceLeavesNonRouteFieldsUntouched(): void
     {
         $route = new Route('examples', '1', 'en', '/my-page');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no
| License | MIT
| Documentation PR | 

#### What's in this PR?

Remove '/' from the parentSlug if the parent page is the homepage.

#### Why?

Otherwise if the page-slug is `/test` and the parentSlug is `/`, `\str_starts_with($slug, $parentSlug)` is true and the first character of the page-slug is removed (`test`) in JS the first Character is then stripped which results in `est`.
