### PR TITLE
Rename selection filter params and validate them at build time

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -14,6 +14,42 @@ We refactored the Migrations the abstract class is now under the Infrastructure 
 
  - `Sulu\Content\Migrations\AbstractTagNameToIdMigration` -> `Sulu\Content\Infrastructure\Doctrine\Migrations\AbstractTagNameToIdMigration`
 
+### Renamed selection filter parameters
+
+The parameters used to pre-filter the snippet and article selection overlays were renamed so they match the naming already used by `smart_content` (see #8716). The frontend `Selection` and `SingleSelection` field types now send the new parameters, and the corresponding list endpoints only read the new names:
+
+| Resource | Old parameter | New parameter | Meaning |
+| --- | --- | --- | --- |
+| Article selection | `types` | `groups` | article template group identifiers |
+| Article selection | `templates` | `templateKeys` | concrete template keys |
+| Snippet selection | `types` | `templateKeys` | concrete template keys |
+
+If you configured these filters through the schema options of a `snippet_selection`, `article_selection` or one of their `single_*` variants, rename the params in your form XML:
+
+```xml
+<!-- before -->
+<property name="mySnippets" type="snippet_selection">
+    <params>
+        <param name="types" value="footer,header"/>
+    </params>
+</property>
+
+<!-- after -->
+<property name="mySnippets" type="snippet_selection">
+    <params>
+        <param name="templateKeys" value="footer,header"/>
+    </params>
+</property>
+```
+
+For article selections, `<param name="types" .../>` (group identifiers) becomes `<param name="groups" .../>` and `<param name="templates" .../>` becomes `<param name="templateKeys" .../>`.
+
+> **Note:** The old parameters are no longer read by the snippet/article list endpoints, but they still pass frontend validation and are sent to the server, where they are silently ignored. A selection that is not migrated therefore shows **all** items instead of the filtered subset, without any error. Search your form templates for `types`/`templates` params on selection fields and migrate them.
+
+The `types` parameter of `media_selection`/`single_media_selection` (mime-type filtering, e.g. `image,video`) is unrelated and stays unchanged.
+
+The article and snippet list endpoints now read these parameters with `Request::getString()`, so passing an array-shaped value (e.g. `?templateKeys[]=a&templateKeys[]=b`) results in an HTTP 400 response instead of the previously silent fallback to an unfiltered list. The admin UI always sends a comma-separated string, so this only affects custom/manual requests.
+
 ## 3.0.7
 
 ### Smart content tag and category resolving is opt-in

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -16,15 +16,19 @@ We refactored the Migrations the abstract class is now under the Infrastructure 
 
 ### Renamed selection filter parameters
 
-The parameters used to pre-filter the snippet and article selection overlays were renamed so they match the naming already used by `smart_content` (see #8716). The frontend `Selection` and `SingleSelection` field types now send the new parameters, and the corresponding list endpoints only read the new names:
+The parameters used to pre-filter the snippet and article selection overlays were renamed so they match the naming 
+already used by `smart_content` (see #8716). The frontend `Selection` and `SingleSelection` field types now send the 
+new parameters, and the corresponding list endpoints only read the new names:
 
 | Resource | Old parameter | New parameter | Meaning |
 | --- | --- | --- | --- |
 | Article selection | `types` | `groups` | article template group identifiers |
 | Article selection | `templates` | `templateKeys` | concrete template keys |
 | Snippet selection | `types` | `templateKeys` | concrete template keys |
+| Page selection | `types` | `templateKeys` | concrete template keys — `types` was never read |
 
-If you configured these filters through the schema options of a `snippet_selection`, `article_selection` or one of their `single_*` variants, rename the params in your form XML:
+If you configured these filters through the schema options of a `snippet_selection`, `article_selection` or one of 
+their `single_*` variants, rename the params in your form XML:
 
 ```xml
 <!-- before -->
@@ -42,13 +46,17 @@ If you configured these filters through the schema options of a `snippet_selecti
 </property>
 ```
 
-For article selections, `<param name="types" .../>` (group identifiers) becomes `<param name="groups" .../>` and `<param name="templates" .../>` becomes `<param name="templateKeys" .../>`.
+For article selections, `<param name="types" .../>` (group identifiers) becomes `<param name="groups" .../>` and 
+`<param name="templates" .../>` becomes `<param name="templateKeys" .../>`.
 
-> **Note:** The old parameters are no longer read by the snippet/article list endpoints, but they still pass frontend validation and are sent to the server, where they are silently ignored. A selection that is not migrated therefore shows **all** items instead of the filtered subset, without any error. Search your form templates for `types`/`templates` params on selection fields and migrate them.
+The container build fails for every selection in a configured template or form directory that still uses an outdated param,
+naming the key, the property and the file.
 
 The `types` parameter of `media_selection`/`single_media_selection` (mime-type filtering, e.g. `image,video`) is unrelated and stays unchanged.
 
-The article and snippet list endpoints now read these parameters with `Request::getString()`, so passing an array-shaped value (e.g. `?templateKeys[]=a&templateKeys[]=b`) results in an HTTP 400 response instead of the previously silent fallback to an unfiltered list. The admin UI always sends a comma-separated string, so this only affects custom/manual requests.
+The article and snippet list endpoints now read these parameters with `Request::getString()`, so passing an 
+array-shaped value (e.g. `?templateKeys[]=a&templateKeys[]=b`) results in an HTTP 400 response instead of the previously 
+silent fallback to an unfiltered list. The admin UI always sends a comma-separated string, so this only affects custom/manual requests.
 
 ## 3.0.7
 

--- a/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
+++ b/packages/article/src/Infrastructure/Sulu/Admin/ArticleAdmin.php
@@ -143,7 +143,7 @@ class ArticleAdmin extends Admin
                 ->addListAdapters(['table'])
                 ->setTabTitle($group->title)
                 ->addLocales($locales)
-                ->addRequestParameters(['templates' => \implode(',', $group->templates)])
+                ->addRequestParameters(['templateKeys' => \implode(',', $group->templates)])
                 ->setDefaultLocale($locales[0] ?? '')
                 ->setAddView(static::ADD_TABS_VIEW . '_' . $groupIdentifier)
                 ->setEditView(static::EDIT_TABS_VIEW . '_' . $groupIdentifier)

--- a/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
+++ b/packages/article/src/UserInterface/Controller/Admin/ArticleController.php
@@ -70,20 +70,20 @@ final class ArticleController implements SecuredControllerInterface
 
     public function cgetAction(Request $request): Response
     {
-        $typesParam = $request->get('types', '');
-        $types = \array_filter(\explode(',', \is_string($typesParam) ? $typesParam : ''));
+        $groupsParam = $request->query->getString('groups', '');
+        $groupIdentifiers = \array_filter(\explode(',', $groupsParam));
 
         $groupTemplates = [];
         $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
         foreach ($groups as $group) {
-            if (\in_array($group->identifier, $types)) {
+            if (\in_array($group->identifier, $groupIdentifiers)) {
                 $groupTemplates = \array_merge($groupTemplates, $group->templates);
             }
         }
 
-        $templatesParam = $request->get('templates', '');
-        $templates = \array_filter(\explode(',', \is_string($templatesParam) ? $templatesParam : ''));
-        $templates = \array_unique(\array_merge($templates, $groupTemplates));
+        $templateKeysParam = $request->query->getString('templateKeys', '');
+        $templateKeys = \array_filter(\explode(',', $templateKeysParam));
+        $templateKeys = \array_unique(\array_merge($templateKeys, $groupTemplates));
 
         // TODO this should be ArticleRepository::findFlatBy / ::countFlatBy methods
         //      but first we would need to avoid that the restHelper requires the request.
@@ -114,8 +114,8 @@ final class ArticleController implements SecuredControllerInterface
             $listBuilder->addSelectField($fieldDescriptors['ghostLocale']);
         }
         $listBuilder->setParameter('locale', $this->getLocale($request));
-        if (0 !== \count($templates)) {
-            $listBuilder->in($fieldDescriptors['templateKey'], $templates);
+        if (0 !== \count($templateKeys)) {
+            $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);
         }
 
         $listRepresentation = new PaginatedRepresentation(

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -664,7 +664,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(201, $response3);
 
         // Test single template filter
-        $this->client->request('GET', '/admin/api/articles?locale=en&templates=article');
+        $this->client->request('GET', '/admin/api/articles?locale=en&templateKeys=article');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         $content = \json_decode((string) $response->getContent(), true);
@@ -677,7 +677,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertSame('Article Template Test', $content['_embedded']['articles'][0]['title']);
 
         // Test multiple template filter
-        $this->client->request('GET', '/admin/api/articles?locale=en&templates=article,blog');
+        $this->client->request('GET', '/admin/api/articles?locale=en&templateKeys=article,blog');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         $content = \json_decode((string) $response->getContent(), true);
@@ -691,7 +691,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertContains('Blog Template Test', $titles);
 
         // Test template filter with empty values (should be filtered out)
-        $this->client->request('GET', '/admin/api/articles?locale=en&templates=article,,blog,');
+        $this->client->request('GET', '/admin/api/articles?locale=en&templateKeys=article,,blog,');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         $content = \json_decode((string) $response->getContent(), true);
@@ -714,7 +714,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertSame(3, $content['total']);
 
         // Test empty template filter (should return all)
-        $this->client->request('GET', '/admin/api/articles?locale=en&templates=');
+        $this->client->request('GET', '/admin/api/articles?locale=en&templateKeys=');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         $content = \json_decode((string) $response->getContent(), true);
@@ -723,7 +723,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertSame(3, $content['total']);
 
         // Test non-existent template (should return no results)
-        $this->client->request('GET', '/admin/api/articles?locale=en&templates=nonexistent');
+        $this->client->request('GET', '/admin/api/articles?locale=en&templateKeys=nonexistent');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         $content = \json_decode((string) $response->getContent(), true);
@@ -881,7 +881,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(201, $response3);
 
         // Test type filter
-        $this->client->request('GET', '/admin/api/articles?locale=en&types=blog-group');
+        $this->client->request('GET', '/admin/api/articles?locale=en&groups=blog-group');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         $content = \json_decode((string) $response->getContent(), true);

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -759,7 +759,7 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(201, $this->client->getResponse());
 
         // Request the list in "de" (ghost) with a template filter: the "article" ghost must appear
-        $this->client->request('GET', '/admin/api/articles?locale=de&templates=article');
+        $this->client->request('GET', '/admin/api/articles?locale=de&templateKeys=article');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         /** @var array<string, mixed> $content */
@@ -819,7 +819,7 @@ class ArticleControllerTest extends SuluTestCase
         // List in "en" with the template filter. The real "en" article and the "de"-only
         // ghost must both appear: the join upgrade must not drop the ghost row even when a
         // non-ghost row is also present in the result set.
-        $this->client->request('GET', '/admin/api/articles?locale=en&templates=article');
+        $this->client->request('GET', '/admin/api/articles?locale=en&templateKeys=article');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         /** @var array{total: int, _embedded: array{articles: array<int, array{title: string, locale: string|null, ghostLocale: string|null}>}} $content */

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -429,8 +429,8 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         $templateKeys = $filters['templateKeys'] ?? [];
         unset($filters['templateKeys']);
 
-        if (!empty($templateKeys) && isset($fieldDescriptors['templateKey'])) {
-            $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);
+        if (!empty($templateKeys) && isset($fieldDescriptors['template'])) {
+            $listBuilder->in($fieldDescriptors['template'], $templateKeys);
         }
 
         foreach ($filters as $key => $value) {

--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -94,6 +94,8 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
         $excludeShadows = $request->query->getBoolean('exclude-shadows', false);
         $expandedIds = \array_filter(\explode(',', (string) $request->query->get('expandedIds')));
         $ids = $request->query->get('ids');
+        $templateKeysParam = $request->query->getString('templateKeys');
+        $templateKeys = \array_filter(\explode(',', $templateKeysParam));
 
         $filters = [];
 
@@ -107,6 +109,10 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
 
         if ($excludeShadows) {
             $filters['shadowLocale'] = null;
+        }
+
+        if (!empty($templateKeys)) {
+            $filters['templateKeys'] = $templateKeys;
         }
 
         $includedFields = ['locale', 'ghostLocale', 'shadowLocale', 'webspaceKey', 'template', 'publishedState', 'linkProvider'];
@@ -364,7 +370,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
     }
 
     /**
-     * @param array<string, bool|float|int|string|null> $filters
+     * @param array<string, array<int, string>|bool|float|int|string|null> $filters
      * @param array<string, mixed> $parameters
      * @param string[] $expandedIds
      * @param string[] $includedFields
@@ -418,6 +424,14 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
 
         // Fall back to a non-matching value for an empty set to avoid an invalid `andWhere('()')`.
         $listBuilder->in($fieldDescriptors['webspaceKey'], !empty($webspaces) ? $webspaces : [null]);
+
+        /** @var string[] $templateKeys */
+        $templateKeys = $filters['templateKeys'] ?? [];
+        unset($filters['templateKeys']);
+
+        if (!empty($templateKeys) && isset($fieldDescriptors['templateKey'])) {
+            $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);
+        }
 
         foreach ($filters as $key => $value) {
             if (isset($fieldDescriptors[$key])) {

--- a/packages/page/tests/Functional/Integration/PageControllerTest.php
+++ b/packages/page/tests/Functional/Integration/PageControllerTest.php
@@ -1062,6 +1062,90 @@ class PageControllerTest extends SuluTestCase
         $this->assertNotSame('', $childPage['creator']);
     }
 
+    public function testGetListFilteredByTemplateKeys(): void
+    {
+        self::purgeDatabase();
+
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
+        $homepageId = $homepage->getId();
+
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', $homepageId),
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'default',
+                'title' => 'Default Template Page',
+                'url' => '/default-template-page',
+            ]) ?: null,
+        );
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', $homepageId),
+            [],
+            [],
+            [],
+            \json_encode([
+                'template' => 'blog',
+                'title' => 'Blog Template Page',
+                'url' => '/blog-template-page',
+            ]) ?: null,
+        );
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        self::ensureKernelShutdown();
+
+        // Without a template filter, both children must appear
+        $this->client->request(
+            'GET',
+            \sprintf('/admin/api/pages?locale=en&webspace=sulu-io&parentId=%s', $homepageId),
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array{_embedded: array{pages: array<int, array<string, mixed>>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertCount(2, $content['_embedded']['pages']);
+
+        // Filtering by a single templateKey must return only the matching page
+        $this->client->request(
+            'GET',
+            \sprintf('/admin/api/pages?locale=en&webspace=sulu-io&parentId=%s&templateKeys=default', $homepageId),
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array{_embedded: array{pages: array<int, array<string, mixed>>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $pages = $content['_embedded']['pages'];
+        $this->assertCount(1, $pages);
+        $this->assertSame('Default Template Page', $pages[0]['title']);
+
+        // Filtering by multiple templateKeys must return all matching pages
+        $this->client->request(
+            'GET',
+            \sprintf('/admin/api/pages?locale=en&webspace=sulu-io&parentId=%s&templateKeys=default,blog', $homepageId),
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array{_embedded: array{pages: array<int, array<string, mixed>>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertCount(2, $content['_embedded']['pages']);
+
+        // Filtering by a non-existent templateKey must return no pages
+        $this->client->request(
+            'GET',
+            \sprintf('/admin/api/pages?locale=en&webspace=sulu-io&parentId=%s&templateKeys=nonexistent', $homepageId),
+        );
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array{_embedded: array{pages: array<int, array<string, mixed>>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertCount(0, $content['_embedded']['pages']);
+    }
+
     public function testNestedTemplatePropertyWithSlash(): void
     {
         self::purgeDatabase();

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -104,17 +104,17 @@ final class SnippetController implements SecuredControllerInterface
         }
         $listBuilder->setParameter('locale', $this->getLocale($request));
 
-        $typesParam = $request->query->get('types');
-        $types = \array_filter(\explode(',', \is_string($typesParam) ? $typesParam : ''));
+        $templateKeysParam = $request->query->getString('templateKeys');
+        $templateKeys = \array_filter(\explode(',', $templateKeysParam));
 
-        if (0 !== \count($types)) {
-            $listBuilder->in($fieldDescriptors['templateKey'], $types);
+        if (0 !== \count($templateKeys)) {
+            $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);
         }
 
         $areasParam = $request->query->get('areas');
         if (null !== $areasParam) {
             $areas = \explode(',', (string) $areasParam);
-            $templateKeys = [];
+            $areaTemplateKeys = [];
             foreach ($areas as $area) {
                 if (!\array_key_exists($area, $this->snippetAreas)) {
                     continue;
@@ -124,11 +124,11 @@ final class SnippetController implements SecuredControllerInterface
                 if (empty($templateKey)) {
                     continue;
                 }
-                $templateKeys[] = $templateKey;
+                $areaTemplateKeys[] = $templateKey;
             }
 
-            if (!empty($templateKeys)) {
-                $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);
+            if (!empty($areaTemplateKeys)) {
+                $listBuilder->in($fieldDescriptors['templateKey'], $areaTemplateKeys);
             }
         }
 

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -478,7 +478,7 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(201, $this->client->getResponse());
 
         // Request the list in "en" (ghost) with a type filter: the "snippet" ghost must appear
-        $this->client->request('GET', '/admin/api/snippets?locale=en&types=snippet');
+        $this->client->request('GET', '/admin/api/snippets?locale=en&templateKeys=snippet');
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
         /** @var array<string, mixed> $content */

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -323,17 +323,17 @@ class SnippetControllerTest extends SuluTestCase
     public function testGetListWithTypesFilter(): void
     {
         // Test filtering by existing type - should return the snippet
-        $this->client->request('GET', '/admin/api/snippets?locale=en&types=snippet');
+        $this->client->request('GET', '/admin/api/snippets?locale=en&templateKeys=snippet');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('snippet_cget_types_filter_snippet.json', $response, 200);
 
         // Test filtering by non-existent type - should return no results
-        $this->client->request('GET', '/admin/api/snippets?locale=en&types=non-existent-type');
+        $this->client->request('GET', '/admin/api/snippets?locale=en&templateKeys=non-existent-type');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('snippet_cget_types_filter_nonexistent.json', $response, 200);
 
         // Test filtering by multiple types - should return snippets of the existing type
-        $this->client->request('GET', '/admin/api/snippets?locale=en&types=snippet,other-template');
+        $this->client->request('GET', '/admin/api/snippets?locale=en&templateKeys=snippet,other-template');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('snippet_cget_types_filter_multiple.json', $response, 200);
     }

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ValidateSelectionParamsPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ValidateSelectionParamsPass.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Config\Util\Exception\XmlParsingException;
+use Symfony\Component\Config\Util\XmlUtils;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @internal
+ */
+final class ValidateSelectionParamsPass implements CompilerPassInterface
+{
+    /**
+     * Params which filtered correctly under their old name and were renamed.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const RENAMED_PARAMS = [
+        'snippet_selection' => ['types' => 'templateKeys'],
+        'single_snippet_selection' => ['types' => 'templateKeys'],
+        'article_selection' => ['types' => 'groups', 'templates' => 'templateKeys'],
+        'single_article_selection' => ['types' => 'groups', 'templates' => 'templateKeys'],
+    ];
+
+    private const RENAMED_MESSAGE = '- Key "%s", property "%s": param "%s" was renamed to "%s" (file: %s)';
+
+    /**
+     * Params which were never read for these field types, but now have a working equivalent.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const UNSUPPORTED_PARAMS = [
+        'page_selection' => ['types' => 'templateKeys'],
+        'single_page_selection' => ['types' => 'templateKeys'],
+    ];
+
+    private const UNSUPPORTED_MESSAGE = '- Key "%s", property "%s": param "%s" is not supported, use "%s" (file: %s)';
+
+    private const TEMPLATE_NAMESPACE = 'http://schemas.sulu.io/template/template';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $directories = $this->resolveDirectories($container);
+        if ([] === $directories) {
+            return;
+        }
+
+        $errors = [];
+
+        foreach ((new Finder())->in($directories)->name('*.xml') as $file) {
+            $container->addResource(new FileResource($file->getPathname()));
+            $this->collectErrorsFromFile($file->getPathname(), $errors);
+        }
+
+        if ([] !== $errors) {
+            throw new \RuntimeException(
+                "Outdated selection param names found in template and form XML files:\n\n"
+                . \implode("\n", $errors)
+                . "\n\nPlease update the params to their replacements."
+            );
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveDirectories(ContainerBuilder $container): array
+    {
+        $directories = [];
+
+        if ($container->hasParameter('sulu_admin.templates.configuration')) {
+            /** @var array<string, array{default_type: string|null, directories: array<string>}> $configuration */
+            $configuration = $container->getParameter('sulu_admin.templates.configuration');
+
+            foreach ($configuration as $config) {
+                foreach ($config['directories'] as $directory) {
+                    $directories[] = $directory;
+                }
+            }
+        }
+
+        if ($container->hasParameter('sulu_admin.forms.directories')) {
+            /** @var array<string> $formDirectories */
+            $formDirectories = $container->getParameter('sulu_admin.forms.directories');
+
+            foreach ($formDirectories as $directory) {
+                $directories[] = $directory;
+            }
+        }
+
+        $resolved = [];
+        foreach ($directories as $directory) {
+            $realPath = \realpath($directory);
+            if (false === $realPath) {
+                continue;
+            }
+
+            $resolved[$realPath] = true;
+        }
+
+        return \array_keys($resolved);
+    }
+
+    /**
+     * @param list<string> $errors
+     */
+    private function collectErrorsFromFile(string $filePath, array &$errors): void
+    {
+        try {
+            $document = XmlUtils::loadFile($filePath);
+        } catch (XmlParsingException|\InvalidArgumentException) {
+            return;
+        }
+
+        $xpath = new \DOMXPath($document);
+        $xpath->registerNamespace('t', self::TEMPLATE_NAMESPACE);
+
+        $keyNodes = $xpath->query('/t:template/t:key | /t:form/t:key');
+        $keyNode = false !== $keyNodes ? $keyNodes->item(0) : null;
+        $key = null !== $keyNode ? $keyNode->nodeValue ?? '' : '';
+
+        foreach (self::RENAMED_PARAMS as $fieldType => $replacements) {
+            $this->collectErrorsForFieldType(
+                $xpath,
+                $fieldType,
+                $replacements,
+                self::RENAMED_MESSAGE,
+                $key,
+                $filePath,
+                $errors,
+            );
+        }
+
+        foreach (self::UNSUPPORTED_PARAMS as $fieldType => $replacements) {
+            $this->collectErrorsForFieldType(
+                $xpath,
+                $fieldType,
+                $replacements,
+                self::UNSUPPORTED_MESSAGE,
+                $key,
+                $filePath,
+                $errors,
+            );
+        }
+    }
+
+    /**
+     * @param array<string, string> $replacements
+     * @param list<string> $errors
+     */
+    private function collectErrorsForFieldType(
+        \DOMXPath $xpath,
+        string $fieldType,
+        array $replacements,
+        string $messageFormat,
+        string $key,
+        string $filePath,
+        array &$errors,
+    ): void {
+        $properties = $xpath->query(\sprintf('//t:property[@type="%s"]', $fieldType)) ?: [];
+
+        foreach ($properties as $property) {
+            \assert($property instanceof \DOMElement);
+            $propertyName = $property->getAttribute('name');
+
+            foreach ($xpath->query('t:params/t:param', $property) ?: [] as $param) {
+                \assert($param instanceof \DOMElement);
+                $name = $param->getAttribute('name');
+
+                if (!isset($replacements[$name])) {
+                    continue;
+                }
+
+                $errors[] = \sprintf(
+                    $messageFormat,
+                    $key,
+                    $propertyName,
+                    $name,
+                    $replacements[$name],
+                    $filePath,
+                );
+            }
+        }
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ValidateSelectionParamsPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ValidateSelectionParamsPass.php
@@ -26,30 +26,20 @@ use Symfony\Component\Finder\Finder;
 final class ValidateSelectionParamsPass implements CompilerPassInterface
 {
     /**
-     * Params which filtered correctly under their old name and were renamed.
+     * Outdated param names per selection field type, mapped to their replacement.
      *
      * @var array<string, array<string, string>>
      */
-    private const RENAMED_PARAMS = [
+    private const OUTDATED_PARAMS = [
         'snippet_selection' => ['types' => 'templateKeys'],
         'single_snippet_selection' => ['types' => 'templateKeys'],
         'article_selection' => ['types' => 'groups', 'templates' => 'templateKeys'],
         'single_article_selection' => ['types' => 'groups', 'templates' => 'templateKeys'],
-    ];
-
-    private const RENAMED_MESSAGE = '- Key "%s", property "%s": param "%s" was renamed to "%s" (file: %s)';
-
-    /**
-     * Params which were never read for these field types, but now have a working equivalent.
-     *
-     * @var array<string, array<string, string>>
-     */
-    private const UNSUPPORTED_PARAMS = [
         'page_selection' => ['types' => 'templateKeys'],
         'single_page_selection' => ['types' => 'templateKeys'],
     ];
 
-    private const UNSUPPORTED_MESSAGE = '- Key "%s", property "%s": param "%s" is not supported, use "%s" (file: %s)';
+    private const OUTDATED_MESSAGE = '- Key "%s", property "%s": param "%s" is not supported, use "%s" (file: %s)';
 
     private const TEMPLATE_NAMESPACE = 'http://schemas.sulu.io/template/template';
 
@@ -134,24 +124,11 @@ final class ValidateSelectionParamsPass implements CompilerPassInterface
         $keyNode = false !== $keyNodes ? $keyNodes->item(0) : null;
         $key = null !== $keyNode ? $keyNode->nodeValue ?? '' : '';
 
-        foreach (self::RENAMED_PARAMS as $fieldType => $replacements) {
+        foreach (self::OUTDATED_PARAMS as $fieldType => $replacements) {
             $this->collectErrorsForFieldType(
                 $xpath,
                 $fieldType,
                 $replacements,
-                self::RENAMED_MESSAGE,
-                $key,
-                $filePath,
-                $errors,
-            );
-        }
-
-        foreach (self::UNSUPPORTED_PARAMS as $fieldType => $replacements) {
-            $this->collectErrorsForFieldType(
-                $xpath,
-                $fieldType,
-                $replacements,
-                self::UNSUPPORTED_MESSAGE,
                 $key,
                 $filePath,
                 $errors,
@@ -167,7 +144,6 @@ final class ValidateSelectionParamsPass implements CompilerPassInterface
         \DOMXPath $xpath,
         string $fieldType,
         array $replacements,
-        string $messageFormat,
         string $key,
         string $filePath,
         array &$errors,
@@ -187,7 +163,7 @@ final class ValidateSelectionParamsPass implements CompilerPassInterface
                 }
 
                 $errors[] = \sprintf(
-                    $messageFormat,
+                    self::OUTDATED_MESSAGE,
                     $key,
                     $propertyName,
                     $name,

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ValidateSelectionParamsPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ValidateSelectionParamsPass.php
@@ -25,11 +25,6 @@ use Symfony\Component\Finder\Finder;
  */
 final class ValidateSelectionParamsPass implements CompilerPassInterface
 {
-    /**
-     * Outdated param names per selection field type, mapped to their replacement.
-     *
-     * @var array<string, array<string, string>>
-     */
     private const OUTDATED_PARAMS = [
         'snippet_selection' => ['types' => 'templateKeys'],
         'single_snippet_selection' => ['types' => 'templateKeys'],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Selection.js
@@ -375,6 +375,12 @@ class Selection extends React.Component<Props> {
                 types: {
                     value: types,
                 } = {},
+                templateKeys: {
+                    value: templateKeys,
+                } = {},
+                groups: {
+                    value: groups,
+                } = {},
                 item_disabled_condition: {
                     value: itemDisabledCondition,
                 } = {},
@@ -389,6 +395,14 @@ class Selection extends React.Component<Props> {
 
         if (types !== undefined && typeof types !== 'string') {
             throw new Error('The "types" schema option must be a string if given!');
+        }
+
+        if (templateKeys !== undefined && typeof templateKeys !== 'string') {
+            throw new Error('The "templateKeys" schema option must be a string if given!');
+        }
+
+        if (groups !== undefined && typeof groups !== 'string') {
+            throw new Error('The "groups" schema option must be a string if given!');
         }
 
         if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
@@ -410,6 +424,12 @@ class Selection extends React.Component<Props> {
         const options = {...this.requestOptions};
         if (types) {
             options.types = types;
+        }
+        if (templateKeys) {
+            options.templateKeys = templateKeys;
+        }
+        if (groups) {
+            options.groups = groups;
         }
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SingleSelection.js
@@ -276,11 +276,25 @@ class SingleSelection extends React.Component<Props>
                 types: {
                     value: types,
                 } = {},
+                templateKeys: {
+                    value: templateKeys,
+                } = {},
+                groups: {
+                    value: groups,
+                } = {},
             } = {},
         } = this.props;
 
         if (types !== undefined && typeof types !== 'string') {
             throw new Error('The "types" schema option must be a string if given!');
+        }
+
+        if (templateKeys !== undefined && typeof templateKeys !== 'string') {
+            throw new Error('The "templateKeys" schema option must be a string if given!');
+        }
+
+        if (groups !== undefined && typeof groups !== 'string') {
+            throw new Error('The "groups" schema option must be a string if given!');
         }
 
         if (itemDisabledCondition !== undefined && typeof itemDisabledCondition !== 'string') {
@@ -310,7 +324,16 @@ class SingleSelection extends React.Component<Props>
             return currentOptions;
         }, {});
 
-        const typeOptions = types ? {types} : undefined;
+        const typeOptions = {};
+        if (types) {
+            typeOptions.types = types;
+        }
+        if (templateKeys) {
+            typeOptions.templateKeys = templateKeys;
+        }
+        if (groups) {
+            typeOptions.groups = groups;
+        }
 
         const listOptions = {
             ...this.requestOptions,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -668,7 +668,7 @@ test('Should throw an error if "templateKeys" schema option is not a string', ()
             formInspector={formInspector}
             schemaOptions={{templateKeys: {name: 'templateKeys', value: []}}}
         />
-    )).toThrowError(/"templateKeys"/);
+    )).toThrow(/"templateKeys"/);
 });
 
 test('Should throw an error if "item_disabled_condition" schema option is not a string', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js
@@ -113,8 +113,8 @@ test('Should pass props correctly to MultiSelection component', () => {
     };
 
     const schemaOptions = {
-        types: {
-            name: 'types',
+        templateKeys: {
+            name: 'templateKeys',
             value: 'test',
         },
     };
@@ -153,7 +153,7 @@ test('Should pass props correctly to MultiSelection component', () => {
         label: 'sulu_snippet.selection_label',
         locale,
         resourceKey: 'snippets',
-        options: {types: 'test'},
+        options: {templateKeys: 'test'},
         overlayTitle: 'sulu_snippet.selection_overlay_title',
         value,
     }));
@@ -270,8 +270,8 @@ test('Should pass props with schema-options correctly to MultiSelection componen
             name: 'type',
             value: 'list_overlay',
         },
-        types: {
-            name: 'types',
+        templateKeys: {
+            name: 'templateKeys',
             value: 'image,video',
         },
         allow_deselect_for_disabled_items: {
@@ -346,7 +346,7 @@ test('Should pass props with schema-options correctly to MultiSelection componen
         overlayTitle: 'sulu_snippet.selection_overlay_title',
         value,
         options: {
-            types: 'image,video',
+            templateKeys: 'image,video',
             staticKey: 'some-static-value',
             dynamicKey: 'value-returned-by-form-inspector',
         },
@@ -646,9 +646,29 @@ test('Should throw an error if "types" schema option is not a string', () => {
             {...fieldTypeDefaultProps}
             fieldTypeOptions={fieldTypeOptions}
             formInspector={formInspector}
-            schemaOptions={{types: {name: 'type', value: []}}}
+            schemaOptions={{types: {name: 'types', value: []}}}
         />
     )).toThrow(/"types"/);
+});
+
+test('Should throw an error if "templateKeys" schema option is not a string', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'test',
+        types: {
+            list_overlay: {},
+        },
+    };
+
+    expect(() => shallow(
+        <Selection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={{templateKeys: {name: 'templateKeys', value: []}}}
+        />
+    )).toThrowError(/"templateKeys"/);
 });
 
 test('Should throw an error if "item_disabled_condition" schema option is not a string', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -1172,7 +1172,7 @@ test('Should throw an error if "templateKeys" schema option is not a string', ()
             formInspector={formInspector}
             schemaOptions={{templateKeys: {name: 'templateKeys', value: []}}}
         />
-    )).toThrowError(/"templateKeys"/);
+    )).toThrow(/"templateKeys"/);
 });
 
 test('Should throw an error if no "resource_key" option is passed in fieldOptions', () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js
@@ -734,8 +734,8 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
             name: 'item_disabled_condition',
             value: 'status == "inactive"',
         },
-        types: {
-            name: 'types',
+        templateKeys: {
+            name: 'templateKeys',
             value: 'test',
         },
         request_parameters: {
@@ -793,7 +793,7 @@ test('Pass correct props with schema-options type to SingleItemSelection', () =>
         listOptions: {
             segment: 'developer',
             webspace: 'sulu',
-            types: 'test',
+            templateKeys: 'test',
             rootKey: 'testRootKey',
             dynamicKey: 'value-returned-by-form-inspector',
         },
@@ -1155,6 +1155,26 @@ test('Should throw an error if "types" schema option is not a string', () => {
     )).toThrow(/"types"/);
 });
 
+test('Should throw an error if "templateKeys" schema option is not a string', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
+    const fieldTypeOptions = {
+        default_type: 'list_overlay',
+        resource_key: 'test',
+        types: {
+            list_overlay: {},
+        },
+    };
+
+    expect(() => shallow(
+        <SingleSelection
+            {...fieldTypeDefaultProps}
+            fieldTypeOptions={fieldTypeOptions}
+            formInspector={formInspector}
+            schemaOptions={{templateKeys: {name: 'templateKeys', value: []}}}
+        />
+    )).toThrowError(/"templateKeys"/);
+});
+
 test('Should throw an error if no "resource_key" option is passed in fieldOptions', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'pages'));
 
@@ -1163,7 +1183,7 @@ test('Should throw an error if no "resource_key" option is passed in fieldOption
             {...fieldTypeDefaultProps}
             fieldTypeOptions={{default_type: 'list_overlay'}}
             formInspector={formInspector}
-            schemaOptions={{types: {name: 'types', value: []}}}
+            schemaOptions={{templateKeys: {name: 'templateKeys', value: []}}}
         />
     )).toThrow(/"resource_key"/);
 });

--- a/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
+++ b/src/Sulu/Bundle/AdminBundle/SuluAdminBundle.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\AdminBundle;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ExposeResourceRoutesPass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\FormMetadataCachePass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\SuluVersionPass;
+use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ValidateSelectionParamsPass;
 use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ValidateSmartContentParamsPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -30,6 +31,7 @@ final class SuluAdminBundle extends Bundle
 
         $container->addCompilerPass(new SuluVersionPass());
         $container->addCompilerPass(new ValidateSmartContentParamsPass());
+        $container->addCompilerPass(new ValidateSelectionParamsPass());
 
         if ($container->hasExtension('fos_js_routing')) {
             $container->addCompilerPass(new ExposeResourceRoutesPass());

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/ValidateSelectionParamsPassTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/ValidateSelectionParamsPassTest.php
@@ -1,0 +1,496 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\DependencyInjection\Compiler\ValidateSelectionParamsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ValidateSelectionParamsPassTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $tempDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempDirs as $dir) {
+            $this->removeTempDir($dir);
+        }
+        $this->tempDirs = [];
+    }
+
+    public function testNoTemplatesConfigurationParameter(): void
+    {
+        $container = new ContainerBuilder();
+        (new ValidateSelectionParamsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testNonExistentDirectoriesAreSkipped(): void
+    {
+        $container = $this->createContainer(['/nonexistent/path/that/does/not/exist']);
+
+        (new ValidateSelectionParamsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidSelectionParamsPass(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'valid.xml', 'valid-template', 'my_snippets', 'snippet_selection', [
+            'templateKeys' => 'footer,header',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        (new ValidateSelectionParamsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testTypesParamThrowsForSnippetSelection(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_snippets', 'snippet_selection', [
+            'types' => 'footer',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "types" was renamed to "templateKeys"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testTypesParamThrowsForSingleSnippetSelection(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_snippet', 'single_snippet_selection', [
+            'types' => 'footer',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "types" was renamed to "templateKeys"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testTypesParamThrowsForArticleSelection(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_articles', 'article_selection', [
+            'types' => 'blog',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "types" was renamed to "groups"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testTemplatesParamThrowsForArticleSelection(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_articles', 'article_selection', [
+            'templates' => 'default',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "templates" was renamed to "templateKeys"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testTemplatesParamThrowsForSingleArticleSelection(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_article', 'single_article_selection', [
+            'templates' => 'default',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "templates" was renamed to "templateKeys"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testTypesParamThrowsForPageSelection(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_pages', 'page_selection', [
+            'types' => 'default',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "types" is not supported, use "templateKeys"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testTypesParamThrowsForSinglePageSelection(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_page', 'single_page_selection', [
+            'types' => 'default',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "types" is not supported, use "templateKeys"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testTemplateKeysParamOnPageSelectionIsValid(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'ok.xml', 'ok-template', 'my_pages', 'page_selection', [
+            'templateKeys' => 'default',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        (new ValidateSelectionParamsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testTypesParamOnMediaSelectionIsIgnored(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'ok.xml', 'ok-template', 'my_media', 'media_selection', [
+            'types' => 'image,video',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        (new ValidateSelectionParamsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testTypesParamOnContactSelectionIsIgnored(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'ok.xml', 'ok-template', 'my_contacts', 'contact_selection', [
+            'types' => 'something',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        (new ValidateSelectionParamsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testNonSelectionPropertiesAreIgnored(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'ok.xml', 'ok-template', 'title', 'text_line', [
+            'types' => 'something',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        (new ValidateSelectionParamsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testSelectionInBlockTypeIsValidated(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $xml = $this->templateWrapper(
+            'bad-template',
+            <<<'XML'
+        <block name="content_block" default-type="default">
+            <types>
+                <type name="default">
+                    <properties>
+                        <property name="my_snippets" type="snippet_selection">
+                            <params>
+                                <param name="types" value="footer"/>
+                            </params>
+                        </property>
+                    </properties>
+                </type>
+            </types>
+        </block>
+XML,
+        );
+        \file_put_contents($dir . '/bad.xml', $xml);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "types" was renamed to "templateKeys"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testErrorMessageContainsKeyPropertyAndFile(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'my-template', 'my_snippets', 'snippet_selection', [
+            'types' => 'footer',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        try {
+            (new ValidateSelectionParamsPass())->process($container);
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (\RuntimeException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('Key "my-template"', $message);
+            $this->assertStringContainsString('property "my_snippets"', $message);
+            $this->assertStringContainsString($dir . '/bad.xml', $message);
+        }
+    }
+
+    public function testMultipleErrorsAreCollected(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_articles', 'article_selection', [
+            'types' => 'blog',
+            'templates' => 'default',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        try {
+            (new ValidateSelectionParamsPass())->process($container);
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (\RuntimeException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('param "types" was renamed to "groups"', $message);
+            $this->assertStringContainsString('param "templates" was renamed to "templateKeys"', $message);
+        }
+    }
+
+    public function testSelectionInFormXmlIsValidated(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        \file_put_contents(
+            $dir . '/bad.xml',
+            $this->formWrapper('my-form', $this->propertyXml('my_snippets', 'snippet_selection', [
+                'types' => 'footer',
+            ])),
+        );
+
+        $container = $this->createContainerWithForms([$dir]);
+
+        try {
+            (new ValidateSelectionParamsPass())->process($container);
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (\RuntimeException $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('param "types" was renamed to "templateKeys"', $message);
+            $this->assertStringContainsString('Key "my-form"', $message);
+        }
+    }
+
+    public function testFormsAreScannedWithoutTemplatesConfiguration(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        \file_put_contents(
+            $dir . '/bad.xml',
+            $this->formWrapper('my-form', $this->propertyXml('my_snippets', 'snippet_selection', [
+                'types' => 'footer',
+            ])),
+        );
+
+        $container = new ContainerBuilder();
+        $container->setParameter('sulu_admin.forms.directories', [$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "types" was renamed to "templateKeys"');
+
+        (new ValidateSelectionParamsPass())->process($container);
+    }
+
+    public function testDirectoryInBothConfigurationsIsScannedOnce(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_snippets', 'snippet_selection', [
+            'types' => 'footer',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+        $container->setParameter('sulu_admin.forms.directories', [$dir]);
+
+        try {
+            (new ValidateSelectionParamsPass())->process($container);
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame(
+                1,
+                \substr_count($e->getMessage(), 'param "types" was renamed to "templateKeys"'),
+                'The same file must not be reported twice when a directory is configured as both a template and a form directory.',
+            );
+        }
+    }
+
+    /**
+     * @param list<string> $directories
+     */
+    private function createContainer(array $directories): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('sulu_admin.templates.configuration', [
+            'pages' => [
+                'default_type' => null,
+                'directories' => $directories,
+            ],
+        ]);
+
+        return $container;
+    }
+
+    /**
+     * @param list<string> $directories
+     */
+    private function createContainerWithForms(array $directories): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('sulu_admin.forms.directories', $directories);
+
+        return $container;
+    }
+
+    private function formWrapper(string $formKey, string $propertiesContent): string
+    {
+        return <<<XML
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd">
+    <key>{$formKey}</key>
+
+    <properties>
+{$propertiesContent}
+    </properties>
+</form>
+XML;
+    }
+
+    private function createTempTemplateDir(): string
+    {
+        $dir = \sys_get_temp_dir() . '/sulu_test_' . \uniqid('', true);
+        \mkdir($dir, 0777, true);
+        $this->tempDirs[] = $dir;
+
+        return $dir;
+    }
+
+    /**
+     * @param array<string, string> $params
+     */
+    private function writeTemplateXml(
+        string $dir,
+        string $filename,
+        string $templateKey,
+        string $propertyName,
+        string $fieldType,
+        array $params,
+    ): void {
+        \file_put_contents(
+            $dir . '/' . $filename,
+            $this->templateWrapper($templateKey, $this->propertyXml($propertyName, $fieldType, $params)),
+        );
+    }
+
+    /**
+     * @param array<string, string> $params
+     */
+    private function propertyXml(string $propertyName, string $fieldType, array $params): string
+    {
+        $paramLines = [];
+        foreach ($params as $name => $value) {
+            $paramLines[] = \sprintf('                <param name="%s" value="%s"/>', $name, $value);
+        }
+        $paramsXml = [] !== $paramLines
+            ? "<params>\n" . \implode("\n", $paramLines) . "\n            </params>"
+            : '';
+
+        return <<<XML
+        <property name="{$propertyName}" type="{$fieldType}">
+            <meta><title lang="en">Selection</title></meta>
+            {$paramsXml}
+        </property>
+XML;
+    }
+
+    private function templateWrapper(string $templateKey, string $propertiesContent): string
+    {
+        return <<<XML
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+    <key>{$templateKey}</key>
+    <view>test</view>
+    <controller>TestController::indexAction</controller>
+    <cacheLifetime>0</cacheLifetime>
+    <meta>
+        <title lang="en">Test</title>
+    </meta>
+    <properties>
+{$propertiesContent}
+    </properties>
+</template>
+XML;
+    }
+
+    private function removeTempDir(string $dir): void
+    {
+        if (!\is_dir($dir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($files as $file) {
+            \assert($file instanceof \SplFileInfo);
+            if ($file->isDir()) {
+                \rmdir($file->getPathname());
+
+                continue;
+            }
+
+            \unlink($file->getPathname());
+        }
+
+        \rmdir($dir);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/ValidateSelectionParamsPassTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/ValidateSelectionParamsPassTest.php
@@ -73,7 +73,7 @@ class ValidateSelectionParamsPassTest extends TestCase
         $container = $this->createContainer([$dir]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('param "types" was renamed to "templateKeys"');
+        $this->expectExceptionMessage('param "types" is not supported, use "templateKeys"');
 
         (new ValidateSelectionParamsPass())->process($container);
     }
@@ -88,7 +88,7 @@ class ValidateSelectionParamsPassTest extends TestCase
         $container = $this->createContainer([$dir]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('param "types" was renamed to "templateKeys"');
+        $this->expectExceptionMessage('param "types" is not supported, use "templateKeys"');
 
         (new ValidateSelectionParamsPass())->process($container);
     }
@@ -103,7 +103,7 @@ class ValidateSelectionParamsPassTest extends TestCase
         $container = $this->createContainer([$dir]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('param "types" was renamed to "groups"');
+        $this->expectExceptionMessage('param "types" is not supported, use "groups"');
 
         (new ValidateSelectionParamsPass())->process($container);
     }
@@ -118,7 +118,7 @@ class ValidateSelectionParamsPassTest extends TestCase
         $container = $this->createContainer([$dir]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('param "templates" was renamed to "templateKeys"');
+        $this->expectExceptionMessage('param "templates" is not supported, use "templateKeys"');
 
         (new ValidateSelectionParamsPass())->process($container);
     }
@@ -133,7 +133,7 @@ class ValidateSelectionParamsPassTest extends TestCase
         $container = $this->createContainer([$dir]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('param "templates" was renamed to "templateKeys"');
+        $this->expectExceptionMessage('param "templates" is not supported, use "templateKeys"');
 
         (new ValidateSelectionParamsPass())->process($container);
     }
@@ -250,7 +250,7 @@ XML,
         $container = $this->createContainer([$dir]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('param "types" was renamed to "templateKeys"');
+        $this->expectExceptionMessage('param "types" is not supported, use "templateKeys"');
 
         (new ValidateSelectionParamsPass())->process($container);
     }
@@ -290,8 +290,8 @@ XML,
             $this->fail('Expected RuntimeException was not thrown.');
         } catch (\RuntimeException $e) {
             $message = $e->getMessage();
-            $this->assertStringContainsString('param "types" was renamed to "groups"', $message);
-            $this->assertStringContainsString('param "templates" was renamed to "templateKeys"', $message);
+            $this->assertStringContainsString('param "types" is not supported, use "groups"', $message);
+            $this->assertStringContainsString('param "templates" is not supported, use "templateKeys"', $message);
         }
     }
 
@@ -312,7 +312,7 @@ XML,
             $this->fail('Expected RuntimeException was not thrown.');
         } catch (\RuntimeException $e) {
             $message = $e->getMessage();
-            $this->assertStringContainsString('param "types" was renamed to "templateKeys"', $message);
+            $this->assertStringContainsString('param "types" is not supported, use "templateKeys"', $message);
             $this->assertStringContainsString('Key "my-form"', $message);
         }
     }
@@ -331,7 +331,7 @@ XML,
         $container->setParameter('sulu_admin.forms.directories', [$dir]);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('param "types" was renamed to "templateKeys"');
+        $this->expectExceptionMessage('param "types" is not supported, use "templateKeys"');
 
         (new ValidateSelectionParamsPass())->process($container);
     }
@@ -352,7 +352,7 @@ XML,
         } catch (\RuntimeException $e) {
             $this->assertSame(
                 1,
-                \substr_count($e->getMessage(), 'param "types" was renamed to "templateKeys"'),
+                \substr_count($e->getMessage(), 'param "types" is not supported, use "templateKeys"'),
                 'The same file must not be reported twice when a directory is configured as both a template and a form directory.',
             );
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Article selections now read `groups` for template group identifiers and `templateKeys` for concrete template keys. Snippet selections read `templateKeys` where they previously read `types`. Page selections gain `templateKeys` support, which they never had before. A new `ValidateSelectionParamsPass` fails the container build when a template or form XML still configures an outdated param, and reports the offending key, property and file.

#### Why?

The old param names were ambiguous. On article selections `types` meant group identifiers, while on snippet selections the same name meant template keys, and neither matched the naming that `smart_content` already uses. The list endpoints no longer read the old names, so an unmigrated selection would quietly show all items instead of the filtered subset. The build now fails instead, so the problem surfaces during development rather than reaching an editor.

#### Example Usage

```xml
<!-- before -->
<property name="mySnippets" type="snippet_selection">
    <params>
        <param name="types" value="footer,header"/>
    </params>
</property>

<!-- after -->
<property name="mySnippets" type="snippet_selection">
    <params>
        <param name="templateKeys" value="footer,header"/>
    </params>
</property>
```