### PR TITLE
Enable url auto generate for items with id

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/ResourceLocator.js
@@ -46,12 +46,13 @@ class ResourceLocator extends React.Component<FieldTypeProps<?string>> {
 
     @computed get enableAutoGeneration(): boolean {
         const {
+            value,
             formInspector: {
                 id,
             },
         } = this.props;
 
-        return !id && !this.inputChanged && Object.keys(this.parts).length > 0;
+        return (!id || !value) && !this.inputChanged && Object.keys(this.parts).length > 0;
     }
 
     @computed get enableRefreshButton(): boolean {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js
@@ -452,6 +452,67 @@ test('Should not request new URL when part field is finished on edit form', () =
     expect(Requester.post).not.toHaveBeenCalled();
 });
 
+test('Should automatically request new URL when part field is finished on edit form with no existing URL', () => {
+    const resourceStore = new ResourceStore('tests', 5, {locale: observable.box('en')});
+    const formInspector = new FormInspector(
+        new ResourceFormStore(
+            resourceStore,
+            'test'
+        )
+    );
+    const changeSpy = jest.fn();
+
+    formInspector.getPathsByTag.mockReturnValue(['/title']);
+    resourceStore.data = {
+        '/title': 'title-value',
+    };
+
+    shallow(
+        <ResourceLocator
+            {...fieldTypeDefaultProps}
+            dataPath="/block/0/url"
+            fieldTypeOptions={{
+                generationUrl: '/admin/api/resourcelocators?action=generate',
+                historyResourceKey: 'page_resourcelocators',
+                modeResolver: () => Promise.resolve('leaf'),
+            }}
+            formInspector={formInspector}
+            onChange={changeSpy}
+            schemaPath="/url"
+            value={null}
+        />
+    );
+
+    const finishFieldHandler = formInspector.addFinishFieldHandler.mock.calls[0][0];
+
+    formInspector.getSchemaEntryByPath.mockReturnValue({
+        tags: [
+            {name: 'sulu.rlp.part'},
+        ],
+    });
+
+    const resourceLocatorPromise = Promise.resolve({
+        resourcelocator: '/test',
+    });
+    Requester.post.mockReturnValue(resourceLocatorPromise);
+
+    finishFieldHandler('/block/0/title', '/title');
+
+    expect(Requester.post).toHaveBeenCalledWith(
+        '/admin/api/resourcelocators?action=generate',
+        {
+            locale: 'en',
+            resourceKey: 'tests',
+            id: 5,
+            parts: {title: 'title-value'},
+        }
+    );
+
+    return resourceLocatorPromise.then(() => {
+        expect(changeSpy).toHaveBeenCalledWith('/test');
+    });
+});
+
 test('Should not request new URL when part field is finished if all parts are empty', () => {
     const resourceStore = new ResourceStore('tests', undefined, {locale: observable.box('en')});
     const formInspector = new FormInspector(
@@ -659,6 +720,7 @@ test('Should enable refresh button when value of part field changes on edit form
             }}
             formInspector={formInspector}
             schemaPath="/url"
+            value="/existing-url"
         />
     );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| License | MIT
| Documentation PR |

#### What's in this PR?

Enable route auto generation for elements which already have an id

#### Why?

So if the element has a detail tab and a content tab in the Admin. The id is generated when the detail tab is saved, but the url field is in the content tab, the auto generation should still work.
