### PR TITLE
Prevent session usage increment on anonymous requests (fixes private …

### DIFF
--- a/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Document/Subscriber/SecuritySubscriber.php
@@ -15,6 +15,7 @@ use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
 use Sulu\Component\DocumentManager\Events;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -25,8 +26,10 @@ class SecuritySubscriber implements EventSubscriberInterface
 {
     public const USER_OPTION = 'user';
 
-    public function __construct(private ?TokenStorageInterface $tokenStorage = null)
-    {
+    public function __construct(
+        private ?TokenStorageInterface $tokenStorage = null,
+        private ?RequestStack $requestStack = null
+    ) {
     }
 
     public static function getSubscribedEvents()
@@ -46,6 +49,11 @@ class SecuritySubscriber implements EventSubscriberInterface
         $optionsResolver->setDefault(static::USER_OPTION, null);
 
         if (null === $this->tokenStorage) {
+            return;
+        }
+
+        $request = $this->requestStack?->getCurrentRequest();
+        if (null === $request || !$request->hasPreviousSession()) {
             return;
         }
 

--- a/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Resources/config/behaviors.php
@@ -34,7 +34,10 @@ return static function(ContainerConfigurator $container) {
     $services = $container->services();
 
     $services->set('sulu_document_manager.subscriber.security', SecuritySubscriber::class)
-        ->args([new Reference('security.token_storage', ContainerInterface::NULL_ON_INVALID_REFERENCE)])
+        ->args([
+            new Reference('security.token_storage', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+            new Reference('request_stack', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+        ])
         ->tag('sulu_document_manager.event_subscriber');
 
     $services->set('sulu_document_manager.subscriber.behavior.auto_name', AutoNameSubscriber::class)

--- a/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
+++ b/src/Sulu/Bundle/DocumentManagerBundle/Tests/Unit/Document/Subscriber/SecuritySubscriberTest.php
@@ -17,6 +17,8 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\DocumentManagerBundle\Document\Subscriber\SecuritySubscriber;
 use Sulu\Component\DocumentManager\Event\ConfigureOptionsEvent;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -33,6 +35,16 @@ class SecuritySubscriberTest extends TestCase
     private $tokenStorage;
 
     /**
+     * @var ObjectProphecy<RequestStack>
+     */
+    private $requestStack;
+
+    /**
+     * @var ObjectProphecy<Request>
+     */
+    private $request;
+
+    /**
      * @var SecuritySubscriber
      */
     private $securitySubscriber;
@@ -40,7 +52,41 @@ class SecuritySubscriberTest extends TestCase
     public function setUp(): void
     {
         $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
-        $this->securitySubscriber = new SecuritySubscriber($this->tokenStorage->reveal());
+        $this->request = $this->prophesize(Request::class);
+        $this->request->hasPreviousSession()->willReturn(true);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
+        $this->securitySubscriber = new SecuritySubscriber($this->tokenStorage->reveal(), $this->requestStack->reveal());
+    }
+
+    public function testSetDefaultUserWithoutPreviousSession(): void
+    {
+        $event = $this->prophesize(ConfigureOptionsEvent::class);
+
+        $optionsResolver = $this->prophesize(OptionsResolver::class);
+        $event->getOptions()->willReturn($optionsResolver->reveal());
+
+        $this->request->hasPreviousSession()->willReturn(false);
+        $this->tokenStorage->getToken()->shouldNotBeCalled();
+
+        $optionsResolver->setDefault('user', null)->shouldBeCalled()->willReturn($optionsResolver->reveal());
+
+        $this->securitySubscriber->setDefaultUser($event->reveal());
+    }
+
+    public function testSetDefaultUserWithoutRequest(): void
+    {
+        $event = $this->prophesize(ConfigureOptionsEvent::class);
+
+        $optionsResolver = $this->prophesize(OptionsResolver::class);
+        $event->getOptions()->willReturn($optionsResolver->reveal());
+
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+        $this->tokenStorage->getToken()->shouldNotBeCalled();
+
+        $optionsResolver->setDefault('user', null)->shouldBeCalled()->willReturn($optionsResolver->reveal());
+
+        $this->securitySubscriber->setDefaultUser($event->reveal());
     }
 
     public function testSetDefaultUser(): void

--- a/src/Sulu/Bundle/PersistenceBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/PersistenceBundle/Resources/config/services.php
@@ -31,7 +31,10 @@ return static function(ContainerConfigurator $container) {
 
     // Priority 50 as the MetadataLoader need to be before the ResolveTargetEntityListener of Doctrine
     $services->set('sulu.persistence.event_subscriber.orm.user_blame', '%sulu.persistence.event_subscriber.orm.user_blame.class%')
-        ->args([new Reference('security.token_storage', ContainerInterface::NULL_ON_INVALID_REFERENCE)])
+        ->args([
+            new Reference('security.token_storage', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+            new Reference('request_stack', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+        ])
         ->tag('doctrine.event_listener', ['event' => 'loadClassMetadata', 'priority' => 50])
         ->tag('doctrine.event_listener', ['event' => 'onFlush', 'priority' => 50]);
 

--- a/src/Sulu/Bundle/SecurityBundle/EventListener/UserLocaleListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/UserLocaleListener.php
@@ -39,6 +39,10 @@ class UserLocaleListener implements EventSubscriberInterface
      */
     public function copyUserLocaleToRequest(RequestEvent $event)
     {
+        if (!$event->getRequest()->hasPreviousSession() && null === $event->getRequest()->getUser()) {
+            return;
+        }
+
         $token = $this->tokenStorage->getToken();
         if (!$token) {
             return;

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/UserLocaleListenerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Unit/EventListener/UserLocaleListenerTest.php
@@ -76,12 +76,38 @@ class UserLocaleListenerTest extends TestCase
 
         $this->token = $this->prophesize(TokenInterface::class);
 
+        $this->request->hasPreviousSession()->willReturn(true);
+
         $this->tokenStorage = $this->prophesize(TokenStorageInterface::class);
         $this->tokenStorage->getToken()->willReturn($this->token->reveal());
 
         $this->translator = $this->prophesize(Translator::class);
 
         $this->userLocaleListener = new UserLocaleListener($this->tokenStorage->reveal(), $this->translator->reveal());
+    }
+
+    public function testCopyUserLocaleToRequestWithoutPreviousSession(): void
+    {
+        $this->request->hasPreviousSession()->willReturn(false);
+        $this->request->getUser()->willReturn(null);
+        $this->tokenStorage->getToken()->shouldNotBeCalled();
+        $this->request->setLocale(Argument::any())->shouldNotBeCalled();
+        $this->translator->setLocale(Argument::any())->shouldNotBeCalled();
+        $this->userLocaleListener->copyUserLocaleToRequest($this->event);
+    }
+
+    public function testCopyUserLocaleToRequestWithHttpBasicAuth(): void
+    {
+        $this->request->hasPreviousSession()->willReturn(false);
+        $this->request->getUser()->willReturn('admin');
+
+        $user = $this->prophesize(UserInterface::class);
+        $user->getLocale()->willReturn('en');
+        $this->token->getUser()->willReturn($user);
+
+        $this->request->setLocale('en')->shouldBeCalled();
+        $this->translator->setLocale('en')->shouldBeCalled();
+        $this->userLocaleListener->copyUserLocaleToRequest($this->event);
     }
 
     public function testCopyUserLocaleToRequestWithoutUser(): void

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Sulu\Component\Persistence\Model\UserBlameInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -32,8 +33,10 @@ class UserBlameSubscriber
 
     public const CREATOR_FIELD = 'creator';
 
-    public function __construct(private ?TokenStorageInterface $tokenStorage = null)
-    {
+    public function __construct(
+        private ?TokenStorageInterface $tokenStorage = null,
+        private ?RequestStack $requestStack = null
+    ) {
     }
 
     /**
@@ -81,6 +84,11 @@ class UserBlameSubscriber
     public function onFlush(OnFlushEventArgs $event)
     {
         if (null === $this->tokenStorage) {
+            return;
+        }
+
+        $request = $this->requestStack?->getCurrentRequest();
+        if (null !== $request && !$request->hasPreviousSession()) {
             return;
         }
 


### PR DESCRIPTION
…Cache-Control for anonymous pages)

| Q | A
| --- | ---
| Bug fix? |yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add a $request->hasPreviousSession() guard to each listener before calling getToken().

#### Why?

To prevent issues when Symfonys lazy firewall is active.
Any call to getToken() increments the session's usageIndex, causing AbstractSessionListener to mark the response as Cache-Control: private, even for fully anonymous requests with no session.

