### PR TITLE
Add copy snippet action for feature parity with Sulu 2.6

### DIFF
--- a/packages/snippet/src/Application/Message/CopySnippetMessage.php
+++ b/packages/snippet/src/Application/Message/CopySnippetMessage.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Application\Message;
+
+class CopySnippetMessage
+{
+    /**
+     * @param array{
+     *     uuid?: string
+     * } $sourceIdentifier
+     */
+    public function __construct(
+        private array $sourceIdentifier,
+        private string $locale,
+        private ?string $targetUuid = null,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     uuid?: string
+     * }
+     */
+    public function getSourceIdentifier(): array
+    {
+        return $this->sourceIdentifier;
+    }
+
+    public function getTargetUuid(): ?string
+    {
+        return $this->targetUuid;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+}

--- a/packages/snippet/src/Application/MessageHandler/CopySnippetMessageHandler.php
+++ b/packages/snippet/src/Application/MessageHandler/CopySnippetMessageHandler.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Application\MessageHandler;
+
+use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
+use Sulu\Content\Application\ContentCopier\ContentCopierInterface;
+use Sulu\Content\Domain\Model\DimensionContentCollection;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
+use Sulu\Snippet\Application\Message\CopySnippetMessage;
+use Sulu\Snippet\Domain\Event\SnippetCopiedEvent;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContent;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
+use Sulu\Snippet\Domain\Repository\SnippetRepositoryInterface;
+
+/**
+ * @internal This class should not be instantiated by a project.
+ *           Create your own Message and Handler instead.
+ */
+final class CopySnippetMessageHandler
+{
+    public function __construct(
+        private SnippetRepositoryInterface $snippetRepository,
+        private ContentCopierInterface $contentCopier,
+        private LocalizationManagerInterface $localizationManager,
+        private DomainEventCollectorInterface $domainEventCollector,
+    ) {
+    }
+
+    public function __invoke(CopySnippetMessage $message): SnippetInterface
+    {
+        $allLocales = [];
+        foreach ($this->localizationManager->getLocalizations() as $localization) {
+            $allLocales[] = $localization->getLocale();
+        }
+
+        $sourceSnippet = $this->snippetRepository->getOneBy(
+            $message->getSourceIdentifier(),
+            [
+                SnippetRepositoryInterface::SELECT_SNIPPET_CONTENT => [
+                    'selects' => [DimensionContentQueryEnhancer::GROUP_SELECT_CONTENT_WEBSITE => true],
+                    'dimensionAttributes' => [
+                        'locale' => $allLocales,
+                        'stage' => DimensionContentInterface::STAGE_DRAFT,
+                    ],
+                ],
+            ]
+        );
+
+        $targetSnippet = $this->snippetRepository->createNew($message->getTargetUuid());
+        $this->snippetRepository->add($targetSnippet);
+
+        $dimensionContentCollection = new DimensionContentCollection(
+            $sourceSnippet->getDimensionContents(),
+            [],
+            SnippetDimensionContent::class
+        );
+
+        foreach ($allLocales as $locale) {
+            $sourceDimensionContent = $dimensionContentCollection->getDimensionContent([
+                'locale' => $locale,
+                'stage' => DimensionContentInterface::STAGE_DRAFT,
+            ]);
+
+            if ($sourceDimensionContent?->getLocale() !== $locale) {
+                // If the snippet does not exist in the target locale, we cannot copy content for that locale.
+                continue;
+            }
+
+            $this->contentCopier->copy(
+                $sourceSnippet,
+                [
+                    'stage' => DimensionContentInterface::STAGE_DRAFT,
+                    'locale' => $locale,
+                ],
+                $targetSnippet,
+                [
+                    'stage' => DimensionContentInterface::STAGE_DRAFT,
+                    'locale' => $locale,
+                ]
+            );
+        }
+
+        $sourceDimensionContent = $dimensionContentCollection->getDimensionContent([
+            'locale' => $message->getLocale(),
+            'stage' => DimensionContentInterface::STAGE_DRAFT,
+        ]);
+
+        $this->domainEventCollector->collect(new SnippetCopiedEvent(
+            $targetSnippet,
+            (string) $sourceSnippet->getUuid(),
+            $sourceDimensionContent instanceof SnippetDimensionContent ? $sourceDimensionContent->getTitle() : null,
+            $message->getLocale(),
+        ));
+
+        return $targetSnippet;
+    }
+}

--- a/packages/snippet/src/Domain/Event/SnippetCopiedEvent.php
+++ b/packages/snippet/src/Domain/Event/SnippetCopiedEvent.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Domain\Event;
+
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Content\Domain\Model\DimensionContentCollection;
+use Sulu\Snippet\Domain\Model\SnippetDimensionContent;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
+use Sulu\Snippet\Infrastructure\Sulu\Admin\SnippetAdmin;
+
+class SnippetCopiedEvent extends DomainEvent
+{
+    public function __construct(
+        private SnippetInterface $snippet,
+        private string $sourceSnippetId,
+        private ?string $sourceSnippetTitle,
+        private ?string $sourceSnippetTitleLocale,
+    ) {
+        parent::__construct();
+    }
+
+    public function getSnippet(): SnippetInterface
+    {
+        return $this->snippet;
+    }
+
+    public function getEventType(): string
+    {
+        return 'copied';
+    }
+
+    public function getEventContext(): array
+    {
+        return [
+            'sourceSnippetId' => $this->sourceSnippetId,
+            'sourceSnippetTitle' => $this->sourceSnippetTitle,
+            'sourceSnippetTitleLocale' => $this->sourceSnippetTitleLocale,
+        ];
+    }
+
+    public function getResourceKey(): string
+    {
+        return SnippetInterface::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->snippet->getUuid();
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        if (null === $this->sourceSnippetTitleLocale) {
+            return null;
+        }
+
+        $dimensionContentCollection = new DimensionContentCollection($this->snippet->getDimensionContents(), [], SnippetDimensionContent::class);
+
+        return $dimensionContentCollection->getDimensionContent(['locale' => $this->sourceSnippetTitleLocale])?->getTitle();
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        return $this->sourceSnippetTitleLocale;
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return SnippetAdmin::SECURITY_CONTEXT;
+    }
+}

--- a/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAdmin.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAdmin.php
@@ -130,6 +130,36 @@ class SnippetAdmin extends Admin
                     ),
                 ]
             );
+            $formToolbarActions['edit'] = new DropdownToolbarAction(
+                'sulu_admin.edit',
+                'su-pen',
+                [
+                    new ToolbarAction(
+                        'sulu_admin.copy',
+                        [
+                            'visible_condition' => '(!_permissions || _permissions.edit)',
+                        ]
+                    ),
+                    new ToolbarAction(
+                        'sulu_admin.copy_locale',
+                        [
+                            'visible_condition' => '(!_permissions || _permissions.edit)',
+                        ]
+                    ),
+                    new ToolbarAction(
+                        'sulu_admin.delete_draft',
+                        [
+                            'visible_condition' => '(!_permissions || _permissions.live)',
+                        ]
+                    ),
+                    new ToolbarAction(
+                        'sulu_admin.set_unpublished',
+                        [
+                            'visible_condition' => '(!_permissions || _permissions.live)',
+                        ]
+                    ),
+                ]
+            );
 
             $viewBuilders = $this->contentViewBuilderFactory->createViews(
                 SnippetInterface::class,

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -20,6 +20,7 @@ use Sulu\Snippet\Application\Mapper\SnippetContentMapper;
 use Sulu\Snippet\Application\Mapper\SnippetMapperInterface;
 use Sulu\Snippet\Application\MessageHandler\ApplyWorkflowTransitionSnippetMessageHandler;
 use Sulu\Snippet\Application\MessageHandler\CopyLocaleSnippetMessageHandler;
+use Sulu\Snippet\Application\MessageHandler\CopySnippetMessageHandler;
 use Sulu\Snippet\Application\MessageHandler\CreateSnippetMessageHandler;
 use Sulu\Snippet\Application\MessageHandler\ModifySnippetAreaMessageHandler;
 use Sulu\Snippet\Application\MessageHandler\ModifySnippetMessageHandler;
@@ -184,6 +185,16 @@ final class SuluSnippetBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_snippet.snippet_repository'),
                 new Reference('sulu_content.content_copier'),
+                new Reference('sulu_activity.domain_event_collector'),
+            ])
+            ->tag('messenger.message_handler');
+
+        $services->set('sulu_snippet.copy_snippet_handler')
+            ->class(CopySnippetMessageHandler::class)
+            ->args([
+                new Reference('sulu_snippet.snippet_repository'),
+                new Reference('sulu_content.content_copier'),
+                new Reference('sulu.core.localization_manager'),
                 new Reference('sulu_activity.domain_event_collector'),
             ])
             ->tag('messenger.message_handler');

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -25,6 +25,7 @@ use Sulu\Content\Domain\Model\WorkflowInterface;
 use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
 use Sulu\Snippet\Application\Message\ApplyWorkflowTransitionSnippetMessage;
 use Sulu\Snippet\Application\Message\CopyLocaleSnippetMessage;
+use Sulu\Snippet\Application\Message\CopySnippetMessage;
 use Sulu\Snippet\Application\Message\CreateSnippetMessage;
 use Sulu\Snippet\Application\Message\ModifySnippetMessage;
 use Sulu\Snippet\Application\Message\RemoveSnippetMessage;
@@ -253,9 +254,9 @@ final class SnippetController implements SecuredControllerInterface
 
     public function postTriggerAction(Request $request, string $id): Response
     {
-        $this->handleAction($request, $id);
+        $result = $this->handleAction($request, $id);
 
-        return $this->getAction($request, $id);
+        return $this->getAction($request, $result?->getUuid() ?? $id);
     }
 
     public function deleteAction(Request $request, string $id): Response // TODO route should be a uuid
@@ -313,12 +314,21 @@ final class SnippetController implements SecuredControllerInterface
         if ('copy_locale' === $action) {
             $message = new CopyLocaleSnippetMessage(
                 ['uuid' => $uuid],
-                (string) $request->query->get('src'),
+                (string) ($request->query->get('src') ?: $request->query->get('locale')),
                 (string) $request->query->get('dest')
             );
 
             /** @see \Sulu\Snippet\Application\MessageHandler\CopyLocaleSnippetMessageHandler */
             /** @var null */
+            return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
+        } elseif ('copy' === $action) {
+            $message = new CopySnippetMessage(
+                ['uuid' => $uuid],
+                $this->getLocale($request),
+            );
+
+            /** @see \Sulu\Snippet\Application\MessageHandler\CopySnippetMessageHandler */
+            /** @var SnippetInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('restore' === $action) {
             $version = \intval($request->query->get('version'));

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -319,7 +319,7 @@ final class SnippetController implements SecuredControllerInterface
             );
 
             /** @see \Sulu\Snippet\Application\MessageHandler\CopyLocaleSnippetMessageHandler */
-            /** @var null */
+            /** @var SnippetInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('copy' === $action) {
             $message = new CopySnippetMessage(

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Admin/SnippetAdminTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Admin/SnippetAdminTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Admin;
+
+use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Snippet\Infrastructure\Sulu\Admin\SnippetAdmin;
+
+class SnippetAdminTest extends SuluTestCase
+{
+    public function testEditToolbarContainsCopyLocaleAction(): void
+    {
+        $snippetAdmin = $this->getSnippetAdmin();
+
+        $viewCollection = new ViewCollection();
+        $snippetAdmin->configureViews($viewCollection);
+
+        $actionNames = $this->collectToolbarActionNames($viewCollection);
+
+        $this->assertContains('sulu_admin.copy_locale', $actionNames);
+    }
+
+    public function testEditToolbarContainsCopyAction(): void
+    {
+        $snippetAdmin = $this->getSnippetAdmin();
+
+        $viewCollection = new ViewCollection();
+        $snippetAdmin->configureViews($viewCollection);
+
+        $actionNames = $this->collectToolbarActionNames($viewCollection);
+
+        $this->assertContains('sulu_admin.copy', $actionNames);
+    }
+
+    private function getSnippetAdmin(): SnippetAdmin
+    {
+        /** @var SnippetAdmin $snippetAdmin */
+        $snippetAdmin = self::getContainer()->get('sulu_snippet.snippet_admin');
+
+        return $snippetAdmin;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function collectToolbarActionNames(ViewCollection $viewCollection): array
+    {
+        $names = [];
+
+        foreach ($viewCollection->all() as $viewBuilder) {
+            $toolbarActions = $viewBuilder->getView()->getOption('toolbarActions');
+            if (!\is_array($toolbarActions)) {
+                continue;
+            }
+
+            foreach ($toolbarActions as $action) {
+                if ($action instanceof DropdownToolbarAction) {
+                    $subActions = $action->getOptions()['toolbarActions'] ?? [];
+                    if (!\is_array($subActions)) {
+                        continue;
+                    }
+                    foreach ($subActions as $sub) {
+                        if ($sub instanceof ToolbarAction) {
+                            $names[] = $sub->getType();
+                        }
+                    }
+
+                    continue;
+                }
+
+                if ($action instanceof ToolbarAction) {
+                    $names[] = $action->getType();
+                }
+            }
+        }
+
+        return $names;
+    }
+}

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -240,16 +240,19 @@ class SnippetControllerTest extends SuluTestCase
         $copyId = $data['id'];
         $this->assertNotSame($id, $copyId);
 
-        $this->client->request('GET', '/admin/api/snippets/' . $copyId . '?locale=en');
-        $copyResponse = $this->client->getResponse();
-        $this->assertSame(200, $copyResponse->getStatusCode());
+        try {
+            $this->client->request('GET', '/admin/api/snippets/' . $copyId . '?locale=en');
+            $copyResponse = $this->client->getResponse();
+            $this->assertSame(200, $copyResponse->getStatusCode());
 
-        /** @var array<string, mixed> $copyData */
-        $copyData = \json_decode((string) $copyResponse->getContent(), true);
-        $this->assertSame('Test Snippet', $copyData['title'] ?? null);
-
-        // Clean up so the duplicate does not pollute snapshot-based list tests that run after this one.
-        $this->client->request('DELETE', '/admin/api/snippets/' . $copyId . '?locale=en');
+            /** @var array<string, mixed> $copyData */
+            $copyData = \json_decode((string) $copyResponse->getContent(), true);
+            $this->assertSame('Test Snippet', $copyData['title'] ?? null);
+        } finally {
+            // Clean up so the duplicate does not pollute snapshot-based list tests that run after this one.
+            $this->client->request('DELETE', '/admin/api/snippets/' . $copyId . '?locale=en');
+            $this->assertSame(204, $this->client->getResponse()->getStatusCode());
+        }
     }
 
     #[Depends('testPost')]

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -212,6 +212,47 @@ class SnippetControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testPostTriggerCopyLocaleWithoutSrcParam(string $id): void
+    {
+        $this->client->request('POST', '/admin/api/snippets/' . $id . '?locale=en&action=copy_locale&dest=de');
+
+        $response = $this->client->getResponse();
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        /** @var array{availableLocales?: string[]} $data */
+        $data = \json_decode((string) $response->getContent(), true);
+        $availableLocales = $data['availableLocales'] ?? [];
+        $this->assertContains('de', $availableLocales);
+        $this->assertContains('en', $availableLocales);
+    }
+
+    #[Depends('testPost')]
+    public function testPostTriggerCopy(string $id): void
+    {
+        $this->client->request('POST', '/admin/api/snippets/' . $id . '?locale=en&action=copy');
+
+        $response = $this->client->getResponse();
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        /** @var array{id?: string} $data */
+        $data = \json_decode((string) $response->getContent(), true);
+        $this->assertArrayHasKey('id', $data);
+        $copyId = $data['id'];
+        $this->assertNotSame($id, $copyId);
+
+        $this->client->request('GET', '/admin/api/snippets/' . $copyId . '?locale=en');
+        $copyResponse = $this->client->getResponse();
+        $this->assertSame(200, $copyResponse->getStatusCode());
+
+        /** @var array<string, mixed> $copyData */
+        $copyData = \json_decode((string) $copyResponse->getContent(), true);
+        $this->assertSame('Test Snippet', $copyData['title'] ?? null);
+
+        // Clean up so the duplicate does not pollute snapshot-based list tests that run after this one.
+        $this->client->request('DELETE', '/admin/api/snippets/' . $copyId . '?locale=en');
+    }
+
+    #[Depends('testPost')]
     #[Depends('testGet')]
     public function testPut(string $id): void
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This PR adds a `CopySnippetMessage` and handler that fully duplicates a snippet across all available locales and emits a `SnippetCopiedEvent`. The snippet edit toolbar now exposes a dropdown with the `sulu_admin.copy` and `sulu_admin.copy_locale` actions wired up to the existing handlers. The `SnippetController` returns the freshly created snippet uuid from the `copy` trigger so the admin can reload the new resource. It also falls back from the missing `src` query parameter to `locale` for the `copy_locale` action, matching `PageController` behaviour.

#### Why?

Both the duplicate and copy locale actions already existed for snippets in Sulu 2.6 and were lost on the way to 3.0. The snippet admin was missing the buttons that `PageAdmin` still offered, even though the underlying `CopyLocaleSnippetMessageHandler` was in place. Editors had no way to clone a snippet or transfer content between locales from the UI. The `copy_locale` action additionally failed because the React `CopyLocaleToolbarAction` only sends `locale` and `dest`, which left the source locale empty and crashed in `TemplateDataMapper`.