### PR TITLE
Fix deep links for media and other selections in to FormOverlay by pass Router into component

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
@@ -5,6 +5,7 @@ import {observer} from 'mobx-react';
 import Overlay from '../../components/Overlay';
 import {translate} from '../../utils';
 import Form from '../Form';
+import Router from '../../services/Router';
 import formOverlayStyles from './formOverlay.scss';
 import type {FormStoreInterface} from '../Form/types';
 import type {ResourceFormStore} from '../Form';
@@ -20,6 +21,7 @@ type Props = {|
     onConfirm: () => void,
     onFieldFinish?: (dataPath: string, schemaPath: string) => void,
     open: boolean,
+    router?: Router,
     size?: Size,
     title: string,
 |};
@@ -109,6 +111,7 @@ class FormOverlay extends React.Component<Props> {
             formStore,
             onClose,
             open,
+            router,
             size,
             title,
         } = this.props;
@@ -133,6 +136,7 @@ class FormOverlay extends React.Component<Props> {
                         onFieldFinish={this.handleFieldFinish}
                         onSubmit={this.handleFormSubmit}
                         ref={this.setFormRef}
+                        router={router}
                         store={formStore}
                     />
                 </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
@@ -9,6 +9,7 @@ import MemoryFormStore from '../../../containers/Form/stores/MemoryFormStore';
 import ResourceFormStore from '../../../containers/Form/stores/ResourceFormStore';
 import Form from '../../../containers/Form';
 import Snackbar from '../../../components/Snackbar';
+import Router from '../../../services/Router';
 
 const React = mockReact;
 
@@ -153,6 +154,28 @@ test('Should pass correct props to Form component', () => {
 
     expect(form.props()).toEqual(expect.objectContaining({
         store: formStore,
+    }));
+});
+
+test('Should pass router to Form component', () => {
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+    const router: Router = ({}: any);
+
+    const formOverlay = shallow(<FormOverlay
+        confirmDisabled={false}
+        confirmLoading={false}
+        confirmText="confirm-text"
+        formStore={formStore}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        open={true}
+        router={router}
+        size="small"
+        title="overlay-title"
+    />);
+
+    expect(formOverlay.find(Form).props()).toEqual(expect.objectContaining({
+        router,
     }));
 });
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -194,6 +194,7 @@ class FormOverlayList extends React.Component<Props> {
                         onClose={this.handleFormOverlayClose}
                         onConfirm={this.handleFormOverlayConfirm}
                         open={!!formStore}
+                        router={this.props.router}
                         size={overlaySize ? overlaySize : 'small'}
                         title={overlayTitle}
                     />

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -245,6 +245,7 @@ test('Should open FormOverlay with correct props when List fires the item-add ca
         confirmText: 'sulu_admin.save',
         formStore: formOverlayList.instance().formStore,
         open: true,
+        router,
         size: 'large',
         title: 'app.add_overlay_title',
     }));


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no
| License | MIT

#### What's in this PR?

Pass router to FormOverlay and then to the form component.

#### Why?

So that the click in a media_selection also works in an overlay