### PR TITLE
Fix article list ghost locale handing

### DIFF
--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -324,6 +324,27 @@ class ArticleControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testCgetGhostLocale(string $id): void
+    {
+        // The article from testPost only exists in `en`. Listing in `de` must still return it as a ghost.
+        // The `templates` parameter reproduces what ArticleAdmin always sends for its list views (it filters
+        // the list by the group's templates), which is what triggers the ghost-row regression.
+        $this->client->request('GET', '/admin/api/articles?locale=de&templates=article&fields=id,title,ghostLocale');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($content);
+        /** @var array<int, array<string, mixed>> $articles */
+        $articles = $content['_embedded']['articles'] ?? [];
+
+        $this->assertCount(1, $articles, 'The ghost article must be listed in a locale without translation.');
+        $this->assertSame($id, $articles[0]['id'] ?? null);
+        $this->assertSame('en', $articles[0]['ghostLocale'] ?? null);
+        $this->assertSame('Test Article', $articles[0]['title'] ?? null);
+    }
+
+    #[Depends('testPost')]
     public function testPutShadowLocale(string $id): string
     {
         $this->client->request('PUT', '/admin/api/articles/' . $id . '?locale=de', [], [], [], \json_encode([

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -813,16 +813,31 @@ class DoctrineListBuilder extends AbstractListBuilder
     {
         if ($expression instanceof DoctrineAndExpression) {
             $entityNames = [];
+            $nullableEntityNames = [];
 
             foreach ($expression->getExpressions() as $subExpression) {
                 if (!$subExpression instanceof AbstractDoctrineExpression) {
                     continue;
                 }
 
+                // A join whose field is constrained to be NULL within the same AND group must stay LEFT —
+                // it cannot be promoted to INNER even if another sub-expression references the same join.
+                // This keeps the ghost-fallback branch ("dimensionContent.x IS NULL AND
+                // ghostDimensionContent.y IN (...)") working: the ghost join chain structurally references
+                // dimensionContent, but that row legitimately has a NULL dimensionContent.
+                if ($subExpression instanceof BasicExpressionInterface && $this->allowsNullJoinResult($subExpression)) {
+                    $nullableEntityNames = \array_merge(
+                        $nullableEntityNames,
+                        $this->getJoinEntityNamesForField($subExpression->getFieldName())
+                    );
+
+                    continue;
+                }
+
                 $entityNames = \array_merge($entityNames, $this->getStrictJoinEntityNamesForExpression($subExpression));
             }
 
-            return \array_values(\array_unique($entityNames));
+            return \array_values(\array_diff(\array_unique($entityNames), $nullableEntityNames));
         }
 
         if ($expression instanceof DoctrineOrExpression) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8906 
| Related issues/PRs | #8678 
| License | MIT
| Documentation PR | none

#### What's in this PR?

Fixes ghost-locale rows being dropped from the **article list** when a `templateKey` filter is active.

The root cause is in the shared list builder, `DoctrineListBuilder::getStrictJoinEntityNamesForExpression()`.
The LEFT→INNER join-promotion optimization (added in #8678) walks a `case` field's `IN` expression
`OR(AND(dc.tk IS NOT NULL, dc.tk IN ...), AND(dc.tk IS NULL, ghostDc.tk IN ...))`. The ghost branch's join
chain structurally references `dimensionContent`, so the OR-intersection kept `dimensionContent` "strict"
and promoted its LEFT join to INNER — which drops rows that only exist in another locale (the ghost rows).

Fix: within an `AND` group, subtract the join entities of any sub-expression that is constrained `IS NULL`
(`allowsNullJoinResult()`) from that branch's strict set. A join required to be `NULL` can never be promoted
to `INNER`, so this empties the intersection for the ghost `case`-`IN` and keeps the joins `LEFT`. (The
*search* path already excluded these joins the same way.)

#### Why?

Creating an article in `en` and opening the article list in `de` returned **no entry** — instead of showing
the article as a ghost (en title + ghost-locale indicator). The single-article `GET` ghost path was fine;
only the list (cget) was broken. Snippets were unaffected because their default list view sends no
`templates`/`types` filter, so the promotion never ran — but snippet *area* filtering and the page list use
the same shared code path and benefit from the same fix.
