### PR TITLE
Removing non working default for form of address

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13321,7 +13321,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
 
 		-
-			message: '#^Strict comparison using \=\=\= between numeric\-string and int will always evaluate to false\.$#'
+			message: '#^Strict comparison using \=\=\= between decimal\-int\-string and int will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -13813,25 +13813,7 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\DependencyInjection\\SuluContactExtension\:\:setDefaultForFormOfAddress\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\ContactBundle\\DependencyInjection\\SuluContactExtension\:\:setDefaultForFormOfAddress\(\) has parameter \$config with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
-
-		-
 			message: '#^Parameter \#1 \$objects of method Sulu\\Bundle\\ContactBundle\\DependencyInjection\\SuluContactExtension\:\:configurePersistence\(\) expects array\<string, array\{model\: class\-string, repository\?\: class\-string\}\>, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
-
-		-
-			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\ContactBundle\Entity\Account;
 use Sulu\Bundle\ContactBundle\Entity\AccountRepository;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
+use Sulu\Bundle\ContactBundle\Provider\FormOfAddressProviderInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -63,6 +64,11 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('form_of_address')
+                    ->setDeprecated(
+                        'sulu/sulu',
+                        '2.6',
+                        'This property is deprecated. Use the ' . FormOfAddressProviderInterface::class . ' instead',
+                    )
                     ->useAttributeAsKey('title')
                     ->prototype('array')
                         ->addDefaultsIfNotSet()

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -309,7 +309,6 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
             $config['defaults']
         );
 
-        $this->setDefaultForFormOfAddress($config);
         $container->setParameter(
             'sulu_contact.form_of_address',
             $config['form_of_address']
@@ -330,28 +329,5 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
                 AccountRepositoryInterface::class => 'sulu.repository.account',
             ]
         );
-    }
-
-    /**
-     * Sets default values for form of address if not defined in config.
-     *
-     * @param array $config
-     */
-    private function setDefaultForFormOfAddress($config)
-    {
-        if (!\array_key_exists('form_of_address', $config) || 0 == \count($config['form_of_address'])) {
-            $config['form_of_address'] = [
-                'male' => [
-                    'id' => 0,
-                    'name' => 'male',
-                    'translation' => 'contact.contacts.formOfAddress.male',
-                ],
-                'female' => [
-                    'id' => 1,
-                    'name' => 'female',
-                    'translation' => 'contact.contacts.formOfAddress.female',
-                ],
-            ];
-        }
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing the default value setting for form of address.

And deprecating the feature in favour of the new provider.

#### Why?
* This didn't work because it wasn't passing the value by reference, as phpstan now reports.
* There's already a value set for this in the Configuration class. So it already has a default value.