### PR TITLE
Validate mainWebspace locale in article mapper behind customize flag

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/DataMapper/AdditionalWebspacesDataMapper.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/DataMapper/AdditionalWebspacesDataMapper.php
@@ -18,6 +18,8 @@ use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\DataMapperInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Infrastructure\Sulu\Webspace\Exception\WebspaceLocaleNotSupportedException;
+use Sulu\Content\Infrastructure\Sulu\Webspace\Exception\WebspaceNotFoundException;
 use Webmozart\Assert\Assert;
 
 class AdditionalWebspacesDataMapper implements DataMapperInterface
@@ -65,6 +67,15 @@ class AdditionalWebspacesDataMapper implements DataMapperInterface
             return;
         }
 
+        // Only process mainWebspace if customize is activated
+        if (\array_key_exists('mainWebspace', $data)) {
+            Assert::nullOrString($data['mainWebspace']);
+
+            if ($data['mainWebspace']) {
+                $this->validateWebspaceSupportsLocale($data['mainWebspace'], $dimensionContent->getLocale());
+            }
+        }
+
         // Only process additionalWebspaces if customize is activated
         if (\array_key_exists('additionalWebspaces', $data)) {
             Assert::nullOrIsArray($data['additionalWebspaces']);
@@ -94,13 +105,11 @@ class AdditionalWebspacesDataMapper implements DataMapperInterface
         $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
 
         if (!$webspace) {
-            throw new \InvalidArgumentException(\sprintf('Webspace "%s" not found', $webspaceKey));
+            throw new WebspaceNotFoundException($webspaceKey);
         }
 
         if (!$webspace->getLocalization($locale)) {
-            throw new \InvalidArgumentException(
-                \sprintf('Webspace "%s" does not support locale "%s"', $webspaceKey, $locale)
-            );
+            throw new WebspaceLocaleNotSupportedException($webspaceKey, $locale);
         }
     }
 }

--- a/packages/article/src/Infrastructure/Sulu/Content/DataMapper/AdditionalWebspacesDataMapper.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/DataMapper/AdditionalWebspacesDataMapper.php
@@ -67,7 +67,7 @@ class AdditionalWebspacesDataMapper implements DataMapperInterface
             return;
         }
 
-        // Only process mainWebspace if customize is activated
+        // Only validate mainWebspace if customize is activated; the value itself is written by the generic WebspaceDataMapper
         if (\array_key_exists('mainWebspace', $data)) {
             Assert::nullOrString($data['mainWebspace']);
 

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePass.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePass.php
@@ -175,7 +175,7 @@ final class ValidateDefaultMainWebspacePass implements CompilerPassInterface
             }
 
             $locales = [];
-            $localizationNodes = $xpath->query('/*[local-name()="webspace"]//*[local-name()="localization"]');
+            $localizationNodes = $xpath->query('/*[local-name()="webspace"]/*[local-name()="localizations"]//*[local-name()="localization"]');
             if (false !== $localizationNodes) {
                 foreach ($localizationNodes as $node) {
                     if (!$node instanceof \DOMElement) {

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePass.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePass.php
@@ -95,7 +95,7 @@ final class ValidateDefaultMainWebspacePass implements CompilerPassInterface
     }
 
     /**
-     * Mirrors WebspaceSettingsConfigurationResolver precedence
+     * Mirrors WebspaceSettingsConfigurationResolver precedence.
      *
      * @param array<string, string> $defaultMainWebspace
      * @param list<string> $webspaceKeys

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePass.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePass.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Symfony\HttpKernel\Compiler;
 
+use Sulu\Component\Localization\Localization;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Resource\DirectoryResource;
 use Symfony\Component\Config\Util\Exception\XmlParsingException;
@@ -35,7 +36,8 @@ final class ValidateDefaultMainWebspacePass implements CompilerPassInterface
 
         $container->addResource(new DirectoryResource($configDir, '/\.xml$/'));
 
-        $webspaceKeys = $this->readWebspaceKeys($configDir);
+        $localizations = $this->readWebspaceLocalizations($configDir);
+        $webspaceKeys = \array_keys($localizations);
         $defaultMainWebspace = $this->getConfiguredDefaultMainWebspace($container);
 
         if ([] === $defaultMainWebspace) {
@@ -65,6 +67,54 @@ final class ValidateDefaultMainWebspacePass implements CompilerPassInterface
                 ));
             }
         }
+
+        // Every authorable locale must map to a webspace that supports it, so a
+        // non-pinned article never receives an incompatible mainWebspace at runtime.
+        foreach ($this->collectLocales($localizations) as $locale) {
+            $resolved = $this->resolveConfiguredWebspaceForLocale($defaultMainWebspace, $locale, $webspaceKeys);
+
+            if (null === $resolved) {
+                throw new InvalidConfigurationException(\sprintf(
+                    'The locale "%s" has no "sulu_article.default_main_webspace" mapping. Add a per-locale entry '
+                    . '"%s" or a "default" entry pointing to a webspace that supports this locale.',
+                    $locale,
+                    $locale,
+                ));
+            }
+
+            if (!\in_array($locale, $localizations[$resolved] ?? [], true)) {
+                throw new InvalidConfigurationException(\sprintf(
+                    'The "sulu_article.default_main_webspace" maps locale "%s" to webspace "%s", which does not '
+                    . 'support that locale. Map "%s" to a webspace whose localizations include it.',
+                    $locale,
+                    $resolved,
+                    $locale,
+                ));
+            }
+        }
+    }
+
+    /**
+     * Mirrors WebspaceSettingsConfigurationResolver precedence
+     *
+     * @param array<string, string> $defaultMainWebspace
+     * @param list<string> $webspaceKeys
+     */
+    private function resolveConfiguredWebspaceForLocale(array $defaultMainWebspace, string $locale, array $webspaceKeys): ?string
+    {
+        if (\array_key_exists($locale, $defaultMainWebspace)) {
+            return $defaultMainWebspace[$locale];
+        }
+
+        if (\array_key_exists('default', $defaultMainWebspace)) {
+            return $defaultMainWebspace['default'];
+        }
+
+        if (1 === \count($webspaceKeys)) {
+            return $webspaceKeys[0];
+        }
+
+        return null;
     }
 
     /**
@@ -100,11 +150,14 @@ final class ValidateDefaultMainWebspacePass implements CompilerPassInterface
     }
 
     /**
-     * @return list<string>
+     * Maps each webspace key to its declared locales (`language` or
+     * `language_country`, matching Localization::getLocale()).
+     *
+     * @return array<string, list<string>>
      */
-    private function readWebspaceKeys(string $configDir): array
+    private function readWebspaceLocalizations(string $configDir): array
     {
-        $webspaceKeys = [];
+        $localizations = [];
         foreach ((new Finder())->in($configDir)->files()->name('*.xml') as $file) {
             try {
                 $document = XmlUtils::loadFile($file->getPathname());
@@ -112,14 +165,53 @@ final class ValidateDefaultMainWebspacePass implements CompilerPassInterface
                 continue;
             }
 
-            $keyNodes = (new \DOMXPath($document))->query('/*[local-name()="webspace"]/*[local-name()="key"]');
-            $key = false !== $keyNodes && null !== $keyNodes->item(0) ? (string) $keyNodes->item(0)->nodeValue : '';
+            $xpath = new \DOMXPath($document);
 
-            if ('' !== $key) {
-                $webspaceKeys[] = $key;
+            $keyNodes = $xpath->query('/*[local-name()="webspace"]/*[local-name()="key"]');
+            $key = false !== $keyNodes && null !== $keyNodes->item(0) ? \trim((string) $keyNodes->item(0)->nodeValue) : '';
+
+            if ('' === $key) {
+                continue;
+            }
+
+            $locales = [];
+            $localizationNodes = $xpath->query('/*[local-name()="webspace"]//*[local-name()="localization"]');
+            if (false !== $localizationNodes) {
+                foreach ($localizationNodes as $node) {
+                    if (!$node instanceof \DOMElement) {
+                        continue;
+                    }
+
+                    $language = \trim($node->getAttribute('language'));
+                    if ('' === $language) {
+                        continue;
+                    }
+
+                    $country = \trim($node->getAttribute('country'));
+                    $locales[] = (new Localization($language, '' !== $country ? $country : null))->getLocale();
+                }
+            }
+
+            $localizations[$key] = \array_values(\array_unique($locales));
+        }
+
+        return $localizations;
+    }
+
+    /**
+     * @param array<string, list<string>> $localizations
+     *
+     * @return list<string>
+     */
+    private function collectLocales(array $localizations): array
+    {
+        $locales = [];
+        foreach ($localizations as $webspaceLocales) {
+            foreach ($webspaceLocales as $locale) {
+                $locales[$locale] = true;
             }
         }
 
-        return $webspaceKeys;
+        return \array_keys($locales);
     }
 }

--- a/packages/article/tests/Unit/Application/Content/DataMapper/AdditionalWebspacesDataMapperTest.php
+++ b/packages/article/tests/Unit/Application/Content/DataMapper/AdditionalWebspacesDataMapperTest.php
@@ -23,6 +23,8 @@ use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Infrastructure\Sulu\Webspace\Exception\WebspaceLocaleNotSupportedException;
+use Sulu\Content\Infrastructure\Sulu\Webspace\Exception\WebspaceNotFoundException;
 
 class AdditionalWebspacesDataMapperTest extends TestCase
 {
@@ -79,11 +81,18 @@ class AdditionalWebspacesDataMapperTest extends TestCase
         $dimensionContent->setAdditionalWebspaces(['example-com'])->shouldBeCalled()->willReturn($dimensionContent->reveal());
 
         $localization = new Localization('en');
-        $webspace = new Webspace();
-        $webspace->setKey('example-com');
-        $webspace->setName('Example');
-        $webspace->addLocalization($localization);
-        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($webspace);
+
+        $mainWebspace = new Webspace();
+        $mainWebspace->setKey('sulu-io');
+        $mainWebspace->setName('Sulu IO');
+        $mainWebspace->addLocalization($localization);
+        $this->webspaceManager->findWebspaceByKey('sulu-io')->willReturn($mainWebspace);
+
+        $additionalWebspace = new Webspace();
+        $additionalWebspace->setKey('example-com');
+        $additionalWebspace->setName('Example');
+        $additionalWebspace->addLocalization($localization);
+        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($additionalWebspace);
 
         $data = [
             'customizeWebspaceSettings' => true,
@@ -167,7 +176,15 @@ class AdditionalWebspacesDataMapperTest extends TestCase
         $dimensionContent = $this->prophesize(DimensionContentInterface::class);
         $dimensionContent->willImplement(ArticleDimensionContentInterface::class);
         $dimensionContent->setCustomizeWebspaceSettings(true)->shouldBeCalled()->willReturn($dimensionContent->reveal());
+        $dimensionContent->getLocale()->willReturn('en');
         $dimensionContent->setAdditionalWebspaces([])->shouldBeCalled()->willReturn($dimensionContent->reveal());
+
+        $localization = new Localization('en');
+        $mainWebspace = new Webspace();
+        $mainWebspace->setKey('sulu-io');
+        $mainWebspace->setName('Sulu IO');
+        $mainWebspace->addLocalization($localization);
+        $this->webspaceManager->findWebspaceByKey('sulu-io')->willReturn($mainWebspace);
 
         $data = [
             'customizeWebspaceSettings' => true,
@@ -180,7 +197,7 @@ class AdditionalWebspacesDataMapperTest extends TestCase
 
     public function testMapWithUnsupportedLocaleThrowsException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(WebspaceLocaleNotSupportedException::class);
         $this->expectExceptionMessage('Webspace "example-com" does not support locale "de"');
 
         $dataMapper = $this->getAdditionalWebspacesDataMapperInstance();
@@ -191,12 +208,19 @@ class AdditionalWebspacesDataMapperTest extends TestCase
         $dimensionContent->setCustomizeWebspaceSettings(true)->shouldBeCalled()->willReturn($dimensionContent->reveal());
         $dimensionContent->getLocale()->willReturn('de');
 
+        $localizationDe = new Localization('de');
+        $mainWebspace = new Webspace();
+        $mainWebspace->setKey('sulu-io');
+        $mainWebspace->setName('Sulu IO');
+        $mainWebspace->addLocalization($localizationDe);
+        $this->webspaceManager->findWebspaceByKey('sulu-io')->willReturn($mainWebspace);
+
         $localizationEn = new Localization('en');
-        $webspace = new Webspace();
-        $webspace->setKey('example-com');
-        $webspace->setName('Example');
-        $webspace->addLocalization($localizationEn);
-        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($webspace);
+        $additionalWebspace = new Webspace();
+        $additionalWebspace->setKey('example-com');
+        $additionalWebspace->setName('Example');
+        $additionalWebspace->addLocalization($localizationEn);
+        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($additionalWebspace);
 
         $data = [
             'customizeWebspaceSettings' => true,
@@ -219,14 +243,99 @@ class AdditionalWebspacesDataMapperTest extends TestCase
         $dimensionContent->setAdditionalWebspaces(['example-com'])->shouldBeCalled()->willReturn($dimensionContent->reveal());
 
         $localizationEn = new Localization('en');
-        $webspace = new Webspace();
-        $webspace->setKey('example-com');
-        $webspace->setName('Example');
-        $webspace->addLocalization($localizationEn);
-        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($webspace);
+
+        $mainWebspace = new Webspace();
+        $mainWebspace->setKey('sulu-io');
+        $mainWebspace->setName('Sulu IO');
+        $mainWebspace->addLocalization($localizationEn);
+        $this->webspaceManager->findWebspaceByKey('sulu-io')->willReturn($mainWebspace);
+
+        $additionalWebspace = new Webspace();
+        $additionalWebspace->setKey('example-com');
+        $additionalWebspace->setName('Example');
+        $additionalWebspace->addLocalization($localizationEn);
+        $this->webspaceManager->findWebspaceByKey('example-com')->willReturn($additionalWebspace);
 
         $data = [
             'customizeWebspaceSettings' => true,
+            'mainWebspace' => 'sulu-io',
+            'additionalWebspaces' => ['example-com'],
+        ];
+
+        $dataMapper->map($unlocalizedDimensionContent->reveal(), $dimensionContent->reveal(), $data);
+    }
+
+    public function testMapMainWebspaceNotFoundThrowsExceptionWhenCustomized(): void
+    {
+        $this->expectException(WebspaceNotFoundException::class);
+        $this->expectExceptionMessage('Webspace "missing" not found');
+
+        $dataMapper = $this->getAdditionalWebspacesDataMapperInstance();
+
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(ArticleDimensionContentInterface::class);
+        $dimensionContent->setCustomizeWebspaceSettings(true)->shouldBeCalled()->willReturn($dimensionContent->reveal());
+        $dimensionContent->getLocale()->willReturn('en');
+
+        $this->webspaceManager->findWebspaceByKey('missing')->willReturn(null);
+
+        $data = [
+            'customizeWebspaceSettings' => true,
+            'mainWebspace' => 'missing',
+            'additionalWebspaces' => [],
+        ];
+
+        $dataMapper->map($unlocalizedDimensionContent->reveal(), $dimensionContent->reveal(), $data);
+    }
+
+    public function testMapMainWebspaceWithUnsupportedLocaleThrowsExceptionWhenCustomized(): void
+    {
+        $this->expectException(WebspaceLocaleNotSupportedException::class);
+        $this->expectExceptionMessage('Webspace "sulu-io" does not support locale "de"');
+
+        $dataMapper = $this->getAdditionalWebspacesDataMapperInstance();
+
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(ArticleDimensionContentInterface::class);
+        $dimensionContent->setCustomizeWebspaceSettings(true)->shouldBeCalled()->willReturn($dimensionContent->reveal());
+        $dimensionContent->getLocale()->willReturn('de');
+
+        $localizationEn = new Localization('en');
+        $mainWebspace = new Webspace();
+        $mainWebspace->setKey('sulu-io');
+        $mainWebspace->setName('Sulu IO');
+        $mainWebspace->addLocalization($localizationEn);
+        $this->webspaceManager->findWebspaceByKey('sulu-io')->willReturn($mainWebspace);
+
+        $data = [
+            'customizeWebspaceSettings' => true,
+            'mainWebspace' => 'sulu-io',
+            'additionalWebspaces' => [],
+        ];
+
+        $dataMapper->map($unlocalizedDimensionContent->reveal(), $dimensionContent->reveal(), $data);
+    }
+
+    public function testMapMainWebspaceDoesNotValidateLocaleWhenNotCustomized(): void
+    {
+        $dataMapper = $this->getAdditionalWebspacesDataMapperInstance();
+
+        $locale = 'de';
+        $unlocalizedDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(ArticleDimensionContentInterface::class);
+        $dimensionContent->getLocale()->willReturn($locale);
+        $this->webspaceManager->findWebspaceByKey('sulu-io')->shouldNotBeCalled();
+        $this->configurationResolver->getDefaultMainWebspaceForLocale($locale)->willReturn('sulu-io');
+        $this->configurationResolver->getDefaultAdditionalWebspacesForLocale($locale)->willReturn([]);
+        $dimensionContent->setMainWebspace('sulu-io')->shouldBeCalled();
+        $dimensionContent->setAdditionalWebspaces([])->shouldBeCalled()->willReturn($dimensionContent->reveal());
+        $dimensionContent->setCustomizeWebspaceSettings(false)->shouldBeCalled()->willReturn($dimensionContent->reveal());
+
+        $data = [
+            'customizeWebspaceSettings' => false,
             'mainWebspace' => 'sulu-io',
             'additionalWebspaces' => ['example-com'],
         ];

--- a/packages/article/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePassTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePassTest.php
@@ -226,6 +226,23 @@ class ValidateDefaultMainWebspacePassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testIgnoresPortalLocalizationsWhenCollectingWebspaceLocales(): void
+    {
+        // A <portal> may declare its own <localizations>, but runtime Webspace::getLocalization()
+        // only considers the webspace-level <localizations>. The pass must mirror that and not
+        // treat a portal-only locale ("de") as supported by the webspace.
+        $dir = $this->createTempDir();
+        \file_put_contents($dir . '/website.xml', $this->webspaceXmlWithPortalLocales('website', ['en'], ['de']));
+        \file_put_contents($dir . '/magazine.xml', $this->webspaceXml('magazine', ['de']));
+
+        $container = $this->createContainer($dir, ['default' => 'website']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('maps locale "de" to webspace "website"');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
     public function testRegistersConfigDirAsContainerResource(): void
     {
         $dir = $this->createWebspaceDir(['sulu-io']);
@@ -325,6 +342,44 @@ class ValidateDefaultMainWebspacePassTest extends TestCase
      */
     private function webspaceXml(string $key, array $locales = ['en', 'de']): string
     {
+        return '<?xml version="1.0" encoding="utf-8"?>' . "\n"
+            . '<webspace xmlns="http://schemas.sulu.io/webspace/webspace">' . "\n"
+            . '    <name>' . $key . '</name>' . "\n"
+            . '    <key>' . $key . '</key>' . "\n"
+            . '    <localizations>' . "\n"
+            . $this->renderLocalizations($locales)
+            . '    </localizations>' . "\n"
+            . '</webspace>' . "\n";
+    }
+
+    /**
+     * @param list<string> $webspaceLocales
+     * @param list<string> $portalLocales
+     */
+    private function webspaceXmlWithPortalLocales(string $key, array $webspaceLocales, array $portalLocales): string
+    {
+        return '<?xml version="1.0" encoding="utf-8"?>' . "\n"
+            . '<webspace xmlns="http://schemas.sulu.io/webspace/webspace">' . "\n"
+            . '    <name>' . $key . '</name>' . "\n"
+            . '    <key>' . $key . '</key>' . "\n"
+            . '    <localizations>' . "\n"
+            . $this->renderLocalizations($webspaceLocales)
+            . '    </localizations>' . "\n"
+            . '    <portals>' . "\n"
+            . '        <portal>' . "\n"
+            . '            <localizations>' . "\n"
+            . $this->renderLocalizations($portalLocales)
+            . '            </localizations>' . "\n"
+            . '        </portal>' . "\n"
+            . '    </portals>' . "\n"
+            . '</webspace>' . "\n";
+    }
+
+    /**
+     * @param list<string> $locales
+     */
+    private function renderLocalizations(array $locales): string
+    {
         $localizations = '';
         foreach ($locales as $locale) {
             $parts = \explode('_', $locale, 2);
@@ -332,14 +387,7 @@ class ValidateDefaultMainWebspacePassTest extends TestCase
             $localizations .= \sprintf('        <localization language="%s"%s/>', $parts[0], $country) . "\n";
         }
 
-        return '<?xml version="1.0" encoding="utf-8"?>' . "\n"
-            . '<webspace xmlns="http://schemas.sulu.io/webspace/webspace">' . "\n"
-            . '    <name>' . $key . '</name>' . "\n"
-            . '    <key>' . $key . '</key>' . "\n"
-            . '    <localizations>' . "\n"
-            . $localizations
-            . '    </localizations>' . "\n"
-            . '</webspace>' . "\n";
+        return $localizations;
     }
 
     private function createTempDir(): string

--- a/packages/article/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePassTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Symfony/HttpKernel/Compiler/ValidateDefaultMainWebspacePassTest.php
@@ -108,6 +108,124 @@ class ValidateDefaultMainWebspacePassTest extends TestCase
         (new ValidateDefaultMainWebspacePass())->process($container);
     }
 
+    public function testThrowsWhenDefaultWebspaceDoesNotSupportLocale(): void
+    {
+        $dir = $this->createWebspaceDirWithLocales([
+            'website' => ['en', 'de'],
+            'magazine' => ['en'],
+        ]);
+        $container = $this->createContainer($dir, ['default' => 'magazine']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('locale "de"');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    public function testThrowsWhenLocaleSpecificWebspaceDoesNotSupportItsLocale(): void
+    {
+        $dir = $this->createWebspaceDirWithLocales([
+            'website' => ['en', 'de'],
+            'magazine' => ['en'],
+        ]);
+        $container = $this->createContainer($dir, ['en' => 'website', 'de' => 'magazine']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('maps locale "de" to webspace "magazine"');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    public function testThrowsWhenAuthorableLocaleHasNoMapping(): void
+    {
+        // "de" is authorable but has neither a per-locale nor a "default" mapping.
+        $dir = $this->createWebspaceDirWithLocales([
+            'website' => ['en'],
+            'magazine' => ['de'],
+        ]);
+        $container = $this->createContainer($dir, ['en' => 'website']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('locale "de" has no');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    public function testDoesNotThrowWhenPerLocaleMappingsCoverDisjointLocales(): void
+    {
+        $dir = $this->createWebspaceDirWithLocales([
+            'website' => ['en'],
+            'magazine' => ['de'],
+        ]);
+        $container = $this->createContainer($dir, ['en' => 'website', 'de' => 'magazine']);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testDoesNotThrowWhenDefaultCoversLocalesNotOverriddenPerLocale(): void
+    {
+        $dir = $this->createWebspaceDirWithLocales([
+            'website' => ['en', 'de'],
+            'magazine' => ['fr'],
+        ]);
+        $container = $this->createContainer($dir, ['default' => 'website', 'fr' => 'magazine']);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidatesCountryLocales(): void
+    {
+        // Mixed granularity: language_country locales alongside bare-language ones.
+        $dir = $this->createWebspaceDirWithLocales([
+            'bwt_country' => ['de_de', 'de_at'],
+            'bwt_pharma' => ['de', 'en'],
+        ]);
+        $container = $this->createContainer($dir, [
+            'de_de' => 'bwt_country',
+            'de_at' => 'bwt_country',
+            'de' => 'bwt_pharma',
+            'en' => 'bwt_pharma',
+        ]);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testThrowsWhenDefaultDoesNotSupportCountryLocale(): void
+    {
+        // "default" => bwt_country covers de_de/de_at but not the bare "de" from bwt_pharma.
+        $dir = $this->createWebspaceDirWithLocales([
+            'bwt_country' => ['de_de', 'de_at'],
+            'bwt_pharma' => ['de'],
+        ]);
+        $container = $this->createContainer($dir, ['default' => 'bwt_country']);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('locale "de"');
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+    }
+
+    public function testNormalizesCountryLocaleCaseToMatchRuntime(): void
+    {
+        // Uppercase ISO country codes in the XML must resolve like Localization::getLocale(),
+        // which lowercases them, so a lowercase per-locale config entry still matches.
+        $dir = $this->createWebspaceDirWithLocales([
+            'website' => ['de_AT'],
+            'magazine' => ['en'],
+        ]);
+        $container = $this->createContainer($dir, ['de_at' => 'website', 'en' => 'magazine']);
+
+        (new ValidateDefaultMainWebspacePass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
     public function testRegistersConfigDirAsContainerResource(): void
     {
         $dir = $this->createWebspaceDir(['sulu-io']);
@@ -189,15 +307,39 @@ class ValidateDefaultMainWebspacePassTest extends TestCase
         return $dir;
     }
 
-    private function webspaceXml(string $key): string
+    /**
+     * @param array<string, list<string>> $webspaces webspace key => supported locales
+     */
+    private function createWebspaceDirWithLocales(array $webspaces): string
     {
-        return <<<XML
-            <?xml version="1.0" encoding="utf-8"?>
-            <webspace xmlns="http://schemas.sulu.io/webspace/webspace">
-                <name>{$key}</name>
-                <key>{$key}</key>
-            </webspace>
-            XML;
+        $dir = $this->createTempDir();
+        foreach ($webspaces as $key => $locales) {
+            \file_put_contents($dir . '/' . $key . '.xml', $this->webspaceXml($key, $locales));
+        }
+
+        return $dir;
+    }
+
+    /**
+     * @param list<string> $locales
+     */
+    private function webspaceXml(string $key, array $locales = ['en', 'de']): string
+    {
+        $localizations = '';
+        foreach ($locales as $locale) {
+            $parts = \explode('_', $locale, 2);
+            $country = isset($parts[1]) ? \sprintf(' country="%s"', $parts[1]) : '';
+            $localizations .= \sprintf('        <localization language="%s"%s/>', $parts[0], $country) . "\n";
+        }
+
+        return '<?xml version="1.0" encoding="utf-8"?>' . "\n"
+            . '<webspace xmlns="http://schemas.sulu.io/webspace/webspace">' . "\n"
+            . '    <name>' . $key . '</name>' . "\n"
+            . '    <key>' . $key . '</key>' . "\n"
+            . '    <localizations>' . "\n"
+            . $localizations
+            . '    </localizations>' . "\n"
+            . '</webspace>' . "\n";
     }
 
     private function createTempDir(): string

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/WebspaceDataMapper.php
@@ -54,36 +54,12 @@ class WebspaceDataMapper implements DataMapperInterface
         //      on the template itself which will be injected with ["type" => ["template-key" => "webspace-key"]] into this service.
         if (\array_key_exists('mainWebspace', $data)) {
             Assert::nullOrString($data['mainWebspace']);
-
-            if ($data['mainWebspace']) {
-                $this->validateWebspaceSupportsLocale($data['mainWebspace'], $dimensionContent->getLocale());
-            }
-
             $dimensionContent->setMainWebspace($data['mainWebspace']);
         }
 
         if (!$dimensionContent->getMainWebspace()) {
             // if no main webspace is yet set a default webspace will be set
             $dimensionContent->setMainWebspace($this->getDefaultWebspaceKey());
-        }
-    }
-
-    private function validateWebspaceSupportsLocale(string $webspaceKey, ?string $locale): void
-    {
-        if (!$locale) {
-            return;
-        }
-
-        $webspace = $this->webspaceManager->findWebspaceByKey($webspaceKey);
-
-        if (!$webspace) {
-            throw new \InvalidArgumentException(\sprintf('Webspace "%s" not found', $webspaceKey));
-        }
-
-        if (!$webspace->getLocalization($locale)) {
-            throw new \InvalidArgumentException(
-                \sprintf('Webspace "%s" does not support locale "%s"', $webspaceKey, $locale)
-            );
         }
     }
 

--- a/packages/content/src/Infrastructure/Sulu/Webspace/Exception/WebspaceLocaleNotSupportedException.php
+++ b/packages/content/src/Infrastructure/Sulu/Webspace/Exception/WebspaceLocaleNotSupportedException.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Sulu\Webspace\Exception;
+
+use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+class WebspaceLocaleNotSupportedException extends UnprocessableEntityHttpException implements TranslationErrorMessageExceptionInterface
+{
+    public function __construct(
+        private readonly string $webspaceKey,
+        private readonly string $locale,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct(
+            \sprintf('Webspace "%s" does not support locale "%s"', $this->webspaceKey, $this->locale),
+            $previous,
+        );
+    }
+
+    public function getWebspaceKey(): string
+    {
+        return $this->webspaceKey;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getMessageTranslationKey(): string
+    {
+        return 'sulu_content.webspace_does_not_support_locale';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMessageTranslationParameters(): array
+    {
+        return [
+            '{webspace}' => $this->webspaceKey,
+            '{locale}' => $this->locale,
+        ];
+    }
+}

--- a/packages/content/src/Infrastructure/Sulu/Webspace/Exception/WebspaceNotFoundException.php
+++ b/packages/content/src/Infrastructure/Sulu/Webspace/Exception/WebspaceNotFoundException.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Sulu\Webspace\Exception;
+
+use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+class WebspaceNotFoundException extends UnprocessableEntityHttpException implements TranslationErrorMessageExceptionInterface
+{
+    public function __construct(
+        private readonly string $webspaceKey,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct(
+            \sprintf('Webspace "%s" not found', $this->webspaceKey),
+            $previous,
+        );
+    }
+
+    public function getMessageTranslationKey(): string
+    {
+        return 'sulu_content.webspace_not_found';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMessageTranslationParameters(): array
+    {
+        return [
+            '{webspace}' => $this->webspaceKey,
+        ];
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/WebspaceDataMapperTest.php
@@ -16,7 +16,6 @@ namespace Sulu\Content\Tests\Unit\Content\Application\ContentDataMapper\DataMapp
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Manager\WebspaceCollection;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
@@ -132,11 +131,8 @@ class WebspaceDataMapperTest extends TestCase
         $this->assertNull($localizedDimensionContent->getMainWebspace());
     }
 
-    public function testMapDataWithUnsupportedLocaleThrowsException(): void
+    public function testMapDataWritesMainWebspaceWithoutLocaleValidation(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Webspace "example" does not support locale "de"');
-
         $data = [
             'mainWebspace' => 'example',
         ];
@@ -146,15 +142,11 @@ class WebspaceDataMapperTest extends TestCase
         $localizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent->setLocale('de');
 
-        $localizationEn = new Localization('en');
-        $webspace = new Webspace();
-        $webspace->setKey('example');
-        $webspace->addLocalization($localizationEn);
-
-        $this->webspaceManager->findWebspaceByKey('example')->willReturn($webspace);
-
         $authorMapper = $this->createWebspaceDataMapperInstance();
         $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        // Locale validation is the article bundle's concern; the value is written regardless.
+        $this->assertSame('example', $localizedDimensionContent->getMainWebspace());
     }
 
     public function testMapDataWithSupportedLocale(): void
@@ -167,13 +159,6 @@ class WebspaceDataMapperTest extends TestCase
         $unlocalizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent = new ExampleDimensionContent($example);
         $localizedDimensionContent->setLocale('en');
-
-        $localizationEn = new Localization('en');
-        $webspace = new Webspace();
-        $webspace->setKey('example');
-        $webspace->addLocalization($localizationEn);
-
-        $this->webspaceManager->findWebspaceByKey('example')->willReturn($webspace);
 
         $authorMapper = $this->createWebspaceDataMapperInstance();
         $authorMapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Webspace/Exception/WebspaceLocaleNotSupportedExceptionTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Webspace/Exception/WebspaceLocaleNotSupportedExceptionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Infrastructure\Sulu\Webspace\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Infrastructure\Sulu\Webspace\Exception\WebspaceLocaleNotSupportedException;
+
+class WebspaceLocaleNotSupportedExceptionTest extends TestCase
+{
+    public function testRespondsWithUnprocessableEntityStatus(): void
+    {
+        $exception = new WebspaceLocaleNotSupportedException('magazine', 'de');
+
+        $this->assertSame(422, $exception->getStatusCode());
+    }
+
+    public function testExposesTranslationContract(): void
+    {
+        $exception = new WebspaceLocaleNotSupportedException('magazine', 'de');
+
+        $this->assertSame(
+            'sulu_content.webspace_does_not_support_locale',
+            $exception->getMessageTranslationKey(),
+        );
+        $this->assertSame(
+            ['{webspace}' => 'magazine', '{locale}' => 'de'],
+            $exception->getMessageTranslationParameters(),
+        );
+    }
+
+    public function testKeepsRawMessageAndAccessors(): void
+    {
+        $exception = new WebspaceLocaleNotSupportedException('magazine', 'de');
+
+        $this->assertSame('Webspace "magazine" does not support locale "de"', $exception->getMessage());
+        $this->assertSame('magazine', $exception->getWebspaceKey());
+        $this->assertSame('de', $exception->getLocale());
+    }
+}

--- a/packages/content/tests/Unit/Content/Infrastructure/Sulu/Webspace/Exception/WebspaceNotFoundExceptionTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Sulu/Webspace/Exception/WebspaceNotFoundExceptionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Infrastructure\Sulu\Webspace\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Infrastructure\Sulu\Webspace\Exception\WebspaceNotFoundException;
+
+class WebspaceNotFoundExceptionTest extends TestCase
+{
+    public function testRespondsWithUnprocessableEntityStatus(): void
+    {
+        $exception = new WebspaceNotFoundException('magazine');
+
+        $this->assertSame(422, $exception->getStatusCode());
+    }
+
+    public function testExposesTranslationContract(): void
+    {
+        $exception = new WebspaceNotFoundException('magazine');
+
+        $this->assertSame(
+            'sulu_content.webspace_not_found',
+            $exception->getMessageTranslationKey(),
+        );
+        $this->assertSame(
+            ['{webspace}' => 'magazine'],
+            $exception->getMessageTranslationParameters(),
+        );
+    }
+
+    public function testKeepsRawMessage(): void
+    {
+        $exception = new WebspaceNotFoundException('magazine');
+
+        $this->assertSame('Webspace "magazine" not found', $exception->getMessage());
+    }
+}

--- a/packages/content/translations/admin.de.json
+++ b/packages/content/translations/admin.de.json
@@ -36,6 +36,8 @@
     "sulu_content.webspace": "Webspace",
     "sulu_content.main_webspace": "Hauptwebspace",
     "sulu_content.additional_webspaces": "Weitere Webspaces",
+    "sulu_content.webspace_does_not_support_locale": "Der Webspace \"{webspace}\" unterstützt die Sprache \"{locale}\" nicht.",
+    "sulu_content.webspace_not_found": "Der Webspace \"{webspace}\" konnte nicht gefunden werden.",
     "sulu_content.page_settings": "Seiteneinstellungen",
     "sulu_content.hide_block_label": "Nicht auf publizierter Website darstellen",
     "sulu_content.hide_block_description": "Dieser Block wird nicht veröffentlicht, kann aber weiterhin im Admin bearbeitet werden.",

--- a/packages/content/translations/admin.en.json
+++ b/packages/content/translations/admin.en.json
@@ -36,6 +36,8 @@
     "sulu_content.webspace": "Webspace",
     "sulu_content.main_webspace": "Main Webspace",
     "sulu_content.additional_webspaces": "Additional Webspaces",
+    "sulu_content.webspace_does_not_support_locale": "The webspace \"{webspace}\" does not support the locale \"{locale}\".",
+    "sulu_content.webspace_not_found": "The webspace \"{webspace}\" could not be found.",
     "sulu_content.page_settings": "Page settings",
     "sulu_content.hide_block_label": "Don't display on public website",
     "sulu_content.hide_block_description": "This block will not be published, but remains editable in the admin.",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The mainWebspace locale validation moved out of the generic content WebspaceDataMapper and into the article AdditionalWebspacesDataMapper, where it only runs when the editor pinned a mainWebspace through the customize flag. The non binding default that the form sends when customize is off is no longer validated and is written as is. The raw InvalidArgumentException was replaced with two dedicated exceptions that return HTTP 422 with translated admin messages. The ValidateDefaultMainWebspacePass compiler pass now also checks at build time that every authorable locale maps to a webspace that supports it.

#### Why?

A non customized article sends a default mainWebspace that can name a webspace which does not support the current locale, which made the previous unconditional validation throw and blocked saving. Only an editor pinned value should be validated against the locale. Throwing InvalidArgumentException surfaced as a server error, so the new exceptions give the user a clear 422 with a translated message. The compile time check catches misconfigured default_main_webspace mappings early instead of failing at runtime.