### PR TITLE
Fix allow 2FA for non-SSO users when SSO is enabled

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/Login.js
@@ -86,7 +86,7 @@ class Login extends React.Component<Props> {
 
     handleLoginFormSubmit = (data: LoginFormData) => {
         userStore.login(data).then(() => {
-            if (userStore.loginMethod === 'json_login') {
+            if (userStore.loginMethod === 'json_login' && !userStore.hasSingleSignOn()) {
                 return;
             }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

This PR fixes an issue where non-SSO users with enabled Two Factor Authentication (2FA) cannot complete login when both SSO and 2FA are enabled in a Sulu instance (e.g. SSO for internal users of a company, 2FA for all external users).

### Problem

When SSO is enabled, the login flow is split into two steps:

1. enter username
2. enter password

For non-SSO users, this works until the 2FA step:

* the user enters the username
* the user enters the password
* the verification code is sent by email
* but the user is not redirected to the 2FA verification form

As a result, the login cannot be completed.

### Solution

During runtime, the login method is still treated as `json_login`, and because of that, switching to the 2FA check form fails. This PR changes the logic in the login process accordingly so that when SSO is enabled, the process still allows non-SSO with enabled 2FA to:

* receive the verification code
* see the 2FA verification form
* complete the login successfully