### PR TITLE
Fix list query when sorting by a count or group-concat field

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8187,7 +8187,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$total on mixed\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
 
 		-
@@ -8403,7 +8403,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
 			identifier: argument.type
-			count: 15
+			count: 16
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
 
 		-

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
@@ -100,6 +100,24 @@ class KeywordControllerTest extends SuluTestCase
         $this->assertEquals('keyword2', $response->_embedded->category_keywords[1]->keyword);
     }
 
+    public function testCgetSortedByCount(): void
+    {
+        $this->testPost('keyword1', 'de', $this->category1->getId());
+        $this->testPost('keyword2', 'de', $this->category1->getId());
+
+        // sorting by a count field must not add the aggregate to the GROUP BY
+        // clause, otherwise the generated query is invalid (see #8200)
+        $this->client->jsonRequest(
+            'GET',
+            '/api/categories/' . $this->category1->getId() . '/keywords?locale=de&sortBy=categoryTranslationCount&sortOrder=asc'
+        );
+
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $response = \json_decode($this->client->getResponse()->getContent());
+        $this->assertEquals(2, $response->total);
+    }
+
     public function testGet(): void
     {
         $keyword = $this->testPost('keyword1', 'de', $this->category1->getId());

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -468,7 +468,10 @@ class DoctrineListBuilder extends AbstractListBuilder
 
         if (!empty($groupByFields)) {
             foreach ($groupByFields as $field) {
-                if ($field instanceof DoctrineFieldDescriptor) {
+                // aggregate fields (e.g. COUNT or GROUP_CONCAT sort fields) must
+                // not be added to the GROUP BY clause - grouping by an aggregate
+                // is invalid SQL and rejected by the DQL parser
+                if ($field instanceof DoctrineFieldDescriptor && !$this->isGroupingFieldDescriptor($field)) {
                     $queryBuilder->addGroupBy($field->getSelect());
                 }
             }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8200
| Related issues/PRs | #8200
| License | MIT
| Documentation PR | -

#### What's in this PR?

`DoctrineListBuilder::assignGroupBy()` adds every sort field to the `GROUP BY`
clause. When the list is sorted by an aggregate field (a `count-property` or
`group-concat-property`, e.g. the "multiple usage" column of the category
keywords list), the aggregate expression itself ends up in `GROUP BY`, producing
invalid SQL.

This PR skips grouping field descriptors when building the `GROUP BY` clause, so
aggregates are no longer grouped by.

#### Why?

Opening the category keywords list and sorting by the usage-count column throws:

```
[Semantical Error] ... near 'COUNT(...CategoryTranslation.id)':
Error: Cannot group by undefined identification or result variable.
```

i.e. the generated query is `... GROUP BY Keyword.id, COUNT(CategoryTranslation.id)`.
The same `GROUP BY` fragility is what surfaces as the PostgreSQL
`SQLSTATE[42803] ... must appear in the GROUP BY clause` reported in #8200
(PostgreSQL is stricter than MySQL about `GROUP BY`, which is why it only showed
up there).

A functional test was added to `KeywordControllerTest` (sorting the keywords
list by `categoryTranslationCount`); it fails before the fix and passes after.

#### Note for reviewers

I reproduced and fixed the count-column sort crash above against the maintained
branches via `KeywordControllerTest` (where @alexander-schranz suggested adding a
reproducing test). I could not reproduce the *byte-identical* query from the
original 2.6.6 report on current 2.6/3.x — there the list query already groups by
`id`, which PostgreSQL accepts through primary-key functional dependency — so this
targets the same `GROUP BY` handling in the same feature. Happy to adjust the
scope if you have a different reproduction in mind.
