### PR TITLE
Fix StringFieldTransformer condition when 0 or other falsy value is returned

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/StringFieldTransformer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldTransformers/StringFieldTransformer.js
@@ -6,7 +6,7 @@ import type {FieldTransformer} from '../types';
 
 export default class StringFieldTransformer implements FieldTransformer {
     transform(value: *): Node {
-        if (!value) {
+        if (value == null || value === '') {
             return null;
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/StringFieldTransformer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/StringFieldTransformer.test.js
@@ -19,3 +19,15 @@ test('Test string', () => {
 test('Test number', () => {
     expect(stringFieldTransformer.transform(5)).toEqual(<span className="textBox" title={5}>{5}</span>);
 });
+
+test('Test zero', () => {
+    expect(stringFieldTransformer.transform(0)).toEqual(<span className="textBox" title={0}>{0}</span>);
+});
+
+test('Test null', () => {
+    expect(stringFieldTransformer.transform(null)).toBe(null);
+});
+
+test('Test empty string', () => {
+    expect(stringFieldTransformer.transform('')).toBe(null);
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Update the StringFieldTranformer condition.

#### Why?

So that "0" can also be displayed.
