### PR TITLE
Fix article navigation permission check

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -20,9 +20,10 @@ Without these params, the new `raw` resource loader is used, which keeps the ids
 
 ### Article admin permission gating updated for multi-group setups
 
-When multiple article template groups exist, the `ArticleAdmin` now gates each custom group's navigation entry, list view,
-and toolbar actions (Add, Delete, Export) on the per-group `sulu.article.articles_<group>` EDIT permission instead of the
-umbrella `sulu.article.articles` EDIT permission (see #8830).
+When multiple article template groups exist, the `ArticleAdmin` now gates each custom group's navigation entry and views
+on the per-group `sulu.article.articles_<group>` EDIT permission instead of the umbrella `sulu.article.articles` EDIT
+permission (see #8830). The list toolbar actions (Add, Delete, Export) on those views are checked against the per-group
+context for their respective ADD, DELETE and VIEW permissions.
 
 The umbrella `sulu.article.articles` permission still gates the admin UI in two cases:
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -18,16 +18,17 @@
 
 Without these params, the new `raw` resource loader is used, which keeps the ids unchanged. The HTTP cache reference store is still populated for the tag and category ids regardless of the loader choice, so renaming or removing a referenced tag or category continues to invalidate the affected pages.
 
-### Article admin now gates the navigation and views on per-group permissions
+### Article admin permission gating updated for multi-group setups
 
-The `ArticleAdmin` previously gated its navigation item, per-group views, and toolbar actions (Add, Delete, Export) on the
-umbrella `sulu.article.articles` EDIT permission, with per-group `sulu.article.articles_<group>` checks layered on top. The
-umbrella check has been removed from those code paths, and the per-group permission is now the sole gate for the admin UI
-(see #8830).
+When multiple article template groups exist, the `ArticleAdmin` now gates each group's navigation entry, list view, and
+toolbar actions (Add, Delete, Export) on the per-group `sulu.article.articles_<group>` EDIT permission instead of the
+umbrella `sulu.article.articles` EDIT permission (see #8830).
 
-The umbrella `sulu.article.articles` permission is still required: `ArticleController` reports it as its security context, so
-every article REST endpoint (list, get, create, update, delete, workflow) continues to check it. Roles need both the umbrella
-permission for API access and the per-group permission for the matching navigation item and views to render.
+Single-group setups continue to use the umbrella `sulu.article.articles` permission as the sole gate, because per-group
+contexts are not registered when only one group exists.
+
+The umbrella `sulu.article.articles` permission is still required in all setups: `ArticleController` reports it as its
+security context, so every article REST endpoint (list, get, create, update, delete, workflow) continues to check it.
 
 After upgrading, re-run the reindex command for both kernels so the admin search index reflects the current security contexts:
 
@@ -39,8 +40,9 @@ bin/console cmsig:seal:reindex
 
 After upgrading, review every role with article permissions and adjust the grants accordingly:
 
-- `sulu.article.articles`: always required, because the article REST controllers depend on it.
-- `sulu.article.articles_<group>`: required for each group the role should manage.
+- `sulu.article.articles`: always required, because the article REST controllers depend on it. In single-group setups this
+  is also the only permission gating the admin UI.
+- `sulu.article.articles_<group>`: required for each group the role should manage, in multi-group setups only.
 
 ### Selection view structure changed (snippet, page, article)
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -20,14 +20,19 @@ Without these params, the new `raw` resource loader is used, which keeps the ids
 
 ### Article admin permission gating updated for multi-group setups
 
-When multiple article template groups exist, the `ArticleAdmin` now gates each group's navigation entry, list view, and
-toolbar actions (Add, Delete, Export) on the per-group `sulu.article.articles_<group>` EDIT permission instead of the
+When multiple article template groups exist, the `ArticleAdmin` now gates each custom group's navigation entry, list view,
+and toolbar actions (Add, Delete, Export) on the per-group `sulu.article.articles_<group>` EDIT permission instead of the
 umbrella `sulu.article.articles` EDIT permission (see #8830).
 
-Single-group setups continue to use the umbrella `sulu.article.articles` permission as the sole gate, because per-group
-contexts are not registered when only one group exists.
+The umbrella `sulu.article.articles` permission still gates the admin UI in two cases:
 
-The umbrella `sulu.article.articles` permission is still required in all setups: `ArticleController` reports it as its
+- Single-group setups, because per-group contexts are not registered when only one group exists.
+- The implicit `default` group, which is the catch-all bucket for articles that do not belong to any custom group. Its
+  per-group context (`sulu.article.articles_default`) is intentionally never registered, so the default group remains
+  reachable through the umbrella permission. This means adding a custom group does not strip existing roles of their
+  default-group access; only the new custom group requires an additional grant.
+
+The umbrella `sulu.article.articles` permission is also still required in all setups: `ArticleController` reports it as its
 security context, so every article REST endpoint (list, get, create, update, delete, workflow) continues to check it.
 
 After upgrading, re-run the reindex command for both kernels so the admin search index reflects the current security contexts:
@@ -40,9 +45,10 @@ bin/console cmsig:seal:reindex
 
 After upgrading, review every role with article permissions and adjust the grants accordingly:
 
-- `sulu.article.articles`: always required, because the article REST controllers depend on it. In single-group setups this
-  is also the only permission gating the admin UI.
-- `sulu.article.articles_<group>`: required for each group the role should manage, in multi-group setups only.
+- `sulu.article.articles`: always required, because the article REST controllers depend on it. Also gates the admin UI in
+  single-group setups and for the `default` group in multi-group setups.
+- `sulu.article.articles_<group>`: required for each custom group the role should manage; never registered for the
+  `default` group.
 
 ### Selection view structure changed (snippet, page, article)
 

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -105,9 +105,11 @@ class ArticleAdmin extends Admin
      */
     private function resolveSecurityContext(array $groups, FormGroup $group): string
     {
-        return 1 === \count($groups)
-            ? static::SECURITY_CONTEXT
-            : static::getArticleSecurityContext($group->identifier);
+        if (1 === \count($groups) || GroupProviderInterface::DEFAULT_GROUP === $group->identifier) {
+            return static::SECURITY_CONTEXT;
+        }
+
+        return static::getArticleSecurityContext($group->identifier);
     }
 
     /**
@@ -252,6 +254,10 @@ class ArticleAdmin extends Admin
         $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         if (1 !== \count($groups)) {
             foreach ($groups as $group) {
+                if (GroupProviderInterface::DEFAULT_GROUP === $group->identifier) {
+                    continue;
+                }
+
                 $securityContext[static::getArticleSecurityContext($group->identifier)] = [
                     PermissionTypes::VIEW,
                     PermissionTypes::ADD,

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -62,7 +62,7 @@ class ArticleAdmin extends Admin
         $hasArticleTypeWithEditPermissions = false;
         $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         foreach ($groups as $group) {
-            $securityContext = static::getArticleSecurityContext($group->identifier);
+            $securityContext = 1 === \count($groups) ? static::SECURITY_CONTEXT : static::getArticleSecurityContext($group->identifier);
             if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
                 continue;
             }

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -95,18 +95,9 @@ class ArticleAdmin extends Admin
 
         $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         foreach ($groups as $group) {
-            $securityContext = static::getArticleSecurityContext($group->identifier);
-            if (1 === \count($groups)) {
-                $securityContext = static::SECURITY_CONTEXT;
-            }
-
+            $securityContext = 1 === \count($groups) ? static::SECURITY_CONTEXT : static::getArticleSecurityContext($group->identifier);
             $this->configureGroupViews($group, $locales, $resourceKey, $viewCollection, $securityContext);
         }
-    }
-
-    private function hasPermission(string $groupIdentifier, string $permission, bool $checkGroup): bool
-    {
-        return $this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), $permission);
     }
 
     /**
@@ -122,15 +113,15 @@ class ArticleAdmin extends Admin
 
         $listToolbarActions = [];
 
-        if ($this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), PermissionTypes::ADD)) {
+        if ($this->securityChecker->hasPermission($securityContext, PermissionTypes::ADD)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
-        if ($this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), PermissionTypes::DELETE)) {
+        if ($this->securityChecker->hasPermission($securityContext, PermissionTypes::DELETE)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
-        if ($this->securityChecker->hasPermission(static::getArticleSecurityContext($groupIdentifier), PermissionTypes::VIEW)) {
+        if ($this->securityChecker->hasPermission($securityContext, PermissionTypes::VIEW)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -59,16 +59,14 @@ class ArticleAdmin extends Admin
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
     {
-        $hasArticleTypeWithEditPermissions = false;
         $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
+        $hasArticleTypeWithEditPermissions = false;
         foreach ($groups as $group) {
             $securityContext = $this->resolveSecurityContext($groups, $group);
-            if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
-                continue;
+            if ($this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
+                $hasArticleTypeWithEditPermissions = true;
+                break;
             }
-
-            $hasArticleTypeWithEditPermissions = true;
-            break;
         }
 
         if (!$hasArticleTypeWithEditPermissions) {

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -62,7 +62,7 @@ class ArticleAdmin extends Admin
         $hasArticleTypeWithEditPermissions = false;
         $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         foreach ($groups as $group) {
-            $securityContext = 1 === \count($groups) ? static::SECURITY_CONTEXT : static::getArticleSecurityContext($group->identifier);
+            $securityContext = $this->resolveSecurityContext($groups, $group);
             if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
                 continue;
             }
@@ -95,9 +95,19 @@ class ArticleAdmin extends Admin
 
         $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         foreach ($groups as $group) {
-            $securityContext = 1 === \count($groups) ? static::SECURITY_CONTEXT : static::getArticleSecurityContext($group->identifier);
+            $securityContext = $this->resolveSecurityContext($groups, $group);
             $this->configureGroupViews($group, $locales, $resourceKey, $viewCollection, $securityContext);
         }
+    }
+
+    /**
+     * @param array<string, FormGroup> $groups
+     */
+    private function resolveSecurityContext(array $groups, FormGroup $group): string
+    {
+        return 1 === \count($groups)
+            ? static::SECURITY_CONTEXT
+            : static::getArticleSecurityContext($group->identifier);
     }
 
     /**

--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
@@ -80,7 +80,7 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
             }
 
             $securityContext = ArticleAdmin::getArticleSecurityContext($groupIdentifier ?? GroupProviderInterface::DEFAULT_GROUP);
-            if (1 === \count($groups)) {
+            if (1 === \count($groups) || null === $groupIdentifier || GroupProviderInterface::DEFAULT_GROUP === $groupIdentifier) {
                 $securityContext = ArticleAdmin::SECURITY_CONTEXT;
             }
 

--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
@@ -93,7 +93,7 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
                 'title' => $article['title'],
                 'locale' => $article['locale'],
                 'metadata' => [
-                    'group' => $groupIdentifier,
+                    'group' => $groupIdentifier ?? GroupProviderInterface::DEFAULT_GROUP,
                 ],
                 'securityContext' => $securityContext,
             ];

--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleReindexProvider.php
@@ -79,8 +79,9 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
                 }
             }
 
-            $securityContext = ArticleAdmin::getArticleSecurityContext($groupIdentifier ?? GroupProviderInterface::DEFAULT_GROUP);
-            if (1 === \count($groups) || null === $groupIdentifier || GroupProviderInterface::DEFAULT_GROUP === $groupIdentifier) {
+            $groupIdentifier ??= GroupProviderInterface::DEFAULT_GROUP;
+            $securityContext = ArticleAdmin::getArticleSecurityContext($groupIdentifier);
+            if (1 === \count($groups) || GroupProviderInterface::DEFAULT_GROUP === $groupIdentifier) {
                 $securityContext = ArticleAdmin::SECURITY_CONTEXT;
             }
 
@@ -93,7 +94,7 @@ final class AdminArticleReindexProvider implements ReindexProviderInterface
                 'title' => $article['title'],
                 'locale' => $article['locale'],
                 'metadata' => [
-                    'group' => $groupIdentifier ?? GroupProviderInterface::DEFAULT_GROUP,
+                    'group' => $groupIdentifier,
                 ],
                 'securityContext' => $securityContext,
             ];

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
@@ -129,7 +129,7 @@ class AdminArticleReindexProviderTest extends SuluTestCase
                 'metadata' => [
                     'group' => 'default',
                 ],
-                'securityContext' => ArticleAdmin::getArticleSecurityContext('default'),
+                'securityContext' => ArticleAdmin::SECURITY_CONTEXT,
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__en',
@@ -142,7 +142,7 @@ class AdminArticleReindexProviderTest extends SuluTestCase
                 'metadata' => [
                     'group' => 'default',
                 ],
-                'securityContext' => ArticleAdmin::getArticleSecurityContext('default'),
+                'securityContext' => ArticleAdmin::SECURITY_CONTEXT,
             ],
             [
                 'id' => ArticleInterface::RESOURCE_KEY . '__' . $article2->getUuid() . '__de',
@@ -155,7 +155,7 @@ class AdminArticleReindexProviderTest extends SuluTestCase
                 'metadata' => [
                     'group' => 'default',
                 ],
-                'securityContext' => ArticleAdmin::getArticleSecurityContext('default'),
+                'securityContext' => ArticleAdmin::SECURITY_CONTEXT,
             ],
         ];
 

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Search/AdminArticleReindexProviderTest.php
@@ -202,6 +202,44 @@ class AdminArticleReindexProviderTest extends SuluTestCase
         $this->assertSame(ArticleAdmin::SECURITY_CONTEXT, $results[0]['securityContext']);
     }
 
+    public function testProvideEmitsBroadSecurityContextForDefaultGroupInMultiGroupSetup(): void
+    {
+        $multiGroupProvider = new class() implements GroupProviderInterface {
+            public function getGroups(string $key): array
+            {
+                return [
+                    GroupProviderInterface::DEFAULT_GROUP => new FormGroup(GroupProviderInterface::DEFAULT_GROUP, 'Default', ['article']),
+                    'custom-group' => new FormGroup('custom-group', 'Custom', ['custom-template']),
+                ];
+            }
+        };
+
+        $provider = new AdminArticleReindexProvider($this->entityManager, $multiGroupProvider);
+
+        $article = static::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Default group article in multi-group setup',
+                    'url' => '/default-group-multi-group',
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()
+            ->withIndex('admin')
+            ->withIdentifiers([
+                ArticleInterface::RESOURCE_KEY . '__' . $article->getUuid() . '__en',
+            ]);
+
+        /** @var array<array{securityContext: string, metadata: array{group: string}}> $results */
+        $results = \iterator_to_array($provider->provide($config));
+
+        $this->assertCount(1, $results);
+        $this->assertSame(ArticleAdmin::SECURITY_CONTEXT, $results[0]['securityContext']);
+        $this->assertSame(GroupProviderInterface::DEFAULT_GROUP, $results[0]['metadata']['group']);
+    }
+
     public function testProvideWithSpecificIdentifiers(): void
     {
         $article1 = static::createArticle([

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
@@ -195,6 +195,17 @@ class ArticleAdminTest extends TestCase
         $this->securityChecker->hasPermission(Argument::not(ArticleAdmin::SECURITY_CONTEXT), Argument::any())
             ->willReturn(false);
 
+        $this->contentViewBuilderFactory
+            ->createViews(
+                ArticleInterface::class,
+                ArticleAdmin::EDIT_TABS_VIEW . '_default',
+                ArticleAdmin::ADD_TABS_VIEW . '_default',
+                ArticleAdmin::SECURITY_CONTEXT,
+                Argument::cetera()
+            )
+            ->shouldBeCalled()
+            ->willReturn([]);
+
         $viewCollection = new ViewCollection();
         $this->articleAdmin->configureViews($viewCollection);
 
@@ -255,6 +266,17 @@ class ArticleAdminTest extends TestCase
         $this->securityChecker->hasPermission($blogContext, PermissionTypes::EDIT)->willReturn(true);
         $this->securityChecker->hasPermission($newsContext, PermissionTypes::EDIT)->willReturn(false);
         $this->securityChecker->hasPermission(Argument::cetera())->willReturn(false);
+
+        $this->contentViewBuilderFactory
+            ->createViews(
+                ArticleInterface::class,
+                ArticleAdmin::EDIT_TABS_VIEW . '_blog-group',
+                ArticleAdmin::ADD_TABS_VIEW . '_blog-group',
+                $blogContext,
+                Argument::cetera()
+            )
+            ->shouldBeCalled()
+            ->willReturn([]);
 
         $viewCollection = new ViewCollection();
         $this->articleAdmin->configureViews($viewCollection);

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Tests\Unit\Infrastructure\Sulu\Admin;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Article\Infrastructure\Sulu\Admin\ArticleAdmin;
+use Sulu\Bundle\ActivityBundle\Infrastructure\Sulu\Admin\View\ActivityViewBuilderFactoryInterface;
+use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
+use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
+use Sulu\Component\Security\Authorization\PermissionTypes;
+use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+use Sulu\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface;
+
+class ArticleAdminTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ViewBuilderFactory $viewBuilderFactory;
+
+    /**
+     * @var ObjectProphecy<ContentViewBuilderFactoryInterface>
+     */
+    private ObjectProphecy $contentViewBuilderFactory;
+
+    /**
+     * @var ObjectProphecy<SecurityCheckerInterface>
+     */
+    private ObjectProphecy $securityChecker;
+
+    /**
+     * @var ObjectProphecy<LocalizationManagerInterface>
+     */
+    private ObjectProphecy $localizationManager;
+
+    /**
+     * @var ObjectProphecy<ActivityViewBuilderFactoryInterface>
+     */
+    private ObjectProphecy $activityViewBuilderFactory;
+
+    /**
+     * @var ObjectProphecy<GroupProviderInterface>
+     */
+    private ObjectProphecy $groupProvider;
+
+    private ArticleAdmin $articleAdmin;
+
+    protected function setUp(): void
+    {
+        $this->viewBuilderFactory = new ViewBuilderFactory();
+        $this->contentViewBuilderFactory = $this->prophesize(ContentViewBuilderFactoryInterface::class);
+        $this->securityChecker = $this->prophesize(SecurityCheckerInterface::class);
+        $this->localizationManager = $this->prophesize(LocalizationManagerInterface::class);
+        $this->activityViewBuilderFactory = $this->prophesize(ActivityViewBuilderFactoryInterface::class);
+        $this->groupProvider = $this->prophesize(GroupProviderInterface::class);
+
+        $this->contentViewBuilderFactory->getDefaultToolbarActions(Argument::cetera())->willReturn([]);
+        $this->contentViewBuilderFactory->createViews(Argument::cetera())->willReturn([]);
+        $this->activityViewBuilderFactory->hasActivityListPermission()->willReturn(false);
+
+        $this->articleAdmin = new ArticleAdmin(
+            $this->viewBuilderFactory,
+            $this->contentViewBuilderFactory->reveal(),
+            $this->securityChecker->reveal(),
+            $this->localizationManager->reveal(),
+            $this->activityViewBuilderFactory->reveal(),
+            $this->groupProvider->reveal(),
+        );
+    }
+
+    public function testConfigureNavigationItemsWithNoGroups(): void
+    {
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([]);
+
+        $navigationItemCollection = new NavigationItemCollection();
+        $this->articleAdmin->configureNavigationItems($navigationItemCollection);
+
+        $this->assertFalse($navigationItemCollection->has('sulu_article.articles'));
+    }
+
+    public function testConfigureNavigationItemsWithSingleGroupAndPermission(): void
+    {
+        // With a single (implicit "default") group, getSecurityContexts() registers only
+        // ArticleAdmin::SECURITY_CONTEXT — not the per-group context. The navigation item
+        // must therefore be visible when the user holds the base context permission, even
+        // though the group identifier alone would point to an unregistered context.
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)
+            ->willReturn(['default' => new FormGroup('default', 'Default')]);
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, PermissionTypes::EDIT)
+            ->willReturn(true);
+        $this->securityChecker->hasPermission(Argument::not(ArticleAdmin::SECURITY_CONTEXT), Argument::any())
+            ->willReturn(false);
+
+        $navigationItemCollection = new NavigationItemCollection();
+        $this->articleAdmin->configureNavigationItems($navigationItemCollection);
+
+        $this->assertTrue($navigationItemCollection->has('sulu_article.articles'));
+        $navigationItem = $navigationItemCollection->get('sulu_article.articles');
+        $this->assertSame(ArticleAdmin::LIST_VIEW, $navigationItem->getView());
+        $this->assertSame('su-newspaper', $navigationItem->getIcon());
+    }
+
+    public function testConfigureNavigationItemsWithSingleGroupAndNoPermission(): void
+    {
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)
+            ->willReturn(['default' => new FormGroup('default', 'Default')]);
+
+        $this->securityChecker->hasPermission(Argument::cetera())->willReturn(false);
+
+        $navigationItemCollection = new NavigationItemCollection();
+        $this->articleAdmin->configureNavigationItems($navigationItemCollection);
+
+        $this->assertFalse($navigationItemCollection->has('sulu_article.articles'));
+    }
+
+    public function testConfigureNavigationItemsWithMultipleGroupsAndPermissionOnOne(): void
+    {
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            'blog-group' => new FormGroup('blog-group', 'Blog'),
+            'news-group' => new FormGroup('news-group', 'News'),
+        ]);
+
+        $this->securityChecker->hasPermission(
+            ArticleAdmin::getArticleSecurityContext('blog-group'),
+            PermissionTypes::EDIT
+        )->willReturn(false);
+        $this->securityChecker->hasPermission(
+            ArticleAdmin::getArticleSecurityContext('news-group'),
+            PermissionTypes::EDIT
+        )->willReturn(true);
+
+        $navigationItemCollection = new NavigationItemCollection();
+        $this->articleAdmin->configureNavigationItems($navigationItemCollection);
+
+        $this->assertTrue($navigationItemCollection->has('sulu_article.articles'));
+    }
+
+    public function testConfigureNavigationItemsWithMultipleGroupsAndNoPermission(): void
+    {
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            'blog-group' => new FormGroup('blog-group', 'Blog'),
+            'news-group' => new FormGroup('news-group', 'News'),
+        ]);
+
+        $this->securityChecker->hasPermission(Argument::cetera())->willReturn(false);
+
+        $navigationItemCollection = new NavigationItemCollection();
+        $this->articleAdmin->configureNavigationItems($navigationItemCollection);
+
+        $this->assertFalse($navigationItemCollection->has('sulu_article.articles'));
+    }
+
+    public function testConfigureViewsAlwaysAddsRootTabView(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([]);
+        $this->securityChecker->hasPermission(Argument::cetera())->willReturn(false);
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $this->assertTrue($viewCollection->has(ArticleAdmin::LIST_VIEW));
+    }
+
+    public function testConfigureViewsWithSingleGroupAndPermission(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en', 'de']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)
+            ->willReturn(['default' => (new FormGroup('default', 'Default'))->withTemplate('article')]);
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, PermissionTypes::EDIT)
+            ->willReturn(true);
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, Argument::not(PermissionTypes::EDIT))
+            ->willReturn(false);
+        $this->securityChecker->hasPermission(Argument::not(ArticleAdmin::SECURITY_CONTEXT), Argument::any())
+            ->willReturn(false);
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $this->assertTrue($viewCollection->has(ArticleAdmin::LIST_VIEW));
+        $this->assertTrue($viewCollection->has(ArticleAdmin::LIST_VIEW . '_default'));
+        $this->assertTrue($viewCollection->has(ArticleAdmin::ADD_TABS_VIEW . '_default'));
+        $this->assertTrue($viewCollection->has(ArticleAdmin::EDIT_TABS_VIEW . '_default'));
+    }
+
+    public function testConfigureViewsWithSingleGroupAndNoPermission(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)
+            ->willReturn(['default' => new FormGroup('default', 'Default')]);
+
+        $this->securityChecker->hasPermission(Argument::cetera())->willReturn(false);
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $this->assertTrue($viewCollection->has(ArticleAdmin::LIST_VIEW));
+        $this->assertFalse($viewCollection->has(ArticleAdmin::LIST_VIEW . '_default'));
+        $this->assertFalse($viewCollection->has(ArticleAdmin::ADD_TABS_VIEW . '_default'));
+        $this->assertFalse($viewCollection->has(ArticleAdmin::EDIT_TABS_VIEW . '_default'));
+    }
+
+    public function testConfigureViewsWithSingleGroupGrantsToolbarActionsViaBaseContext(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)
+            ->willReturn(['default' => (new FormGroup('default', 'Default'))->withTemplate('article')]);
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, Argument::any())->willReturn(true);
+        $this->securityChecker->hasPermission(Argument::not(ArticleAdmin::SECURITY_CONTEXT), Argument::any())
+            ->willReturn(false);
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $this->assertToolbarActions(
+            ['sulu_admin.add', 'sulu_admin.delete', 'sulu_admin.export'],
+            $viewCollection,
+            ArticleAdmin::LIST_VIEW . '_default',
+        );
+    }
+
+    public function testConfigureViewsWithMultipleGroups(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            'blog-group' => (new FormGroup('blog-group', 'Blog'))->withTemplate('blog'),
+            'news-group' => (new FormGroup('news-group', 'News'))->withTemplate('news'),
+        ]);
+
+        $blogContext = ArticleAdmin::getArticleSecurityContext('blog-group');
+        $newsContext = ArticleAdmin::getArticleSecurityContext('news-group');
+
+        $this->securityChecker->hasPermission($blogContext, PermissionTypes::EDIT)->willReturn(true);
+        $this->securityChecker->hasPermission($newsContext, PermissionTypes::EDIT)->willReturn(false);
+        $this->securityChecker->hasPermission(Argument::cetera())->willReturn(false);
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $this->assertTrue($viewCollection->has(ArticleAdmin::LIST_VIEW));
+        $this->assertTrue($viewCollection->has(ArticleAdmin::LIST_VIEW . '_blog-group'));
+        $this->assertTrue($viewCollection->has(ArticleAdmin::ADD_TABS_VIEW . '_blog-group'));
+        $this->assertTrue($viewCollection->has(ArticleAdmin::EDIT_TABS_VIEW . '_blog-group'));
+        $this->assertFalse($viewCollection->has(ArticleAdmin::LIST_VIEW . '_news-group'));
+        $this->assertFalse($viewCollection->has(ArticleAdmin::ADD_TABS_VIEW . '_news-group'));
+        $this->assertFalse($viewCollection->has(ArticleAdmin::EDIT_TABS_VIEW . '_news-group'));
+    }
+
+    public function testConfigureViewsWithMultipleGroupsScopesToolbarActionsPerGroup(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            'blog-group' => (new FormGroup('blog-group', 'Blog'))->withTemplate('blog'),
+            'news-group' => (new FormGroup('news-group', 'News'))->withTemplate('news'),
+        ]);
+
+        $blogContext = ArticleAdmin::getArticleSecurityContext('blog-group');
+        $newsContext = ArticleAdmin::getArticleSecurityContext('news-group');
+
+        $this->securityChecker->hasPermission($blogContext, Argument::any())->willReturn(true);
+        $this->securityChecker->hasPermission($newsContext, PermissionTypes::EDIT)->willReturn(true);
+        $this->securityChecker->hasPermission($newsContext, Argument::not(PermissionTypes::EDIT))->willReturn(false);
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, Argument::any())->willReturn(false);
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $this->assertToolbarActions(
+            ['sulu_admin.add', 'sulu_admin.delete', 'sulu_admin.export'],
+            $viewCollection,
+            ArticleAdmin::LIST_VIEW . '_blog-group',
+        );
+        $this->assertToolbarActions([], $viewCollection, ArticleAdmin::LIST_VIEW . '_news-group');
+    }
+
+    public function testGetSecurityContextsWithSingleGroupRegistersOnlyBaseContext(): void
+    {
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)
+            ->willReturn(['default' => new FormGroup('default', 'Default')]);
+
+        $securityContexts = $this->articleAdmin->getSecurityContexts();
+
+        $this->assertArrayHasKey(ArticleAdmin::SECURITY_CONTEXT, $securityContexts['Sulu']['Article']);
+        $this->assertArrayNotHasKey(
+            ArticleAdmin::getArticleSecurityContext('default'),
+            $securityContexts['Sulu']['Article']
+        );
+        $this->assertCount(1, $securityContexts['Sulu']['Article']);
+    }
+
+    public function testGetSecurityContextsWithMultipleGroupsRegistersPerGroupContexts(): void
+    {
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            'blog-group' => new FormGroup('blog-group', 'Blog'),
+            'news-group' => new FormGroup('news-group', 'News'),
+        ]);
+
+        $securityContexts = $this->articleAdmin->getSecurityContexts();
+
+        $this->assertArrayHasKey(ArticleAdmin::SECURITY_CONTEXT, $securityContexts['Sulu']['Article']);
+        $this->assertArrayHasKey(
+            ArticleAdmin::getArticleSecurityContext('blog-group'),
+            $securityContexts['Sulu']['Article']
+        );
+        $this->assertArrayHasKey(
+            ArticleAdmin::getArticleSecurityContext('news-group'),
+            $securityContexts['Sulu']['Article']
+        );
+    }
+
+    public function testGetArticleSecurityContext(): void
+    {
+        $this->assertSame(
+            ArticleAdmin::SECURITY_CONTEXT . '_blog-group',
+            ArticleAdmin::getArticleSecurityContext('blog-group')
+        );
+    }
+
+    /**
+     * @param string[] $expectedActions
+     */
+    private function assertToolbarActions(array $expectedActions, ViewCollection $viewCollection, string $viewName): void
+    {
+        $this->assertTrue($viewCollection->has($viewName), \sprintf('Expected view "%s" to be configured', $viewName));
+
+        /** @var ToolbarAction[] $toolbarActions */
+        $toolbarActions = $viewCollection->get($viewName)->getView()->getOption('toolbarActions') ?? [];
+        $actionNames = [];
+        foreach ($toolbarActions as $toolbarAction) {
+            $actionNames[] = $toolbarAction->getType();
+        }
+
+        $this->assertSame($expectedActions, $actionNames);
+    }
+}

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
@@ -352,6 +352,87 @@ class ArticleAdminTest extends TestCase
         );
     }
 
+    public function testGetSecurityContextsWithDefaultAndCustomGroupSkipsDefaultContext(): void
+    {
+        // The "default" group is the catch-all bucket; it must stay reachable through the
+        // umbrella context so that adding a custom group does not strip existing roles of
+        // their default-group access.
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            GroupProviderInterface::DEFAULT_GROUP => new FormGroup(GroupProviderInterface::DEFAULT_GROUP, 'Default'),
+            'custom' => new FormGroup('custom', 'Custom'),
+        ]);
+
+        $securityContexts = $this->articleAdmin->getSecurityContexts();
+
+        $this->assertArrayHasKey(ArticleAdmin::SECURITY_CONTEXT, $securityContexts['Sulu']['Article']);
+        $this->assertArrayHasKey(
+            ArticleAdmin::getArticleSecurityContext('custom'),
+            $securityContexts['Sulu']['Article']
+        );
+        $this->assertArrayNotHasKey(
+            ArticleAdmin::getArticleSecurityContext(GroupProviderInterface::DEFAULT_GROUP),
+            $securityContexts['Sulu']['Article']
+        );
+    }
+
+    public function testConfigureViewsWithDefaultAndCustomGroupGatesDefaultViaUmbrella(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            GroupProviderInterface::DEFAULT_GROUP => (new FormGroup(GroupProviderInterface::DEFAULT_GROUP, 'Default'))->withTemplate('article'),
+            'custom' => (new FormGroup('custom', 'Custom'))->withTemplate('custom'),
+        ]);
+
+        $customContext = ArticleAdmin::getArticleSecurityContext('custom');
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, Argument::any())->willReturn(true);
+        $this->securityChecker->hasPermission($customContext, Argument::any())->willReturn(false);
+        $this->securityChecker->hasPermission(
+            ArticleAdmin::getArticleSecurityContext(GroupProviderInterface::DEFAULT_GROUP),
+            Argument::any()
+        )->willReturn(false);
+
+        $this->contentViewBuilderFactory
+            ->createViews(
+                ArticleInterface::class,
+                ArticleAdmin::EDIT_TABS_VIEW . '_' . GroupProviderInterface::DEFAULT_GROUP,
+                ArticleAdmin::ADD_TABS_VIEW . '_' . GroupProviderInterface::DEFAULT_GROUP,
+                ArticleAdmin::SECURITY_CONTEXT,
+                Argument::cetera()
+            )
+            ->shouldBeCalled()
+            ->willReturn([]);
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $this->assertTrue($viewCollection->has(ArticleAdmin::LIST_VIEW . '_' . GroupProviderInterface::DEFAULT_GROUP));
+        $this->assertFalse($viewCollection->has(ArticleAdmin::LIST_VIEW . '_custom'));
+        $this->assertToolbarActions(
+            ['sulu_admin.add', 'sulu_admin.delete', 'sulu_admin.export'],
+            $viewCollection,
+            ArticleAdmin::LIST_VIEW . '_' . GroupProviderInterface::DEFAULT_GROUP,
+        );
+    }
+
+    public function testConfigureNavigationItemsWithDefaultAndCustomGroupVisibleViaUmbrella(): void
+    {
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            GroupProviderInterface::DEFAULT_GROUP => new FormGroup(GroupProviderInterface::DEFAULT_GROUP, 'Default'),
+            'custom' => new FormGroup('custom', 'Custom'),
+        ]);
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, PermissionTypes::EDIT)
+            ->willReturn(true);
+        $this->securityChecker->hasPermission(Argument::not(ArticleAdmin::SECURITY_CONTEXT), Argument::any())
+            ->willReturn(false);
+
+        $navigationItemCollection = new NavigationItemCollection();
+        $this->articleAdmin->configureNavigationItems($navigationItemCollection);
+
+        $this->assertTrue($navigationItemCollection->has('sulu_article.articles'));
+    }
+
     public function testGetArticleSecurityContext(): void
     {
         $this->assertSame(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/8836
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The ArticleAdmin navigation, views and toolbar actions now fall back to the umbrella `sulu.article.articles` permission for single-group setups and for the implicit default group in multi-group setups. The AdminArticleReindexProvider applies the same rule so default-group articles are indexed with a security context that roles can actually hold.

#### Why?

Without the fallback the UI was gated by per-group contexts (like `sulu.article.articles_default`) that are never registered, so the navigation and toolbar actions stayed hidden for every role. Adding a custom group to an existing install would also have silently revoked default-group access for all roles holding the umbrella permission.