### PR TITLE
Use getLocale instead of query->get and fix a translation typo

### DIFF
--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -112,7 +112,7 @@ final class ArticleController implements SecuredControllerInterface
         if (isset($fieldDescriptors['ghostLocale'])) {
             $listBuilder->addSelectField($fieldDescriptors['ghostLocale']);
         }
-        $listBuilder->setParameter('locale', $request->query->get('locale'));
+        $listBuilder->setParameter('locale', $this->getLocale($request));
         if (0 !== \count($templates)) {
             $listBuilder->in($fieldDescriptors['templateKey'], $templates);
         }
@@ -140,7 +140,7 @@ final class ArticleController implements SecuredControllerInterface
 
     public function getVersionsAction(Request $request, string $id): JsonResponse
     {
-        $locale = $request->query->get('locale');
+        $locale = $this->getLocale($request);
 
         /** @var DoctrineFieldDescriptorInterface[] $fieldDescriptors */
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('articles_versions');

--- a/packages/article/translations/admin.de.json
+++ b/packages/article/translations/admin.de.json
@@ -27,7 +27,7 @@
     "sulu_activity.description.articles.workflow_transition.unpublish": "{userFullName} hat den Artikel \"{resourceTitle}\" nicht mehr veröffentlicht",
     "sulu_activity.description.articles.workflow_transition.remove_draft": "{userFullName} hat den Entwurf des Artikels \"{resourceTitle}\" verworfen",
     "sulu_activity.description.articles.copied": "{userFullName} hat den Artikel \"{resourceTitle}\" kopiert",
-    "sulu_activity.description.pages.restored": "{userFullName} hat den Artikel \"{resourceTitle}\" wiederhergestellt",
+    "sulu_activity.description.articles.restored": "{userFullName} hat den Artikel \"{resourceTitle}\" wiederhergestellt",
     "sulu_activity.description.articles.translation_added": "{userFullName} hat eine neue Sprachvariante für \"{resourceLocale}\" zum Artikel \"{resourceTitle}\" hinzugefügt",
     "sulu_activity.description.articles.translation_copied": "{userFullName} hat die Sprachvariante für \"{context_sourceLocale}\" des Artikels \"{resourceTitle}\" nach \"{resourceLocale}\" kopiert",
     "sulu_activity.description.articles.translation_removed": "{userFullName} hat die Sprachvariante für \"{resourceLocale}\" des Artikels \"{resourceTitle}\" gelöscht",

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -85,7 +85,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
 
     public function cgetAction(Request $request): Response
     {
-        $locale = $request->query->get('locale');
+        $locale = $this->getLocale($request);
         $parentId = $request->query->get('parentId');
         $webspaceKey = $request->query->get('webspace');
         $excludeGhosts = $request->query->getBoolean('exclude-ghosts', false);
@@ -135,7 +135,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
 
     public function getVersionsAction(Request $request, string $id): JsonResponse
     {
-        $locale = $request->query->get('locale');
+        $locale = $this->getLocale($request);
 
         /** @var DoctrineFieldDescriptorInterface[] $fieldDescriptors */
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('pages_versions');

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -101,7 +101,7 @@ final class SnippetController implements SecuredControllerInterface
         if (isset($fieldDescriptors['ghostLocale'])) {
             $listBuilder->addSelectField($fieldDescriptors['ghostLocale']);
         }
-        $listBuilder->setParameter('locale', $request->query->get('locale'));
+        $listBuilder->setParameter('locale', $this->getLocale($request));
 
         $typesParam = $request->query->get('types');
         $types = \array_filter(\explode(',', \is_string($typesParam) ? $typesParam : ''));
@@ -154,7 +154,7 @@ final class SnippetController implements SecuredControllerInterface
 
     public function getVersionsAction(Request $request, string $id): JsonResponse
     {
-        $locale = $request->query->get('locale');
+        $locale = $this->getLocale($request);
 
         /** @var DoctrineFieldDescriptorInterface[] $fieldDescriptors */
         $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('snippets_versions');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| License | MIT

#### What's in this PR?

Use the `getLocale` function instead of `$request->query->get('locale')` and fix typo in translation key