### PR TITLE
Refine URL scheme check before generating absolute URL

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -57,7 +57,7 @@ class LinkTag implements TagInterface
                 $item = $contents[$provider . '-' . $uuid];
 
                 $url = $item->getUrl();
-                if ($this->urlHelper) {
+                if ($this->urlHelper && !preg_match('/^[a-z][a-z0-9+-.]*:/i', $url)) {
                     $url = $this->urlHelper->getAbsoluteUrl($url);
                 }
 


### PR DESCRIPTION
Only generate absolute URL in front of Link if it does not match http(s), mailto or tel

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no 
| Fixed tickets | no
| Related issues/PRs | no
| License | MIT
| Documentation PR | -

#### What's in this PR?

<!-- Explain the contents of the PR. -->
Adds a preg_match to the conditional that adds the absolute url in front of URLs in the CKEditor

#### Why?

<!-- Which problem does the PR fix? (add some context and maybe link to an issue here) -->
When adding mailto or tel links, it prepends the absolute url like so:

https://example.com/tel:12345
https://example.com/mailto:test@example.com


#### Example Usage

Open a page with a text_editor field in the Sulu admin
Select text and click the external link button in the CKEditor toolbar
Select mailto: or tel: as protocol and enter a value
Save the page
View the rendered page — the href attribute contains the base URL prepended to the value

