### PR TITLE
Fix webpack font build after CKEditor update

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,14 +132,6 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         'postcss-loader',
                     ],
                 },
-               {
-                    test: /\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
-                    issuer: /\.css$/,
-                    type: 'asset/resource',
-                    generator: {
-                        filename: '[name].[contenthash][ext]',
-                    },
-                },
                 {
                     // CKEditor plugins icons
                     test: /\.svg$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,6 +40,7 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
             clean: true,
             path: path.resolve(projectRootPath, publicDir, outputPath),
             filename: '[name].[chunkhash].js',
+            assetModuleFilename: '[name].[contenthash][ext]',
         },
         stats: 'minimal',
         performance: {
@@ -130,6 +131,14 @@ module.exports = (env, argv) => { // eslint-disable-line no-undef
                         },
                         'postcss-loader',
                     ],
+                },
+               {
+                    test: /\.(svg|ttf|woff|woff2|eot)(\?.*$|$)/,
+                    issuer: /\.css$/,
+                    type: 'asset/resource',
+                    generator: {
+                        filename: '[name].[contenthash][ext]',
+                    },
                 },
                 {
                     // CKEditor plugins icons


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes 
| BC breaks? | no | Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs |  https://github.com/sulu/sulu/pull/8833,  https://github.com/sulu/skeleton/pull/332
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix webpack font build after CKEditor update.

#### Why?

See problem with manifest.json changes in https://github.com/sulu/skeleton/pull/332
