### PR TITLE
Fix smart content group and template key filtering returning unrelated results

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -156,7 +156,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
         $filters = $this->mapFilters($filters, $params);
-        if (null === $filters['templateKeys']) {
+        if (null === $filters['templateKeys']) { // means admin or website requested templates and defined groups or templates do not match together so we can early return with zero results
             return 0;
         }
 
@@ -195,7 +195,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
         $filters = $this->mapFilters($filters, $params);
-        if (null === $filters['templateKeys']) {
+        if (null === $filters['templateKeys']) { // means admin or website requested templates and defined groups or templates do not match together so we can early return with no results
             return [];
         }
 

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -155,10 +155,20 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         /** @var ArticleSmartContentCountFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
+        $templateKeys = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
+        if (null === $templateKeys) {
+            return 0;
+        }
+        $filters['templateKeys'] = $templateKeys;
+        $filters = $this->mapFilters($filters);
+
         $alias = 'article';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
 
-        $filters = $this->mapFilters($filters, $params);
         $this->dimensionContentQueryEnhancer->addFilters(
             $queryBuilder,
             $alias,
@@ -190,12 +200,22 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         /** @var ArticleSmartContentFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
+        $templateKeys = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
+        if (null === $templateKeys) {
+            return [];
+        }
+        $filters['templateKeys'] = $templateKeys;
+        $filters = $this->mapFilters($filters);
+
         $sortBys = $this->mapSortBys($sortBys);
 
         $alias = 'article';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
 
-        $filters = $this->mapFilters($filters, $params);
         $this->dimensionContentQueryEnhancer->addFilters(
             $queryBuilder,
             $alias,
@@ -235,7 +255,6 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
 
     /**
      * @param ArticleSmartContentFilters|ArticleSmartContentCountFilters $filters
-     * @param array<string, mixed> $params
      *
      * @return array{
      *         categoryIds?: int[],
@@ -246,7 +265,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      *         tagOperator: 'AND'|'OR',
      *         websiteTags: string[],
      *         websiteTagOperator: 'AND'|'OR',
-     *         templateKeys?: string[],
+     *         templateKeys: string[],
      *         typesOperator: 'OR',
      *         locale: string,
      *         dataSource: string|null,
@@ -258,13 +277,8 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      *         webspaceKey?: string
      *     }
      */
-    protected function mapFilters(array $filters, array $params = []): array
+    protected function mapFilters(array $filters): array
     {
-        $filters['templateKeys'] = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
         unset($filters['types']);
 
         if ($filters['categories']) {
@@ -285,16 +299,19 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      * @param array<string> $filterGroupIdentifiers
      * @param array<string, mixed> $params
      *
-     * @return list<string>
+     * @return list<string>|null null = no overlap with the requested filters
      */
-    private function resolveTemplateKeys(array $existingTemplateKeys, array $filterGroupIdentifiers, array $params): array
+    private function resolveTemplateKeys(array $existingTemplateKeys, array $filterGroupIdentifiers, array $params): ?array
     {
-        $groupIdentifiers = $filterGroupIdentifiers;
-        if ([] === $groupIdentifiers) {
-            $groupsParam = $params['groups'] ?? null;
-            if (\is_string($groupsParam)) {
-                $groupIdentifiers = \array_values(\array_filter(\array_map('trim', \explode(',', $groupsParam))));
+        $xmlGroupIdentifiers = $this->parseListParameter($params['groups'] ?? null);
+
+        if ([] !== $xmlGroupIdentifiers && [] !== $filterGroupIdentifiers) {
+            $groupIdentifiers = \array_values(\array_intersect($filterGroupIdentifiers, $xmlGroupIdentifiers));
+            if ([] === $groupIdentifiers) {
+                return null;
             }
+        } else {
+            $groupIdentifiers = $filterGroupIdentifiers ?: $xmlGroupIdentifiers;
         }
 
         $templateKeys = \array_values($existingTemplateKeys);
@@ -303,19 +320,34 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
             $templateKeys = [] !== $templateKeys
                 ? \array_values(\array_intersect($templateKeys, $templatesFromGroups))
                 : $templatesFromGroups;
+            if ([] === $templateKeys) {
+                return null;
+            }
         }
 
-        $templateParam = $params['templateKeys'] ?? null;
-        if (\is_string($templateParam)) {
-            $templateKeysParam = \array_values(\array_filter(\array_map('trim', \explode(',', $templateParam))));
-            if ([] !== $templateKeysParam) {
-                $templateKeys = [] !== $templateKeys
-                    ? \array_values(\array_intersect($templateKeys, $templateKeysParam))
-                    : $templateKeysParam;
+        $xmlTemplateKeys = $this->parseListParameter($params['templateKeys'] ?? null);
+        if ([] !== $xmlTemplateKeys) {
+            $templateKeys = [] !== $templateKeys
+                ? \array_values(\array_intersect($templateKeys, $xmlTemplateKeys))
+                : $xmlTemplateKeys;
+            if ([] === $templateKeys) {
+                return null;
             }
         }
 
         return $templateKeys;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseListParameter(mixed $value): array
+    {
+        if (!\is_string($value)) {
+            return [];
+        }
+
+        return \array_values(\array_filter(\array_map('trim', \explode(',', $value))));
     }
 
     /**

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -155,16 +155,10 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         /** @var ArticleSmartContentCountFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
-        $templateKeys = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
-        if (null === $templateKeys) {
+        $filters = $this->mapFilters($filters, $params);
+        if (null === $filters['templateKeys']) {
             return 0;
         }
-        $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters, $params);
 
         $alias = 'article';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
@@ -200,16 +194,10 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         /** @var ArticleSmartContentFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
-        $templateKeys = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
-        if (null === $templateKeys) {
+        $filters = $this->mapFilters($filters, $params);
+        if (null === $filters['templateKeys']) {
             return [];
         }
-        $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters, $params);
 
         $sortBys = $this->mapSortBys($sortBys);
 
@@ -266,7 +254,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      *         tagOperator: 'AND'|'OR',
      *         websiteTags: string[],
      *         websiteTagOperator: 'AND'|'OR',
-     *         templateKeys: string[],
+     *         templateKeys: string[]|null,
      *         typesOperator: 'OR',
      *         locale: string,
      *         dataSource: string|null,
@@ -280,6 +268,11 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      */
     protected function mapFilters(array $filters, array $params = []): array
     {
+        $filters['templateKeys'] = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
         unset($filters['types']);
 
         if ($filters['categories']) {

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -250,7 +250,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      *         categoryOperator: 'AND'|'OR',
      *         websiteCategories: string[],
      *         websiteCategoryOperator: 'AND'|'OR',
-     *         tagNames?: string[],
+     *         tagIds?: int[],
      *         tagOperator: 'AND'|'OR',
      *         websiteTags: string[],
      *         websiteTagOperator: 'AND'|'OR',

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -164,7 +164,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
             return 0;
         }
         $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters);
+        $filters = $this->mapFilters($filters, $params);
 
         $alias = 'article';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
@@ -209,7 +209,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
             return [];
         }
         $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters);
+        $filters = $this->mapFilters($filters, $params);
 
         $sortBys = $this->mapSortBys($sortBys);
 
@@ -255,6 +255,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
 
     /**
      * @param ArticleSmartContentFilters|ArticleSmartContentCountFilters $filters
+     * @param array<string, mixed> $params
      *
      * @return array{
      *         categoryIds?: int[],
@@ -277,7 +278,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      *         webspaceKey?: string
      *     }
      */
-    protected function mapFilters(array $filters): array
+    protected function mapFilters(array $filters, array $params = []): array
     {
         unset($filters['types']);
 

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
@@ -770,6 +770,64 @@ class ArticleSmartContentProviderTest extends SuluTestCase
         $this->assertContains(self::$articles['entertainment2']->getUuid(), $resultIds);
     }
 
+    public function testFindFlatByXmlGroupsIntersectsWithUiTypes(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy([
+            ...$this->getDefaultFilters(),
+            ...['locale' => 'en', 'types' => ['blog-group']],
+        ], [], ['groups' => 'blog-group,news-group']);
+
+        $this->assertCount(2, $result);
+
+        $resultIds = \array_map(fn ($article) => $article['id'], $result);
+        $this->assertContains(self::$articles['tech2']->getUuid(), $resultIds);
+        $this->assertContains(self::$articles['business2']->getUuid(), $resultIds);
+
+        $this->assertSame(
+            2,
+            $this->smartContentProvider->countBy([
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en', 'types' => ['blog-group']],
+            ], ['groups' => 'blog-group,news-group']),
+        );
+    }
+
+    public function testFindFlatByUiTypeOutsideXmlGroupsReturnsZero(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy([
+            ...$this->getDefaultFilters(),
+            ...['locale' => 'en', 'types' => ['default']],
+        ], [], ['groups' => 'blog-group,news-group']);
+
+        $this->assertCount(0, $result);
+
+        $this->assertSame(
+            0,
+            $this->smartContentProvider->countBy([
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en', 'types' => ['default']],
+            ], ['groups' => 'blog-group,news-group']),
+        );
+    }
+
+    public function testFindFlatByUnknownXmlGroupReturnsZero(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy([
+            ...$this->getDefaultFilters(),
+            ...['locale' => 'en'],
+        ], [], ['groups' => 'this-group-does-not-exist']);
+
+        $this->assertCount(0, $result);
+
+        $this->assertSame(
+            0,
+            $this->smartContentProvider->countBy([
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en'],
+            ], ['groups' => 'this-group-does-not-exist']),
+        );
+    }
+
     public function testFindFlatByWebspace(): void
     {
         $result = $this->smartContentProvider->findFlatBy([...$this->getDefaultFilters(), ...['locale' => 'en', 'webspaceKey' => 'blog']], []);

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -254,7 +254,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
      *        categoryOperator: 'AND'|'OR',
      *        websiteCategories: string[],
      *        websiteCategoryOperator: 'AND'|'OR',
-     *        tagNames?: string[],
+     *        tagIds?: int[],
      *        tagOperator: 'AND'|'OR',
      *        websiteTags: string[],
      *        websiteTagOperator: 'AND'|'OR',

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -178,7 +178,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
             return 0;
         }
         $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters);
+        $filters = $this->mapFilters($filters, $params);
 
         $alias = 'page';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
@@ -224,7 +224,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
             return [];
         }
         $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters);
+        $filters = $this->mapFilters($filters, $params);
 
         $sortBys = $this->mapSortBys($sortBys);
 
@@ -259,6 +259,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
 
     /**
      * @param PageSmartContentFilters|PageSmartContentCountFilters $filters
+     * @param array<string, mixed> $params
      *
      * @return array{
      *        categoryIds?: int[],
@@ -282,7 +283,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
      *        segmentKey?: string,
      *    }
      */
-    protected function mapFilters(array $filters): array
+    protected function mapFilters(array $filters, array $params = []): array
     {
         unset($filters['types']);
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -170,7 +170,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
         $filters = $this->mapFilters($filters, $params);
-        if (null === $filters['templateKeys']) {
+        if (null === $filters['templateKeys']) { // means admin or website requested templates and they do not match together so we can early return with zero results
             return 0;
         }
 
@@ -210,7 +210,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
         $filters = $this->mapFilters($filters, $params);
-        if (null === $filters['templateKeys']) {
+        if (null === $filters['templateKeys']) { // means admin or website requested templates and they do not match together so we can early return with no results
             return [];
         }
 

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -169,16 +169,10 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         /** @var PageSmartContentCountFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
-        $templateKeys = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
-        if (null === $templateKeys) {
+        $filters = $this->mapFilters($filters, $params);
+        if (null === $filters['templateKeys']) {
             return 0;
         }
-        $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters, $params);
 
         $alias = 'page';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
@@ -215,16 +209,10 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         /** @var PageSmartContentFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
-        $templateKeys = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
-        if (null === $templateKeys) {
+        $filters = $this->mapFilters($filters, $params);
+        if (null === $filters['templateKeys']) {
             return [];
         }
-        $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters, $params);
 
         $sortBys = $this->mapSortBys($sortBys);
 
@@ -270,7 +258,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
      *        tagOperator: 'AND'|'OR',
      *        websiteTags: string[],
      *        websiteTagOperator: 'AND'|'OR',
-     *        templateKeys: string[],
+     *        templateKeys: string[]|null,
      *        typesOperator: 'OR',
      *        locale: string,
      *        dataSource: string|null,
@@ -285,6 +273,11 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
      */
     protected function mapFilters(array $filters, array $params = []): array
     {
+        $filters['templateKeys'] = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
         unset($filters['types']);
 
         if ($filters['categories']) {

--- a/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageSmartContentProvider.php
@@ -169,10 +169,20 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         /** @var PageSmartContentCountFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
+        $templateKeys = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
+        if (null === $templateKeys) {
+            return 0;
+        }
+        $filters['templateKeys'] = $templateKeys;
+        $filters = $this->mapFilters($filters);
+
         $alias = 'page';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
 
-        $filters = $this->mapFilters($filters, $params);
         $this->dimensionContentQueryEnhancer->addFilters(
             $queryBuilder,
             $alias,
@@ -205,12 +215,22 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
         /** @var PageSmartContentFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
+        $templateKeys = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
+        if (null === $templateKeys) {
+            return [];
+        }
+        $filters['templateKeys'] = $templateKeys;
+        $filters = $this->mapFilters($filters);
+
         $sortBys = $this->mapSortBys($sortBys);
 
         $alias = 'page';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
 
-        $filters = $this->mapFilters($filters, $params);
         $this->dimensionContentQueryEnhancer->addFilters(
             $queryBuilder,
             $alias,
@@ -239,7 +259,6 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
 
     /**
      * @param PageSmartContentFilters|PageSmartContentCountFilters $filters
-     * @param array<string, mixed> $params
      *
      * @return array{
      *        categoryIds?: int[],
@@ -250,7 +269,7 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
      *        tagOperator: 'AND'|'OR',
      *        websiteTags: string[],
      *        websiteTagOperator: 'AND'|'OR',
-     *        templateKeys?: string[],
+     *        templateKeys: string[],
      *        typesOperator: 'OR',
      *        locale: string,
      *        dataSource: string|null,
@@ -263,13 +282,8 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
      *        segmentKey?: string,
      *    }
      */
-    protected function mapFilters(array $filters, array $params = []): array
+    protected function mapFilters(array $filters): array
     {
-        $filters['templateKeys'] = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
         unset($filters['types']);
 
         if ($filters['categories']) {
@@ -290,23 +304,35 @@ readonly class PageSmartContentProvider implements SmartContentProviderInterface
      * @param array<string> $filterTemplateKeys
      * @param array<string, mixed> $params
      *
-     * @return list<string>
+     * @return list<string>|null null = no overlap with the requested filters
      */
-    private function resolveTemplateKeys(array $existingTemplateKeys, array $filterTemplateKeys, array $params): array
+    private function resolveTemplateKeys(array $existingTemplateKeys, array $filterTemplateKeys, array $params): ?array
     {
         $templateKeys = \array_values(\array_unique(\array_merge($existingTemplateKeys, $filterTemplateKeys)));
 
-        $templateParam = $params['templateKeys'] ?? null;
-        if (\is_string($templateParam)) {
-            $templateKeysParam = \array_values(\array_filter(\array_map('trim', \explode(',', $templateParam))));
-            if ([] !== $templateKeysParam) {
-                $templateKeys = [] !== $templateKeys
-                    ? \array_values(\array_intersect($templateKeys, $templateKeysParam))
-                    : $templateKeysParam;
+        $xmlTemplateKeys = $this->parseListParameter($params['templateKeys'] ?? null);
+        if ([] !== $xmlTemplateKeys) {
+            $templateKeys = [] !== $templateKeys
+                ? \array_values(\array_intersect($templateKeys, $xmlTemplateKeys))
+                : $xmlTemplateKeys;
+            if ([] === $templateKeys) {
+                return null;
             }
         }
 
         return $templateKeys;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseListParameter(mixed $value): array
+    {
+        if (!\is_string($value)) {
+            return [];
+        }
+
+        return \array_values(\array_filter(\array_map('trim', \explode(',', $value))));
     }
 
     /**

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageSmartContentProviderTest.php
@@ -1157,6 +1157,57 @@ class PageSmartContentProviderTest extends SuluTestCase
         $this->assertNotContains(self::$pages['entertainment_business']->getUuid(), $resultIds, "Page 'entertainment_business' should not be in the homepage template result");
     }
 
+    public function testFindFlatByXmlTemplateKeysIntersectsWithUiTypes(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy(
+            [
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en', 'types' => ['blog']],
+            ],
+            [],
+            ['templateKeys' => 'blog,landing_page'],
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertSame(
+            1,
+            $this->smartContentProvider->countBy(
+                [
+                    ...$this->getDefaultFilters(),
+                    ...['locale' => 'en', 'types' => ['blog']],
+                ],
+                ['templateKeys' => 'blog,landing_page'],
+            ),
+        );
+
+        $resultIds = \array_map(fn ($page) => $page['id'], $result);
+        $this->assertContains(self::$pages['entertainment1']->getUuid(), $resultIds);
+    }
+
+    public function testFindFlatByUiTypeOutsideXmlTemplateKeysReturnsZero(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy(
+            [
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en', 'types' => ['default']],
+            ],
+            [],
+            ['templateKeys' => 'blog,landing_page'],
+        );
+
+        $this->assertCount(0, $result);
+        $this->assertSame(
+            0,
+            $this->smartContentProvider->countBy(
+                [
+                    ...$this->getDefaultFilters(),
+                    ...['locale' => 'en', 'types' => ['default']],
+                ],
+                ['templateKeys' => 'blog,landing_page'],
+            ),
+        );
+    }
+
     public function testFindFlatByDataSourceFilter(): void
     {
         // Test filtering by sulu-io parent page (dataSource)

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
@@ -130,7 +130,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
         $filters = $this->mapFilters($filters, $params);
-        if (null === $filters['templateKeys']) {
+        if (null === $filters['templateKeys']) { // means admin or website requested templates and they do not match together so we can early return with zero results
             return 0;
         }
 
@@ -167,7 +167,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
         $filters = $this->mapFilters($filters, $params);
-        if (null === $filters['templateKeys']) {
+        if (null === $filters['templateKeys']) { // means admin or website requested templates and they do not match together so we can early return with no results
             return [];
         }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
@@ -138,7 +138,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
             return 0;
         }
         $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters);
+        $filters = $this->mapFilters($filters, $params);
 
         $alias = 'snippet';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
@@ -181,7 +181,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
             return [];
         }
         $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters);
+        $filters = $this->mapFilters($filters, $params);
 
         $sortBys = $this->mapSortBys($sortBys);
 
@@ -237,6 +237,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
 
     /**
      * @param SnippetSmartContentFilters|SnippetSmartContentCountFilters $filters
+     * @param array<string, mixed> $params
      *
      * @return array{
      *         categoryIds?: int[],
@@ -258,7 +259,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      *         audienceTargeting?: bool
      *     }
      */
-    protected function mapFilters(array $filters): array
+    protected function mapFilters(array $filters, array $params = []): array
     {
         unset($filters['types']);
 

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
@@ -129,10 +129,20 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         /** @var SnippetSmartContentCountFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
+        $templateKeys = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
+        if (null === $templateKeys) {
+            return 0;
+        }
+        $filters['templateKeys'] = $templateKeys;
+        $filters = $this->mapFilters($filters);
+
         $alias = 'snippet';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
 
-        $filters = $this->mapFilters($filters, $params);
         $this->dimensionContentQueryEnhancer->addFilters(
             $queryBuilder,
             $alias,
@@ -159,14 +169,25 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      */
     public function findFlatBy(array $filters, array $sortBys, array $params = []): array
     {
+        /** @var SnippetSmartContentFilters $filters */
+        $filters = $this->enhanceWithDimensionAttributes($filters);
+
+        $templateKeys = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
+        if (null === $templateKeys) {
+            return [];
+        }
+        $filters['templateKeys'] = $templateKeys;
+        $filters = $this->mapFilters($filters);
+
         $sortBys = $this->mapSortBys($sortBys);
 
         $alias = 'snippet';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
 
-        /** @var SnippetSmartContentFilters $filters */
-        $filters = $this->enhanceWithDimensionAttributes($filters);
-        $filters = $this->mapFilters($filters, $params);
         $this->dimensionContentQueryEnhancer->addFilters(
             $queryBuilder,
             $alias,
@@ -216,7 +237,6 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
 
     /**
      * @param SnippetSmartContentFilters|SnippetSmartContentCountFilters $filters
-     * @param array<string, mixed> $params
      *
      * @return array{
      *         categoryIds?: int[],
@@ -227,7 +247,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      *         tagOperator: 'AND'|'OR',
      *         websiteTags: string[],
      *         websiteTagOperator: 'AND'|'OR',
-     *         templateKeys?: string[],
+     *         templateKeys: string[],
      *         typesOperator: 'OR',
      *         locale: string,
      *         dataSource: string|null,
@@ -238,13 +258,8 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      *         audienceTargeting?: bool
      *     }
      */
-    protected function mapFilters(array $filters, array $params = []): array
+    protected function mapFilters(array $filters): array
     {
-        $filters['templateKeys'] = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
         unset($filters['types']);
 
         if ($filters['categories']) {
@@ -265,23 +280,35 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      * @param array<string> $filterTemplateKeys
      * @param array<string, mixed> $params
      *
-     * @return list<string>
+     * @return list<string>|null null = no overlap with the requested filters
      */
-    private function resolveTemplateKeys(array $existingTemplateKeys, array $filterTemplateKeys, array $params): array
+    private function resolveTemplateKeys(array $existingTemplateKeys, array $filterTemplateKeys, array $params): ?array
     {
         $templateKeys = \array_values(\array_unique(\array_merge($existingTemplateKeys, $filterTemplateKeys)));
 
-        $templateParam = $params['templateKeys'] ?? null;
-        if (\is_string($templateParam)) {
-            $templateKeysParam = \array_values(\array_filter(\array_map('trim', \explode(',', $templateParam))));
-            if ([] !== $templateKeysParam) {
-                $templateKeys = [] !== $templateKeys
-                    ? \array_values(\array_intersect($templateKeys, $templateKeysParam))
-                    : $templateKeysParam;
+        $xmlTemplateKeys = $this->parseListParameter($params['templateKeys'] ?? null);
+        if ([] !== $xmlTemplateKeys) {
+            $templateKeys = [] !== $templateKeys
+                ? \array_values(\array_intersect($templateKeys, $xmlTemplateKeys))
+                : $xmlTemplateKeys;
+            if ([] === $templateKeys) {
+                return null;
             }
         }
 
         return $templateKeys;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parseListParameter(mixed $value): array
+    {
+        if (!\is_string($value)) {
+            return [];
+        }
+
+        return \array_values(\array_filter(\array_map('trim', \explode(',', $value))));
     }
 
     /**

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
@@ -129,16 +129,10 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         /** @var SnippetSmartContentCountFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
-        $templateKeys = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
-        if (null === $templateKeys) {
+        $filters = $this->mapFilters($filters, $params);
+        if (null === $filters['templateKeys']) {
             return 0;
         }
-        $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters, $params);
 
         $alias = 'snippet';
         $queryBuilder = $this->entityRepository->createQueryBuilder($alias);
@@ -172,16 +166,10 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         /** @var SnippetSmartContentFilters $filters */
         $filters = $this->enhanceWithDimensionAttributes($filters);
 
-        $templateKeys = $this->resolveTemplateKeys(
-            $filters['templateKeys'] ?? [],
-            $filters['types'],
-            $params,
-        );
-        if (null === $templateKeys) {
+        $filters = $this->mapFilters($filters, $params);
+        if (null === $filters['templateKeys']) {
             return [];
         }
-        $filters['templateKeys'] = $templateKeys;
-        $filters = $this->mapFilters($filters, $params);
 
         $sortBys = $this->mapSortBys($sortBys);
 
@@ -248,7 +236,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      *         tagOperator: 'AND'|'OR',
      *         websiteTags: string[],
      *         websiteTagOperator: 'AND'|'OR',
-     *         templateKeys: string[],
+     *         templateKeys: string[]|null,
      *         typesOperator: 'OR',
      *         locale: string,
      *         dataSource: string|null,
@@ -261,6 +249,11 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      */
     protected function mapFilters(array $filters, array $params = []): array
     {
+        $filters['templateKeys'] = $this->resolveTemplateKeys(
+            $filters['templateKeys'] ?? [],
+            $filters['types'],
+            $params,
+        );
         unset($filters['types']);
 
         if ($filters['categories']) {

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
@@ -232,7 +232,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      *         categoryOperator: 'AND'|'OR',
      *         websiteCategories: string[],
      *         websiteCategoryOperator: 'AND'|'OR',
-     *         tagNames?: string[],
+     *         tagIds?: int[],
      *         tagOperator: 'AND'|'OR',
      *         websiteTags: string[],
      *         websiteTagOperator: 'AND'|'OR',

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Content/SnippetSmartContentProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Content/SnippetSmartContentProviderTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Content;
+
+use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
+use Sulu\Snippet\Tests\Traits\CreateSnippetTrait;
+
+/**
+ * @phpstan-import-type SmartContentBaseFilters from SmartContentProviderInterface
+ */
+class SnippetSmartContentProviderTest extends SuluTestCase
+{
+    use CreateSnippetTrait;
+
+    private readonly SmartContentProviderInterface $smartContentProvider;
+
+    /**
+     * @var array<string, SnippetInterface>
+     */
+    private static array $snippets = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->smartContentProvider = $this->getContainer()->get('sulu_snippet.snippet_smart_content_provider');
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::purgeDatabase();
+        self::bootKernel();
+
+        self::$snippets['default'] = self::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet',
+                    'title' => 'Default Snippet',
+                ],
+            ],
+        ]);
+
+        self::$snippets['alternate'] = self::createSnippet([
+            'en' => [
+                'live' => [
+                    'template' => 'snippet-alternate',
+                    'title' => 'Alternate Snippet',
+                ],
+            ],
+        ]);
+    }
+
+    public function testFindFlatByXmlTemplateKeysIntersectsWithUiTypes(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy(
+            [
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en', 'types' => ['snippet']],
+            ],
+            [],
+            ['templateKeys' => 'snippet,snippet-alternate'],
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertSame(
+            1,
+            $this->smartContentProvider->countBy(
+                [
+                    ...$this->getDefaultFilters(),
+                    ...['locale' => 'en', 'types' => ['snippet']],
+                ],
+                ['templateKeys' => 'snippet,snippet-alternate'],
+            ),
+        );
+
+        $resultIds = \array_map(fn ($snippet) => $snippet['id'], $result);
+        $this->assertContains(self::$snippets['default']->getUuid(), $resultIds);
+    }
+
+    public function testFindFlatByUiTypeOutsideXmlTemplateKeysReturnsZero(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy(
+            [
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en', 'types' => ['snippet-alternate']],
+            ],
+            [],
+            ['templateKeys' => 'snippet'],
+        );
+
+        $this->assertCount(0, $result);
+        $this->assertSame(
+            0,
+            $this->smartContentProvider->countBy(
+                [
+                    ...$this->getDefaultFilters(),
+                    ...['locale' => 'en', 'types' => ['snippet-alternate']],
+                ],
+                ['templateKeys' => 'snippet'],
+            ),
+        );
+    }
+
+    /**
+     * @return SmartContentBaseFilters
+     */
+    private function getDefaultFilters(): array
+    {
+        return [
+            'categories' => [],
+            'categoryOperator' => 'OR',
+            'websiteCategories' => [],
+            'websiteCategoryOperator' => 'OR',
+            'tags' => [],
+            'tagOperator' => 'OR',
+            'websiteTags' => [],
+            'websiteTagOperator' => 'OR',
+            'types' => [],
+            'typesOperator' => 'OR',
+            'locale' => 'en',
+            'dataSource' => null,
+            'limit' => null,
+            'offset' => 0,
+            'includeSubFolders' => false,
+            'excludeDuplicates' => false,
+        ];
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

The smart content providers for articles, pages and snippets now correctly intersect the template keys coming from the XML configuration with the UI filter selection. When the resolved intersection is empty, the providers short-circuit and return zero results instead of falling back to an unfiltered query. The `resolveTemplateKeys` helpers now return `null` to signal "no overlap" and `mapFilters` is called before building the query so the short-circuit can take effect. Functional tests cover the intersection behaviour and the unknown group case for all three providers.

#### Why?

Previously an empty template key list after intersecting XML groups with UI types was treated as "no filter", which caused smart content blocks to return content that did not belong to the configured group. Unknown group identifiers from the XML configuration silently produced full result sets for the same reason. Filtering by group must restrict results, never expand them, so the providers now treat an empty intersection as an explicit empty result.