### PR TITLE
Fix linting issues

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,7 +34,7 @@ $config->setRiskyAllowed(true)
         'single_line_throw' => false,
         'single_line_comment_spacing' => false,
         'phpdoc_to_comment' => [
-            'ignored_tags' => ['todo', 'var'],
+            'ignored_tags' => ['todo', 'var', 'param', 'return', 'see'],
         ],
         'phpdoc_separation' => [
             'groups' => [

--- a/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
+++ b/src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -330,7 +330,7 @@ class AccountController extends AbstractRestController implements ClassResourceI
             $account = $accountContact->getAccount();
 
             // Remove main contact when relation with main was removed.
-            if ($account->getMainContact() && \strval($account->getMainContact()->getId()) === $id) {
+            if ($account->getMainContact() && $account->getMainContact()->getId() === $id) {
                 $account->setMainContact(null);
             }
 

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -325,10 +325,4 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
             ]
         );
     }
-
-    /**
-     * Sets default values for form of address if not defined in config.
-     *
-     * @param array $config
-     */
 }

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -326,7 +326,7 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
         );
     }
 
-    /*
+    /**
      * Sets default values for form of address if not defined in config.
      *
      * @param array $config

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/SuluContactExtension.php
@@ -304,7 +304,6 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
             $config['defaults']
         );
 
-        $this->setDefaultForFormOfAddress($config);
         $container->setParameter(
             'sulu_contact.form_of_address',
             $config['form_of_address']
@@ -327,26 +326,9 @@ class SuluContactExtension extends Extension implements PrependExtensionInterfac
         );
     }
 
-    /**
+    /*
      * Sets default values for form of address if not defined in config.
      *
      * @param array $config
      */
-    private function setDefaultForFormOfAddress($config)
-    {
-        if (!\array_key_exists('form_of_address', $config) || 0 == \count($config['form_of_address'])) {
-            $config['form_of_address'] = [
-                'male' => [
-                    'id' => 0,
-                    'name' => 'male',
-                    'translation' => 'contact.contacts.formOfAddress.male',
-                ],
-                'female' => [
-                    'id' => 1,
-                    'name' => 'female',
-                    'translation' => 'contact.contacts.formOfAddress.female',
-                ],
-            ];
-        }
-    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The main contact comparison in the account controller now compares the contact id directly as an integer instead of casting it to a string. The redundant `setDefaultForFormOfAddress` method and its call have been removed from the contact extension. The form of address defaults are already provided by the configuration definition.

#### Why?

PHPStan reported a strict comparison between a string and an integer that always evaluated to false, which prevented the main contact from being unset when its relation was removed. PHPStan also flagged the extension method call as having no effect because it mutated a copy of the config array passed by value. Removing the dead method resolves the warning without changing behaviour since the defaults come from the configuration.