### PR TITLE
Add better DX for password input during sulu:build

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -55,7 +55,7 @@ class UserBuilder extends SuluBuilder
 
         // Running after the admin user check, otherwise we don't need the password.
         $helper = new QuestionHelper();
-        $question = new Question("Please provide an admin password (default: admin)\n");
+        $question = new Question("Please provide an admin password (default: admin): ");
 
         /** @var string $password */
         $password = $helper->ask($this->input, $this->output, $question) ?: 'admin';

--- a/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
+++ b/src/Sulu/Bundle/SecurityBundle/Build/UserBuilder.php
@@ -55,7 +55,7 @@ class UserBuilder extends SuluBuilder
 
         // Running after the admin user check, otherwise we don't need the password.
         $helper = new QuestionHelper();
-        $question = new Question("Please provide an admin password (default: admin): ");
+        $question = new Question('Please provide an admin password (default: admin): ');
 
         /** @var string $password */
         $password = $helper->ask($this->input, $this->output, $question) ?: 'admin';


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add better DX for password input during sulu:build.

#### Why?

The line break just feels like the step is done and the process is still running and not seems indicate there is a wait for an input. With no line break and the `: ` it indicate more user need input something here.
