### PR TITLE
Add compiler pass to validate default webspace configuration for articles

### DIFF
--- a/config/packages/sulu_article.yaml
+++ b/config/packages/sulu_article.yaml
@@ -1,0 +1,3 @@
+sulu_article:
+    # Required when more than one webspace exists: defines the main webspace new articles are assigned to.
+    default_main_webspace: 'sulu-test'

--- a/packages/article/src/Application/Webspace/WebspaceSettingsConfigurationResolver.php
+++ b/packages/article/src/Application/Webspace/WebspaceSettingsConfigurationResolver.php
@@ -43,7 +43,12 @@ class WebspaceSettingsConfigurationResolver
             return \reset($webspaces)->getKey();
         }
 
-        throw new \RuntimeException('No configured default main webspace for locale "' . $searchedLocale . '".');
+        throw new \RuntimeException(\sprintf(
+            'No default main webspace configured for locale "%s". When more than one webspace exists, the '
+            . '"sulu_article.default_main_webspace" option must be set to one of your webspace keys '
+            . '(optionally per locale).',
+            $searchedLocale,
+        ));
     }
 
     /**

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePass.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePass.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Infrastructure\Symfony\HttpKernel\Compiler;
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\Config\Util\Exception\XmlParsingException;
+use Symfony\Component\Config\Util\XmlUtils;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @internal this class is not part of the public API and should only be called by the Symfony framework classes
+ */
+final class ValidateDefaultMainWebspacePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $configDir = $this->resolveWebspaceConfigDir($container);
+        if (null === $configDir) {
+            return;
+        }
+
+        $container->addResource(new DirectoryResource($configDir, '/\.xml$/'));
+
+        $webspaceKeys = $this->readWebspaceKeys($configDir);
+        $defaultMainWebspace = $this->getConfiguredDefaultMainWebspace($container);
+
+        if ([] === $defaultMainWebspace) {
+            if (\count($webspaceKeys) > 1) {
+                throw new InvalidConfigurationException(\sprintf(
+                    'The "sulu_article.default_main_webspace" option must be configured when more than one webspace '
+                    . 'exists (found %d webspaces in "%s"). Set it to one of your webspace keys.',
+                    \count($webspaceKeys),
+                    $configDir,
+                ));
+            }
+
+            return;
+        }
+
+        if ([] === $webspaceKeys) {
+            return;
+        }
+
+        foreach ($defaultMainWebspace as $webspaceKey) {
+            if (!\in_array($webspaceKey, $webspaceKeys, true)) {
+                throw new InvalidConfigurationException(\sprintf(
+                    'The "sulu_article.default_main_webspace" option is set to the unknown webspace "%s". '
+                    . 'Configure it with one of the existing webspace keys: "%s".',
+                    $webspaceKey,
+                    \implode('", "', $webspaceKeys),
+                ));
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getConfiguredDefaultMainWebspace(ContainerBuilder $container): array
+    {
+        if (!$container->hasParameter('sulu_article.default_main_webspace')) {
+            return [];
+        }
+
+        /** @var array<string, string> $defaultMainWebspace */
+        $defaultMainWebspace = $container->getParameter('sulu_article.default_main_webspace');
+
+        return $defaultMainWebspace;
+    }
+
+    private function resolveWebspaceConfigDir(ContainerBuilder $container): ?string
+    {
+        if (!$container->hasParameter('sulu_core.webspace.config_dir')) {
+            return null;
+        }
+
+        $configDir = $container->getParameterBag()->resolveValue(
+            $container->getParameter('sulu_core.webspace.config_dir'),
+        );
+
+        if (!\is_string($configDir) || !\is_dir($configDir)) {
+            return null;
+        }
+
+        return $configDir;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readWebspaceKeys(string $configDir): array
+    {
+        $webspaceKeys = [];
+        foreach ((new Finder())->in($configDir)->files()->name('*.xml') as $file) {
+            try {
+                $document = XmlUtils::loadFile($file->getPathname());
+            } catch (XmlParsingException|\InvalidArgumentException) {
+                continue;
+            }
+
+            $keyNodes = (new \DOMXPath($document))->query('/*[local-name()="webspace"]/*[local-name()="key"]');
+            $key = false !== $keyNodes && null !== $keyNodes->item(0) ? (string) $keyNodes->item(0)->nodeValue : '';
+
+            if ('' !== $key) {
+                $webspaceKeys[] = $key;
+            }
+        }
+
+        return $webspaceKeys;
+    }
+}

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -64,6 +64,7 @@ use Sulu\Article\Infrastructure\Sulu\Search\WebsiteArticleIndexListener;
 use Sulu\Article\Infrastructure\Sulu\Search\WebsiteArticleReindexProvider;
 use Sulu\Article\Infrastructure\Sulu\Sitemap\ArticlesSitemapProvider;
 use Sulu\Article\Infrastructure\Sulu\Trash\ArticleTrashItemHandler;
+use Sulu\Article\Infrastructure\Symfony\HttpKernel\Compiler\ValidateDefaultMainWebspacePass;
 use Sulu\Article\Infrastructure\Symfony\Twig\ArticleTwigExtension;
 use Sulu\Article\UserInterface\Controller\Admin\ArticleController;
 use Sulu\Bundle\HttpCacheBundle\ReferenceStore\ReferenceStore;
@@ -697,5 +698,7 @@ final class SuluArticleBundle extends AbstractBundle
             ArticleInterface::class => 'sulu.model.article.class',
             ArticleDimensionContentInterface::class => 'sulu.model.article_content.class',
         ], $container);
+
+        $container->addCompilerPass(new ValidateDefaultMainWebspacePass());
     }
 }

--- a/packages/article/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePassTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePassTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Tests\Unit\Infrastructure\Symfony\HttpKernel\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Article\Infrastructure\Symfony\HttpKernel\Compiler\ValidateDefaultMainWebspacePass;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ValidateDefaultMainWebspacePassTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeTempDir($dir);
+        }
+        $this->tempDirs = [];
+    }
+
+    public function testThrowsWhenMultipleWebspacesAndNoDefaultConfigured(): void
+    {
+        $dir = $this->createWebspaceDir(['sulu-io', 'blog']);
+        $container = $this->createContainer($dir, []);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('sulu_article.default_main_webspace');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    public function testDoesNotThrowWhenDefaultMainWebspaceConfigured(): void
+    {
+        $dir = $this->createWebspaceDir(['sulu-io', 'blog']);
+        $container = $this->createContainer($dir, ['default' => 'sulu-io']);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testDoesNotThrowWhenLocaleSpecificMainWebspaceConfigured(): void
+    {
+        $dir = $this->createWebspaceDir(['sulu-io', 'blog']);
+        $container = $this->createContainer($dir, ['en' => 'sulu-io', 'de' => 'blog']);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testDoesNotThrowWhenSingleWebspace(): void
+    {
+        $dir = $this->createWebspaceDir(['sulu-io']);
+        $container = $this->createContainer($dir, []);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testThrowsWhenConfiguredMainWebspaceDoesNotExist(): void
+    {
+        $dir = $this->createWebspaceDir(['sulu-io', 'blog']);
+        $container = $this->createContainer($dir, ['default' => 'nonexistent']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('nonexistent');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    public function testThrowsWhenLocaleSpecificConfiguredWebspaceDoesNotExist(): void
+    {
+        $dir = $this->createWebspaceDir(['sulu-io', 'blog']);
+        $container = $this->createContainer($dir, ['en' => 'sulu-io', 'de' => 'nope']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('nope');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    public function testThrowsWhenConfiguredWebspaceDoesNotExistWithSingleWebspace(): void
+    {
+        $dir = $this->createWebspaceDir(['sulu-io']);
+        $container = $this->createContainer($dir, ['default' => 'nonexistent']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('nonexistent');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    public function testRegistersConfigDirAsContainerResource(): void
+    {
+        $dir = $this->createWebspaceDir(['sulu-io']);
+        $container = $this->createContainer($dir, []);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $directoryResources = \array_filter(
+            $container->getResources(),
+            static fn ($resource): bool => $resource instanceof DirectoryResource,
+        );
+        $resourcePaths = \array_map(
+            static fn (DirectoryResource $resource): string => $resource->getResource(),
+            $directoryResources,
+        );
+
+        $this->assertContains(\realpath($dir), $resourcePaths);
+    }
+
+    public function testDoesNotThrowWhenConfigDirParameterMissing(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('sulu_article.default_main_webspace', []);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testDoesNotThrowWhenConfigDirDoesNotExist(): void
+    {
+        $container = $this->createContainer('/nonexistent/path/that/does/not/exist', []);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testResolvesProjectDirPlaceholderInConfigDir(): void
+    {
+        $projectDir = $this->createTempDir();
+        $webspacesDir = $projectDir . '/config/webspaces';
+        \mkdir($webspacesDir, 0777, true);
+        \file_put_contents($webspacesDir . '/sulu.io.xml', $this->webspaceXml('sulu-io'));
+        \file_put_contents($webspacesDir . '/blog.xml', $this->webspaceXml('blog'));
+
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $projectDir);
+        $container->setParameter('sulu_core.webspace.config_dir', '%kernel.project_dir%/config/webspaces');
+        $container->setParameter('sulu_article.default_main_webspace', []);
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    /**
+     * @param array<string, string> $defaultMainWebspace
+     */
+    private function createContainer(string $configDir, array $defaultMainWebspace): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('sulu_core.webspace.config_dir', $configDir);
+        $container->setParameter('sulu_article.default_main_webspace', $defaultMainWebspace);
+
+        return $container;
+    }
+
+    /**
+     * @param list<string> $keys
+     */
+    private function createWebspaceDir(array $keys): string
+    {
+        $dir = $this->createTempDir();
+        foreach ($keys as $key) {
+            \file_put_contents($dir . '/' . $key . '.xml', $this->webspaceXml($key));
+        }
+
+        return $dir;
+    }
+
+    private function webspaceXml(string $key): string
+    {
+        return <<<XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <webspace xmlns="http://schemas.sulu.io/webspace/webspace">
+                <name>{$key}</name>
+                <key>{$key}</key>
+            </webspace>
+            XML;
+    }
+
+    private function createTempDir(): string
+    {
+        $dir = \sys_get_temp_dir() . '/sulu_test_' . \uniqid('', true);
+        \mkdir($dir, 0777, true);
+        $this->tempDirs[] = $dir;
+
+        return $dir;
+    }
+
+    private function removeTempDir(string $dir): void
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        /** @var \SplFileInfo $file */
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                \rmdir((string) $file->getRealPath());
+            } else {
+                \unlink((string) $file->getRealPath());
+            }
+        }
+
+        \rmdir($dir);
+    }
+}

--- a/packages/search/tests/Application/config/config.yml
+++ b/packages/search/tests/Application/config/config.yml
@@ -1,4 +1,5 @@
-sulu_article: {}
+sulu_article:
+    default_main_webspace: 'sulu-io'
 
 framework:
     # symfony recipe default configuration:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #8875 <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The SuluArticleBundle now runs a compiler pass that checks the "sulu_article.default_main_webspace" option against the webspaces found in the project. It fails the container build with a clear message when more than one webspace exists but no default is configured, and when the configured value points to a webspace key that does not exist. The runtime exception in the WebspaceSettingsConfigurationResolver was reworded to name the same option so both checks give consistent guidance.

#### Why?

With multiple webspaces and no default configured, creating an article failed with a vague runtime error that did not explain how to resolve it. Moving the validation to container compile time surfaces the misconfiguration early during the build instead of on first use. The new message tells the developer exactly which option to set and lists the valid webspace keys.