### PR TITLE
Upgrade css-minimizer-webpack-plugin to Version 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "cheerio": "1.0.0-rc.12",
         "core-js": "^3.18.0",
         "css-loader": "^6.10.0",
-        "css-minimizer-webpack-plugin": "^6.0.0",
+        "css-minimizer-webpack-plugin": "^8.0.0",
         "dependency-cruiser": "^16.2.0",
         "empty": "^0.10.1",
         "enzyme": "^3.3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade css-minimizer-webpack-plugin to Version 8.

#### Why?

The 6 and 8 Version are not free of vulnerabilities in there dependency tree.