### PR TITLE
Fix avoid create new Version if publish did not succeed by defer it

### DIFF
--- a/packages/content/src/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
+++ b/packages/content/src/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
@@ -75,14 +75,6 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
             }
         }
 
-        // Create a new version of the content before it is published
-        $this->contentCopier->copyFromDimensionContentCollection(
-            $dimensionContentCollection,
-            $contentRichEntity,
-            \array_merge($dimensionAttributes, ['locale' => $locale, 'version' => \time()]),
-            ['ignoredAttributes' => ['url']] // ignore url, because we cannot restore it from a version
-        );
-
         $shadowLocale = $dimensionContent instanceof ShadowInterface
             ? $dimensionContent->getShadowLocale()
             : null;
@@ -95,6 +87,8 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
             );
 
             if (!$publishedDimensionContent instanceof ShadowInterface) {
+                $this->createVersion($dimensionContentCollection, $contentRichEntity, $dimensionAttributes, $locale);
+
                 return;
             }
 
@@ -116,6 +110,8 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
                     ]
                 );
             }
+
+            $this->createVersion($dimensionContentCollection, $contentRichEntity, $dimensionAttributes, $locale);
 
             return;
         }
@@ -144,6 +140,29 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
             $contentRichEntity,
             $targetDimensionAttributes,
             ['data' => $data]
+        );
+
+        $this->createVersion($dimensionContentCollection, $contentRichEntity, $dimensionAttributes, $locale);
+    }
+
+    /**
+     * @template T of DimensionContentInterface
+     *
+     * @param DimensionContentCollectionInterface<T> $dimensionContentCollection
+     * @param ContentRichEntityInterface<T> $contentRichEntity
+     * @param mixed[] $dimensionAttributes
+     */
+    private function createVersion(
+        DimensionContentCollectionInterface $dimensionContentCollection,
+        ContentRichEntityInterface $contentRichEntity,
+        array $dimensionAttributes,
+        string $locale,
+    ): void {
+        $this->contentCopier->copyFromDimensionContentCollection(
+            $dimensionContentCollection,
+            $contentRichEntity,
+            \array_merge($dimensionAttributes, ['locale' => $locale, 'version' => \time()]),
+            ['ignoredAttributes' => ['url']] // ignore url, because we cannot restore it from a version
         );
     }
 

--- a/packages/content/tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
@@ -373,4 +373,57 @@ class PublishTransitionSubscriberTest extends TestCase
 
         $contentPublishSubscriber->onPublish($event);
     }
+
+    public function testOnPublishFailedPublishDoesNotCreateVersion(): void
+    {
+        // The new version must only be created when the publish-side copy succeeds,
+        // otherwise a failed publish (e.g. duplicate route) leaves an orphan version.
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(WorkflowInterface::class);
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
+        $dimensionAttributes = ['locale' => 'en', 'stage' => 'draft'];
+
+        $dimensionContent->getLocale()->willReturn('en');
+        $dimensionContent->getWorkflowPublished()->willReturn(null);
+        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldBeCalled();
+
+        $event = new TransitionEvent(
+            $dimensionContent->reveal(),
+            new Marking()
+        );
+        $event->setContext([
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
+        ]);
+
+        $contentCopier = $this->prophesize(ContentCopierInterface::class);
+        $targetDimensionAttributes = $dimensionAttributes;
+        $targetDimensionAttributes['stage'] = 'live';
+
+        $contentCopier->copyFromDimensionContentCollection(
+            $dimensionContentCollection->reveal(),
+            $contentRichEntity->reveal(),
+            $targetDimensionAttributes
+        )
+            ->willThrow(new \RuntimeException('Duplicate entry'));
+
+        $contentCopier->copyFromDimensionContentCollection(
+            $dimensionContentCollection->reveal(),
+            $contentRichEntity->reveal(),
+            Argument::that(static fn (array $attrs) => isset($attrs['version']) && $attrs['version'] > 0),
+            Argument::any()
+        )
+            ->shouldNotBeCalled();
+
+        $contentPublishSubscriber = $this->createContentPublisherSubscriberInstance($contentCopier->reveal());
+
+        try {
+            $contentPublishSubscriber->onPublish($event);
+            $this->fail('Expected the publish failure to bubble up.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Duplicate entry', $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The new version that is created when content is published is now created only after the publish-side copy has succeeded. The version creation moved into a dedicated `createVersion` method that runs at the end of each publish path.

#### Why?

Previously the new version was created before the live copy ran. Intermediate flushes inside the `ContentCopier` persisted that version even when the publish copy failed afterwards, for example on a duplicate route entry. This left orphan version rows that appeared in the admin as restorable versions the editor never confirmed.
