### PR TITLE
Fix smart-content category/tag filter for taxonomy-only dimension contents

### DIFF
--- a/packages/content/src/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
+++ b/packages/content/src/Infrastructure/Doctrine/DimensionContentQueryEnhancer.php
@@ -18,7 +18,6 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Content\Domain\Model\ExcerptInterface;
 use Sulu\Content\Domain\Model\RoutableInterface;
 use Sulu\Content\Domain\Model\TaxonomyInterface;
 use Sulu\Content\Domain\Model\TemplateInterface;
@@ -147,7 +146,7 @@ class DimensionContentQueryEnhancer
                 ->setParameter('version', $version);
         }
 
-        if (\is_subclass_of($dimensionContentClassName, ExcerptInterface::class)) {
+        if (\is_subclass_of($dimensionContentClassName, TaxonomyInterface::class)) {
             $categoryIds = $filters['categoryIds'] ?? null;
             if ($categoryIds) {
                 Assert::isArray($categoryIds); // @phpstan-ignore staticMethod.alreadyNarrowedType
@@ -403,7 +402,7 @@ class DimensionContentQueryEnhancer
             return true;
         }
 
-        if (\is_subclass_of($dimensionContentClassName, ExcerptInterface::class)) {
+        if (\is_subclass_of($dimensionContentClassName, TaxonomyInterface::class)) {
             if (!empty($filters['categoryIds'] ?? null)
                 || !empty($filters['categoryKeys'] ?? null)
                 || !empty($filters['tagIds'] ?? null)

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Content/SnippetSmartContentProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Content/SnippetSmartContentProviderTest.php
@@ -13,8 +13,12 @@ declare(strict_types=1);
 
 namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Content;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
+use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Tests\Traits\CreateCategoryTrait;
+use Sulu\Content\Tests\Traits\CreateTagTrait;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
 use Sulu\Snippet\Tests\Traits\CreateSnippetTrait;
 
@@ -23,7 +27,9 @@ use Sulu\Snippet\Tests\Traits\CreateSnippetTrait;
  */
 class SnippetSmartContentProviderTest extends SuluTestCase
 {
+    use CreateCategoryTrait;
     use CreateSnippetTrait;
+    use CreateTagTrait;
 
     private readonly SmartContentProviderInterface $smartContentProvider;
 
@@ -31,6 +37,16 @@ class SnippetSmartContentProviderTest extends SuluTestCase
      * @var array<string, SnippetInterface>
      */
     private static array $snippets = [];
+
+    /**
+     * @var array<string, CategoryInterface>
+     */
+    private static array $categories = [];
+
+    /**
+     * @var array<string, int>
+     */
+    private static array $tags = [];
 
     protected function setUp(): void
     {
@@ -44,11 +60,29 @@ class SnippetSmartContentProviderTest extends SuluTestCase
         self::purgeDatabase();
         self::bootKernel();
 
+        $entityManager = self::getEntityManager();
+
+        self::$categories['tech'] = self::createCategory(['en' => ['title' => 'Technology']]);
+        self::$categories['sports'] = self::createCategory(['en' => ['title' => 'Sports']]);
+        $entityManager->flush();
+
+        $tagEntities = [];
+        foreach (['mobile', 'football'] as $tagName) {
+            $tagEntities[$tagName] = self::createTag(['name' => $tagName]);
+        }
+        $entityManager->flush();
+
+        foreach ($tagEntities as $tagName => $tagEntity) {
+            self::$tags[$tagName] = $tagEntity->getId();
+        }
+
         self::$snippets['default'] = self::createSnippet([
             'en' => [
                 'live' => [
                     'template' => 'snippet',
                     'title' => 'Default Snippet',
+                    'excerptCategories' => [self::$categories['tech']->getId()],
+                    'excerptTags' => [self::$tags['mobile']],
                 ],
             ],
         ]);
@@ -58,6 +92,8 @@ class SnippetSmartContentProviderTest extends SuluTestCase
                 'live' => [
                     'template' => 'snippet-alternate',
                     'title' => 'Alternate Snippet',
+                    'excerptCategories' => [self::$categories['sports']->getId()],
+                    'excerptTags' => [self::$tags['football']],
                 ],
             ],
         ]);
@@ -114,6 +150,34 @@ class SnippetSmartContentProviderTest extends SuluTestCase
         );
     }
 
+    public function testFindFlatByCategoryFiltersByExcerptCategory(): void
+    {
+        $filters = [
+            ...$this->getDefaultFilters(),
+            ...['categories' => [self::$categories['tech']->getId()]],
+        ];
+
+        $result = $this->smartContentProvider->findFlatBy($filters, []);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(self::$snippets['default']->getUuid(), $result[0]['id']);
+        $this->assertSame(1, $this->smartContentProvider->countBy($filters));
+    }
+
+    public function testFindFlatByTagFiltersByExcerptTag(): void
+    {
+        $filters = [
+            ...$this->getDefaultFilters(),
+            ...['tags' => [self::$tags['football']]],
+        ];
+
+        $result = $this->smartContentProvider->findFlatBy($filters, []);
+
+        $this->assertCount(1, $result);
+        $this->assertSame(self::$snippets['alternate']->getUuid(), $result[0]['id']);
+        $this->assertSame(1, $this->smartContentProvider->countBy($filters));
+    }
+
     /**
      * @return SmartContentBaseFilters
      */
@@ -137,5 +201,10 @@ class SnippetSmartContentProviderTest extends SuluTestCase
             'includeSubFolders' => false,
             'excludeDuplicates' => false,
         ];
+    }
+
+    protected static function getEntityManager(): EntityManagerInterface
+    {
+        return self::getContainer()->get('doctrine.orm.entity_manager');
     }
 }


### PR DESCRIPTION
The category, categoryKey, tag and tagName filters in DimensionContentQueryEnhancer were gated on ExcerptInterface, but the underlying fields (excerptCategories, excerptTags) live in TaxonomyTrait / TaxonomyInterface.

SnippetDimensionContent implements only TaxonomyInterface (correctly, since snippets have no excerpt title/description/image), so the entire filter block was silently skipped for the snippets smart-content provider. Page and article happen to implement both interfaces, so they were unaffected.

This change aligns the guard with TaxonomyInterface, matching the neighbouring addSelects() method in the same class which already uses TaxonomyInterface. No data migration is required — the change only adds previously-missing WHERE clauses to the query.

Includes a regression test in SnippetSmartContentProviderTest covering both category and tag filters.

| Q | A
| --- | ---
| Sulu | 3.0.6
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
