### PR TITLE
Fix redirect after successful login via SSO

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/single_sign_on.php
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/single_sign_on.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\SecurityBundle\SingleSignOn\Adapter\OpenId\OpenIdSingleSignOnAda
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnAdapterFactory;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnAdapterProvider;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnLoginRequestSubscriber;
+use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnLoginSuccessSubscriber;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnTokenExtractor;
 use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnTokenHandler;
 use Symfony\Component\DependencyInjection\Reference;
@@ -28,6 +29,9 @@ return static function(ContainerConfigurator $container) {
             new Reference('router'),
             new Reference('sulu.repository.user'),
         ])
+        ->tag('kernel.event_subscriber');
+
+    $services->set('sulu_security.single_sign_on_login_success_subscriber', SingleSignOnLoginSuccessSubscriber::class)
         ->tag('kernel.event_subscriber');
 
     $services->set('sulu_security.single_sign_on_adapter_factory_open_id', OpenIdSingleSignOnAdapterFactory::class)

--- a/src/Sulu/Bundle/SecurityBundle/SingleSignOn/SingleSignOnLoginSuccessSubscriber.php
+++ b/src/Sulu/Bundle/SecurityBundle/SingleSignOn/SingleSignOnLoginSuccessSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\SingleSignOn;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
+
+/**
+ * @final
+ *
+ * @internal
+ *
+ * @experimental
+ */
+class SingleSignOnLoginSuccessSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LoginSuccessEvent::class => ['onLoginSuccess', 0],
+        ];
+    }
+
+    public function onLoginSuccess(LoginSuccessEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if ('sulu_admin' !== $request->attributes->get('_route')) {
+            return;
+        }
+
+        if (!$request->query->has('code') || !$request->query->has('state')) {
+            return;
+        }
+
+        $event->setResponse(new RedirectResponse($request->getPathInfo()));
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginSuccessSubscriberTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/SingleSignOn/SingleSignOnLoginSuccessSubscriberTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Tests\Unit\SingleSignOn;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\SecurityBundle\SingleSignOn\SingleSignOnLoginSuccessSubscriber;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
+
+class SingleSignOnLoginSuccessSubscriberTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testGetSubscribedEvents(): void
+    {
+        $this->assertSame([
+            LoginSuccessEvent::class => ['onLoginSuccess', 0],
+        ], SingleSignOnLoginSuccessSubscriber::getSubscribedEvents());
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    #[DataProvider('provideOnLoginSuccessScenarios')]
+    public function testOnLoginSuccess(?string $route, array $query, ?string $expectedRedirect): void
+    {
+        $request = Request::create('/admin/', Request::METHOD_GET, $query);
+        if (null !== $route) {
+            $request->attributes->set('_route', $route);
+        }
+
+        $event = $this->createLoginSuccessEvent($request);
+        (new SingleSignOnLoginSuccessSubscriber())->onLoginSuccess($event);
+
+        $response = $event->getResponse();
+
+        if (null === $expectedRedirect) {
+            $this->assertNull($response);
+
+            return;
+        }
+
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertSame($expectedRedirect, $response->getTargetUrl());
+    }
+
+    /**
+     * @return iterable<string, array{0: string|null, 1: array<string, string>, 2: string|null}>
+     */
+    public static function provideOnLoginSuccessScenarios(): iterable
+    {
+        yield 'redirects on sulu_admin route with code and state' => [
+            'sulu_admin',
+            ['code' => 'auth-code', 'state' => 'uuid-state'],
+            '/admin/',
+        ];
+
+        yield 'ignores non sulu_admin route even with code and state' => [
+            'sulu_admin.login_check',
+            ['code' => 'auth-code', 'state' => 'uuid-state'],
+            null,
+        ];
+
+        yield 'ignores sulu_admin route without code' => [
+            'sulu_admin',
+            ['state' => 'uuid-state'],
+            null,
+        ];
+
+        yield 'ignores sulu_admin route without state' => [
+            'sulu_admin',
+            ['code' => 'auth-code'],
+            null,
+        ];
+
+        yield 'ignores request without route attribute' => [
+            null,
+            ['code' => 'auth-code', 'state' => 'uuid-state'],
+            null,
+        ];
+    }
+
+    private function createLoginSuccessEvent(Request $request): LoginSuccessEvent
+    {
+        $authenticator = $this->prophesize(AuthenticatorInterface::class)->reveal();
+        $passport = $this->prophesize(Passport::class)->reveal();
+        $token = $this->prophesize(TokenInterface::class)->reveal();
+
+        return new LoginSuccessEvent($authenticator, $passport, $token, $request, null, 'admin');
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #7847
| Related issues/PRs | #8377
| License | MIT
| Documentation PR | -

#### What's in this PR?

The admin is a SPA, so the original URL (containing `?code=…&state=…`) stays in the browser address bar. Reloading the page (e.g. by browser refresh) replays the authorization code against the OpenID provider, which fails because the code is single-use (HTTP 400 from the IdP).

This PR removes the OpenID `code` and `state` query parameters from the admin URL after a successful SSO login by redirecting to the bare admin route.