### PR TITLE
Fix target webspace in RouteGenerator

### DIFF
--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageLinkProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageLinkProviderTest.php
@@ -128,4 +128,54 @@ class PageLinkProviderTest extends SuluTestCase
         $this->assertSame('Internal Link Page', $linksByUuid[$internalPage->getUuid()]->getTitle());
         $this->assertSame('http://sulu.io/en/link-target', $linksByUuid[$internalPage->getUuid()]->getUrl());
     }
+
+    public function testPreloadWithCrossWebspaceContentLink(): void
+    {
+        // current request is handled in the context of the "sulu-io" webspace (see setUp)
+
+        // Create target page in a *different* webspace ("blog" => blog.io)
+        $targetPage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Blog Target Page',
+                    'url' => '/blog-target',
+                    'template' => 'default',
+                ],
+            ],
+        ], 'blog');
+
+        // Internal link page lives in "sulu-io" but points to the page in the "blog" webspace
+        $internalPage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Cross Webspace Link Page',
+                    'url' => '/cross-webspace-link',
+                    'template' => 'default',
+                    'linkOn' => true,
+                    'linkData' => [
+                        'href' => $targetPage->getUuid(),
+                        'provider' => 'page',
+                    ],
+                ],
+            ],
+        ]);
+
+        $links = $this->linkProvider->preload(
+            [$internalPage->getUuid()],
+            'en',
+            true
+        );
+
+        $this->assertCount(1, $links);
+
+        $linksByUuid = [];
+        foreach ($links as $link) {
+            $linksByUuid[$link->getId()] = $link;
+        }
+
+        // The url must target the "blog" webspace (blog.io), not the current request's "sulu-io"
+        $this->assertArrayHasKey($internalPage->getUuid(), $linksByUuid);
+        $this->assertSame('Cross Webspace Link Page', $linksByUuid[$internalPage->getUuid()]->getTitle());
+        $this->assertSame('http://blog.io/en/blog-target', $linksByUuid[$internalPage->getUuid()]->getUrl());
+    }
 }

--- a/packages/route/src/Application/Routing/Generator/RouteGenerator.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGenerator.php
@@ -64,7 +64,16 @@ final class RouteGenerator implements RouteGeneratorInterface
 
         \assert($webspaceRouteGenerator instanceof WebspaceRouteGeneratorInterface, 'The WebspaceRouteGenerator for "' . $webspace . '" must implement WebspaceRouteGeneratorInterface but got: ' . \get_debug_type($webspaceRouteGenerator));
 
-        $generatedUrl = $webspaceRouteGenerator->generate($this->requestContext, $slug, $locale);
+        // propagate the resolved target webspace to the generator via the request context so that
+        // cross-webspace urls are generated for the requested webspace instead of the current request's one
+        $previousWebspace = $this->requestContext->getParameter(RequestAttributeEnum::WEBSPACE->value);
+        $this->requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, $webspace);
+
+        try {
+            $generatedUrl = $webspaceRouteGenerator->generate($this->requestContext, $slug, $locale);
+        } finally {
+            $this->requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, $previousWebspace);
+        }
 
         $schemeAndHttpHost = \sprintf(
             '%s://%s%s/',

--- a/packages/route/src/Application/Routing/Generator/RouteGenerator.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGenerator.php
@@ -65,14 +65,16 @@ final class RouteGenerator implements RouteGeneratorInterface
         \assert($webspaceRouteGenerator instanceof WebspaceRouteGeneratorInterface, 'The WebspaceRouteGenerator for "' . $webspace . '" must implement WebspaceRouteGeneratorInterface but got: ' . \get_debug_type($webspaceRouteGenerator));
 
         // propagate the resolved target webspace to the generator via the request context so that
-        // cross-webspace urls are generated for the requested webspace instead of the current request's one
-        $previousWebspace = $this->requestContext->getParameter(RequestAttributeEnum::WEBSPACE->value);
+        // cross-webspace urls are generated for the requested webspace instead of the current request's one.
+        // snapshot and restore the whole parameters array so both the value and the presence of the
+        // webspace parameter are restored (a key set to null still counts as present for hasParameter()).
+        $previousParameters = $this->requestContext->getParameters();
         $this->requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, $webspace);
 
         try {
             $generatedUrl = $webspaceRouteGenerator->generate($this->requestContext, $slug, $locale);
         } finally {
-            $this->requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, $previousWebspace);
+            $this->requestContext->setParameters($previousParameters);
         }
 
         $schemeAndHttpHost = \sprintf(

--- a/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
@@ -174,10 +174,13 @@ class RouteGeneratorTest extends TestCase
 
     public function testGenerateRestoresMissingWebspaceParameter(): void
     {
+        // the webspace parameter is absent before generation and must stay absent afterwards
+        $this->assertFalse($this->requestContext->hasParameter('webspace'));
+
         $result = $this->routeGenerator->generate('/test', 'en', 'webspace-b');
 
         $this->assertSame('https://example.org/webspace-b/en/test', $result);
-        $this->assertNull($this->requestContext->getParameter('webspace'));
+        $this->assertFalse($this->requestContext->hasParameter('webspace'));
     }
 
     public function testGenerateRequestContextLocaleMissing(): void

--- a/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Generator/RouteGeneratorTest.php
@@ -63,6 +63,23 @@ class RouteGeneratorTest extends TestCase
             }
         });
 
+        // mirrors the real PageWebspaceRouteGenerator which resolves the webspace from the
+        // request context, so the target webspace becomes observable in the generated url
+        $container->set('.default', new class() implements WebspaceRouteGeneratorInterface {
+            public function generate(RequestContext $requestContext, string $slug, string $locale): string
+            {
+                $webspace = $requestContext->getParameter('webspace');
+                \assert(\is_string($webspace));
+
+                return \sprintf(
+                    'https://example.org/%s/%s%s',
+                    $webspace,
+                    $locale,
+                    $slug,
+                );
+            }
+        });
+
         $this->requestContext = new RequestContext();
         $this->routeGenerator = new RouteGenerator($container, $this->requestContext, new RequestStack(), new LocaleSwitcher('en', [], $this->requestContext));
     }
@@ -139,6 +156,28 @@ class RouteGeneratorTest extends TestCase
 
         $result = $this->routeGenerator->generate('/test', 'en', null);
         $this->assertSame('/en/test', $result);
+    }
+
+    public function testGenerateUsesTargetWebspaceForDefaultGenerator(): void
+    {
+        // simulate a request handled in the context of "webspace-a"
+        $this->requestContext->setParameter('webspace', 'webspace-a');
+
+        // generate a route for a resource of a different target webspace "webspace-b"
+        $result = $this->routeGenerator->generate('/test', 'en', 'webspace-b');
+
+        $this->assertSame('https://example.org/webspace-b/en/test', $result);
+
+        // the current request's webspace must be restored after generation
+        $this->assertSame('webspace-a', $this->requestContext->getParameter('webspace'));
+    }
+
+    public function testGenerateRestoresMissingWebspaceParameter(): void
+    {
+        $result = $this->routeGenerator->generate('/test', 'en', 'webspace-b');
+
+        $this->assertSame('https://example.org/webspace-b/en/test', $result);
+        $this->assertNull($this->requestContext->getParameter('webspace'));
     }
 
     public function testGenerateRequestContextLocaleMissing(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8899, #8857
| Related issues/PRs | #8899
| License | MIT
| Documentation PR | -

#### What's in this PR?

`RouteGenerator::generate()` now propagates the resolved target `$webspace` to the URL generation step. Before delegating to the `WebspaceRouteGenerator`, the resolved webspace is set on the `RequestContext` (`RequestAttributeEnum::WEBSPACE`) for the duration of the generation and the previous value is restored afterwards in a `finally` block.

This requires no interface or signature change (no BC break): `PageWebspaceRouteGenerator` already reads the webspace from the `RequestContext`, so it now resolves the requested target webspace.

Added test coverage:
- Unit (`RouteGeneratorTest`): generating a route for a target webspace different from the current request's webspace produces a URL for the target webspace, and the request context webspace is restored afterwards.
- Functional (`PageLinkProviderTest`): a cross-webspace internal link (link page in `sulu-io` pointing to a page in `blog`) now resolves to the target webspace's URL (`http://blog.io/...`).

#### Why?

`RouteGenerator::generate()` accepts an explicit `$webspace` argument, but that argument was not honored when the URL was actually built. Because the webspace route generators are registered under the `.default` key (not one per webspace), the same generator was always selected, and only the `RequestContext` was passed down — never the resolved target webspace. As a result `PageWebspaceRouteGenerator` always used the **current request's** webspace.

Concrete symptom: an internal link in the editor pointing to a page in another webspace was generated against the current webspace, producing a broken URL. See #8899 for the full trace.