### PR TITLE
Add cache for rendered error pages

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Controller/ErrorController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/ErrorController.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ErrorController as SymfonyErrorController;
 use Twig\Environment;
+use Psr\Cache\CacheItemPoolInterface;
 
 class ErrorController
 {
@@ -42,15 +43,19 @@ class ErrorController
      */
     private $twig;
 
+    private CacheItemPoolInterface $cache;
+
     public function __construct(
         SymfonyErrorController $symfonyErrorController,
         TemplateAttributeResolverInterface $templateAttributeResolver,
         Environment $twig,
-        bool $debug = false
+        CacheItemPoolInterface $cache,
+        bool $debug = false,
     ) {
         $this->symfonyErrorController = $symfonyErrorController;
         $this->templateAttributeResolver = $templateAttributeResolver;
         $this->twig = $twig;
+        $this->cache = $cache;
         $this->debug = $debug;
     }
 
@@ -69,17 +74,31 @@ class ErrorController
             return $this->symfonyErrorController->__invoke($exception);
         }
 
-        return new Response(
-            $this->twig->render(
-                $errorTemplate,
-                $this->templateAttributeResolver->resolve([
-                    'exception' => $flattenException,
-                    'status_code' => $flattenException->getStatusCode(),
-                    'status_text' => $flattenException->getStatusText(),
-                ])
-            ),
-            $code
+        $webspaceAttributes = $request->attributes->get("_sulu");
+        $locale = $webspaceAttributes->getAttribute('locale');
+        $webspaceKey = $webspaceAttributes->getAttribute('webspace')->getKey();
+
+        $cacheKey = sprintf('%s-%s-%s', $webspaceKey, $locale, $code);
+
+        $item = $this->cache->getItem($cacheKey);
+
+        if ($item->isHit()) {
+            return new Response($item->get(), $code);
+        }
+
+        $htmlResponse = $this->twig->render(
+            $errorTemplate,
+            $this->templateAttributeResolver->resolve([
+                'exception' => $flattenException,
+                'status_code' => $flattenException->getStatusCode(),
+                'status_text' => $flattenException->getStatusText(),
+            ])
         );
+
+        $item->set($htmlResponse);
+        $this->cache->save($item);
+
+        return new Response($htmlResponse, $code);
     }
 
     private function getErrorTemplate(Request $request, int $code): ?string

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/Configuration.php
@@ -73,6 +73,12 @@ final class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('provider_service_id')->defaultValue('sulu_website.default_locale.portal_provider')->end()
                 ->end()
+            ->end()
+            ->arrayNode('error_pages')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->booleanNode('cache')->defaultNull()->end()
+                ->end()
             ->end();
 
         $this->addObjectsSection($rootNode);

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -152,5 +152,12 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
                 AnalyticsRepositoryInterface::class => 'sulu.repository.analytics',
             ]
         );
+
+        $cacheEnabled = $config['error_pages']['cache'];
+        if (null === $cacheEnabled) {
+            $cacheEnabled = !$container->getParameter('kernel.debug');
+        }
+
+        $container->setParameter('sulu_website.error_pages.cache', $cacheEnabled);
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/CacheClearListener.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/CacheClearListener.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Sulu\Bundle\WebsiteBundle\Event\CacheClearEvent;
+use Psr\Cache\CacheItemPoolInterface;
+use Sulu\Bundle\WebsiteBundle\Events;
+
+class CacheClearListener implements EventSubscriberInterface
+{
+    public function __construct(private CacheItemPoolInterface $cache)
+    {
+
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            Events::CACHE_CLEAR => 'onCacheClear',
+        ];
+    }
+
+    public function onCacheClear(CacheClearEvent $event): void
+    {
+        $this->cache->clear();
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/services.php
@@ -32,6 +32,8 @@ use Sulu\Bundle\WebsiteBundle\Twig\Core\UtilTwigExtension;
 use Sulu\Component\Webspace\EventSubscriber\WebspaceTagSubscriber;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Sulu\Bundle\WebsiteBundle\EventListener\CacheClearListener;
 
 return static function(ContainerConfigurator $container) {
     $services = $container->services();
@@ -111,12 +113,20 @@ return static function(ContainerConfigurator $container) {
         ])
         ->tag('kernel.event_subscriber');
 
+    $services->set('sulu_website.error_page_cache', FilesystemAdapter::class)
+        ->args([
+            'error_pages_cache',
+            0,
+            '%kernel.cache_dir%/pools'
+        ]);
+
     $services->set('sulu_website.error_controller', ErrorController::class)
         ->decorate('error_controller')
         ->args([
             new Reference('sulu_website.error_controller.inner'),
             new Reference('sulu_website.resolver.template_attribute'),
             new Reference('twig'),
+            new Reference('sulu_website.error_page_cache'),
             '%kernel.debug%',
         ])
         ->tag('sulu.context', ['context' => 'website']);
@@ -173,5 +183,11 @@ return static function(ContainerConfigurator $container) {
             new Reference('sulu_core.webspace.request_analyzer'),
         ])
         ->tag('sulu.context', ['context' => 'website'])
+        ->tag('kernel.event_subscriber');
+
+    $services->set('sulu_website.event_listener.cache_clear', CacheClearListener::class)
+        ->args([
+            new Reference('sulu_website.error_page_cache'),
+        ])
         ->tag('kernel.event_subscriber');
 };

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Cache/ErrorCacheClearTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Cache/ErrorCacheClearTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Cache;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\WebsiteBundle\EventListener\CacheClearListener;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Sulu\Bundle\TestBundle\Testing\KernelTestCase;
+use Sulu\Bundle\WebsiteBundle\Events;
+use Sulu\Bundle\WebsiteBundle\Event\CacheClearEvent;
+
+class ErrorCacheClearTest extends KernelTestCase
+{
+    public function testSubscribedEventsHasCorrectMapping(): void
+    {
+        $cacheMock = $this->createMock(CacheItemPoolInterface::class);
+        $listener = new CacheClearListener($cacheMock);
+
+        $events = $listener::getSubscribedEvents();
+
+        $this->assertArrayHasKey(Events::CACHE_CLEAR, $events);
+        $this->assertEquals('onCacheClear', $events[Events::CACHE_CLEAR]);
+    }
+
+    public function testOnCacheClearDoesNotClearPoolWhenDebugIsTrue(): void
+    {
+        $cacheMock = $this->createMock(CacheItemPoolInterface::class);
+        $eventMock = $this->createMock(CacheClearEvent::class);
+
+        $cacheMock->expects($this->never())->method('clear');
+    }
+
+    public function testListenerIsRegisteredInContainerInProduction(): void
+    {
+        $kernel = self::bootKernel([
+            'debug' => true,
+            'environment' => 'test',
+        ]);
+
+        $container = $kernel->getContainer();
+
+        /** @var EventDispatcherInterface $eventDispatcher */
+        $eventDispatcher = $container->get('event_dispatcher');
+        $listeners = $eventDispatcher->getListeners(Events::CACHE_CLEAR);
+
+        $hasCacheClearListener = false;
+        foreach ($listeners as $listener) {
+            if (is_array($listener) && $listener[0] instanceof CacheClearListener) {
+                $hasCacheClearListener = true;
+                break;
+            }
+        }
+
+        $this->assertTrue(
+            $hasCacheClearListener,
+            'Failed asserting that CacheClearListener is registered to ' . Events::CACHE_CLEAR . ' when debug is false.'
+        );
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #8868
| License | MIT

#### What's in this PR?

Caching error pages when debug is false and clearing them when cache clear is invoked

#### Why?

Issue #8868 
