### PR TITLE
Add all property params into the view in the DefaultPropertyResolver

### DIFF
--- a/packages/content/src/Application/PropertyResolver/Resolver/DefaultPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/DefaultPropertyResolver.php
@@ -19,7 +19,7 @@ class DefaultPropertyResolver implements PropertyResolverInterface
 {
     public function resolve(mixed $data, string $locale, array $params = []): ContentView
     {
-        return ContentView::create($data, []);
+        return ContentView::create($data, $params);
     }
 
     public static function getType(): string

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -812,7 +812,7 @@ class ContentResolverTest extends SuluTestCase
         // root view mapping (ids/displayOption); ignore metadata
         /** @var array{content: array<int, mixed>, view: array<int, mixed>, title: array<mixed>, url: array<mixed>} $view */
         $view = $result['view'];
-        self::assertSame([], $view['title']);
+        self::assertSame(['headline' => true], $view['title']);
         self::assertSame([], $view['url']);
 
         /** @var array<int, mixed> $viewContentBlocks */

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/DefaultPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/DefaultPropertyResolverTest.php
@@ -24,7 +24,7 @@ class DefaultPropertyResolverTest extends TestCase
         $result = $defaultPropertyResolver->resolve('data', 'locale', ['params' => 'value']);
 
         $this->assertSame('data', $result->getContent());
-        $this->assertSame([], $result->getView());
+        $this->assertSame(['params' => 'value'], $result->getView());
     }
 
     public function testGetType(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Push all property params into the view.

#### Why?

So in the view are all params available, for example for the `single_icon_selection` the `icon_set`.