### PR TITLE
Set canonical URL to main webspace for articles served through additional webspaces

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Route/ArticleRouteDefaultsProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Route/ArticleRouteDefaultsProvider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Route;
 
+use Sulu\Article\Domain\Model\ArticleDimensionContent;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\CacheLifetimeMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
@@ -21,13 +22,19 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeRequestStore;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolverInterface;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Exception\ContentNotFoundException;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Application\Routing\Matcher\RouteDefaultsProviderInterface;
+use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
 use Sulu\Route\Domain\Model\Route;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @internal this class is internal and should not be extended or relied on in custom code
@@ -39,6 +46,8 @@ class ArticleRouteDefaultsProvider implements RouteDefaultsProviderInterface
         private ContentAggregatorInterface $contentAggregator,
         private MetadataProviderRegistry $metadataProviderRegistry,
         private CacheLifetimeResolverInterface $cacheLifetimeResolver,
+        private RouteGeneratorInterface $routeGenerator,
+        private RequestStack $requestStack,
     ) {
     }
 
@@ -96,12 +105,66 @@ class ArticleRouteDefaultsProvider implements RouteDefaultsProviderInterface
             '_controller' => $templateMetadata->getController(),
         ];
 
+        $canonicalUrl = $this->resolveAdditionalWebspaceCanonicalUrl($route, $dimensionContent);
+        if (null !== $canonicalUrl) {
+            $defaults['_seo'] = ['canonicalUrl' => $canonicalUrl];
+        }
+
         $cacheLifetime = $this->getCacheLifetime($templateMetadata);
         if (null !== $cacheLifetime) {
             $defaults[CacheLifetimeRequestStore::ATTRIBUTE_KEY] = $cacheLifetime;
         }
 
         return $defaults;
+    }
+
+    /**
+     * When an article is served through one of its additional webspaces, the canonical URL should point
+     * to the article URL of its main webspace.
+     */
+    private function resolveAdditionalWebspaceCanonicalUrl(Route $route, ArticleDimensionContent $dimensionContent): ?string
+    {
+        $mainWebspace = $dimensionContent->getMainWebspace();
+        if (null === $mainWebspace) {
+            return null;
+        }
+
+        $requestWebspace = $this->getRequestWebspaceKey();
+        if (null === $requestWebspace || $requestWebspace === $mainWebspace) {
+            return null;
+        }
+
+        if (!\in_array($requestWebspace, $dimensionContent->getAdditionalWebspaces(), true)) {
+            return null;
+        }
+
+        try {
+            return $this->routeGenerator->generate(
+                $route->getSlug(),
+                $route->getLocale(),
+                $mainWebspace,
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            );
+        } catch (MissingRequestContextParameterException) {
+            return null;
+        }
+    }
+
+    private function getRequestWebspaceKey(): ?string
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return null;
+        }
+
+        $suluAttribute = $request->attributes->get('_sulu');
+        if (!$suluAttribute instanceof RequestAttributes) {
+            return null;
+        }
+
+        $webspace = $suluAttribute->getAttribute('webspace');
+
+        return $webspace instanceof Webspace ? $webspace->getKey() : null;
     }
 
     private function getCacheLifetime(TemplateMetadata $templateMetadata): ?int

--- a/packages/article/src/Infrastructure/Sulu/Route/ArticleRouteDefaultsProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Route/ArticleRouteDefaultsProvider.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Route;
 
-use Sulu\Article\Domain\Model\ArticleDimensionContent;
+use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\CacheLifetimeMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
@@ -122,7 +122,7 @@ class ArticleRouteDefaultsProvider implements RouteDefaultsProviderInterface
      * When an article is served through one of its additional webspaces, the canonical URL should point
      * to the article URL of its main webspace.
      */
-    private function resolveAdditionalWebspaceCanonicalUrl(Route $route, ArticleDimensionContent $dimensionContent): ?string
+    private function resolveAdditionalWebspaceCanonicalUrl(Route $route, ArticleDimensionContentInterface $dimensionContent): ?string
     {
         $mainWebspace = $dimensionContent->getMainWebspace();
         if (null === $mainWebspace) {

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -458,6 +458,8 @@ final class SuluArticleBundle extends AbstractBundle
                 new Reference('sulu_content.content_aggregator'),
                 new Reference('sulu_admin.metadata_provider_registry'),
                 new Reference('sulu_http_cache.cache_lifetime.resolver'),
+                new Reference('sulu_route.route_generator'),
+                new Reference('request_stack'),
             ])
             ->tag('sulu_route.route_defaults_provider', ['resource_key' => 'articles']);
 

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Route/ArticleRouteDefaultsProviderTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Route/ArticleRouteDefaultsProviderTest.php
@@ -27,12 +27,18 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TemplateMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeResolver;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
 use Sulu\Route\Application\Routing\Matcher\RouteDefaultsProviderInterface;
 use Sulu\Route\Domain\Model\Route;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ArticleRouteDefaultsProviderTest extends TestCase
 {
@@ -46,6 +52,9 @@ class ArticleRouteDefaultsProviderTest extends TestCase
     private CacheLifetimeResolver $cacheLifetimeResolver;
     /** @var ObjectProphecy<FormMetadataProvider> */
     private ObjectProphecy $formMetadataProvider;
+    /** @var ObjectProphecy<RouteGeneratorInterface> */
+    private ObjectProphecy $routeGenerator;
+    private RequestStack $requestStack;
 
     protected function setUp(): void
     {
@@ -56,6 +65,8 @@ class ArticleRouteDefaultsProviderTest extends TestCase
         $container = new Container();
         $container->set('form', $this->formMetadataProvider->reveal());
         $this->metadataProviderRegistry = new MetadataProviderRegistry($container);
+        $this->routeGenerator = $this->prophesize(RouteGeneratorInterface::class);
+        $this->requestStack = new RequestStack();
     }
 
     protected function getArticleRouteDefaultsProviderInstance(): RouteDefaultsProviderInterface
@@ -65,7 +76,20 @@ class ArticleRouteDefaultsProviderTest extends TestCase
             $this->contentAggregator->reveal(),
             $this->metadataProviderRegistry,
             $this->cacheLifetimeResolver,
+            $this->routeGenerator->reveal(),
+            $this->requestStack,
         );
+    }
+
+    private function pushRequestWithWebspace(string $webspaceKey): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey($webspaceKey);
+
+        $request = new Request();
+        $request->attributes->set('_sulu', new RequestAttributes(['webspace' => $webspace]));
+
+        $this->requestStack->push($request);
     }
 
     public function testGetDefaults(): void
@@ -187,6 +211,112 @@ class ArticleRouteDefaultsProviderTest extends TestCase
         $this->assertSame($resolvedDimensionContent, $result['object']);
         $this->assertSame('article.html.twig', $result['view']);
         $this->assertSame('ArticleController::indexAction', $result['_controller']);
+    }
+
+    public function testGetDefaultsSetsCanonicalUrlWhenServedThroughAdditionalWebspace(): void
+    {
+        $provider = $this->getArticleRouteDefaultsProviderInstance();
+
+        $locale = 'en';
+        $slug = '/test-article';
+
+        $article = new Article('123-123-123');
+        $resolvedDimensionContent = new ArticleDimensionContent($article);
+        $resolvedDimensionContent->setLocale($locale);
+        $resolvedDimensionContent->setTemplateKey('default');
+        $resolvedDimensionContent->setMainWebspace('sulu-io');
+        $resolvedDimensionContent->setAdditionalWebspaces(['blog']);
+
+        $this->prepareArticle($article, $resolvedDimensionContent, $locale);
+        $this->prepareTemplateMetadata('ArticleController::indexAction', 'article.html.twig', 'seconds', '3600');
+
+        $this->pushRequestWithWebspace('blog');
+
+        $this->routeGenerator->generate($slug, $locale, 'sulu-io', UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://sulu.io/test-article')
+            ->shouldBeCalled();
+
+        $result = $provider->getDefaults(new Route(Article::RESOURCE_KEY, '123-123-123', $locale, $slug));
+
+        $this->assertSame(['canonicalUrl' => 'https://sulu.io/test-article'], $result['_seo']);
+    }
+
+    public function testGetDefaultsDoesNotSetCanonicalUrlWhenServedThroughMainWebspace(): void
+    {
+        $provider = $this->getArticleRouteDefaultsProviderInstance();
+
+        $locale = 'en';
+        $slug = '/test-article';
+
+        $article = new Article('123-123-123');
+        $resolvedDimensionContent = new ArticleDimensionContent($article);
+        $resolvedDimensionContent->setLocale($locale);
+        $resolvedDimensionContent->setTemplateKey('default');
+        $resolvedDimensionContent->setMainWebspace('sulu-io');
+        $resolvedDimensionContent->setAdditionalWebspaces(['blog']);
+
+        $this->prepareArticle($article, $resolvedDimensionContent, $locale);
+        $this->prepareTemplateMetadata('ArticleController::indexAction', 'article.html.twig', 'seconds', '3600');
+
+        $this->pushRequestWithWebspace('sulu-io');
+
+        $this->routeGenerator->generate(Argument::cetera())->shouldNotBeCalled();
+
+        $result = $provider->getDefaults(new Route(Article::RESOURCE_KEY, '123-123-123', $locale, $slug));
+
+        $this->assertArrayNotHasKey('_seo', $result);
+    }
+
+    public function testGetDefaultsDoesNotSetCanonicalUrlForUnrelatedWebspace(): void
+    {
+        $provider = $this->getArticleRouteDefaultsProviderInstance();
+
+        $locale = 'en';
+        $slug = '/test-article';
+
+        $article = new Article('123-123-123');
+        $resolvedDimensionContent = new ArticleDimensionContent($article);
+        $resolvedDimensionContent->setLocale($locale);
+        $resolvedDimensionContent->setTemplateKey('default');
+        $resolvedDimensionContent->setMainWebspace('sulu-io');
+        $resolvedDimensionContent->setAdditionalWebspaces(['blog']);
+
+        $this->prepareArticle($article, $resolvedDimensionContent, $locale);
+        $this->prepareTemplateMetadata('ArticleController::indexAction', 'article.html.twig', 'seconds', '3600');
+
+        $this->pushRequestWithWebspace('unrelated');
+
+        $this->routeGenerator->generate(Argument::cetera())->shouldNotBeCalled();
+
+        $result = $provider->getDefaults(new Route(Article::RESOURCE_KEY, '123-123-123', $locale, $slug));
+
+        $this->assertArrayNotHasKey('_seo', $result);
+    }
+
+    private function prepareArticle(Article $article, ArticleDimensionContent $dimensionContent, string $routeLocale): void
+    {
+        $this->articleRepository->findOneBy(
+            [
+                'uuid' => $article->getUuid(),
+            ],
+            [
+                ArticleRepositoryInterface::SELECT_ARTICLE_CONTENT => [
+                    'dimensionAttributes' => [
+                        'locale' => $routeLocale,
+                        'stage' => DimensionContentInterface::STAGE_LIVE,
+                        'version' => DimensionContentInterface::CURRENT_VERSION,
+                    ],
+                    'selects' => [
+                        DimensionContentQueryEnhancer::SELECT_EXCERPT_TAGS => true,
+                        DimensionContentQueryEnhancer::SELECT_EXCERPT_CATEGORIES => true,
+                        DimensionContentQueryEnhancer::SELECT_EXCERPT_CATEGORIES_TRANSLATION => true,
+                    ],
+                ],
+            ]
+        )->willReturn($article);
+
+        $this->contentAggregator->aggregate($article, ['locale' => $routeLocale, 'stage' => 'live', 'version' => 0])
+            ->willReturn($dimensionContent);
     }
 
     private function prepareTemplateMetadata(


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8746
| Related issues/PRs | #8746
| License | MIT
| Documentation PR | -

#### What's in this PR?

When an article has a main webspace and additional webspaces and is opened through an **additional** webspace URL, the `ArticleRouteDefaultsProvider` now exposes the article URL of the **main** webspace as the `_seo` canonical URL. The SEO Twig extension already merges `_seo` from the request attributes, so the rendered `<link rel="canonical">` points to the main webspace.

This mirrors the behavior of the `ArticleRouteEnhancer` from the 2.x `SuluArticleBundle`, which was not ported to the new 3.x article architecture.

#### Why?

As reported in #8746, opening an article through one of its additional webspaces rendered a canonical tag pointing to the additional webspace URL itself, instead of the main webspace article URL. This is harmful for SEO (duplicate content).

The canonical is only set when:
- the content is an article with a main webspace, and
- the current request webspace is one of the article's additional webspaces.

The main webspace, preview and cache-warmup paths are left untouched.

#### Example Usage

1. Create a project with 2 webspaces (e.g. `sulu-io` and `blog`).
2. Create an article with main webspace `sulu-io` and additional webspace `blog`.
3. Open the article through the `blog` URL.
4. The canonical tag now points to the `sulu-io` article URL.

#### Tests

Extended `ArticleRouteDefaultsProviderTest` with three cases: canonical set when served through an additional webspace, and not set when served through the main webspace or an unrelated webspace.
