### PR TITLE
Fix shadow page creation and publishing across different locales

### DIFF
--- a/packages/page/src/Application/MessageHandler/ApplyWorkflowTransitionPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/ApplyWorkflowTransitionPageMessageHandler.php
@@ -11,9 +11,11 @@
 
 namespace Sulu\Page\Application\MessageHandler;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\ShadowInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage;
 use Sulu\Page\Domain\Event\PageWorkflowTransitionAppliedEvent;
@@ -29,33 +31,80 @@ final class ApplyWorkflowTransitionPageMessageHandler
     public function __construct(
         private PageRepositoryInterface $pageRepository,
         private ContentWorkflowInterface $contentWorkflow,
+        private EntityManagerInterface $entityManager,
         private DomainEventCollectorInterface $domainEventCollector,
     ) {
     }
 
     public function __invoke(ApplyWorkflowTransitionPageMessage $message): PageInterface
     {
-        $page = $this->pageRepository->getOneBy(
-            $message->getIdentifier(),
-            [
-                PageRepositoryInterface::SELECT_PAGE_CONTENT => [
-                    'selects' => [DimensionContentQueryEnhancer::GROUP_SELECT_CONTENT_ADMIN => true],
-                    'dimensionAttributes' => [
-                        'locale' => $message->getLocale(),
-                        'stage' => [DimensionContentInterface::STAGE_DRAFT, DimensionContentInterface::STAGE_LIVE],
-                    ],
-                ],
-            ]
-        );
+        $locale = $message->getLocale();
+
+        $page = $this->loadPage($message, [$locale]);
+
+        // The workflow also touches the published locale's shadow source and the locales shadowing
+        // it; those are only known once this locale is loaded.
+        $relatedLocales = $this->resolveRelatedLocales($page, $locale);
+        if ([] !== $relatedLocales) {
+            // reset the single-locale collection (a preceding ModifyPageMessage initialized it) so
+            // the wider query re-hydrates it instead of reusing the identity-map one
+            $this->entityManager->refresh($page);
+
+            $page = $this->loadPage($message, [$locale, ...$relatedLocales]);
+        }
 
         $this->contentWorkflow->apply(
             $page,
-            ['locale' => $message->getLocale()],
+            ['locale' => $locale],
             $message->getTransitionName()
         );
 
         $this->domainEventCollector->collect(new PageWorkflowTransitionAppliedEvent($page, $message->getTransitionName(), $message->getLocale()));
 
         return $page;
+    }
+
+    /**
+     * @param string[] $locales
+     */
+    private function loadPage(ApplyWorkflowTransitionPageMessage $message, array $locales): PageInterface
+    {
+        return $this->pageRepository->getOneBy(
+            $message->getIdentifier(),
+            [
+                PageRepositoryInterface::SELECT_PAGE_CONTENT => [
+                    'selects' => [DimensionContentQueryEnhancer::GROUP_SELECT_CONTENT_ADMIN => true],
+                    'dimensionAttributes' => [
+                        'locale' => $locales,
+                        'stage' => [DimensionContentInterface::STAGE_DRAFT, DimensionContentInterface::STAGE_LIVE],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveRelatedLocales(PageInterface $page, string $locale): array
+    {
+        foreach ($page->getDimensionContents() as $dimensionContent) {
+            if (DimensionContentInterface::STAGE_DRAFT !== $dimensionContent->getStage()
+                || null !== $dimensionContent->getLocale()
+                || !$dimensionContent instanceof ShadowInterface
+            ) {
+                continue;
+            }
+
+            $relatedLocales = $dimensionContent->getShadowLocalesForLocale($locale);
+            $sourceLocale = ($dimensionContent->getShadowLocales() ?? [])[$locale] ?? null;
+            if (null !== $sourceLocale) {
+                $relatedLocales[] = $sourceLocale;
+            }
+
+            return \array_values(\array_unique($relatedLocales));
+        }
+
+        return [];
     }
 }

--- a/packages/page/src/Application/MessageHandler/ApplyWorkflowTransitionPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/ApplyWorkflowTransitionPageMessageHandler.php
@@ -15,7 +15,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
 use Sulu\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
-use Sulu\Content\Domain\Model\ShadowInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage;
 use Sulu\Page\Domain\Event\PageWorkflowTransitionAppliedEvent;
@@ -91,7 +90,6 @@ final class ApplyWorkflowTransitionPageMessageHandler
         foreach ($page->getDimensionContents() as $dimensionContent) {
             if (DimensionContentInterface::STAGE_DRAFT !== $dimensionContent->getStage()
                 || null !== $dimensionContent->getLocale()
-                || !$dimensionContent instanceof ShadowInterface
             ) {
                 continue;
             }

--- a/packages/page/src/Application/MessageHandler/ApplyWorkflowTransitionPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/ApplyWorkflowTransitionPageMessageHandler.php
@@ -41,12 +41,11 @@ final class ApplyWorkflowTransitionPageMessageHandler
 
         $page = $this->loadPage($message, [$locale]);
 
-        // The workflow also touches the published locale's shadow source and the locales shadowing
-        // it; those are only known once this locale is loaded.
+        // The shadow source and dependent locales are only known once this locale is loaded.
         $relatedLocales = $this->resolveRelatedLocales($page, $locale);
         if ([] !== $relatedLocales) {
-            // reset the single-locale collection (a preceding ModifyPageMessage initialized it) so
-            // the wider query re-hydrates it instead of reusing the identity-map one
+            // Drop the identity-map collection (filled by a preceding ModifyPageMessage) so the
+            // wider query re-hydrates it with all locales.
             $this->entityManager->refresh($page);
 
             $page = $this->loadPage($message, [$locale, ...$relatedLocales]);
@@ -58,7 +57,7 @@ final class ApplyWorkflowTransitionPageMessageHandler
             $message->getTransitionName()
         );
 
-        $this->domainEventCollector->collect(new PageWorkflowTransitionAppliedEvent($page, $message->getTransitionName(), $message->getLocale()));
+        $this->domainEventCollector->collect(new PageWorkflowTransitionAppliedEvent($page, $message->getTransitionName(), $locale));
 
         return $page;
     }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -204,6 +204,7 @@ final class SuluPageBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_page.page_repository'),
                 new Reference('sulu_content.content_workflow'),
+                new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_activity.domain_event_collector'),
             ])
             ->tag('messenger.message_handler');

--- a/packages/page/tests/Functional/Integration/PageShadowPublishReproTest.php
+++ b/packages/page/tests/Functional/Integration/PageShadowPublishReproTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Model\PageDimensionContent;
+use Sulu\Page\Domain\Model\PageInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * Regression test for https://github.com/sulu/sulu/issues/8883
+ * "Shadow Locale Fails to Publish".
+ *
+ * Publishing a shadow locale must copy the live content of its source locale. The workflow
+ * handler therefore has to load the source locale's dimension contents, not only the locale
+ * being published.
+ */
+#[CoversNothing]
+class PageShadowPublishReproTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient(
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+        );
+    }
+
+    private function createHomepage(string $uuid, string $webspaceKey): PageInterface
+    {
+        $homepage = new Page($uuid);
+        $homepage->setLft(0);
+        $homepage->setRgt(1);
+        $homepage->setDepth(0);
+        $homepage->setWebspaceKey($webspaceKey);
+        self::getEntityManager()->persist($homepage);
+        self::getEntityManager()->flush();
+
+        return $homepage;
+    }
+
+    public function testPublishShadowLocaleSucceeds(): void
+    {
+        self::purgeDatabase();
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
+
+        // 1. Create and publish the source page in EN.
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', $homepage->getId()),
+            [], [], [],
+            \json_encode([
+                'template' => 'default',
+                'title' => 'Source EN',
+                'url' => '/source-en',
+            ]) ?: null,
+        );
+        self::assertSame(201, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        /** @var array{id: string} $content */
+        $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $id = $content['id'];
+
+        // 2. Save DE as a shadow of EN.
+        $this->client->request(
+            'PUT',
+            '/admin/api/pages/' . $id . '?locale=de&webspace=sulu-io',
+            [], [], [],
+            \json_encode([
+                'template' => 'default',
+                'title' => 'Source EN',
+                'url' => '/source-en',
+                'shadowOn' => true,
+                'shadowLocale' => 'en',
+            ]) ?: null,
+        );
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        // 3. Publish the DE shadow locale - this used to fail with
+        //    "TypedFormMetadata::getDefaultType() null returned" and then
+        //    "Expected \"published\" to be set in the data array.".
+        $this->client->request(
+            'PUT',
+            '/admin/api/pages/' . $id . '?locale=de&action=publish&webspace=sulu-io',
+            [], [], [],
+            \json_encode([
+                'template' => 'default',
+                'title' => 'Source EN',
+                'url' => '/source-en',
+                'shadowOn' => true,
+                'shadowLocale' => 'en',
+            ]) ?: null,
+        );
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        // The DE live dimension content exists, shadows EN and carries EN's published template/content.
+        $liveDe = $this->getLiveDimensionContent($id, 'de');
+        self::assertNotNull($liveDe, 'Expected a published (live) DE dimension content.');
+        self::assertSame('en', $liveDe['shadowLocale']);
+        self::assertSame('default', $liveDe['templateKey']);
+        self::assertNotNull($liveDe['workflowPublished']);
+        self::assertSame('Source EN', $liveDe['templateData']['title'] ?? null);
+    }
+
+    /**
+     * Republishing a source locale must update (not duplicate) the live content of locales shadowing it.
+     */
+    public function testRepublishingSourceUpdatesLiveShadowDependent(): void
+    {
+        self::purgeDatabase();
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
+
+        // Create and publish EN.
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', $homepage->getId()),
+            [], [], [],
+            \json_encode(['template' => 'default', 'title' => 'Source EN', 'url' => '/source-en']) ?: null,
+        );
+        self::assertSame(201, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        /** @var array{id: string} $content */
+        $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $id = $content['id'];
+
+        // Save DE as a shadow of EN and publish it.
+        $shadowData = ['template' => 'default', 'title' => 'Source EN', 'url' => '/source-en', 'shadowOn' => true, 'shadowLocale' => 'en'];
+        $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=de&webspace=sulu-io', [], [], [], \json_encode($shadowData) ?: null);
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=de&action=publish&webspace=sulu-io', [], [], [], \json_encode($shadowData) ?: null);
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        self::assertSame('Source EN', $this->getLiveDimensionContent($id, 'de')['templateData']['title'] ?? null);
+
+        // Republish EN with new content; the DE shadow dependent's live content must update too.
+        $this->client->request(
+            'PUT',
+            '/admin/api/pages/' . $id . '?locale=en&action=publish&webspace=sulu-io',
+            [], [], [],
+            \json_encode(['template' => 'default', 'title' => 'Source EN Updated', 'url' => '/source-en']) ?: null,
+        );
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        $liveDe = $this->getLiveDimensionContent($id, 'de');
+        self::assertNotNull($liveDe);
+        self::assertSame('en', $liveDe['shadowLocale']);
+        self::assertSame('Source EN Updated', $liveDe['templateData']['title'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getLiveDimensionContent(string $pageId, string $locale): ?array
+    {
+        /** @var EntityManagerInterface $em */
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+
+        /** @var array<string, mixed>|null $row */
+        $row = $em->createQueryBuilder()
+            ->from(PageDimensionContent::class, 'd')
+            ->select('d.stage', 'd.locale', 'd.templateKey', 'd.workflowPublished', 'd.shadowLocale', 'd.templateData')
+            ->where('IDENTITY(d.page) = :id')
+            ->andWhere('d.stage = :stage')
+            ->andWhere('d.locale = :locale')
+            ->andWhere('d.version = 0')
+            ->setParameter('id', $pageId)
+            ->setParameter('stage', 'live')
+            ->setParameter('locale', $locale)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $row;
+    }
+}

--- a/packages/page/tests/Functional/Integration/PageShadowPublishReproTest.php
+++ b/packages/page/tests/Functional/Integration/PageShadowPublishReproTest.php
@@ -117,7 +117,9 @@ class PageShadowPublishReproTest extends SuluTestCase
         self::assertSame('en', $liveDe['shadowLocale']);
         self::assertSame('default', $liveDe['templateKey']);
         self::assertNotNull($liveDe['workflowPublished']);
-        self::assertSame('Source EN', $liveDe['templateData']['title'] ?? null);
+        /** @var array<string, mixed> $templateData */
+        $templateData = $liveDe['templateData'];
+        self::assertSame('Source EN', $templateData['title'] ?? null);
     }
 
     /**
@@ -147,7 +149,11 @@ class PageShadowPublishReproTest extends SuluTestCase
         $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=de&action=publish&webspace=sulu-io', [], [], [], \json_encode($shadowData) ?: null);
         self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
 
-        self::assertSame('Source EN', $this->getLiveDimensionContent($id, 'de')['templateData']['title'] ?? null);
+        $liveDe = $this->getLiveDimensionContent($id, 'de');
+        self::assertNotNull($liveDe);
+        /** @var array<string, mixed> $templateData */
+        $templateData = $liveDe['templateData'];
+        self::assertSame('Source EN', $templateData['title'] ?? null);
 
         // Republish EN with new content; the DE shadow dependent's live content must update too.
         $this->client->request(
@@ -161,7 +167,9 @@ class PageShadowPublishReproTest extends SuluTestCase
         $liveDe = $this->getLiveDimensionContent($id, 'de');
         self::assertNotNull($liveDe);
         self::assertSame('en', $liveDe['shadowLocale']);
-        self::assertSame('Source EN Updated', $liveDe['templateData']['title'] ?? null);
+        /** @var array<string, mixed> $templateData */
+        $templateData = $liveDe['templateData'];
+        self::assertSame('Source EN Updated', $templateData['title'] ?? null);
     }
 
     /**

--- a/packages/page/tests/Functional/Integration/PageShadowPublishTest.php
+++ b/packages/page/tests/Functional/Integration/PageShadowPublishTest.php
@@ -21,16 +21,8 @@ use Sulu\Page\Domain\Model\PageDimensionContent;
 use Sulu\Page\Domain\Model\PageInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
-/**
- * Regression test for https://github.com/sulu/sulu/issues/8883
- * "Shadow Locale Fails to Publish".
- *
- * Publishing a shadow locale must copy the live content of its source locale. The workflow
- * handler therefore has to load the source locale's dimension contents, not only the locale
- * being published.
- */
 #[CoversNothing]
-class PageShadowPublishReproTest extends SuluTestCase
+class PageShadowPublishTest extends SuluTestCase
 {
     /**
      * @var KernelBrowser
@@ -63,7 +55,6 @@ class PageShadowPublishReproTest extends SuluTestCase
         self::purgeDatabase();
         $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
 
-        // 1. Create and publish the source page in EN.
         $this->client->request(
             'POST',
             \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', $homepage->getId()),
@@ -79,7 +70,6 @@ class PageShadowPublishReproTest extends SuluTestCase
         $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
         $id = $content['id'];
 
-        // 2. Save DE as a shadow of EN.
         $this->client->request(
             'PUT',
             '/admin/api/pages/' . $id . '?locale=de&webspace=sulu-io',
@@ -94,9 +84,7 @@ class PageShadowPublishReproTest extends SuluTestCase
         );
         self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
 
-        // 3. Publish the DE shadow locale - this used to fail with
-        //    "TypedFormMetadata::getDefaultType() null returned" and then
-        //    "Expected \"published\" to be set in the data array.".
+        // Publishing the shadow used to fail because the source locale's content was not loaded.
         $this->client->request(
             'PUT',
             '/admin/api/pages/' . $id . '?locale=de&action=publish&webspace=sulu-io',
@@ -111,7 +99,6 @@ class PageShadowPublishReproTest extends SuluTestCase
         );
         self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
 
-        // The DE live dimension content exists, shadows EN and carries EN's published template/content.
         $liveDe = $this->getLiveDimensionContent($id, 'de');
         self::assertNotNull($liveDe, 'Expected a published (live) DE dimension content.');
         self::assertSame('en', $liveDe['shadowLocale']);
@@ -122,15 +109,11 @@ class PageShadowPublishReproTest extends SuluTestCase
         self::assertSame('Source EN', $templateData['title'] ?? null);
     }
 
-    /**
-     * Republishing a source locale must update (not duplicate) the live content of locales shadowing it.
-     */
     public function testRepublishingSourceUpdatesLiveShadowDependent(): void
     {
         self::purgeDatabase();
         $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
 
-        // Create and publish EN.
         $this->client->request(
             'POST',
             \sprintf('/admin/api/pages?locale=en&action=publish&parentId=%s&webspace=sulu-io', $homepage->getId()),
@@ -142,7 +125,6 @@ class PageShadowPublishReproTest extends SuluTestCase
         $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
         $id = $content['id'];
 
-        // Save DE as a shadow of EN and publish it.
         $shadowData = ['template' => 'default', 'title' => 'Source EN', 'url' => '/source-en', 'shadowOn' => true, 'shadowLocale' => 'en'];
         $this->client->request('PUT', '/admin/api/pages/' . $id . '?locale=de&webspace=sulu-io', [], [], [], \json_encode($shadowData) ?: null);
         self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
@@ -155,7 +137,7 @@ class PageShadowPublishReproTest extends SuluTestCase
         $templateData = $liveDe['templateData'];
         self::assertSame('Source EN', $templateData['title'] ?? null);
 
-        // Republish EN with new content; the DE shadow dependent's live content must update too.
+        // Republishing the source must update the shadow dependent's live content, not duplicate it.
         $this->client->request(
             'PUT',
             '/admin/api/pages/' . $id . '?locale=en&action=publish&webspace=sulu-io',
@@ -177,18 +159,25 @@ class PageShadowPublishReproTest extends SuluTestCase
      */
     private function getLiveDimensionContent(string $pageId, string $locale): ?array
     {
-        /** @var EntityManagerInterface $em */
-        $em = self::getContainer()->get(EntityManagerInterface::class);
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
 
         /** @var array<string, mixed>|null $row */
-        $row = $em->createQueryBuilder()
-            ->from(PageDimensionContent::class, 'd')
-            ->select('d.stage', 'd.locale', 'd.templateKey', 'd.workflowPublished', 'd.shadowLocale', 'd.templateData')
-            ->where('IDENTITY(d.page) = :id')
-            ->andWhere('d.stage = :stage')
-            ->andWhere('d.locale = :locale')
-            ->andWhere('d.version = 0')
-            ->setParameter('id', $pageId)
+        $row = $entityManager->createQueryBuilder()
+            ->from(PageDimensionContent::class, 'dimensionContent')
+            ->select(
+                'dimensionContent.stage',
+                'dimensionContent.locale',
+                'dimensionContent.templateKey',
+                'dimensionContent.workflowPublished',
+                'dimensionContent.shadowLocale',
+                'dimensionContent.templateData',
+            )
+            ->where('IDENTITY(dimensionContent.page) = :pageId')
+            ->andWhere('dimensionContent.stage = :stage')
+            ->andWhere('dimensionContent.locale = :locale')
+            ->andWhere('dimensionContent.version = 0')
+            ->setParameter('pageId', $pageId)
             ->setParameter('stage', 'live')
             ->setParameter('locale', $locale)
             ->getQuery()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The page workflow handler now loads the shadow source locale and the locales shadowing it before applying a transition, so a shadow can be created and published when its locales differ. 

Publishing a shadow whose source has not been published yet raises a new translatable ShadowSourceNotPublishedException instead of crashing during the copy. 

A new DefaultTemplateNormalizer fills a page locale that has no template yet with the webspace default template, so the admin form can submit a valid template on save. 

The optimistic lock hash check is now skipped for a locale that has no persisted content, and the page tabs other than content only appear once the locale has been saved.

#### Why?

See https://github.com/sulu/sulu/issues/8883