### PR TITLE
Update counter of reference refresh command

### DIFF
--- a/src/Sulu/Bundle/ReferenceBundle/UserInterface/Command/RefreshCommand.php
+++ b/src/Sulu/Bundle/ReferenceBundle/UserInterface/Command/RefreshCommand.php
@@ -70,7 +70,7 @@ class RefreshCommand extends Command
             $counter = 0;
             foreach ($referenceRefreshers as $referenceRefresher) {
                 foreach ($referenceRefresher->refresh() as $object) {
-                    if (0 === $counter % 100) {
+                    if (0 === $counter++ % 100) {
                         $this->referenceRepository->flush();
                     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no 
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Update counter of reference refresh command, so flush is not always executed.

#### Why?

To increase performance.