### PR TITLE
Add copy article action for feature parity with Sulu 2.6

### DIFF
--- a/packages/article/src/Application/Message/CopyArticleMessage.php
+++ b/packages/article/src/Application/Message/CopyArticleMessage.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Application\Message;
+
+class CopyArticleMessage
+{
+    /**
+     * @param array{
+     *     uuid?: string
+     * } $sourceIdentifier
+     */
+    public function __construct(
+        private array $sourceIdentifier,
+        private string $locale,
+        private ?string $targetUuid = null,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     uuid?: string
+     * }
+     */
+    public function getSourceIdentifier(): array
+    {
+        return $this->sourceIdentifier;
+    }
+
+    public function getTargetUuid(): ?string
+    {
+        return $this->targetUuid;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+}

--- a/packages/article/src/Application/MessageHandler/CopyArticleMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/CopyArticleMessageHandler.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Application\MessageHandler;
+
+use Sulu\Article\Application\Message\CopyArticleMessage;
+use Sulu\Article\Domain\Event\ArticleCopiedEvent;
+use Sulu\Article\Domain\Model\ArticleDimensionContent;
+use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
+use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
+use Sulu\Content\Application\ContentCopier\ContentCopierInterface;
+use Sulu\Content\Domain\Model\DimensionContentCollection;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+
+/**
+ * @internal This class should not be instantiated by a project.
+ *           Create your own Message and Handler instead.
+ */
+final class CopyArticleMessageHandler
+{
+    public function __construct(
+        private ArticleRepositoryInterface $articleRepository,
+        private ContentCopierInterface $contentCopier,
+        private LocalizationManagerInterface $localizationManager,
+        private DomainEventCollectorInterface $domainEventCollector,
+    ) {
+    }
+
+    public function __invoke(CopyArticleMessage $message): ArticleInterface
+    {
+        $allLocales = [];
+        foreach ($this->localizationManager->getLocalizations() as $localization) {
+            $allLocales[] = $localization->getLocale();
+        }
+
+        $sourceArticle = $this->articleRepository->getOneBy(
+            $message->getSourceIdentifier(),
+            [
+                ArticleRepositoryInterface::SELECT_ARTICLE_CONTENT => [
+                    'selects' => [],
+                    'dimensionAttributes' => [
+                        'locale' => $allLocales,
+                        'stage' => DimensionContentInterface::STAGE_DRAFT,
+                    ],
+                ],
+            ]
+        );
+
+        $targetArticle = $this->articleRepository->createNew($message->getTargetUuid());
+        $this->articleRepository->add($targetArticle);
+
+        $dimensionContentCollection = new DimensionContentCollection(
+            $sourceArticle->getDimensionContents(),
+            [],
+            ArticleDimensionContent::class
+        );
+
+        foreach ($allLocales as $locale) {
+            $sourceDimensionContent = $dimensionContentCollection->getDimensionContent([
+                'locale' => $locale,
+                'stage' => DimensionContentInterface::STAGE_DRAFT,
+            ]);
+
+            if ($sourceDimensionContent?->getLocale() !== $locale) {
+                // If the article does not exist in the target locale, we cannot copy content for that locale.
+                continue;
+            }
+
+            $this->contentCopier->copy(
+                $sourceArticle,
+                [
+                    'stage' => DimensionContentInterface::STAGE_DRAFT,
+                    'locale' => $locale,
+                ],
+                $targetArticle,
+                [
+                    'stage' => DimensionContentInterface::STAGE_DRAFT,
+                    'locale' => $locale,
+                ],
+                [
+                    'ignoredAttributes' => [
+                        'url', // TODO remove this once the route resolving is implemented on duplicates
+                    ],
+                ]
+            );
+        }
+
+        $sourceDimensionContent = $dimensionContentCollection->getDimensionContent([
+            'locale' => $message->getLocale(),
+            'stage' => DimensionContentInterface::STAGE_DRAFT,
+        ]);
+
+        $this->domainEventCollector->collect(new ArticleCopiedEvent(
+            $targetArticle,
+            (string) $sourceArticle->getUuid(),
+            $sourceDimensionContent instanceof ArticleDimensionContent ? $sourceDimensionContent->getTitle() : null,
+            $message->getLocale(),
+        ));
+
+        return $targetArticle;
+    }
+}

--- a/packages/article/src/Domain/Event/ArticleCopiedEvent.php
+++ b/packages/article/src/Domain/Event/ArticleCopiedEvent.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Domain\Event;
+
+use Sulu\Article\Domain\Model\ArticleDimensionContent;
+use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Article\Infrastructure\Sulu\Admin\ArticleAdmin;
+use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Content\Domain\Model\DimensionContentCollection;
+
+class ArticleCopiedEvent extends DomainEvent
+{
+    public function __construct(
+        private ArticleInterface $article,
+        private string $sourceArticleId,
+        private ?string $sourceArticleTitle,
+        private ?string $sourceArticleTitleLocale,
+    ) {
+        parent::__construct();
+    }
+
+    public function getArticle(): ArticleInterface
+    {
+        return $this->article;
+    }
+
+    public function getEventType(): string
+    {
+        return 'copied';
+    }
+
+    public function getEventContext(): array
+    {
+        return [
+            'sourceArticleId' => $this->sourceArticleId,
+            'sourceArticleTitle' => $this->sourceArticleTitle,
+            'sourceArticleTitleLocale' => $this->sourceArticleTitleLocale,
+        ];
+    }
+
+    public function getResourceKey(): string
+    {
+        return ArticleInterface::RESOURCE_KEY;
+    }
+
+    public function getResourceId(): string
+    {
+        return (string) $this->article->getUuid();
+    }
+
+    public function getResourceLocale(): ?string
+    {
+        return $this->sourceArticleTitleLocale;
+    }
+
+    public function getResourceTitle(): ?string
+    {
+        if (null === $this->sourceArticleTitleLocale) {
+            return null;
+        }
+
+        $dimensionContentCollection = new DimensionContentCollection($this->article->getDimensionContents(), [], ArticleDimensionContent::class);
+
+        return $dimensionContentCollection->getDimensionContent(['locale' => $this->sourceArticleTitleLocale])?->getTitle();
+    }
+
+    public function getResourceTitleLocale(): ?string
+    {
+        return $this->sourceArticleTitleLocale;
+    }
+
+    public function getResourceSecurityContext(): ?string
+    {
+        return ArticleAdmin::SECURITY_CONTEXT;
+    }
+}

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -184,6 +184,36 @@ class ArticleAdmin extends Admin
                 ),
             ]
         );
+        $formToolbarActions['edit'] = new DropdownToolbarAction(
+            'sulu_admin.edit',
+            'su-pen',
+            [
+                new ToolbarAction(
+                    'sulu_admin.copy',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.edit)',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.copy_locale',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.edit)',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.delete_draft',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.live)',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.set_unpublished',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.live)',
+                    ]
+                ),
+            ]
+        );
 
         $viewBuilders = $this->contentViewBuilderFactory->createViews(
             ArticleInterface::class,

--- a/packages/article/src/Infrastructure/Sulu/Search/AdminArticleIndexListener.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/AdminArticleIndexListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Article\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
+use Sulu\Article\Domain\Event\ArticleCopiedEvent;
 use Sulu\Article\Domain\Event\ArticleCreatedEvent;
 use Sulu\Article\Domain\Event\ArticleModifiedEvent;
 use Sulu\Article\Domain\Event\ArticleRemovedEvent;
@@ -36,7 +37,7 @@ final class AdminArticleIndexListener
     ) {
     }
 
-    public function onArticleChanged(ArticleCreatedEvent|ArticleModifiedEvent|ArticleRemovedEvent|ArticleRestoredEvent|ArticleTranslationRestoredEvent|ArticleTranslationAddedEvent|ArticleTranslationRemovedEvent|ArticleTranslationCopiedEvent $event): void
+    public function onArticleChanged(ArticleCreatedEvent|ArticleCopiedEvent|ArticleModifiedEvent|ArticleRemovedEvent|ArticleRestoredEvent|ArticleTranslationRestoredEvent|ArticleTranslationAddedEvent|ArticleTranslationRemovedEvent|ArticleTranslationCopiedEvent $event): void
     {
         $locale = $event->getResourceLocale();
         $identifiers = [];

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -16,6 +16,7 @@ namespace Sulu\Article\Infrastructure\Symfony\HttpKernel;
 use Sulu\Article\Application\Mapper\ArticleContentMapper;
 use Sulu\Article\Application\Mapper\ArticleMapperInterface;
 use Sulu\Article\Application\MessageHandler\ApplyWorkflowTransitionArticleMessageHandler;
+use Sulu\Article\Application\MessageHandler\CopyArticleMessageHandler;
 use Sulu\Article\Application\MessageHandler\CopyLocaleArticleMessageHandler;
 use Sulu\Article\Application\MessageHandler\CreateArticleMessageHandler;
 use Sulu\Article\Application\MessageHandler\ModifyArticleMessageHandler;
@@ -23,6 +24,7 @@ use Sulu\Article\Application\MessageHandler\RemoveArticleMessageHandler;
 use Sulu\Article\Application\MessageHandler\RemoveArticleTranslationMessageHandler;
 use Sulu\Article\Application\MessageHandler\RestoreArticleVersionMessageHandler;
 use Sulu\Article\Application\Webspace\WebspaceSettingsConfigurationResolver;
+use Sulu\Article\Domain\Event\ArticleCopiedEvent;
 use Sulu\Article\Domain\Event\ArticleCreatedEvent;
 use Sulu\Article\Domain\Event\ArticleModifiedEvent;
 use Sulu\Article\Domain\Event\ArticleRemovedEvent;
@@ -217,6 +219,16 @@ final class SuluArticleBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_article.article_repository'),
                 new Reference('sulu_content.content_copier'),
+                new Reference('sulu_activity.domain_event_collector'),
+            ])
+            ->tag('messenger.message_handler');
+
+        $services->set('sulu_article.copy_article_handler')
+            ->class(CopyArticleMessageHandler::class)
+            ->args([
+                new Reference('sulu_article.article_repository'),
+                new Reference('sulu_content.content_copier'),
+                new Reference('sulu.core.localization_manager'),
                 new Reference('sulu_activity.domain_event_collector'),
             ])
             ->tag('messenger.message_handler');
@@ -454,6 +466,7 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_message_bus'),
             ])
             ->tag('kernel.event_listener', ['event' => ArticleCreatedEvent::class, 'method' => 'onArticleChanged'])
+            ->tag('kernel.event_listener', ['event' => ArticleCopiedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleModifiedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleRemovedEvent::class, 'method' => 'onArticleChanged'])
             ->tag('kernel.event_listener', ['event' => ArticleRestoredEvent::class, 'method' => 'onArticleChanged'])

--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -12,6 +12,7 @@
 namespace Sulu\Article\UserInterface\Controller\Admin;
 
 use Sulu\Article\Application\Message\ApplyWorkflowTransitionArticleMessage;
+use Sulu\Article\Application\Message\CopyArticleMessage;
 use Sulu\Article\Application\Message\CopyLocaleArticleMessage;
 use Sulu\Article\Application\Message\CreateArticleMessage;
 use Sulu\Article\Application\Message\ModifyArticleMessage;
@@ -239,9 +240,9 @@ final class ArticleController implements SecuredControllerInterface
 
     public function postTriggerAction(Request $request, string $id): Response
     {
-        $this->handleAction($request, $id);
+        $result = $this->handleAction($request, $id);
 
-        return $this->getAction($request, $id);
+        return $this->getAction($request, $result?->getUuid() ?? $id);
     }
 
     public function deleteAction(Request $request, string $id): Response // TODO route should be a uuid
@@ -299,11 +300,20 @@ final class ArticleController implements SecuredControllerInterface
         if ('copy_locale' === $action) {
             $message = new CopyLocaleArticleMessage(
                 ['uuid' => $uuid],
-                (string) $request->query->get('src'),
+                (string) ($request->query->get('src') ?: $request->query->get('locale')),
                 (string) $request->query->get('dest'),
             );
 
             /** @see \Sulu\Article\Application\MessageHandler\CopyLocaleArticleMessageHandler */
+            /** @var ArticleInterface|null */
+            return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
+        } elseif ('copy' === $action) {
+            $message = new CopyArticleMessage(
+                ['uuid' => $uuid],
+                $this->getLocale($request),
+            );
+
+            /** @see \Sulu\Article\Application\MessageHandler\CopyArticleMessageHandler */
             /** @var ArticleInterface|null */
             return $this->handle(new Envelope($message, [new EnableFlushStamp()]));
         } elseif ('restore' === $action) {

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -367,6 +367,47 @@ class ArticleControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testPostTriggerCopyLocaleWithoutSrcParam(string $id): void
+    {
+        $this->client->request('POST', '/admin/api/articles/' . $id . '?locale=en&action=copy_locale&dest=de');
+
+        $response = $this->client->getResponse();
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        /** @var array{availableLocales?: string[]} $data */
+        $data = \json_decode((string) $response->getContent(), true);
+        $availableLocales = $data['availableLocales'] ?? [];
+        $this->assertContains('de', $availableLocales);
+        $this->assertContains('en', $availableLocales);
+    }
+
+    #[Depends('testPost')]
+    public function testPostTriggerCopy(string $id): void
+    {
+        $this->client->request('POST', '/admin/api/articles/' . $id . '?locale=en&action=copy');
+
+        $response = $this->client->getResponse();
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        /** @var array{id?: string} $data */
+        $data = \json_decode((string) $response->getContent(), true);
+        $this->assertArrayHasKey('id', $data);
+        $copyId = $data['id'];
+        $this->assertNotSame($id, $copyId);
+
+        $this->client->request('GET', '/admin/api/articles/' . $copyId . '?locale=en');
+        $copyResponse = $this->client->getResponse();
+        $this->assertSame(200, $copyResponse->getStatusCode());
+
+        /** @var array<string, mixed> $copyData */
+        $copyData = \json_decode((string) $copyResponse->getContent(), true);
+        $this->assertSame('Test Article', $copyData['title'] ?? null);
+
+        // Clean up so the duplicate does not pollute snapshot-based list tests that run after this one.
+        $this->client->request('DELETE', '/admin/api/articles/' . $copyId . '?locale=en');
+    }
+
+    #[Depends('testPost')]
     #[Depends('testGet')]
     #[Depends('testPutShadowLocale')]
     public function testPut(string $id): void

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
@@ -21,6 +21,7 @@ use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Infrastructure\Sulu\Admin\ArticleAdmin;
 use Sulu\Bundle\ActivityBundle\Infrastructure\Sulu\Admin\View\ActivityViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationItemCollection;
+use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
@@ -213,6 +214,52 @@ class ArticleAdminTest extends TestCase
         $this->assertTrue($viewCollection->has(ArticleAdmin::LIST_VIEW . '_default'));
         $this->assertTrue($viewCollection->has(ArticleAdmin::ADD_TABS_VIEW . '_default'));
         $this->assertTrue($viewCollection->has(ArticleAdmin::EDIT_TABS_VIEW . '_default'));
+    }
+
+    public function testConfigureViewsEditToolbarContainsCopyAndCopyLocaleActions(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en', 'de']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)
+            ->willReturn(['default' => (new FormGroup('default', 'Default'))->withTemplate('article')]);
+
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, PermissionTypes::EDIT)
+            ->willReturn(true);
+        $this->securityChecker->hasPermission(ArticleAdmin::SECURITY_CONTEXT, Argument::not(PermissionTypes::EDIT))
+            ->willReturn(false);
+        $this->securityChecker->hasPermission(Argument::not(ArticleAdmin::SECURITY_CONTEXT), Argument::any())
+            ->willReturn(false);
+
+        /** @var array<string, mixed>|null $capturedToolbarActions */
+        $capturedToolbarActions = null;
+        $this->contentViewBuilderFactory
+            ->createViews(Argument::cetera())
+            ->will(function(array $args) use (&$capturedToolbarActions) {
+                $toolbarActions = $args[4] ?? null;
+                $capturedToolbarActions = \is_array($toolbarActions) ? $toolbarActions : null;
+
+                return [];
+            });
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $this->assertIsArray($capturedToolbarActions);
+        $this->assertArrayHasKey('edit', $capturedToolbarActions);
+
+        $editAction = $capturedToolbarActions['edit'];
+        $this->assertInstanceOf(DropdownToolbarAction::class, $editAction);
+
+        $subActions = $editAction->getOptions()['toolbarActions'] ?? [];
+        $this->assertIsArray($subActions);
+
+        $subActionTypes = [];
+        foreach ($subActions as $subAction) {
+            $this->assertInstanceOf(ToolbarAction::class, $subAction);
+            $subActionTypes[] = $subAction->getType();
+        }
+
+        $this->assertContains('sulu_admin.copy', $subActionTypes);
+        $this->assertContains('sulu_admin.copy_locale', $subActionTypes);
     }
 
     public function testConfigureViewsWithSingleGroupAndNoPermission(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #8867 <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This PR adds a `CopyArticleMessage` and handler that duplicates an article into a brand new article across all available locales and emits an `ArticleCopiedEvent`. The article edit toolbar now exposes a dropdown with the `sulu_admin.copy` and `sulu_admin.copy_locale` actions, and the `ArticleController` returns the freshly created article uuid from the `copy` trigger so the admin can reload the new resource. The `copy_locale` action now also falls back from a missing `src` query parameter to `locale`, matching the page and snippet behaviour. The new event is wired into the admin search index listener so the duplicate becomes searchable.

#### Why?

The duplicate article action already existed for articles in Sulu 2.6 but was lost on the way to 3.0, leaving editors without a way to clone an article from the UI. This mirrors the snippet copy work in #8867 and restores parity with the 2.6 `ArticleCopiedEvent`.