### PR TITLE
Fix validation for property names containing a slash

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2383,12 +2383,6 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/ObjectMetadata.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertiesMetadata\:\:toJsonSchema\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata\:\:toJsonSchema\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
@@ -72,7 +72,10 @@ class PropertiesMetadata implements SchemaMetadataInterface
         }
 
         foreach ($nestedProperties as $parent => $childProperties) {
-            $properties[$parent] = (new self($childProperties))->buildJsonSchema(true);
+            $nestedSchema = (new self($childProperties))->buildJsonSchema(true);
+            if ($nestedSchema) {
+                $properties[$parent] = $nestedSchema;
+            }
         }
 
         return $this->assembleJsonSchema($properties, $required, $includeType);

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
@@ -26,84 +26,82 @@ class PropertiesMetadata implements SchemaMetadataInterface
         $this->properties = $properties;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toJsonSchema(): array
     {
-        return $this->buildJsonSchema($this->createPropertyTree(), false);
+        return $this->buildJsonSchema(false);
     }
 
     /**
-     * @return array<string, array{children: array, mandatory: bool, schema: array|null}>
+     * @return array<string, mixed>
      */
-    private function createPropertyTree(): array
+    private function buildJsonSchema(bool $includeType): array
     {
-        $tree = [];
-
-        foreach ($this->properties as $property) {
-            $pathSegments = \explode('/', $property->getName());
-            $siblings = &$tree;
-
-            foreach ($pathSegments as $pathSegment) {
-                if (!\array_key_exists($pathSegment, $siblings)) {
-                    $siblings[$pathSegment] = [
-                        'children' => [],
-                        'mandatory' => false,
-                        'schema' => null,
-                    ];
-                }
-
-                $node = &$siblings[$pathSegment];
-                $siblings = &$node['children'];
-            }
-
-            $node['mandatory'] = $property->isMandatory();
-            $node['schema'] = $property->toJsonSchema();
-
-            unset($node, $siblings);
-        }
-
-        return $tree;
-    }
-
-    /**
-     * @param array<string, array{children: array, mandatory: bool, schema: array|null}> $propertyTree
-     */
-    private function buildJsonSchema(array $propertyTree, bool $includeType): array
-    {
-        $jsonSchema = [];
         $properties = [];
         $required = [];
 
-        foreach ($propertyTree as $propertyName => $propertyNode) {
-            $propertySchema = $propertyNode['schema'];
+        /** @var array<string, PropertyMetadata[]> $nestedProperties */
+        $nestedProperties = [];
 
-            if (!empty($propertyNode['children'])) {
-                $propertySchema = \array_merge(
-                    $propertySchema ?? [],
-                    $this->buildJsonSchema($propertyNode['children'], true)
+        foreach ($this->properties as $property) {
+            $name = $property->getName();
+
+            // a name with a slash (e.g. "attributes/1") describes a nested property; the first segment is grouped
+            // and the rest is handled recursively, so it ends up as a nested object in the JSON schema
+            if (\str_contains($name, '/')) {
+                [$parent, $child] = \explode('/', $name, 2);
+                $nestedProperties[$parent][] = new PropertyMetadata(
+                    $child,
+                    $property->isMandatory(),
+                    $property->getSchemaMetadata()
                 );
+
+                continue;
             }
 
+            $propertySchema = $property->toJsonSchema();
             if ($propertySchema) {
-                $properties[$propertyName] = $propertySchema;
+                $properties[$name] = $propertySchema;
             }
 
-            if ($propertyNode['mandatory']) {
-                // cast to string because PHP coerces numeric property names (e.g. "1") to integer array keys,
-                // which would produce an invalid JSON schema (the "required" keyword only allows strings)
-                $required[] = (string) $propertyName;
+            if ($property->isMandatory()) {
+                $required[$name] = true;
             }
         }
+
+        foreach ($nestedProperties as $parent => $childProperties) {
+            $properties[$parent] = (new self($childProperties))->buildJsonSchema(true);
+        }
+
+        return $this->assembleJsonSchema($properties, $required, $includeType);
+    }
+
+    /**
+     * @param array<int|string, mixed> $properties
+     * @param array<int|string, bool> $required
+     *
+     * @return array<string, mixed>
+     */
+    private function assembleJsonSchema(array $properties, array $required, bool $includeType): array
+    {
+        $jsonSchema = [];
 
         if ($includeType && (!empty($properties) || !empty($required))) {
             $jsonSchema['type'] = 'object';
         }
 
         if (!empty($properties)) {
-            $jsonSchema['properties'] = $properties;
+            // cast to object because PHP coerces numeric property names (e.g. "0", "1") to a list, which json_encode
+            // would serialize as a JSON array although the "properties" keyword of a JSON schema requires an object
+            $jsonSchema['properties'] = \array_is_list($properties) ? (object) $properties : $properties;
         }
 
         if (!empty($required)) {
-            $jsonSchema['required'] = $required;
+            // cast to string because PHP coerces numeric property names to integer array keys, which would produce
+            // an invalid JSON schema (the "required" keyword only allows strings)
+            $jsonSchema['required'] = \array_map('\strval', \array_keys($required));
         }
 
         return $jsonSchema;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
@@ -48,8 +48,7 @@ class PropertiesMetadata implements SchemaMetadataInterface
         foreach ($this->properties as $property) {
             $name = $property->getName();
 
-            // a name with a slash (e.g. "attributes/1") describes a nested property; the first segment is grouped
-            // and the rest is handled recursively, so it ends up as a nested object in the JSON schema
+            // a slash in the name (e.g. "settings/title") denotes a nested object
             if (\str_contains($name, '/')) {
                 [$parent, $child] = \explode('/', $name, 2);
                 $nestedProperties[$parent][] = new PropertyMetadata(
@@ -96,14 +95,12 @@ class PropertiesMetadata implements SchemaMetadataInterface
         }
 
         if (!empty($properties)) {
-            // cast to object because PHP coerces numeric property names (e.g. "0", "1") to a list, which json_encode
-            // would serialize as a JSON array although the "properties" keyword of a JSON schema requires an object
+            // numeric names (e.g. "0", "1") form a PHP list, which json_encode would emit as a JSON array
             $jsonSchema['properties'] = \array_is_list($properties) ? (object) $properties : $properties;
         }
 
         if (!empty($required)) {
-            // cast to string because PHP coerces numeric property names to integer array keys, which would produce
-            // an invalid JSON schema (the "required" keyword only allows strings)
+            // PHP coerces numeric names to int keys, but "required" only allows strings
             $jsonSchema['required'] = \array_map('\strval', \array_keys($required));
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertiesMetadata.php
@@ -28,35 +28,79 @@ class PropertiesMetadata implements SchemaMetadataInterface
 
     public function toJsonSchema(): array
     {
-        $jsonSchema = [];
-        $properties = [];
+        return $this->buildJsonSchema($this->createPropertyTree(), false);
+    }
+
+    /**
+     * @return array<string, array{children: array, mandatory: bool, schema: array|null}>
+     */
+    private function createPropertyTree(): array
+    {
+        $tree = [];
 
         foreach ($this->properties as $property) {
-            $jsonSchemaProperty = $property->toJsonSchema();
-            if (!$jsonSchemaProperty) {
-                continue;
+            $pathSegments = \explode('/', $property->getName());
+            $siblings = &$tree;
+
+            foreach ($pathSegments as $pathSegment) {
+                if (!\array_key_exists($pathSegment, $siblings)) {
+                    $siblings[$pathSegment] = [
+                        'children' => [],
+                        'mandatory' => false,
+                        'schema' => null,
+                    ];
+                }
+
+                $node = &$siblings[$pathSegment];
+                $siblings = &$node['children'];
             }
 
-            $properties[$property->getName()] = $jsonSchemaProperty;
+            $node['mandatory'] = $property->isMandatory();
+            $node['schema'] = $property->toJsonSchema();
+
+            unset($node, $siblings);
+        }
+
+        return $tree;
+    }
+
+    /**
+     * @param array<string, array{children: array, mandatory: bool, schema: array|null}> $propertyTree
+     */
+    private function buildJsonSchema(array $propertyTree, bool $includeType): array
+    {
+        $jsonSchema = [];
+        $properties = [];
+        $required = [];
+
+        foreach ($propertyTree as $propertyName => $propertyNode) {
+            $propertySchema = $propertyNode['schema'];
+
+            if (!empty($propertyNode['children'])) {
+                $propertySchema = \array_merge(
+                    $propertySchema ?? [],
+                    $this->buildJsonSchema($propertyNode['children'], true)
+                );
+            }
+
+            if ($propertySchema) {
+                $properties[$propertyName] = $propertySchema;
+            }
+
+            if ($propertyNode['mandatory']) {
+                // cast to string because PHP coerces numeric property names (e.g. "1") to integer array keys,
+                // which would produce an invalid JSON schema (the "required" keyword only allows strings)
+                $required[] = (string) $propertyName;
+            }
+        }
+
+        if ($includeType && (!empty($properties) || !empty($required))) {
+            $jsonSchema['type'] = 'object';
         }
 
         if (!empty($properties)) {
             $jsonSchema['properties'] = $properties;
         }
-
-        $required = \array_values(
-            \array_map(
-                function(PropertyMetadata $propertyMetadata) {
-                    return $propertyMetadata->getName();
-                },
-                \array_filter(
-                    $this->properties,
-                    function(PropertyMetadata $propertyMetadata) {
-                        return $propertyMetadata->isMandatory();
-                    }
-                )
-            )
-        );
 
         if (!empty($required)) {
             $jsonSchema['required'] = $required;

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadata.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadata.php
@@ -45,6 +45,11 @@ class PropertyMetadata
         return $this->mandatory;
     }
 
+    public function getSchemaMetadata(): ?SchemaMetadataInterface
+    {
+        return $this->schemaMetadata;
+    }
+
     public function toJsonSchema(): ?array
     {
         if (null !== $this->schemaMetadata) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/Renderer.js
@@ -57,8 +57,11 @@ class Renderer extends React.Component<Props> {
         const {data, dataPath, errors, formInspector, onChange, onSuccess, router, showAllErrors, value} = this.props;
         const itemDataPath = dataPath + '/' + schemaKey;
 
-        const error = (showAllErrors || formInspector.isFieldModified(itemDataPath)) && errors && errors[schemaKey]
-            ? errors[schemaKey]
+        const schemaError = errors && jsonpointer.has(errors, '/' + schemaKey)
+            ? jsonpointer.get(errors, '/' + schemaKey)
+            : undefined;
+        const error = (showAllErrors || formInspector.isFieldModified(itemDataPath)) && schemaError
+            ? schemaError
             : undefined;
 
         return (

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -29,11 +29,34 @@ function deepMerge(base: Object, override: Object): Object {
     return result;
 }
 
+// json-pointer creates an array when the next path segment is numeric; this creates objects instead, so that a
+// property whose name contains a numeric segment (e.g. "attributes/1") is stored as a nested object matching its schema
+function setNestedProperty(data: Object, key: string, value: mixed) {
+    const tokens = key.split('/');
+    let current = data;
+
+    for (let i = 0; i < tokens.length - 1; i++) {
+        const token = tokens[i];
+
+        if (token === '__proto__' || token === 'constructor' || token === 'prototype') {
+            return;
+        }
+
+        if (typeof current[token] !== 'object' || current[token] === null) {
+            current[token] = {};
+        }
+
+        current = current[token];
+    }
+
+    current[tokens[tokens.length - 1]] = value;
+}
+
 function addSchemaProperties(data: Object, key: string, schema: Schema) {
     const type = schema[key].type;
 
     if (type !== SECTION_TYPE) {
-        jsonpointer.set(data, '/' + key, undefined);
+        setNestedProperty(data, key, undefined);
     }
 
     const items = schema[key].items;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/AbstractFormStore.js
@@ -29,8 +29,7 @@ function deepMerge(base: Object, override: Object): Object {
     return result;
 }
 
-// json-pointer creates an array when the next path segment is numeric; this creates objects instead, so that a
-// property whose name contains a numeric segment (e.g. "attributes/1") is stored as a nested object matching its schema
+// json-pointer creates an array when the next segment is numeric; the schema always expects an object
 function setNestedProperty(data: Object, key: string, value: mixed) {
     const tokens = key.split('/');
     let current = data;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js
@@ -498,6 +498,49 @@ test('Should pass all errors to fields if showAllErrors is set to true', () => {
     expect(fields.at(1).prop('error')).toBe(datetimeError);
 });
 
+test('Should pass nested errors to fields with slashes in schema keys', () => {
+    const schema = {
+        'attributes/1': {
+            label: 'Attribute',
+            type: 'text_line',
+        },
+    };
+
+    const attributeError = {
+        keyword: 'maximum',
+        parameters: {
+            limit: 10,
+        },
+    };
+    const errors = {
+        attributes: [
+            undefined,
+            attributeError,
+        ],
+    };
+
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('snippets'), 'snippets'));
+    formInspector.isFieldModified.mockImplementation((dataPath) => dataPath === '/attributes/1');
+
+    const renderer = shallow(
+        <Renderer
+            data={{}}
+            dataPath=""
+            errors={errors}
+            formInspector={formInspector}
+            onChange={jest.fn()}
+            onFieldFinish={jest.fn()}
+            onSuccess={undefined}
+            router={undefined}
+            schema={schema}
+            schemaPath=""
+            value={{}}
+        />
+    );
+
+    expect(renderer.find(Field).at(0).prop('error')).toBe(attributeError);
+});
+
 test('Should render nested sections', () => {
     const changeSpy = jest.fn();
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/MemoryFormStore.test.js
@@ -618,3 +618,21 @@ test('Forbidden flag should always be set to false', () => {
 
     expect(memoryFormStore.forbidden).toEqual(false);
 });
+
+test('Store slash-named properties with a numeric segment as nested objects and validate them', () => {
+    const schema = {'attributes/1': {label: 'Attribute', type: 'text_line'}};
+    const jsonSchema = {
+        type: 'object',
+        properties: {attributes: {type: 'object', properties: {'1': {maximum: 10, type: 'number'}}}},
+    };
+
+    const memoryFormStore = new MemoryFormStore({}, schema, jsonSchema);
+    memoryFormStore.change('/attributes/1', 999);
+
+    // must stay an object (not a json-pointer array) so it matches the "type: object" schema and is validated
+    expect(Array.isArray(memoryFormStore.data.attributes)).toEqual(false);
+    expect(memoryFormStore.validate()).toEqual(false);
+    expect(memoryFormStore.errors.attributes[1]).toEqual(
+        {keyword: 'maximum', parameters: {comparison: '<=', limit: 10}}
+    );
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/types.js
@@ -33,7 +33,8 @@ export type PropertyError = {
 
 export type BlockError = Array<?{[key: string]: Error}>;
 
-export type Error = BlockError | PropertyError;
+// nested errors are built from slash separated property names: objects, plus arrays for numeric segments (blocks)
+export type Error = PropertyError | ErrorCollection | Array<?Error>;
 
 export type ErrorCollection = {[key: string]: Error};
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_nested_schema.xml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/forms/form_with_nested_schema.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<form xmlns="http://schemas.sulu.io/template/template"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/form-1.0.xsd"
+>
+    <key>form_with_nested_schema</key>
+
+    <properties>
+        <property name="settings/title" type="text_line" mandatory="true"/>
+        <property name="settings/description" type="text_line"/>
+    </properties>
+</form>

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -53,6 +53,28 @@ class FormMetadataProviderTest extends KernelTestCase
         $this->assertCount(1, \array_keys($schema));
     }
 
+    public function testGetMetadataWithNestedPropertyNames(): void
+    {
+        $form = $this->formMetadataProvider->getMetadata('form_with_nested_schema', 'en');
+        $this->assertInstanceOf(FormMetadata::class, $form);
+
+        $schema = $form->getSchema()->toJsonSchema();
+
+        // a property name containing a "/" (e.g. "settings/title") is nested into an object instead of a literal key
+        $properties = $schema['properties'];
+        $this->assertIsArray($properties);
+
+        $settings = $properties['settings'];
+        $this->assertIsArray($settings);
+        $this->assertSame('object', $settings['type']);
+        $this->assertSame(['title'], $settings['required']);
+
+        $settingsProperties = $settings['properties'];
+        $this->assertIsArray($settingsProperties);
+        $this->assertArrayHasKey('title', $settingsProperties);
+        $this->assertArrayHasKey('description', $settingsProperties);
+    }
+
     public function testGetMetadataWithExpression(): void
     {
         $form = $this->formMetadataProvider->getMetadata(

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Metadata/FormMetadata/FormMetadataProviderTest.php
@@ -60,7 +60,6 @@ class FormMetadataProviderTest extends KernelTestCase
 
         $schema = $form->getSchema()->toJsonSchema();
 
-        // a property name containing a "/" (e.g. "settings/title") is nested into an object instead of a literal key
         $properties = $schema['properties'];
         $this->assertIsArray($properties);
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
@@ -12,10 +12,12 @@
 namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\SchemaMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ArrayMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ConstMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NumberMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
 
 class SchemaMetadataTest extends TestCase
 {
@@ -180,6 +182,49 @@ class SchemaMetadataTest extends TestCase
             '{"type":"object","properties":{"attributes":{"type":"object","properties":{
                 "0":{"minimum":0,"type":"number"},"1":{"maximum":10,"type":"number"}}}}}',
             (string) \json_encode($schema->toJsonSchema())
+        );
+    }
+
+    public function testNestedPropertyNamesKeepFieldConstraints(): void
+    {
+        $schema = new SchemaMetadata(
+            [
+                new PropertyMetadata('settings/text', false, new StringMetadata(3, 10)),
+                new PropertyMetadata('settings/number', false, new NumberMetadata(0.0, 100.0)),
+                new PropertyMetadata('settings/selection', false, new ArrayMetadata(new StringMetadata(), 1, 5)),
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                'properties' => [
+                    'settings' => [
+                        'properties' => [
+                            'text' => [
+                                'type' => 'string',
+                                'minLength' => 3,
+                                'maxLength' => 10,
+                            ],
+                            'number' => [
+                                'minimum' => 0.0,
+                                'maximum' => 100.0,
+                                'type' => 'number',
+                            ],
+                            'selection' => [
+                                'type' => 'array',
+                                'items' => [
+                                    'type' => 'string',
+                                ],
+                                'minItems' => 1,
+                                'maxItems' => 5,
+                            ],
+                        ],
+                        'type' => 'object',
+                    ],
+                ],
+                'type' => 'object',
+            ],
+            $schema->toJsonSchema()
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
@@ -165,9 +165,7 @@ class SchemaMetadataTest extends TestCase
     }
 
     /**
-     * PHP coerces numeric-string array keys to integers, so a zero-based group of segments forms a list which
-     * json_encode would serialize as a JSON array. This can only be caught on the encoded JSON, because the coercion
-     * already happens when the expected array literal is created.
+     * Asserted on the encoded JSON because the key coercion already happens in the expected array literal.
      */
     public function testNestedNumericPropertyNamesEncodeAsObject(): void
     {
@@ -186,9 +184,7 @@ class SchemaMetadataTest extends TestCase
     }
 
     /**
-     * A field type without a registered PropertyMetadataMapper has no schema metadata, so a group whose children all
-     * lack one has nothing to validate and has to be omitted like a flat property is. An empty group would encode as
-     * "options":[] - a JSON array where the "properties" keyword requires a schema object.
+     * Field types without a PropertyMetadataMapper have no schema, and an empty group would encode as "options":[].
      */
     public function testNestedPropertyNamesWithoutSchemaAreOmitted(): void
     {

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\SchemaMetadata;
 
 use PHPUnit\Framework\TestCase;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ConstMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NumberMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
 
@@ -119,6 +120,39 @@ class SchemaMetadataTest extends TestCase
                     ],
                     [
                         'required' => ['article'],
+                        'type' => 'object',
+                    ],
+                ],
+                'type' => 'object',
+            ],
+            $schema->toJsonSchema()
+        );
+    }
+
+    public function testNestedPropertyNames(): void
+    {
+        $schema = new SchemaMetadata(
+            [
+                new PropertyMetadata('attributes/1', false, new NumberMetadata(null, 10.0)),
+                new PropertyMetadata('attributes/2', true, new NumberMetadata(0.0)),
+            ]
+        );
+
+        $this->assertEquals(
+            [
+                'properties' => [
+                    'attributes' => [
+                        'properties' => [
+                            '1' => [
+                                'maximum' => 10.0,
+                                'type' => 'number',
+                            ],
+                            '2' => [
+                                'minimum' => 0.0,
+                                'type' => 'number',
+                            ],
+                        ],
+                        'required' => ['2'],
                         'type' => 'object',
                     ],
                 ],

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
@@ -161,4 +161,25 @@ class SchemaMetadataTest extends TestCase
             $schema->toJsonSchema()
         );
     }
+
+    /**
+     * PHP coerces numeric-string array keys to integers, so a zero-based group of segments forms a list which
+     * json_encode would serialize as a JSON array. This can only be caught on the encoded JSON, because the coercion
+     * already happens when the expected array literal is created.
+     */
+    public function testNestedNumericPropertyNamesEncodeAsObject(): void
+    {
+        $schema = new SchemaMetadata(
+            [
+                new PropertyMetadata('attributes/0', false, new NumberMetadata(0.0)),
+                new PropertyMetadata('attributes/1', false, new NumberMetadata(null, 10.0)),
+            ]
+        );
+
+        $this->assertJsonStringEqualsJsonString(
+            '{"type":"object","properties":{"attributes":{"type":"object","properties":{
+                "0":{"minimum":0,"type":"number"},"1":{"maximum":10,"type":"number"}}}}}',
+            (string) \json_encode($schema->toJsonSchema())
+        );
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/SchemaMetadataTest.php
@@ -185,6 +185,27 @@ class SchemaMetadataTest extends TestCase
         );
     }
 
+    /**
+     * A field type without a registered PropertyMetadataMapper has no schema metadata, so a group whose children all
+     * lack one has nothing to validate and has to be omitted like a flat property is. An empty group would encode as
+     * "options":[] - a JSON array where the "properties" keyword requires a schema object.
+     */
+    public function testNestedPropertyNamesWithoutSchemaAreOmitted(): void
+    {
+        $schema = new SchemaMetadata(
+            [
+                new PropertyMetadata('title', false, new StringMetadata()),
+                new PropertyMetadata('options/flag', false),
+                new PropertyMetadata('options/note', false),
+            ]
+        );
+
+        $this->assertJsonStringEqualsJsonString(
+            '{"type":"object","properties":{"title":{"type":"string"}}}',
+            (string) \json_encode($schema->toJsonSchema())
+        );
+    }
+
     public function testNestedPropertyNamesKeepFieldConstraints(): void
     {
         $schema = new SchemaMetadata(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

A property name containing a slash such as seo/title now produces a nested object in the generated JSON schema instead of a literal key, because PropertiesMetadata groups each name by its first segment and builds the nested properties recursively. A group whose children have no schema is omitted so that it cannot encode as an empty JSON array, which ajv rejects when it compiles the schema. On the JavaScript side Renderer resolves field errors with jsonpointer and AbstractFormStore stores the data as nested objects rather than the arrays jsonpointer creates for numeric segments. The exported Error type is widened to cover that nested shape.

#### Why?

Form fields whose name contains a slash already used jsonpointer to look up their value, but the schema generation and the error lookup still treated the name as a flat key. Validation errors for those fields were written to a nested path and never reached the field, so they were silently dropped. This affects every shipped form that groups fields under a prefix. The SEO and Excerpt tabs of pages and articles are the main examples.