### PR TITLE
Fix Article list for ghost locales

### DIFF
--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -794,6 +794,54 @@ class ArticleControllerTest extends SuluTestCase
         }
     }
 
+    public function testGetListWithTemplateFilteringShowsGhostLocaleAlongsidePublished(): void
+    {
+        self::purgeDatabase();
+
+        // Article that exists in the requested locale "en"
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'English Article',
+            'url' => '/english-article',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        // Article that only exists in "de"
+        $this->client->request('POST', '/admin/api/articles?locale=de&action=publish', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'German Ghost Article',
+            'url' => '/german-ghost-article',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        // List in "en" with the template filter. The real "en" article and the "de"-only
+        // ghost must both appear: the join upgrade must not drop the ghost row even when a
+        // non-ghost row is also present in the result set.
+        $this->client->request('GET', '/admin/api/articles?locale=en&templates=article');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array{total: int, _embedded: array{articles: array<int, array{title: string, locale: string|null, ghostLocale: string|null}>}} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+
+        $this->assertSame(2, $content['total']);
+        $this->assertCount(2, $content['_embedded']['articles']);
+
+        $articlesByTitle = [];
+        foreach ($content['_embedded']['articles'] as $article) {
+            $articlesByTitle[$article['title']] = $article;
+        }
+
+        $this->assertArrayHasKey('English Article', $articlesByTitle);
+        $this->assertSame('en', $articlesByTitle['English Article']['locale']);
+        $this->assertNull($articlesByTitle['English Article']['ghostLocale']);
+
+        $this->assertArrayHasKey('German Ghost Article', $articlesByTitle);
+        $this->assertNull($articlesByTitle['German Ghost Article']['locale']);
+        $this->assertSame('de', $articlesByTitle['German Ghost Article']['ghostLocale']);
+    }
+
     public function testGetListWithGroupFiltering(): void
     {
         self::purgeDatabase();

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -732,6 +732,68 @@ class ArticleControllerTest extends SuluTestCase
         $this->assertSame(0, $content['total']);
     }
 
+    public function testGetListWithGhostLocaleAndTemplateFiltering(): void
+    {
+        self::purgeDatabase();
+
+        // Article only exists in "en", template "article"
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'article',
+            'title' => 'Ghost Article',
+            'url' => '/ghost-article',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+        /** @var array<string, mixed> $created */
+        $created = \json_decode((string) $response->getContent(), true);
+        $articleId = $created['id'];
+
+        // Article only exists in "en", different template "blog"
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'blog',
+            'title' => 'Ghost Blog',
+            'url' => '/ghost-blog',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        // Request the list in "de" (ghost) with a template filter: the "article" ghost must appear
+        $this->client->request('GET', '/admin/api/articles?locale=de&templates=article');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+
+        $this->assertSame(1, $content['total']);
+        $this->assertIsArray($content['_embedded']);
+        $this->assertIsArray($content['_embedded']['articles']);
+        $this->assertCount(1, $content['_embedded']['articles']);
+
+        /** @var array<string, mixed> $item */
+        $item = $content['_embedded']['articles'][0];
+        $this->assertSame($articleId, $item['id']);
+        $this->assertSame('Ghost Article', $item['title']);
+        // it is a ghost in "de": no localized row, falling back to "en"
+        $this->assertNull($item['locale']);
+        $this->assertSame('en', $item['ghostLocale']);
+
+        // Without a template filter, both ghosts must appear in "de"
+        $this->client->request('GET', '/admin/api/articles?locale=de');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame(2, $content['total']);
+        $this->assertIsArray($content['_embedded']);
+        $this->assertIsArray($content['_embedded']['articles']);
+        foreach ($content['_embedded']['articles'] as $ghost) {
+            $this->assertIsArray($ghost);
+            $this->assertNull($ghost['locale']);
+            $this->assertSame('en', $ghost['ghostLocale']);
+        }
+    }
+
     public function testGetListWithGroupFiltering(): void
     {
         self::purgeDatabase();

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -455,6 +455,64 @@ class SnippetControllerTest extends SuluTestCase
         $this->assertResponseSnapshot('snippet_post_restore.json', $response, 200);
     }
 
+    public function testGetListWithGhostLocaleAndTypesFiltering(): void
+    {
+        self::purgeDatabase();
+
+        // Snippet only exists in "de", template "snippet"
+        $this->client->request('POST', '/admin/api/snippets?locale=de&action=publish', [], [], [], \json_encode([
+            'template' => 'snippet',
+            'title' => 'Ghost Snippet',
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+        /** @var array<string, mixed> $created */
+        $created = \json_decode((string) $response->getContent(), true);
+        $snippetId = $created['id'];
+
+        // Snippet only exists in "de", different template "snippet-alternate"
+        $this->client->request('POST', '/admin/api/snippets?locale=de&action=publish', [], [], [], \json_encode([
+            'template' => 'snippet-alternate',
+            'title' => 'Ghost Snippet Alternate',
+        ]) ?: null);
+        $this->assertHttpStatusCode(201, $this->client->getResponse());
+
+        // Request the list in "en" (ghost) with a type filter: the "snippet" ghost must appear
+        $this->client->request('GET', '/admin/api/snippets?locale=en&types=snippet');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+
+        $this->assertSame(1, $content['total']);
+        $this->assertIsArray($content['_embedded']);
+        $this->assertIsArray($content['_embedded']['snippets']);
+        $this->assertCount(1, $content['_embedded']['snippets']);
+
+        /** @var array<string, mixed> $item */
+        $item = $content['_embedded']['snippets'][0];
+        $this->assertSame($snippetId, $item['id']);
+        $this->assertSame('Ghost Snippet', $item['title']);
+        // it is a ghost in "en": no localized row, falling back to "de"
+        $this->assertNull($item['locale']);
+        $this->assertSame('de', $item['ghostLocale']);
+
+        // Without a type filter, both ghosts must appear in "en"
+        $this->client->request('GET', '/admin/api/snippets?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+        /** @var array<string, mixed> $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame(2, $content['total']);
+        $this->assertIsArray($content['_embedded']);
+        $this->assertIsArray($content['_embedded']['snippets']);
+        foreach ($content['_embedded']['snippets'] as $ghost) {
+            $this->assertIsArray($ghost);
+            $this->assertNull($ghost['locale']);
+            $this->assertSame('de', $ghost['ghostLocale']);
+        }
+    }
+
     protected function getSnapshotFolder(): string
     {
         return 'responses';

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -813,16 +813,26 @@ class DoctrineListBuilder extends AbstractListBuilder
     {
         if ($expression instanceof DoctrineAndExpression) {
             $entityNames = [];
+            $nullAssertedEntityNames = [];
 
             foreach ($expression->getExpressions() as $subExpression) {
                 if (!$subExpression instanceof AbstractDoctrineExpression) {
                     continue;
                 }
 
+                if ($subExpression instanceof BasicExpressionInterface && $this->allowsNullJoinResult($subExpression)) {
+                    $nullAssertedEntityNames = \array_merge(
+                        $nullAssertedEntityNames,
+                        $this->getJoinEntityNamesForField($subExpression->getFieldName())
+                    );
+
+                    continue;
+                }
+
                 $entityNames = \array_merge($entityNames, $this->getStrictJoinEntityNamesForExpression($subExpression));
             }
 
-            return \array_values(\array_unique($entityNames));
+            return \array_values(\array_diff(\array_unique($entityNames), $nullAssertedEntityNames));
         }
 
         if ($expression instanceof DoctrineOrExpression) {

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -125,6 +125,12 @@ class DoctrineListBuilderTest extends TestCase
     /** @var string */
     private static $translationEntityNameAlias = 'Sulu_Bundle_CoreBundle_Entity_ExampleTranslation';
 
+    /** @var string */
+    private static $fallbackEntityName = 'Sulu\Bundle\CoreBundle\Entity\ExampleFallbackTranslation';
+
+    /** @var string */
+    private static $fallbackEntityNameAlias = 'Sulu_Bundle_CoreBundle_Entity_ExampleFallbackTranslation';
+
     public function setUp(): void
     {
         $this->entityManager = $this->prophesize(EntityManager::class);
@@ -1303,6 +1309,56 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->leftJoin(
             self::$entityNameAlias . '.translations',
             self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->innerJoin(Argument::cetera())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    public function testLeftJoinNotUpgradedWhenSiblingIsNullAssertionTargetsJoinOfFallbackChain(): void
+    {
+        $localizedFieldDescriptor = $this->createLeftJoinedTranslationFieldDescriptor();
+        $fallbackFieldDescriptor = $this->createFallbackChainFieldDescriptor();
+
+        $this->doctrineListBuilder->setFieldDescriptors([
+            'name' => $localizedFieldDescriptor,
+            'fallbackName' => $fallbackFieldDescriptor,
+        ]);
+        $this->doctrineListBuilder->addExpression(
+            $this->doctrineListBuilder->createOrExpression([
+                $this->doctrineListBuilder->createAndExpression([
+                    $this->doctrineListBuilder->createIsNotNullExpression($localizedFieldDescriptor),
+                    $this->doctrineListBuilder->createInExpression($localizedFieldDescriptor, ['value1', 'value2']),
+                ]),
+                $this->doctrineListBuilder->createAndExpression([
+                    $this->doctrineListBuilder->createIsNullExpression($localizedFieldDescriptor),
+                    $this->doctrineListBuilder->createInExpression($fallbackFieldDescriptor, ['value1', 'value2']),
+                ]),
+            ])
+        );
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::containingString(' IS NULL'))->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::cetera())->willReturn($this->queryBuilder->reveal());
+
+        // the localized join (shared with the fallback chain) must stay LEFT
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        // the fallback join itself also stays LEFT
+        $this->queryBuilder->leftJoin(
+            self::$translationEntityNameAlias . '.fallback',
+            self::$fallbackEntityNameAlias,
             'WITH',
             ''
         )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
@@ -2525,6 +2581,30 @@ class DoctrineListBuilderTest extends TestCase
                 self::$translationEntityName => new DoctrineJoinDescriptor(
                     self::$translationEntityName,
                     self::$entityNameAlias . '.translations',
+                    '',
+                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                ),
+            ]
+        );
+    }
+
+    private function createFallbackChainFieldDescriptor(): DoctrineFieldDescriptor
+    {
+        return new DoctrineFieldDescriptor(
+            'name',
+            'fallbackName',
+            self::$fallbackEntityName,
+            'fallback',
+            [
+                self::$translationEntityName => new DoctrineJoinDescriptor(
+                    self::$translationEntityName,
+                    self::$entityNameAlias . '.translations',
+                    '',
+                    DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                ),
+                self::$fallbackEntityName => new DoctrineJoinDescriptor(
+                    self::$fallbackEntityName,
+                    self::$translationEntityNameAlias . '.fallback',
                     '',
                     DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
                 ),

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -1368,6 +1368,81 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->execute();
     }
 
+    public function testLeftJoinNotUpgradedWhenCaseFieldDescriptorUsedForFilter(): void
+    {
+        $case1EntityName = 'Sulu\Bundle\CoreBundle\Entity\ExampleTranslation';
+        $case2EntityName = 'Sulu\Bundle\CoreBundle\Entity\ExampleFallback';
+        $case2EntityNameAlias = 'Sulu_Bundle_CoreBundle_Entity_ExampleFallback';
+
+        $caseFieldDescriptor = new DoctrineCaseFieldDescriptor(
+            'title',
+            new DoctrineDescriptor(
+                $case1EntityName,
+                'title',
+                [
+                    $case1EntityName => new DoctrineJoinDescriptor(
+                        $case1EntityName,
+                        self::$entityNameAlias . '.translations',
+                        '',
+                        DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                    ),
+                ]
+            ),
+            new DoctrineDescriptor(
+                $case2EntityName,
+                'title',
+                [
+                    // The fallback (ghost) branch depends on the case1 join being present
+                    // but NULL (its join condition references the case1 entity), so its
+                    // join chain includes the case1 join in addition to its own.
+                    $case1EntityName => new DoctrineJoinDescriptor(
+                        $case1EntityName,
+                        self::$entityNameAlias . '.translations',
+                        '',
+                        DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                    ),
+                    $case2EntityName => new DoctrineJoinDescriptor(
+                        $case2EntityName,
+                        self::$entityNameAlias . '.fallbacks',
+                        '',
+                        DoctrineJoinDescriptor::JOIN_METHOD_LEFT,
+                    ),
+                ]
+            ),
+        );
+
+        $this->doctrineListBuilder->setFieldDescriptors(['title' => $caseFieldDescriptor]);
+        $this->doctrineListBuilder->in($caseFieldDescriptor, ['value1', 'value2']);
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(Argument::any())->willReturn($this->queryBuilder->reveal());
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->andWhere(Argument::any())->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter(Argument::cetera())->willReturn($this->queryBuilder->reveal());
+
+        // the localized join, shared by both case branches, must stay LEFT
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.translations',
+            self::$translationEntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        // the fallback join itself also stays LEFT
+        $this->queryBuilder->leftJoin(
+            self::$entityNameAlias . '.fallbacks',
+            $case2EntityNameAlias,
+            'WITH',
+            ''
+        )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->innerJoin(Argument::cetera())->willReturn($this->queryBuilder->reveal())->shouldNotBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
     public function testLeftJoinNotUpgradedWhenNoExpressionReferencesJoin(): void
     {
         $this->doctrineListBuilder->addSelectField($this->createLeftJoinedTranslationFieldDescriptor());


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no
| Fixed tickets | fixes #8906
| License | MIT

#### What's in this PR?

Fixes the ghost locale disappearing from the article list as soon as you filter by template (article type).

The cause is in the list builder, not the article bundle. Its optimization upgrades a LEFT join to INNER when a filter references it, assuming the NULL rows get dropped anyway. But the ghost template filter is (localized IS NOT NULL AND localized IN (...)) OR (localized IS NULL AND ghost IN (...)), and the ghost field's join chain still includes the localized join, so it got upgraded to INNER and dropped exactly the ghost rows.
 
The fix skips a join when a sibling part of the same AND asserts it's NULL, so it stays LEFT. This only makes the optimization more cautious, so results elsewhere can't change.

Also added a unit test for this OR/IS NULL case and a functional test that lists articles in a ghost locale with a template filter. Both fail without the fix, pass with it.

#### Why?

Filtering the article list by type hid all ghost-locale articles, so editors couldn't see or reach translations that only existed in another language.
