### PR TITLE
Return external url in PageLinkProvider for external link pages

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Markup/Link/PageLinkProvider.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderInterface;
 use Sulu\Bundle\PageBundle\Admin\PageAdmin;
+use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Repository\Content;
 use Sulu\Component\Content\Repository\ContentRepositoryInterface;
 use Sulu\Component\Content\Repository\Mapping\MappingBuilder;
@@ -68,7 +69,7 @@ class PageLinkProvider implements LinkProviderInterface
             $locale,
             MappingBuilder::create()
                 ->setResolveUrl(true)
-                ->addProperties(['title', 'published'])
+                ->addProperties(['title', 'published', 'external'])
                 ->setOnlyPublished($published)
                 ->setHydrateGhost(false)
                 ->getMapping()
@@ -114,14 +115,19 @@ class PageLinkProvider implements LinkProviderInterface
     protected function getLinkItem(Content $content, $locale, $scheme, $domain = null)
     {
         $published = !empty($content->getPropertyWithDefault('published'));
-        $url = $this->webspaceManager->findUrlByResourceLocator(
-            $content->getUrl(),
-            $this->environment,
-            $locale,
-            $content->getWebspaceKey(),
-            $domain,
-            $scheme
-        );
+
+        if (RedirectType::EXTERNAL === $content->getNodeType()) {
+            $url = $content->getPropertyWithDefault('external');
+        } else {
+            $url = $this->webspaceManager->findUrlByResourceLocator(
+                $content->getUrl(),
+                $this->environment,
+                $locale,
+                $content->getWebspaceKey(),
+                $domain,
+                $scheme
+            );
+        }
 
         return new LinkItem($content->getId(), $content->getPropertyWithDefault('title'), $url, $published);
     }

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Markup/Link/PageLinkProviderTest.php
@@ -20,6 +20,7 @@ use Sulu\Bundle\MarkupBundle\Markup\Link\LinkConfigurationBuilder;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\PageBundle\Markup\Link\PageLinkProvider;
 use Sulu\Bundle\SecurityBundle\Entity\User;
+use Sulu\Component\Content\Document\RedirectType;
 use Sulu\Component\Content\Repository\Content;
 use Sulu\Component\Content\Repository\ContentRepositoryInterface;
 use Sulu\Component\Content\Repository\Mapping\MappingInterface;
@@ -163,7 +164,7 @@ class PageLinkProviderTest extends TestCase
                     return $mapping->resolveUrl()
                         && !$mapping->shouldHydrateGhost()
                         && $mapping->onlyPublished()
-                        && ['title', 'published'] === $mapping->getProperties();
+                        && ['title', 'published', 'external'] === $mapping->getProperties();
                 }
             )
         )->shouldBeCalledTimes(1)->willReturn($contents);
@@ -189,6 +190,48 @@ class PageLinkProviderTest extends TestCase
         $this->assertEquals(!empty($contents[2]->getPropertyWithDefault('published')), $result[2]->isPublished());
     }
 
+    public function testPreloadExternalLink(): void
+    {
+        $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
+        $this->webspaceManager->findWebspaceByKey('sulu_io')->willReturn(new Webspace());
+
+        $contents = [
+            $this->createContent(
+                1,
+                'External page',
+                '/external-page',
+                null,
+                'sulu.io',
+                'sulu_io',
+                [],
+                RedirectType::EXTERNAL,
+                'https://example.com',
+            ),
+        ];
+
+        $this->contentRepository->findByUuids(
+            [1],
+            $this->locale,
+            Argument::that(
+                function(MappingInterface $mapping) {
+                    return $mapping->resolveUrl()
+                        && !$mapping->shouldHydrateGhost()
+                        && $mapping->onlyPublished()
+                        && ['title', 'published', 'external'] === $mapping->getProperties();
+                }
+            )
+        )->shouldBeCalledTimes(1)->willReturn($contents);
+
+        /** @var LinkItem[] $result */
+        $result = $this->pageLinkProvider->preload([1], $this->locale, true);
+
+        $this->assertCount(1, $result);
+
+        // the external url must be used instead of the resolved resource locator
+        $this->assertEquals('https://example.com', $result[0]->getUrl());
+        $this->assertEquals('External page', $result[0]->getTitle());
+    }
+
     public function testPreloadRemoved(): void
     {
         $this->requestStack->getCurrentRequest()->willReturn($this->request->reveal());
@@ -207,7 +250,7 @@ class PageLinkProviderTest extends TestCase
                     return $mapping->resolveUrl()
                         && !$mapping->shouldHydrateGhost()
                         && $mapping->onlyPublished()
-                        && ['title', 'published'] === $mapping->getProperties();
+                        && ['title', 'published', 'external'] === $mapping->getProperties();
                 }
             )
         )->shouldBeCalledTimes(1)->willReturn($contents);
@@ -245,7 +288,7 @@ class PageLinkProviderTest extends TestCase
                     return $mapping->resolveUrl()
                     && !$mapping->shouldHydrateGhost()
                     && $mapping->onlyPublished()
-                    && ['title', 'published'] === $mapping->getProperties();
+                    && ['title', 'published', 'external'] === $mapping->getProperties();
                 }
             )
         )->shouldBeCalledTimes(1)->willReturn($contents);
@@ -312,7 +355,7 @@ class PageLinkProviderTest extends TestCase
                     return $mapping->resolveUrl()
                         && !$mapping->shouldHydrateGhost()
                         && $mapping->onlyPublished()
-                        && ['title', 'published'] === $mapping->getProperties();
+                        && ['title', 'published', 'external'] === $mapping->getProperties();
                 }
             )
         )->shouldBeCalledTimes(1)->willReturn($contents);
@@ -376,7 +419,7 @@ class PageLinkProviderTest extends TestCase
                     return $mapping->resolveUrl()
                         && !$mapping->shouldHydrateGhost()
                         && $mapping->onlyPublished()
-                        && ['title', 'published'] === $mapping->getProperties();
+                        && ['title', 'published', 'external'] === $mapping->getProperties();
                 }
             )
         )->shouldBeCalledTimes(1)->willReturn($contents);
@@ -408,7 +451,9 @@ class PageLinkProviderTest extends TestCase
         $published = null,
         $domain = 'sulu.io',
         $webspaceKey = 'sulu_io',
-        $permissions = []
+        $permissions = [],
+        $nodeType = RedirectType::NONE,
+        $external = null
     ) {
         $content = $this->prophesize(Content::class);
         $content->getId()->willReturn($id);
@@ -416,8 +461,10 @@ class PageLinkProviderTest extends TestCase
         $content->getLocale()->willReturn($this->locale);
         $content->getPermissions()->willReturn($permissions);
         $content->getWebspaceKey()->willReturn($webspaceKey);
+        $content->getNodeType()->willReturn($nodeType);
         $content->getPropertyWithDefault('title', null)->willReturn($title);
         $content->getPropertyWithDefault('published', null)->willReturn($published);
+        $content->getPropertyWithDefault('external', null)->willReturn($external);
 
         $this->webspaceManager->findUrlByResourceLocator(
             $url,


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8248
| Related issues/PRs | #8248
| License | MIT
| Documentation PR | -

#### What's in this PR?

`PageLinkProvider` now returns the external URL when the linked page is of redirect type `EXTERNAL`.

#### Why?

As reported in #8248, linking (via the `link` content type) to a page configured as an **external link** returned the wrong URL: `PageLinkProvider::getLinkItem()` always resolved the URL from the page's resource locator via `findUrlByResourceLocator()`, ignoring the external redirect target.

The fix loads the `external` property (the `redirectExternal` field) in the preload mapping and, when `getNodeType() === RedirectType::EXTERNAL`, returns that external URL instead of the resolved resource locator. Internal-link pages are unaffected (they are already resolved through `followInternalLink`, which is enabled by default), and regular pages keep the existing behavior.

#### Example Usage

1. Create a page "documentation" configured as an external link to `https://example.com`.
2. Link this page through the `link` content type on another page.
3. The rendered link now points to `https://example.com` instead of the documentation page's internal resource locator.

#### Tests

Extended `PageLinkProviderTest` with `testPreloadExternalLink` asserting the external URL is returned for `RedirectType::EXTERNAL` pages.
