### PR TITLE
Speed up indexing of FileVersionMeta

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/FileVersionMetaRepository.php
@@ -36,7 +36,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND CAST(accessControl.entityId AS STRING) = CAST(collection.id AS STRING)'
+                . 'AND accessControl.entityIdInteger = collection.id'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null');
@@ -64,7 +64,7 @@ class FileVersionMetaRepository extends EntityRepository implements FileVersionM
                 'accessControl',
                 'WITH',
                 'accessControl.entityClass = :entityClass '
-                . 'AND CAST(accessControl.entityId AS STRING) = CAST(collection.id AS STRING)'
+                . 'AND accessControl.entityIdInteger = collection.id'
             )
             ->where('file.version = fileVersion.version')
             ->andWhere('accessControl.id is null')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

This PR speeds up the indexing of FileVersionMeta objects on large codebases with many permission entries.

#### Why?

We currently have about 60000 entries in `me_file_version_meta` and many collections with attached permissions (about 7700 entries in `se_access_control`). The reindexing with massive search grew slower and slower during the process, because of the offset and the inefficent casting of the database fields `accessControl.entityId` and `collection.id` to strings.
Since the `entityIdInteger`-field was introduced in Sulu 2.3.5 for most likely the exact same reason, I switched the condition from the `entityId`-field to the `entityIdInteger`-field and removed the casting.

This sped up the indexing from nearly a day to several minutes.

#### Example Usage

```
./bin/websiteconsole massive:search:reindex --env=prod
```
