### PR TITLE
Add commands to lock and unlock users

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Command/LockUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/LockUserCommand.php
@@ -22,8 +22,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(name: 'sulu:security:user:lock', description: 'Lock a user.')]
-class LockUserCommand extends Command
+/**
+ * @internal this class should not be instated by a project
+ *           Use instead a command event listener to
+ *           extend or change the commands behaviours
+ */
+#[AsCommand(name: 'sulu:security:user-lock', description: 'Lock a user.')]
+final class LockUserCommand extends Command
 {
     public function __construct(
         private readonly UserRepository $userRepository,

--- a/src/Sulu/Bundle/SecurityBundle/Command/LockUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/LockUserCommand.php
@@ -26,8 +26,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class LockUserCommand extends Command
 {
     public function __construct(
-        private UserRepository $userRepository,
-        private UserManager $userManager,
+        private readonly UserRepository $userRepository,
+        private readonly UserManager $userManager,
     ) {
         parent::__construct();
     }
@@ -70,7 +70,7 @@ class LockUserCommand extends Command
         }
 
         if ($user->getLocked()) {
-            $io->warning(\sprintf('User "%s" is already locked.', $identifier));
+            $io->info(\sprintf('User "%s" is already locked, doing nothing.', $identifier));
 
             return Command::SUCCESS;
         }

--- a/src/Sulu/Bundle/SecurityBundle/Command/LockUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/LockUserCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Command;
+
+use Doctrine\ORM\NoResultException;
+use Sulu\Bundle\SecurityBundle\Entity\UserRepository;
+use Sulu\Bundle\SecurityBundle\UserManager\UserManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'sulu:security:user:lock', description: 'Lock or unlock a user.')]
+class LockUserCommand extends Command
+{
+    public function __construct(
+        private UserRepository $userRepository,
+        private UserManager $userManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('username', InputArgument::REQUIRED, 'The username of the user to lock')
+            ->addOption('unlock', null, InputOption::VALUE_NONE, 'Unlock the user instead of locking it');
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        if (null !== $input->getArgument('username')) {
+            return;
+        }
+
+        $question = new Question('Please enter the username: ');
+        $question->setValidator(function($username) {
+            if (empty($username)) {
+                throw new \InvalidArgumentException('Username can not be empty');
+            }
+
+            return $username;
+        });
+
+        $input->setArgument('username', $this->getHelper('question')->ask($input, $output, $question));
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $username = $input->getArgument('username');
+        $unlock = $input->getOption('unlock');
+        $action = $unlock ? 'unlock' : 'lock';
+
+        try {
+            $user = $this->userRepository->findUserByUsername($username);
+        } catch (NoResultException) {
+            $io->error(\sprintf('User "%s" not found.', $username));
+
+            return Command::FAILURE;
+        }
+
+        if ($user->getLocked() === !$unlock) {
+            $io->warning(\sprintf('User "%s" is already %sed.', $username, $action));
+
+            return Command::SUCCESS;
+        }
+
+        if (!$io->confirm(\sprintf('Are you sure you want to %s the user "%s"?', $action, $username))) {
+            return Command::SUCCESS;
+        }
+
+        if ($unlock) {
+            $this->userManager->unlockUser($user->getId());
+        } else {
+            $this->userManager->lockUser($user->getId());
+        }
+
+        $io->success(\sprintf('User "%s" has been %sed.', $username, $action));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Command/UnlockUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/UnlockUserCommand.php
@@ -22,8 +22,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(name: 'sulu:security:user:lock', description: 'Lock a user.')]
-class LockUserCommand extends Command
+#[AsCommand(name: 'sulu:security:user:unlock', description: 'Unlock a user.')]
+class UnlockUserCommand extends Command
 {
     public function __construct(
         private UserRepository $userRepository,
@@ -35,7 +35,7 @@ class LockUserCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('identifier', InputArgument::REQUIRED, 'The username or email of the user to lock');
+            ->addArgument('identifier', InputArgument::REQUIRED, 'The username or email of the user to unlock');
     }
 
     protected function interact(InputInterface $input, OutputInterface $output): void
@@ -69,15 +69,15 @@ class LockUserCommand extends Command
             return Command::FAILURE;
         }
 
-        if ($user->getLocked()) {
-            $io->warning(\sprintf('User "%s" is already locked.', $identifier));
+        if (!$user->getLocked()) {
+            $io->warning(\sprintf('User "%s" is already unlocked.', $identifier));
 
             return Command::SUCCESS;
         }
 
-        $this->userManager->lockUser($user->getId());
+        $this->userManager->unlockUser($user->getId());
 
-        $io->success(\sprintf('User "%s" has been locked.', $identifier));
+        $io->success(\sprintf('User "%s" has been unlocked.', $identifier));
 
         return Command::SUCCESS;
     }

--- a/src/Sulu/Bundle/SecurityBundle/Command/UnlockUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/UnlockUserCommand.php
@@ -22,8 +22,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(name: 'sulu:security:user:unlock', description: 'Unlock a user.')]
-class UnlockUserCommand extends Command
+/**
+ * @internal this class should not be instated by a project
+ *           Use instead a command event listener to
+ *           extend or change the commands behaviours
+ */
+#[AsCommand(name: 'sulu:security:user-unlock', description: 'Unlock a user.')]
+final class UnlockUserCommand extends Command
 {
     public function __construct(
         private readonly UserRepository $userRepository,

--- a/src/Sulu/Bundle/SecurityBundle/Command/UnlockUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/UnlockUserCommand.php
@@ -26,8 +26,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class UnlockUserCommand extends Command
 {
     public function __construct(
-        private UserRepository $userRepository,
-        private UserManager $userManager,
+        private readonly UserRepository $userRepository,
+        private readonly UserManager $userManager,
     ) {
         parent::__construct();
     }
@@ -70,7 +70,7 @@ class UnlockUserCommand extends Command
         }
 
         if (!$user->getLocked()) {
-            $io->warning(\sprintf('User "%s" is already unlocked.', $identifier));
+            $io->info(\sprintf('User "%s" is already unlocked, doing nothing.', $identifier));
 
             return Command::SUCCESS;
         }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/command.php
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/command.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\SecurityBundle\Command\CreateRoleCommand;
 use Sulu\Bundle\SecurityBundle\Command\CreateUserCommand;
 use Sulu\Bundle\SecurityBundle\Command\InitCommand;
 use Sulu\Bundle\SecurityBundle\Command\LockUserCommand;
+use Sulu\Bundle\SecurityBundle\Command\UnlockUserCommand;
 use Symfony\Component\DependencyInjection\Reference;
 
 return static function(ContainerConfigurator $container) {
@@ -53,6 +54,14 @@ return static function(ContainerConfigurator $container) {
         ->tag('sulu.context', ['context' => 'admin']);
 
     $services->set('sulu_security.command.lock_user', LockUserCommand::class)
+        ->args([
+            new Reference('sulu.repository.user'),
+            new Reference('sulu_security.user_manager'),
+        ])
+        ->tag('console.command')
+        ->tag('sulu.context', ['context' => 'admin']);
+
+    $services->set('sulu_security.command.unlock_user', UnlockUserCommand::class)
         ->args([
             new Reference('sulu.repository.user'),
             new Reference('sulu_security.user_manager'),

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/command.php
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/command.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Sulu\Bundle\SecurityBundle\Command\CreateRoleCommand;
 use Sulu\Bundle\SecurityBundle\Command\CreateUserCommand;
 use Sulu\Bundle\SecurityBundle\Command\InitCommand;
+use Sulu\Bundle\SecurityBundle\Command\LockUserCommand;
 use Symfony\Component\DependencyInjection\Reference;
 
 return static function(ContainerConfigurator $container) {
@@ -47,6 +48,14 @@ return static function(ContainerConfigurator $container) {
             new Reference('sulu_security.salt_generator'),
             new Reference('security.password_hasher_factory'),
             '%sulu_core.locales%',
+        ])
+        ->tag('console.command')
+        ->tag('sulu.context', ['context' => 'admin']);
+
+    $services->set('sulu_security.command.lock_user', LockUserCommand::class)
+        ->args([
+            new Reference('sulu.repository.user'),
+            new Reference('sulu_security.user_manager'),
         ])
         ->tag('console.command')
         ->tag('sulu.context', ['context' => 'admin']);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/LockUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/LockUserCommandTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\ContactBundle\Entity\Contact;
+use Sulu\Bundle\SecurityBundle\Command\LockUserCommand;
+use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Component\Security\Authentication\UserInterface;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class LockUserCommandTest extends SuluTestCase
+{
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+
+    public function setUp(): void
+    {
+        $this->purgeDatabase();
+        $this->em = $this->getEntityManager();
+
+        $application = new Application($this->getContainer()->get('kernel'));
+        $command = new LockUserCommand(
+            $this->getContainer()->get('sulu.repository.user'),
+            $this->getContainer()->get('sulu_security.user_manager')
+        );
+        $command->setApplication($application);
+        $this->tester = new CommandTester($command);
+    }
+
+    public function testLockUser(): void
+    {
+        $this->createUser('john');
+
+        $this->tester->execute(['username' => 'john'], ['interactive' => false]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('User "john" has been locked.', $this->tester->getDisplay());
+        $this->assertTrue($this->findUser('john')->getLocked());
+    }
+
+    public function testUnlockUser(): void
+    {
+        $this->createUser('john', true);
+
+        $this->tester->execute(['username' => 'john', '--unlock' => true], ['interactive' => false]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('User "john" has been unlocked.', $this->tester->getDisplay());
+        $this->assertFalse($this->findUser('john')->getLocked());
+    }
+
+    public function testLockAlreadyLockedUser(): void
+    {
+        $this->createUser('john', true);
+
+        $this->tester->execute(['username' => 'john'], ['interactive' => false]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('User "john" is already locked.', $this->tester->getDisplay());
+        $this->assertTrue($this->findUser('john')->getLocked());
+    }
+
+    public function testLockNonExistingUser(): void
+    {
+        $this->tester->execute(['username' => 'ghost'], ['interactive' => false]);
+
+        $this->assertSame(1, $this->tester->getStatusCode());
+        $this->assertStringContainsString('User "ghost" not found.', $this->tester->getDisplay());
+    }
+
+    private function createUser(string $username, bool $locked = false): void
+    {
+        $contact = new Contact();
+        $contact->setFirstName('John');
+        $contact->setLastName('Doe');
+        $this->em->persist($contact);
+
+        $user = new User();
+        $user->setUsername($username);
+        $user->setEmail($username . '@example.com');
+        $user->setPassword('securepassword');
+        $user->setSalt('salt');
+        $user->setLocale('en');
+        $user->setLocked($locked);
+        $user->setContact($contact);
+        $this->em->persist($user);
+
+        $this->em->flush();
+        $this->em->clear();
+    }
+
+    private function findUser(string $username): UserInterface
+    {
+        return $this->getContainer()->get('sulu.repository.user')->findUserByUsername($username);
+    }
+}

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/LockUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/LockUserCommandTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
-use Sulu\Bundle\SecurityBundle\Command\LockUserCommand;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Security\Authentication\UserInterface;
@@ -22,15 +21,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class LockUserCommandTest extends SuluTestCase
 {
-    /**
-     * @var CommandTester
-     */
-    private $tester;
+    private CommandTester $tester;
 
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
     public function setUp(): void
     {
@@ -38,10 +31,7 @@ class LockUserCommandTest extends SuluTestCase
         $this->em = $this->getEntityManager();
 
         $application = new Application($this->getContainer()->get('kernel'));
-        $command = new LockUserCommand(
-            $this->getContainer()->get('sulu.repository.user'),
-            $this->getContainer()->get('sulu_security.user_manager')
-        );
+        $command = $this->getContainer()->get('sulu_security.command.lock_user');
         $command->setApplication($application);
         $this->tester = new CommandTester($command);
     }
@@ -75,7 +65,7 @@ class LockUserCommandTest extends SuluTestCase
         $this->tester->execute(['identifier' => 'john'], ['interactive' => false]);
 
         $this->tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('User "john" is already locked.', $this->tester->getDisplay());
+        $this->assertStringContainsString('User "john" is already locked, doing nothing.', $this->tester->getDisplay());
         $this->assertTrue($this->findUser('john')->getLocked());
     }
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/UnlockUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/UnlockUserCommandTest.php
@@ -13,14 +13,14 @@ namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
-use Sulu\Bundle\SecurityBundle\Command\LockUserCommand;
+use Sulu\Bundle\SecurityBundle\Command\UnlockUserCommand;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class LockUserCommandTest extends SuluTestCase
+class UnlockUserCommandTest extends SuluTestCase
 {
     /**
      * @var CommandTester
@@ -38,7 +38,7 @@ class LockUserCommandTest extends SuluTestCase
         $this->em = $this->getEntityManager();
 
         $application = new Application($this->getContainer()->get('kernel'));
-        $command = new LockUserCommand(
+        $command = new UnlockUserCommand(
             $this->getContainer()->get('sulu.repository.user'),
             $this->getContainer()->get('sulu_security.user_manager')
         );
@@ -46,40 +46,40 @@ class LockUserCommandTest extends SuluTestCase
         $this->tester = new CommandTester($command);
     }
 
-    public function testLockUser(): void
-    {
-        $this->createUser('john');
-
-        $this->tester->execute(['identifier' => 'john'], ['interactive' => false]);
-
-        $this->tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('User "john" has been locked.', $this->tester->getDisplay());
-        $this->assertTrue($this->findUser('john')->getLocked());
-    }
-
-    public function testLockUserByEmail(): void
-    {
-        $this->createUser('john');
-
-        $this->tester->execute(['identifier' => 'john@example.com'], ['interactive' => false]);
-
-        $this->tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('User "john@example.com" has been locked.', $this->tester->getDisplay());
-        $this->assertTrue($this->findUser('john')->getLocked());
-    }
-
-    public function testLockAlreadyLockedUser(): void
+    public function testUnlockUser(): void
     {
         $this->createUser('john', true);
 
         $this->tester->execute(['identifier' => 'john'], ['interactive' => false]);
 
         $this->tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('User "john" is already locked.', $this->tester->getDisplay());
-        $this->assertTrue($this->findUser('john')->getLocked());
+        $this->assertStringContainsString('User "john" has been unlocked.', $this->tester->getDisplay());
+        $this->assertFalse($this->findUser('john')->getLocked());
     }
 
-    public function testLockNonExistingUser(): void
+    public function testUnlockUserByEmail(): void
+    {
+        $this->createUser('john', true);
+
+        $this->tester->execute(['identifier' => 'john@example.com'], ['interactive' => false]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('User "john@example.com" has been unlocked.', $this->tester->getDisplay());
+        $this->assertFalse($this->findUser('john')->getLocked());
+    }
+
+    public function testUnlockAlreadyUnlockedUser(): void
+    {
+        $this->createUser('john');
+
+        $this->tester->execute(['identifier' => 'john'], ['interactive' => false]);
+
+        $this->tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('User "john" is already unlocked.', $this->tester->getDisplay());
+        $this->assertFalse($this->findUser('john')->getLocked());
+    }
+
+    public function testUnlockNonExistingUser(): void
     {
         $this->tester->execute(['identifier' => 'ghost'], ['interactive' => false]);
 

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/UnlockUserCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/UnlockUserCommandTest.php
@@ -13,7 +13,6 @@ namespace Sulu\Bundle\SecurityBundle\Tests\Functional\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
-use Sulu\Bundle\SecurityBundle\Command\UnlockUserCommand;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\Security\Authentication\UserInterface;
@@ -22,15 +21,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class UnlockUserCommandTest extends SuluTestCase
 {
-    /**
-     * @var CommandTester
-     */
-    private $tester;
+    private CommandTester $tester;
 
-    /**
-     * @var EntityManagerInterface
-     */
-    private $em;
+    private EntityManagerInterface $em;
 
     public function setUp(): void
     {
@@ -38,10 +31,7 @@ class UnlockUserCommandTest extends SuluTestCase
         $this->em = $this->getEntityManager();
 
         $application = new Application($this->getContainer()->get('kernel'));
-        $command = new UnlockUserCommand(
-            $this->getContainer()->get('sulu.repository.user'),
-            $this->getContainer()->get('sulu_security.user_manager')
-        );
+        $command = $this->getContainer()->get('sulu_security.command.unlock_user');
         $command->setApplication($application);
         $this->tester = new CommandTester($command);
     }
@@ -75,7 +65,7 @@ class UnlockUserCommandTest extends SuluTestCase
         $this->tester->execute(['identifier' => 'john'], ['interactive' => false]);
 
         $this->tester->assertCommandIsSuccessful();
-        $this->assertStringContainsString('User "john" is already unlocked.', $this->tester->getDisplay());
+        $this->assertStringContainsString('User "john" is already unlocked, doing nothing.', $this->tester->getDisplay());
         $this->assertFalse($this->findUser('john')->getLocked());
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #8754
| License | MIT
| Documentation PR | -

#### What's in this PR?

N ew console commands `sulu:security:user-lock` and `sulu:security:user-unlock` to locka nd unlock a user from the CLI:

```
# Lock a user
bin/console sulu:security:user-lock john

# Unlock a user
bin/console sulu:security:user-unlock john
```

The command resolves the user by username, asks for confirmation, and delegates to `UserManager::lockUser()` / `unlockUser()` so the existing domain events (`UserLockedEvent` / `UserUnlockedEvent`) are dispatched, exactly like the admin UI. It reports a clear message when the user does not exist or is already in the requested state.

#### Why?

Follow-up of #8754. In that discussion @alexander-schranz pointed out that the admin UI only allows to **lock** a user (not delete), and that a CLI **lock** command would be welcome (*"Totally fine if somebody wants to add a lock command currently"*). Deleting a user via CLI was intentionally left out, as removing a user can break content that still references it.

This mirrors the existing `sulu:security:user:create` command and reuses the same domain layer used by the admin.

#### Example Usage

```
$ bin/console sulu:security:user:lock john

 [OK] User "john" has been locked.
```

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md (none)