### PR TITLE
Draft: New Property Type: Table

### DIFF
--- a/packages/content/config/data-mapper.php
+++ b/packages/content/config/data-mapper.php
@@ -17,6 +17,7 @@ use Sulu\Content\Application\ContentDataMapper\DataMapper\LinkDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\RoutableDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\SeoDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\ShadowDataMapper;
+use Sulu\Content\Application\ContentDataMapper\DataMapper\TableTemplateDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\TaxonomyDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\WebspaceDataMapper;
@@ -30,6 +31,10 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_content.template_data_mapper', TemplateDataMapper::class)
         ->args([new Reference('sulu_admin.metadata_provider_registry')])
         ->tag('sulu_content.data_mapper', ['priority' => 128]);
+
+    $services->set('sulu_content.table_template_data_mapper', TableTemplateDataMapper::class)
+        ->args([new Reference('sulu_admin.metadata_provider_registry')])
+        ->tag('sulu_content.data_mapper', ['priority' => 120]);
 
     $services->set('sulu_content.excerpt_data_mapper', ExcerptDataMapper::class)
         ->args([new Reference('sulu_admin.form_metadata_provider')])

--- a/packages/content/config/data-mapper.php
+++ b/packages/content/config/data-mapper.php
@@ -18,6 +18,7 @@ use Sulu\Content\Application\ContentDataMapper\DataMapper\RoutableDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\SeoDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\ShadowDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\TableTemplateDataMapper;
+use Sulu\Content\Domain\Table\TableTemplateDataNormalizer;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\TaxonomyDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper;
 use Sulu\Content\Application\ContentDataMapper\DataMapper\WebspaceDataMapper;
@@ -32,8 +33,13 @@ return static function(ContainerConfigurator $container) {
         ->args([new Reference('sulu_admin.metadata_provider_registry')])
         ->tag('sulu_content.data_mapper', ['priority' => 128]);
 
+    $services->set('sulu_content.table_template_data_normalizer', TableTemplateDataNormalizer::class);
+
     $services->set('sulu_content.table_template_data_mapper', TableTemplateDataMapper::class)
-        ->args([new Reference('sulu_admin.metadata_provider_registry')])
+        ->args([
+            new Reference('sulu_admin.metadata_provider_registry'),
+            new Reference('sulu_content.table_template_data_normalizer'),
+        ])
         ->tag('sulu_content.data_mapper', ['priority' => 120]);
 
     $services->set('sulu_content.excerpt_data_mapper', ExcerptDataMapper::class)

--- a/packages/content/config/normalizer.php
+++ b/packages/content/config/normalizer.php
@@ -22,6 +22,7 @@ use Sulu\Content\Application\ContentNormalizer\Normalizer\SecuredEntityNormalize
 use Sulu\Content\Application\ContentNormalizer\Normalizer\SeoNormalizer;
 use Sulu\Content\Application\ContentNormalizer\Normalizer\ShadowNormalizer;
 use Sulu\Content\Application\ContentNormalizer\Normalizer\TaxonomyNormalizer;
+use Sulu\Content\Application\ContentNormalizer\Normalizer\TableTemplateNormalizer;
 use Sulu\Content\Application\ContentNormalizer\Normalizer\TemplateNormalizer;
 use Sulu\Content\Application\ContentNormalizer\Normalizer\WorkflowNormalizer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -32,6 +33,13 @@ return static function(ContainerConfigurator $container) {
 
     $services->set('sulu_content.dimension_content_normalizer', DimensionContentNormalizer::class)
         ->tag('sulu_content.normalizer', ['priority' => 256]);
+
+    $services->set('sulu_content.table_template_normalizer', TableTemplateNormalizer::class)
+        ->args([
+            new Reference('sulu_admin.metadata_provider_registry'),
+            new Reference('sulu_content.table_template_data_normalizer'),
+        ])
+        ->tag('sulu_content.normalizer', ['priority' => 129]);
 
     $services->set('sulu_content.template_normalizer', TemplateNormalizer::class)
         ->tag('sulu_content.normalizer', ['priority' => 128]);

--- a/packages/content/config/resolvers.php
+++ b/packages/content/config/resolvers.php
@@ -37,6 +37,7 @@ use Sulu\Content\Application\PropertyResolver\Resolver\DateTimePropertyResolver;
 use Sulu\Content\Application\PropertyResolver\Resolver\DefaultPropertyResolver;
 use Sulu\Content\Application\PropertyResolver\Resolver\LinkPropertyResolver;
 use Sulu\Content\Application\PropertyResolver\Resolver\SmartContentPropertyResolver;
+use Sulu\Content\Application\PropertyResolver\Resolver\TablePropertyResolver;
 use Sulu\Content\Application\PropertyResolver\Resolver\TeaserSelectionPropertyResolver;
 use Sulu\Content\Application\SmartResolver\Resolver\SmartContentSmartResolver;
 use Sulu\Content\Application\SmartResolver\SmartResolverProvider;
@@ -154,6 +155,9 @@ return static function(ContainerConfigurator $container) {
         ->tag('sulu_content.property_resolver');
 
     $services->set('sulu_content.link_property_resolver', LinkPropertyResolver::class)
+        ->tag('sulu_content.property_resolver');
+
+    $services->set('sulu_content.table_property_resolver', TablePropertyResolver::class)
         ->tag('sulu_content.property_resolver');
 
     $services->set('sulu_content.teaser_selection_property_resolver', TeaserSelectionPropertyResolver::class)

--- a/packages/content/config/services.php
+++ b/packages/content/config/services.php
@@ -44,6 +44,8 @@ use Sulu\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactory;
 use Sulu\Content\Infrastructure\Sulu\Admin\ContentViewBuilderFactoryInterface;
 use Sulu\Content\Infrastructure\Sulu\HttpCache\EventSubscriber\DimensionContentTagSubscriber;
 use Sulu\Content\Infrastructure\Sulu\Page\Select\WebspaceSelect;
+use Sulu\Content\Infrastructure\Symfony\Twig\Runtime\TableRuntime;
+use Sulu\Content\Infrastructure\Symfony\Twig\TableTwigExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -194,4 +196,12 @@ return static function(ContainerConfigurator $container) {
         ]);
 
     $services->alias(ContentManagerInterface::class, 'sulu_content.content_manager');
+
+    $services->set('sulu_content.table_twig_extension', TableTwigExtension::class)
+        ->tag('twig.extension')
+        ->tag('sulu.context', ['context' => 'website']);
+
+    $services->set('sulu_content.table_runtime', TableRuntime::class)
+        ->tag('twig.runtime')
+        ->tag('sulu.context', ['context' => 'website']);
 };

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/TableTemplateDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/TableTemplateDataMapper.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\TemplateInterface;
-use Sulu\Content\Domain\Table\TableData;
+use Sulu\Content\Domain\Table\TableTemplateDataNormalizer;
 
 /**
  * Normalizes every `table` property of the active template after the
@@ -31,6 +31,7 @@ final readonly class TableTemplateDataMapper implements DataMapperInterface
 
     public function __construct(
         private MetadataProviderRegistry $metadataProviderRegistry,
+        private TableTemplateDataNormalizer $tableTemplateDataNormalizer,
     ) {
     }
 
@@ -50,47 +51,37 @@ final readonly class TableTemplateDataMapper implements DataMapperInterface
             return;
         }
 
-        $tableProperties = $this->resolveTableProperties(
+        $tablePropertyPaths = $this->resolveTablePropertyPaths(
             $localizedDimensionContent::getTemplateType(),
             $localizedDimensionContent->getLocale(),
             $template,
         );
 
-        if ([] === $tableProperties) {
+        if ([] === $tablePropertyPaths) {
             return;
         }
 
         foreach ([$unlocalizedDimensionContent, $localizedDimensionContent] as $dimensionContent) {
-            $this->normalize($dimensionContent, $tableProperties);
+            $this->normalize($dimensionContent, $tablePropertyPaths);
         }
     }
 
     /**
-     * @param list<string> $tableProperties
+     * @param list<string> $tablePropertyPaths
      */
-    private function normalize(TemplateInterface $dimensionContent, array $tableProperties): void
+    private function normalize(TemplateInterface $dimensionContent, array $tablePropertyPaths): void
     {
         $templateData = $dimensionContent->getTemplateData();
-        $changed = false;
 
-        foreach ($tableProperties as $name) {
-            if (!\array_key_exists($name, $templateData)) {
-                continue;
-            }
-
-            $templateData[$name] = TableData::fromArray($templateData[$name])->toArray();
-            $changed = true;
-        }
-
-        if ($changed) {
-            $dimensionContent->setTemplateData($templateData);
-        }
+        $dimensionContent->setTemplateData(
+            $this->tableTemplateDataNormalizer->normalize($templateData, $tablePropertyPaths),
+        );
     }
 
     /**
      * @return list<string>
      */
-    private function resolveTableProperties(string $type, ?string $locale, string $template): array
+    private function resolveTablePropertyPaths(string $type, ?string $locale, string $template): array
     {
         if (null === $locale) {
             return [];
@@ -109,17 +100,15 @@ final readonly class TableTemplateDataMapper implements DataMapperInterface
             return [];
         }
 
-        $tableProperties = [];
+        $tablePropertyPaths = [];
         foreach ($metadata->getFlatFieldMetadata() as $property) {
             if (self::TABLE_TYPE !== $property->getType()) {
                 continue;
             }
 
-            // Only handle top-level properties (block paths use a "/" separator).
-            $name = \explode('/', $property->getName(), 2)[0];
-            $tableProperties[$name] = true;
+            $tablePropertyPaths[] = $property->getName();
         }
 
-        return \array_keys($tableProperties);
+        return $tablePropertyPaths;
     }
 }

--- a/packages/content/src/Application/ContentDataMapper/DataMapper/TableTemplateDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/TableTemplateDataMapper.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentDataMapper\DataMapper;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
+use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\TemplateInterface;
+use Sulu\Content\Domain\Table\TableData;
+
+/**
+ * Normalizes every `table` property of the active template after the
+ * TemplateDataMapper has written the raw values, so the persisted JSON always
+ * follows the {@see TableData} contract (rectangular, no empty rows).
+ */
+final readonly class TableTemplateDataMapper implements DataMapperInterface
+{
+    private const TABLE_TYPE = 'table';
+
+    public function __construct(
+        private MetadataProviderRegistry $metadataProviderRegistry,
+    ) {
+    }
+
+    public function map(
+        DimensionContentInterface $unlocalizedDimensionContent,
+        DimensionContentInterface $localizedDimensionContent,
+        array $data,
+    ): void {
+        if (!$localizedDimensionContent instanceof TemplateInterface
+            || !$unlocalizedDimensionContent instanceof TemplateInterface
+        ) {
+            return;
+        }
+
+        $template = $localizedDimensionContent->getTemplateKey();
+        if (null === $template) {
+            return;
+        }
+
+        $tableProperties = $this->resolveTableProperties(
+            $localizedDimensionContent::getTemplateType(),
+            $localizedDimensionContent->getLocale(),
+            $template,
+        );
+
+        if ([] === $tableProperties) {
+            return;
+        }
+
+        foreach ([$unlocalizedDimensionContent, $localizedDimensionContent] as $dimensionContent) {
+            $this->normalize($dimensionContent, $tableProperties);
+        }
+    }
+
+    /**
+     * @param list<string> $tableProperties
+     */
+    private function normalize(TemplateInterface $dimensionContent, array $tableProperties): void
+    {
+        $templateData = $dimensionContent->getTemplateData();
+        $changed = false;
+
+        foreach ($tableProperties as $name) {
+            if (!\array_key_exists($name, $templateData)) {
+                continue;
+            }
+
+            $templateData[$name] = TableData::fromArray($templateData[$name])->toArray();
+            $changed = true;
+        }
+
+        if ($changed) {
+            $dimensionContent->setTemplateData($templateData);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveTableProperties(string $type, ?string $locale, string $template): array
+    {
+        if (null === $locale) {
+            return [];
+        }
+
+        $typedMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')
+            ->getMetadata($type, $locale, []);
+
+        if (!$typedMetadata instanceof TypedFormMetadata) {
+            return [];
+        }
+
+        $metadata = $typedMetadata->getForms()[$template] ?? null;
+
+        if (!$metadata instanceof FormMetadata) {
+            return [];
+        }
+
+        $tableProperties = [];
+        foreach ($metadata->getFlatFieldMetadata() as $property) {
+            if (self::TABLE_TYPE !== $property->getType()) {
+                continue;
+            }
+
+            // Only handle top-level properties (block paths use a "/" separator).
+            $name = \explode('/', $property->getName(), 2)[0];
+            $tableProperties[$name] = true;
+        }
+
+        return \array_keys($tableProperties);
+    }
+}

--- a/packages/content/src/Application/ContentNormalizer/Normalizer/TableTemplateNormalizer.php
+++ b/packages/content/src/Application/ContentNormalizer/Normalizer/TableTemplateNormalizer.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\ContentNormalizer\Normalizer;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
+use Sulu\Content\Domain\Model\TemplateInterface;
+use Sulu\Content\Domain\Table\TableTemplateDataNormalizer;
+
+/**
+ * Ensures every `table` property in template data is returned to the Admin UI in
+ * the {@see TableData} JSON shape (`version`, `head`, `body`) after save/load.
+ */
+final readonly class TableTemplateNormalizer implements NormalizerInterface
+{
+    private const TABLE_TYPE = 'table';
+
+    public function __construct(
+        private MetadataProviderRegistry $metadataProviderRegistry,
+        private TableTemplateDataNormalizer $tableTemplateDataNormalizer,
+    ) {
+    }
+
+    public function enhance(object $object, array $normalizedData): array
+    {
+        if (!$object instanceof TemplateInterface) {
+            return $normalizedData;
+        }
+
+        $template = $object->getTemplateKey();
+        $locale = $object->getLocale();
+
+        if (null === $template || null === $locale) {
+            return $normalizedData;
+        }
+
+        if (!\is_array($normalizedData['templateData'] ?? null)) {
+            return $normalizedData;
+        }
+
+        $tablePropertyPaths = $this->resolveTablePropertyPaths(
+            $object::getTemplateType(),
+            $locale,
+            $template,
+        );
+
+        if ([] === $tablePropertyPaths) {
+            return $normalizedData;
+        }
+
+        /** @var array<string, mixed> $templateData */
+        $templateData = $normalizedData['templateData'];
+        $normalizedData['templateData'] = $this->tableTemplateDataNormalizer->normalize(
+            $templateData,
+            $tablePropertyPaths,
+        );
+
+        return $normalizedData;
+    }
+
+    public function getIgnoredAttributes(object $object): array
+    {
+        return [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveTablePropertyPaths(string $type, string $locale, string $template): array
+    {
+        $typedMetadata = $this->metadataProviderRegistry->getMetadataProvider('form')
+            ->getMetadata($type, $locale, []);
+
+        if (!$typedMetadata instanceof TypedFormMetadata) {
+            return [];
+        }
+
+        $metadata = $typedMetadata->getForms()[$template] ?? null;
+
+        if (!$metadata instanceof FormMetadata) {
+            return [];
+        }
+
+        $tablePropertyPaths = [];
+        foreach ($metadata->getFlatFieldMetadata() as $property) {
+            if (self::TABLE_TYPE !== $property->getType()) {
+                continue;
+            }
+
+            $tablePropertyPaths[] = $property->getName();
+        }
+
+        return $tablePropertyPaths;
+    }
+}

--- a/packages/content/src/Application/PropertyResolver/Resolver/TablePropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/TablePropertyResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Application\PropertyResolver\Resolver;
+
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
+use Sulu\Content\Domain\Table\TableData;
+
+/**
+ * Resolves the `table` content type into a normalized, rectangular structure so
+ * templates always receive consistent `head`/`body` data, even for legacy or
+ * malformed stored values.
+ */
+final readonly class TablePropertyResolver implements PropertyResolverInterface
+{
+    public function resolve(mixed $data, string $locale, array $params = []): ContentView
+    {
+        return ContentView::create(TableData::fromArray($data)->toArray(), []);
+    }
+
+    public static function getType(): string
+    {
+        return 'table';
+    }
+}

--- a/packages/content/src/Domain/Table/TableCell.php
+++ b/packages/content/src/Domain/Table/TableCell.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Table;
+
+/**
+ * A single body cell of the `table` content type.
+ *
+ * Besides the textual content a cell carries simple inline formatting flags
+ * (bold/italic/underline) so each cell can be styled individually. The stored
+ * JSON for a cell is an object:
+ *
+ *  { "text": "Foo", "bold": true, "italic": false, "underline": false }
+ *
+ * Legacy values where a cell was a plain string are still accepted and treated
+ * as unformatted text, keeping the persisted data forward- and backward
+ * compatible.
+ */
+final readonly class TableCell
+{
+    public function __construct(
+        public string $text,
+        public bool $bold = false,
+        public bool $italic = false,
+        public bool $underline = false,
+    ) {
+    }
+
+    public static function fromRaw(mixed $raw): self
+    {
+        if (\is_array($raw)) {
+            return new self(
+                self::toText($raw['text'] ?? ''),
+                (bool) ($raw['bold'] ?? false),
+                (bool) ($raw['italic'] ?? false),
+                (bool) ($raw['underline'] ?? false),
+            );
+        }
+
+        return new self(self::toText($raw));
+    }
+
+    public static function blank(): self
+    {
+        return new self('');
+    }
+
+    public function isBlank(): bool
+    {
+        return '' === $this->text;
+    }
+
+    /**
+     * @return array{text: string, bold: bool, italic: bool, underline: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'text' => $this->text,
+            'bold' => $this->bold,
+            'italic' => $this->italic,
+            'underline' => $this->underline,
+        ];
+    }
+
+    /**
+     * Space separated CSS classes for the active formatting, ready to drop into
+     * a template. Returns an empty string when the cell has no formatting.
+     */
+    public function classes(): string
+    {
+        $classes = [];
+
+        if ($this->bold) {
+            $classes[] = 'font-bold';
+        }
+
+        if ($this->italic) {
+            $classes[] = 'italic';
+        }
+
+        if ($this->underline) {
+            $classes[] = 'underline';
+        }
+
+        return \implode(' ', $classes);
+    }
+
+    private static function toText(mixed $value): string
+    {
+        return \is_scalar($value) ? (string) $value : '';
+    }
+}

--- a/packages/content/src/Domain/Table/TableData.php
+++ b/packages/content/src/Domain/Table/TableData.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Table;
+
+/**
+ * Central data contract for the `table` content type.
+ *
+ * The persisted JSON is intentionally forward-compatible:
+ *  - `version`: schema version, allows future migrations of stored values.
+ *  - `head`: the header row as a list of plain strings.
+ *  - `body`: the data rows as a rectangular matrix of {@see TableCell} objects.
+ *  - `options`: open extension bag for future global table settings
+ *    (e.g. caption, striped, per-column alignment under `options.columns`).
+ *
+ * Backward compatibility: version 1 stored body cells as plain strings. Such
+ * values are transparently upgraded to unformatted {@see TableCell} objects by
+ * {@see TableCell::fromRaw()}, so no explicit migration branch is required.
+ */
+final readonly class TableData
+{
+    /**
+     * Current schema version of the stored JSON. Bump this when the structure
+     * changes in a non-backward-compatible way and add a migration in fromArray().
+     *
+     * v2: body cells are objects ({text, bold, italic, underline}) instead of
+     * plain strings.
+     */
+    public const VERSION = 2;
+
+    /**
+     * @param list<string>          $head
+     * @param list<list<TableCell>> $rows
+     * @param array<string, mixed>  $options
+     */
+    private function __construct(
+        public int $version,
+        public array $head,
+        public array $rows,
+        public array $options,
+    ) {
+    }
+
+    public static function fromArray(mixed $raw): self
+    {
+        if (!\is_array($raw)) {
+            return new self(self::VERSION, [], [], []);
+        }
+
+        $options = \is_array($raw['options'] ?? null) ? $raw['options'] : [];
+
+        $rawHead = \is_array($raw['head'] ?? null) ? \array_values($raw['head']) : [];
+        $rawBody = \is_array($raw['body'] ?? null) ? \array_values($raw['body']) : [];
+
+        $head = \array_map(self::toHeadCell(...), $rawHead);
+        $rows = \array_map(
+            static fn (mixed $row): array => \is_array($row)
+                ? \array_map(TableCell::fromRaw(...), \array_values($row))
+                : [],
+            $rawBody,
+        );
+
+        $columns = \max(\count($head), 0, ...\array_map('\count', $rows));
+
+        if (0 === $columns) {
+            return new self(self::VERSION, [], [], $options);
+        }
+
+        $head = \array_pad($head, $columns, '');
+        $rows = \array_values(\array_map(
+            static fn (array $row): array => \array_pad($row, $columns, TableCell::blank()),
+            $rows,
+        ));
+
+        // Drop completely empty rows to keep the stored data clean.
+        $rows = \array_values(\array_filter(
+            $rows,
+            static fn (array $row): bool => self::rowHasContent($row),
+        ));
+
+        return new self(self::VERSION, $head, $rows, $options);
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->rows && '' === \implode('', $this->head);
+    }
+
+    /**
+     * @return array{version: int, head: list<string>, body: list<list<array{text: string, bold: bool, italic: bool, underline: bool}>>, options?: array<string, mixed>}
+     */
+    public function toArray(): array
+    {
+        $data = [
+            'version' => $this->version,
+            'head' => $this->head,
+            'body' => \array_map(
+                static fn (array $row): array => \array_map(
+                    static fn (TableCell $cell): array => $cell->toArray(),
+                    $row,
+                ),
+                $this->rows,
+            ),
+        ];
+
+        if ([] !== $this->options) {
+            $data['options'] = $this->options;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param list<TableCell> $row
+     */
+    private static function rowHasContent(array $row): bool
+    {
+        foreach ($row as $cell) {
+            if (!$cell->isBlank()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function toHeadCell(mixed $cell): string
+    {
+        return \is_scalar($cell) ? (string) $cell : '';
+    }
+}

--- a/packages/content/src/Domain/Table/TableTemplateDataNormalizer.php
+++ b/packages/content/src/Domain/Table/TableTemplateDataNormalizer.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Table;
+
+/**
+ * Normalizes `table` property values inside template data at their metadata path.
+ *
+ * Top-level properties (e.g. `specs`) are normalized directly. Slash-separated
+ * paths (e.g. `contentBlocks/table`) target a field inside each block entry or
+ * a nested object — never the container itself.
+ */
+final class TableTemplateDataNormalizer
+{
+    /**
+     * @param array<string, mixed> $templateData
+     * @param list<string>         $propertyPaths
+     *
+     * @return array<string, mixed>
+     */
+    public function normalize(array $templateData, array $propertyPaths): array
+    {
+        foreach ($propertyPaths as $path) {
+            $this->normalizeAtPath($templateData, $path);
+        }
+
+        return $templateData;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function normalizeAtPath(array &$data, string $path): void
+    {
+        if (!\str_contains($path, '/')) {
+            if (\array_key_exists($path, $data)) {
+                $data[$path] = TableData::fromArray($data[$path])->toArray();
+            }
+
+            return;
+        }
+
+        [$container, $field] = \explode('/', $path, 2);
+
+        if (!\array_key_exists($container, $data) || !\is_array($data[$container])) {
+            return;
+        }
+
+        if ($this->isList($data[$container])) {
+            foreach ($data[$container] as &$item) {
+                if (!\is_array($item) || !\array_key_exists($field, $item)) {
+                    continue;
+                }
+
+                $item[$field] = TableData::fromArray($item[$field])->toArray();
+            }
+            unset($item);
+
+            return;
+        }
+
+        if (\array_key_exists($field, $data[$container])) {
+            $data[$container][$field] = TableData::fromArray($data[$container][$field])->toArray();
+        }
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function isList(array $value): bool
+    {
+        return [] === $value || \array_is_list($value);
+    }
+}

--- a/packages/content/src/Domain/Table/TableView.php
+++ b/packages/content/src/Domain/Table/TableView.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Table;
+
+/**
+ * Template-facing presentation view for the `table` content type.
+ *
+ * Wraps the normalized {@see TableData} and exposes convenience accessors so
+ * Twig templates stay free of preparation logic.
+ */
+final readonly class TableView
+{
+    /**
+     * @param list<string>            $head
+     * @param list<list<TableCell>>   $rows
+     * @param array<string, mixed>    $options
+     */
+    private function __construct(
+        public array $head,
+        public array $rows,
+        public array $options,
+    ) {
+    }
+
+    public static function fromData(TableData $data): self
+    {
+        return new self($data->head, $data->rows, $data->options);
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->rows && '' === \implode('', $this->head);
+    }
+
+    public function hasHead(): bool
+    {
+        return '' !== \implode('', $this->head);
+    }
+
+    public function caption(): ?string
+    {
+        $caption = $this->options['caption'] ?? null;
+
+        return \is_string($caption) && '' !== $caption ? $caption : null;
+    }
+
+    /**
+     * CSS alignment class for a column, always with a sensible default.
+     */
+    public function alignClass(int $columnIndex): string
+    {
+        $align = $this->options['columns'][$columnIndex]['align'] ?? 'left';
+
+        return match ($align) {
+            'right' => 'text-right',
+            'center' => 'text-center',
+            default => 'text-left',
+        };
+    }
+}

--- a/packages/content/src/Infrastructure/Symfony/Twig/Runtime/TableRuntime.php
+++ b/packages/content/src/Infrastructure/Symfony/Twig/Runtime/TableRuntime.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Symfony\Twig\Runtime;
+
+use Sulu\Content\Domain\Table\TableData;
+use Sulu\Content\Domain\Table\TableView;
+use Twig\Extension\RuntimeExtensionInterface;
+
+/**
+ * Holds the logic for the `sulu_resolve_table` Twig function. Lazily
+ * instantiated by Twig only when the function is actually used.
+ */
+final class TableRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * Normalizes any stored/raw value into a template-ready {@see TableView}.
+     */
+    public function resolveTableFunction(mixed $value): TableView
+    {
+        return TableView::fromData(TableData::fromArray($value));
+    }
+}

--- a/packages/content/src/Infrastructure/Symfony/Twig/TableTwigExtension.php
+++ b/packages/content/src/Infrastructure/Symfony/Twig/TableTwigExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Symfony\Twig;
+
+use Sulu\Content\Infrastructure\Symfony\Twig\Runtime\TableRuntime;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Exposes the `table` content type to templates following the Sulu naming
+ * convention (cf. sulu_resolve_media). The actual work is delegated to the
+ * lazily loaded {@see TableRuntime}.
+ */
+final class TableTwigExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sulu_resolve_table', [TableRuntime::class, 'resolveTableFunction']),
+        ];
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/ContentNormalizer/Normalizer/TableTemplateNormalizerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentNormalizer/Normalizer/TableTemplateNormalizerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\ContentNormalizer\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
+use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderRegistry;
+use Sulu\Content\Application\ContentNormalizer\Normalizer\TableTemplateNormalizer;
+use Sulu\Content\Application\ContentNormalizer\Normalizer\TemplateNormalizer;
+use Sulu\Content\Domain\Table\TableData;
+use Sulu\Content\Domain\Table\TableTemplateDataNormalizer;
+use Sulu\Content\Tests\Application\ExampleTestBundle\Entity\ExampleDimensionContent;
+
+class TableTemplateNormalizerTest extends TestCase
+{
+    use \Prophecy\PhpUnit\ProphecyTrait;
+
+    public function testEnhanceNormalizesTableFieldsBeforeTemplateFlattening(): void
+    {
+        $specsField = new FieldMetadata('specs');
+        $specsField->setType('table');
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($specsField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm($formMetadata);
+
+        $metadataProvider = $this->prophesize(MetadataProviderInterface::class);
+        $metadataProvider->getMetadata('example', 'en', [])->willReturn($typedFormMetadata);
+
+        $metadataProviderRegistry = $this->prophesize(MetadataProviderRegistry::class);
+        $metadataProviderRegistry->getMetadataProvider('form')->willReturn($metadataProvider->reveal());
+
+        $dimensionContent = new ExampleDimensionContent(new \Sulu\Content\Tests\Application\ExampleTestBundle\Entity\Example());
+        $dimensionContent->setLocale('en');
+        $dimensionContent->setTemplateKey('default');
+
+        $tableNormalizer = new TableTemplateNormalizer(
+            $metadataProviderRegistry->reveal(),
+            new TableTemplateDataNormalizer(),
+        );
+        $templateNormalizer = new TemplateNormalizer();
+
+        $normalizedData = [
+            'templateData' => [
+                'specs' => [
+                    'head' => ['A'],
+                    'body' => [['1']],
+                ],
+            ],
+            'templateKey' => 'default',
+        ];
+
+        $normalizedData = $tableNormalizer->enhance($dimensionContent, $normalizedData);
+        $result = $templateNormalizer->enhance($dimensionContent, $normalizedData);
+
+        $this->assertSame([
+            'version' => TableData::VERSION,
+            'head' => ['A'],
+            'body' => [
+                [
+                    ['text' => '1', 'bold' => false, 'italic' => false, 'underline' => false],
+                ],
+            ],
+        ], $result['specs']);
+        $this->assertSame('default', $result['template']);
+        $this->assertArrayNotHasKey('templateData', $result);
+    }
+
+    public function testEnhanceIgnoresNonTemplateObjects(): void
+    {
+        $metadataProviderRegistry = $this->prophesize(MetadataProviderRegistry::class);
+        $metadataProviderRegistry->getMetadataProvider(Argument::any())->shouldNotBeCalled();
+
+        $normalizer = new TableTemplateNormalizer(
+            $metadataProviderRegistry->reveal(),
+            new TableTemplateDataNormalizer(),
+        );
+
+        $data = ['templateData' => ['specs' => []]];
+
+        $this->assertSame($data, $normalizer->enhance(new \stdClass(), $data));
+    }
+}

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/TablePropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/TablePropertyResolverTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Application\PropertyResolver\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Application\PropertyResolver\Resolver\TablePropertyResolver;
+
+class TablePropertyResolverTest extends TestCase
+{
+    private TablePropertyResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new TablePropertyResolver();
+    }
+
+    public function testGetType(): void
+    {
+        $this->assertSame('table', TablePropertyResolver::getType());
+    }
+
+    public function testResolveEmpty(): void
+    {
+        $contentView = $this->resolver->resolve(null, 'en');
+
+        $this->assertSame([
+            'version' => 2,
+            'head' => [],
+            'body' => [],
+        ], $contentView->getContent());
+        $this->assertSame([], $contentView->getView());
+    }
+
+    public function testResolveNormalizesTableData(): void
+    {
+        $contentView = $this->resolver->resolve([
+            'version' => 2,
+            'head' => ['A', 'B'],
+            'body' => [
+                [
+                    ['text' => '1', 'bold' => true, 'italic' => false, 'underline' => false],
+                    'legacy',
+                ],
+                ['', ''],
+            ],
+            'options' => ['caption' => 'Prices'],
+        ], 'en');
+
+        $this->assertSame([
+            'version' => 2,
+            'head' => ['A', 'B'],
+            'body' => [
+                [
+                    ['text' => '1', 'bold' => true, 'italic' => false, 'underline' => false],
+                    ['text' => 'legacy', 'bold' => false, 'italic' => false, 'underline' => false],
+                ],
+            ],
+            'options' => ['caption' => 'Prices'],
+        ], $contentView->getContent());
+    }
+}

--- a/packages/content/tests/Unit/Content/Domain/Table/TableDataTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Table/TableDataTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Domain\Table;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Domain\Table\TableCell;
+use Sulu\Content\Domain\Table\TableData;
+use Sulu\Content\Domain\Table\TableView;
+
+class TableDataTest extends TestCase
+{
+    public function testFromArrayWithInvalidInput(): void
+    {
+        $data = TableData::fromArray('invalid');
+
+        $this->assertTrue($data->isEmpty());
+        $this->assertSame(TableData::VERSION, $data->version);
+    }
+
+    public function testFromArrayNormalizesRectangularMatrix(): void
+    {
+        $data = TableData::fromArray([
+            'head' => ['A'],
+            'body' => [
+                ['x', ['text' => 'y', 'bold' => true]],
+            ],
+        ]);
+
+        $this->assertSame(['A'], $data->head);
+        $this->assertCount(1, $data->rows);
+        $this->assertSame('x', $data->rows[0][0]->text);
+        $this->assertTrue($data->rows[0][1]->bold);
+    }
+
+    public function testFromArrayRemovesEmptyRows(): void
+    {
+        $data = TableData::fromArray([
+            'head' => ['A'],
+            'body' => [
+                ['value'],
+                [''],
+            ],
+        ]);
+
+        $this->assertCount(1, $data->rows);
+        $this->assertSame('value', $data->rows[0][0]->text);
+    }
+
+    public function testToArrayOmitsEmptyOptions(): void
+    {
+        $data = TableData::fromArray([
+            'head' => [],
+            'body' => [],
+        ]);
+
+        $this->assertArrayNotHasKey('options', $data->toArray());
+    }
+
+    public function testTableCellClasses(): void
+    {
+        $cell = new TableCell('text', true, true, false);
+
+        $this->assertSame('font-bold italic', $cell->classes());
+    }
+
+    public function testTableViewHelpers(): void
+    {
+        $view = TableView::fromData(TableData::fromArray([
+            'head' => ['A'],
+            'body' => [['1']],
+            'options' => [
+                'caption' => 'Caption',
+                'columns' => [
+                    ['align' => 'center'],
+                ],
+            ],
+        ]));
+
+        $this->assertFalse($view->isEmpty());
+        $this->assertTrue($view->hasHead());
+        $this->assertSame('Caption', $view->caption());
+        $this->assertSame('text-center', $view->alignClass(0));
+        $this->assertSame('text-left', $view->alignClass(1));
+    }
+}

--- a/packages/content/tests/Unit/Content/Domain/Table/TableTemplateDataNormalizerTest.php
+++ b/packages/content/tests/Unit/Content/Domain/Table/TableTemplateDataNormalizerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Domain\Table;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Domain\Table\TableData;
+use Sulu\Content\Domain\Table\TableTemplateDataNormalizer;
+
+class TableTemplateDataNormalizerTest extends TestCase
+{
+    private TableTemplateDataNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new TableTemplateDataNormalizer();
+    }
+
+    public function testNormalizeTopLevelProperty(): void
+    {
+        $result = $this->normalizer->normalize([
+            'specs' => [
+                'head' => ['A'],
+                'body' => [['value']],
+            ],
+        ], ['specs']);
+
+        $this->assertSame([
+            'version' => TableData::VERSION,
+            'head' => ['A'],
+            'body' => [
+                [
+                    ['text' => 'value', 'bold' => false, 'italic' => false, 'underline' => false],
+                ],
+            ],
+        ], $result['specs']);
+    }
+
+    public function testNormalizeTableInsideBlockWithoutTouchingOtherBlocks(): void
+    {
+        $result = $this->normalizer->normalize([
+            'contentBlocks' => [
+                [
+                    'type' => 'table_block',
+                    'table' => [
+                        'head' => ['Column'],
+                        'body' => [['Cell']],
+                    ],
+                ],
+                [
+                    'type' => 'text_block',
+                    'title' => 'Keep me',
+                ],
+            ],
+        ], ['contentBlocks/table']);
+
+        $this->assertSame('Keep me', $result['contentBlocks'][1]['title']);
+        $this->assertSame('Column', $result['contentBlocks'][0]['table']['head'][0]);
+        $this->assertSame('Cell', $result['contentBlocks'][0]['table']['body'][0][0]['text']);
+    }
+
+    public function testNormalizeNestedObjectProperty(): void
+    {
+        $result = $this->normalizer->normalize([
+            'section' => [
+                'table' => [
+                    'head' => ['H'],
+                    'body' => [['1']],
+                ],
+            ],
+        ], ['section/table']);
+
+        $this->assertSame('H', $result['section']['table']['head'][0]);
+        $this->assertSame('1', $result['section']['table']['body'][0][0]['text']);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapper/TablePropertyMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/PropertyMetadataMapper/TablePropertyMetadataMapper.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper;
+
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\AnyOfsMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ArrayMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NullMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\NumberMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\ObjectMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperInterface;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SchemaMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
+
+/**
+ * @internal use symfony dependency injection container to override the service if you want to change the behavior
+ */
+final readonly class TablePropertyMetadataMapper implements PropertyMetadataMapperInterface
+{
+    public function mapPropertyMetadata(FieldMetadata $fieldMetadata): PropertyMetadata
+    {
+        $mandatory = $fieldMetadata->isRequired();
+
+        $cellMetadata = new ObjectMetadata([
+            new PropertyMetadata('text', true, new StringMetadata()),
+            new PropertyMetadata('bold', false, new SchemaMetadata()),
+            new PropertyMetadata('italic', false, new SchemaMetadata()),
+            new PropertyMetadata('underline', false, new SchemaMetadata()),
+        ]);
+
+        $tableMetadata = new ObjectMetadata([
+            new PropertyMetadata('version', false, new NumberMetadata()),
+            new PropertyMetadata('head', false, new ArrayMetadata(new StringMetadata())),
+            new PropertyMetadata('body', false, new ArrayMetadata(
+                new ArrayMetadata(new AnyOfsMetadata([
+                    new StringMetadata(),
+                    $cellMetadata,
+                ]))
+            )),
+            new PropertyMetadata('options', false, new SchemaMetadata()),
+        ]);
+
+        if (!$mandatory) {
+            $tableMetadata = new AnyOfsMetadata([
+                new NullMetadata(),
+                $tableMetadata,
+            ]);
+        }
+
+        return new PropertyMetadata($fieldMetadata->getName(), $mandatory, $tableMetadata);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
@@ -67,6 +67,7 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper\Numbe
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper\SelectionPropertyMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper\SelectPropertyMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper\SingleSelectionPropertyMetadataMapper;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper\TablePropertyMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper\TeaserSelectionPropertyMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper\TextPropertyMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegistry;
@@ -292,6 +293,9 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_admin.property_metadata_mapper.teaser_selection', TeaserSelectionPropertyMetadataMapper::class)
         ->args([new Reference('sulu_admin.property_metadata_min_max_value_resolver')])
         ->tag('sulu_admin.property_metadata_mapper', ['type' => 'teaser_selection']);
+
+    $services->set('sulu_admin.property_metadata_mapper.table', TablePropertyMetadataMapper::class)
+        ->tag('sulu_admin.property_metadata_mapper', ['type' => 'table']);
 
     $services->set('sulu_admin.schema_metadata_provider', SchemaMetadataProvider::class)
         ->args([new Reference('sulu_admin.property_metadata_mapper_registry')]);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Table.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Table.js
@@ -54,6 +54,29 @@ function toCell(raw: mixed): Cell {
     return {text: raw == null ? '' : String(raw), bold: false, italic: false, underline: false};
 }
 
+function resolveTableValue(raw: mixed): ?TableValue {
+    if (!raw || typeof raw !== 'object') {
+        return null;
+    }
+
+    // Unwrap ContentView-shaped values ({content, view}) if they were stored accidentally.
+    if (raw.content && typeof raw.content === 'object' && !Array.isArray(raw.content)) {
+        const content = raw.content;
+        if (Array.isArray(content.head) && Array.isArray(content.body)) {
+            const {head, body, ...rest} = content; // eslint-disable-line no-unused-vars
+            const {content: contentView, view, ...outerRest} = raw; // eslint-disable-line no-unused-vars
+
+            return {...outerRest, ...rest, head, body};
+        }
+    }
+
+    if (!Array.isArray(raw.head) || !Array.isArray(raw.body)) {
+        return null;
+    }
+
+    return raw;
+}
+
 function emptyCell(): Cell {
     return {text: '', bold: false, italic: false, underline: false};
 }
@@ -65,9 +88,9 @@ export default class Table extends React.Component<FieldTypeProps<?TableValue>, 
     };
 
     get extras(): Object {
-        const value = toJS(this.props.value);
+        const value = resolveTableValue(toJS(this.props.value));
 
-        if (!value || typeof value !== 'object') {
+        if (!value) {
             return {};
         }
 
@@ -77,9 +100,9 @@ export default class Table extends React.Component<FieldTypeProps<?TableValue>, 
     }
 
     get value(): NormalizedValue {
-        const value = toJS(this.props.value);
+        const value = resolveTableValue(toJS(this.props.value));
 
-        if (!value || !Array.isArray(value.head) || !Array.isArray(value.body)) {
+        if (!value) {
             return {head: [], body: []};
         }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Table.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Table.js
@@ -1,0 +1,464 @@
+// @flow
+import React, {Fragment} from 'react';
+import {toJS} from 'mobx';
+import {Button, Icon, Overlay} from 'sulu-admin-bundle/components';
+import {translate} from '../../../utils/Translator';
+import tableStyles from './table.scss';
+import type {FieldTypeProps} from 'sulu-admin-bundle/types';
+
+type Cell = {
+    bold: boolean,
+    italic: boolean,
+    text: string,
+    underline: boolean,
+};
+
+type TableValue = {
+    body: Array<Array<mixed>>,
+    head: Array<?string>,
+    options?: Object,
+    version?: number,
+};
+
+type NormalizedValue = {
+    body: Array<Array<Cell>>,
+    head: Array<string>,
+};
+
+type ActiveCell = {
+    columnIndex: number,
+    rowIndex: number,
+};
+
+type State = {
+    activeCell: ?ActiveCell,
+    fullscreen: boolean,
+};
+
+const FORMATS = [
+    {key: 'bold', label: 'F', styleClass: tableStyles.bold, titleKey: 'sulu_admin.table.format_bold'},
+    {key: 'italic', label: 'K', styleClass: tableStyles.italic, titleKey: 'sulu_admin.table.format_italic'},
+    {key: 'underline', label: 'U', styleClass: tableStyles.underline, titleKey: 'sulu_admin.table.format_underline'},
+];
+
+function toCell(raw: mixed): Cell {
+    if (raw && typeof raw === 'object') {
+        return {
+            text: raw.text == null ? '' : String(raw.text),
+            bold: Boolean(raw.bold),
+            italic: Boolean(raw.italic),
+            underline: Boolean(raw.underline),
+        };
+    }
+
+    return {text: raw == null ? '' : String(raw), bold: false, italic: false, underline: false};
+}
+
+function emptyCell(): Cell {
+    return {text: '', bold: false, italic: false, underline: false};
+}
+
+export default class Table extends React.Component<FieldTypeProps<?TableValue>, State> {
+    state = {
+        activeCell: null,
+        fullscreen: false,
+    };
+
+    get extras(): Object {
+        const value = toJS(this.props.value);
+
+        if (!value || typeof value !== 'object') {
+            return {};
+        }
+
+        const {head, body, ...rest} = value; // eslint-disable-line no-unused-vars
+
+        return rest;
+    }
+
+    get value(): NormalizedValue {
+        const value = toJS(this.props.value);
+
+        if (!value || !Array.isArray(value.head) || !Array.isArray(value.body)) {
+            return {head: [], body: []};
+        }
+
+        return {
+            head: value.head.map((cell) => (cell == null ? '' : String(cell))),
+            body: value.body.map((row) => (Array.isArray(row) ? row.map(toCell) : [])),
+        };
+    }
+
+    get columnCount(): number {
+        const {head, body} = this.value;
+
+        return Math.max(head.length, ...body.map((row) => row.length), 0);
+    }
+
+    normalize(value: NormalizedValue): NormalizedValue {
+        const head = value.head.map((cell) => (cell == null ? '' : String(cell)));
+        const body = value.body.map((row) => (Array.isArray(row) ? row.map(toCell) : []));
+        const columns = Math.max(head.length, ...body.map((row) => row.length), 0);
+
+        return {
+            head: columns > 0 ? [...head, ...new Array(Math.max(columns - head.length, 0)).fill('')] : [],
+            body: body.map((row) => [
+                ...row,
+                ...Array.from({length: Math.max(columns - row.length, 0)}, emptyCell),
+            ]),
+        };
+    }
+
+    emit(head: Array<string>, body: Array<Array<Cell>>): TableValue {
+        return {...this.extras, head, body};
+    }
+
+    handleChange = (nextValue: NormalizedValue) => {
+        const {onChange, onFinish} = this.props;
+        const normalized = this.normalize(nextValue);
+
+        this.setState({activeCell: null});
+
+        onChange(this.emit(normalized.head, normalized.body));
+        onFinish();
+    };
+
+    handleCellFocus = (rowIndex: number, columnIndex: number) => {
+        this.setState({activeCell: {rowIndex, columnIndex}});
+    };
+
+    handleOpenFullscreen = () => {
+        this.setState({fullscreen: true});
+    };
+
+    handleCloseFullscreen = () => {
+        this.setState({fullscreen: false});
+    };
+
+    handleHeadChange = (columnIndex: number, event: SyntheticInputEvent<HTMLInputElement>) => {
+        const {onChange} = this.props;
+        const {head, body} = this.value;
+
+        const nextHead = [...head];
+        nextHead[columnIndex] = event.currentTarget.value;
+
+        onChange(this.emit(nextHead, body));
+    };
+
+    handleCellChange = (
+        rowIndex: number,
+        columnIndex: number,
+        event: SyntheticInputEvent<HTMLInputElement>
+    ) => {
+        const {onChange} = this.props;
+        const {head, body} = this.value;
+        const text = event.currentTarget.value;
+
+        const nextBody = body.map((row, index) => {
+            if (index !== rowIndex) {
+                return row;
+            }
+
+            return row.map((cell, cellIndex) => (
+                cellIndex === columnIndex ? {...cell, text} : cell
+            ));
+        });
+
+        onChange(this.emit(head, nextBody));
+    };
+
+    handleToggleFormat = (rowIndex: number, columnIndex: number, key: string) => {
+        const {onChange, onFinish} = this.props;
+        const {head, body} = this.value;
+
+        const nextBody = body.map((row, index) => {
+            if (index !== rowIndex) {
+                return row;
+            }
+
+            return row.map((cell, cellIndex) => (
+                cellIndex === columnIndex ? {...cell, [key]: !cell[key]} : cell
+            ));
+        });
+
+        onChange(this.emit(head, nextBody));
+        onFinish();
+    };
+
+    handleBlur = () => {
+        this.props.onFinish();
+    };
+
+    handleInsertColumn = (index: number) => {
+        const {head, body} = this.value;
+
+        const nextHead = [...head];
+        nextHead.splice(index, 0, '');
+
+        const nextBody = body.map((row) => {
+            const nextRow = [...row];
+            nextRow.splice(index, 0, emptyCell());
+
+            return nextRow;
+        });
+
+        this.handleChange({head: nextHead, body: nextBody});
+    };
+
+    handleInsertRow = (index: number) => {
+        const {head, body} = this.value;
+        const columnCount = Math.max(this.columnCount, 1);
+
+        const nextBody = [...body];
+        nextBody.splice(index, 0, Array.from({length: columnCount}, emptyCell));
+
+        this.handleChange({head, body: nextBody});
+    };
+
+    handleAddColumn = () => {
+        this.handleInsertColumn(this.columnCount);
+    };
+
+    handleAddRow = () => {
+        this.handleInsertRow(this.value.body.length);
+    };
+
+    handleRemoveColumn = (columnIndex: number) => {
+        const {head, body} = this.value;
+
+        this.handleChange({
+            head: head.filter((cell, index) => index !== columnIndex),
+            body: body.map((row) => row.filter((cell, index) => index !== columnIndex)),
+        });
+    };
+
+    handleRemoveRow = (rowIndex: number) => {
+        const {head, body} = this.value;
+
+        this.handleChange({
+            head,
+            body: body.filter((row, index) => index !== rowIndex),
+        });
+    };
+
+    renderColumnInsert(index: number, position: 'left' | 'right') {
+        return (
+            <span className={tableStyles.colInsert + ' ' + tableStyles[position]}>
+                <span className={tableStyles.insertLineV} />
+                <button
+                    className={tableStyles.insertButton}
+                    onClick={() => this.handleInsertColumn(index)}
+                    tabIndex={-1}
+                    title={translate('sulu_admin.table.insert_column')}
+                    type="button"
+                >
+                    +
+                </button>
+            </span>
+        );
+    }
+
+    renderRowInsert(index: number, position: 'top' | 'bottom') {
+        return (
+            <span className={tableStyles.rowInsert + ' ' + tableStyles[position]}>
+                <span className={tableStyles.insertLineH} />
+                <button
+                    className={tableStyles.insertButton}
+                    onClick={() => this.handleInsertRow(index)}
+                    tabIndex={-1}
+                    title={translate('sulu_admin.table.insert_row')}
+                    type="button"
+                >
+                    +
+                </button>
+            </span>
+        );
+    }
+
+    renderCell(cell: Cell, rowIndex: number, columnIndex: number) {
+        const {disabled} = this.props;
+        const {activeCell} = this.state;
+        const isActive = Boolean(
+            activeCell && activeCell.rowIndex === rowIndex && activeCell.columnIndex === columnIndex
+        );
+
+        const inputClassName = [tableStyles.input]
+            .concat(cell.bold ? [tableStyles.bold] : [])
+            .concat(cell.italic ? [tableStyles.italic] : [])
+            .concat(cell.underline ? [tableStyles.underline] : [])
+            .join(' ');
+
+        return (
+            <div className={tableStyles.bodyCell + (isActive ? ' ' + tableStyles.activeCell : '')}>
+                <input
+                    className={inputClassName}
+                    disabled={disabled}
+                    onBlur={this.handleBlur}
+                    onChange={(event) => this.handleCellChange(rowIndex, columnIndex, event)}
+                    onFocus={() => this.handleCellFocus(rowIndex, columnIndex)}
+                    type="text"
+                    value={cell.text}
+                />
+            </div>
+        );
+    }
+
+    renderFormatWindow() {
+        const {disabled} = this.props;
+        const {activeCell, fullscreen} = this.state;
+        const {body} = this.value;
+
+        const cell = activeCell
+            ? (body[activeCell.rowIndex] || [])[activeCell.columnIndex]
+            : null;
+        const hasActiveCell = Boolean(activeCell && cell);
+
+        return (
+            <div className={tableStyles.toolbarRow}>
+                <div className={tableStyles.formatWindow}>
+                    <div className={tableStyles.formatWindowButtons}>
+                        {FORMATS.map((format) => (
+                            <button
+                                className={
+                                    tableStyles.formatButton
+                                    + (cell && cell[format.key] ? ' ' + tableStyles.active : '')
+                                }
+                                disabled={disabled || !hasActiveCell}
+                                key={format.key}
+                                onClick={() => activeCell
+                                    && this.handleToggleFormat(activeCell.rowIndex, activeCell.columnIndex, format.key)}
+                                onMouseDown={(event) => event.preventDefault()}
+                                title={translate(format.titleKey)}
+                                type="button"
+                            >
+                                <span className={format.styleClass}>{format.label}</span>
+                            </button>
+                        ))}
+                    </div>
+                </div>
+                {!fullscreen &&
+                    <div className={tableStyles.fullscreenWindow}>
+                        <button
+                            className={tableStyles.fullscreenButton}
+                            onClick={this.handleOpenFullscreen}
+                            title={translate('sulu_admin.table.fullscreen')}
+                            type="button"
+                        >
+                            <Icon name="su-expand" />
+                        </button>
+                    </div>
+                }
+            </div>
+        );
+    }
+
+    renderContent() {
+        const {disabled} = this.props;
+        const {head, body} = this.value;
+        const columnCount = this.columnCount;
+        const columns = Array.from({length: columnCount}, (value, index) => index);
+
+        return (
+            <Fragment>
+                {!disabled && this.renderFormatWindow()}
+                <div className={tableStyles.gridPanel}>
+                <table className={tableStyles.grid}>
+                    <thead>
+                        <tr>
+                            <th className={tableStyles.cornerCell} />
+                            {columns.map((columnIndex) => (
+                                <th className={tableStyles.headCell} key={columnIndex}>
+                                    {!disabled && columnIndex === 0 && this.renderColumnInsert(0, 'left')}
+                                    <div className={tableStyles.cellContent}>
+                                        <input
+                                            className={tableStyles.input}
+                                            disabled={disabled}
+                                            onBlur={this.handleBlur}
+                                            onChange={(event) => this.handleHeadChange(columnIndex, event)}
+                                            placeholder={translate('sulu_admin.table.column_title_placeholder')}
+                                            type="text"
+                                            value={head[columnIndex] || ''}
+                                        />
+                                        <Button
+                                            disabled={disabled}
+                                            icon="su-trash-alt"
+                                            onClick={() => this.handleRemoveColumn(columnIndex)}
+                                            skin="link"
+                                        />
+                                    </div>
+                                    {!disabled && this.renderColumnInsert(columnIndex + 1, 'right')}
+                                </th>
+                            ))}
+                            <th className={tableStyles.actionColumn} />
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {body.map((row, rowIndex) => (
+                            <tr key={rowIndex}>
+                                <td className={tableStyles.gutterCell}>
+                                    {!disabled && rowIndex === 0 && this.renderRowInsert(0, 'top')}
+                                    {!disabled && this.renderRowInsert(rowIndex + 1, 'bottom')}
+                                </td>
+                                {columns.map((columnIndex) => (
+                                    <td key={columnIndex}>
+                                        {this.renderCell(row[columnIndex] || emptyCell(), rowIndex, columnIndex)}
+                                    </td>
+                                ))}
+                                <td className={tableStyles.actionColumn}>
+                                    <Button
+                                        disabled={disabled}
+                                        icon="su-trash-alt"
+                                        onClick={() => this.handleRemoveRow(rowIndex)}
+                                        skin="link"
+                                    />
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+                </div>
+
+                <div className={tableStyles.toolbar}>
+                    <Button
+                        disabled={disabled}
+                        icon="su-plus"
+                        onClick={this.handleAddRow}
+                        skin="secondary"
+                    >
+                        {translate('sulu_admin.table.add_row')}
+                    </Button>
+                    <Button
+                        disabled={disabled}
+                        icon="su-plus"
+                        onClick={this.handleAddColumn}
+                        skin="secondary"
+                    >
+                        {translate('sulu_admin.table.add_column')}
+                    </Button>
+                </div>
+            </Fragment>
+        );
+    }
+
+    render() {
+        const {fullscreen} = this.state;
+
+        return (
+            <div className={tableStyles.table}>
+                {!fullscreen && this.renderContent()}
+                <Overlay
+                    confirmText={translate('sulu_admin.table.close')}
+                    onClose={this.handleCloseFullscreen}
+                    onConfirm={this.handleCloseFullscreen}
+                    open={fullscreen}
+                    size="large"
+                    title={translate('sulu_admin.table.edit_overlay_title')}
+                >
+                    <div className={tableStyles.table + ' ' + tableStyles.overlayContent}>
+                        {fullscreen && this.renderContent()}
+                    </div>
+                </Overlay>
+            </div>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/table.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/table.scss
@@ -1,0 +1,321 @@
+@import '../../Application/colors.scss';
+
+$accent: $shakespeare;
+
+.table {
+    position: relative;
+
+    .toolbarRow {
+        position: sticky;
+        top: 0;
+        z-index: 6;
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+        margin-bottom: 10px;
+    }
+
+    .fullscreenWindow {
+        display: inline-flex;
+        align-items: center;
+        padding: 6px 10px;
+        background: #f3f5f6;
+        border: 1px solid #e1e1e1;
+        border-radius: 4px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    }
+
+    .fullscreenButton {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 26px;
+        height: 24px;
+        padding: 0;
+        color: #666;
+        background: #fff;
+        border: 1px solid #d4d4d4;
+        border-radius: 3px;
+        cursor: pointer;
+
+        &:hover {
+            border-color: $accent;
+            color: $accent;
+        }
+    }
+
+    &.overlayContent {
+        padding: 20px;
+    }
+
+    .gridPanel {
+        display: block;
+        width: -moz-fit-content;
+        width: fit-content;
+        max-width: 100%;
+        overflow-x: auto;
+        padding: 12px;
+        background: #fff;
+        border: 1px solid #e1e1e1;
+        border-radius: 4px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+
+        scrollbar-width: thin;
+        scrollbar-color: #ccc transparent;
+
+        &::-webkit-scrollbar {
+            height: 8px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: #f7f7f7;
+            border-radius: 4px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background: #ccc;
+            border-radius: 4px;
+
+            &:hover {
+                background: $accent;
+            }
+        }
+    }
+
+    .grid {
+        border-collapse: separate;
+        border-spacing: 0;
+
+        td,
+        th {
+            border: 1px solid #e1e1e1;
+            padding: 0;
+            vertical-align: middle;
+        }
+
+        th {
+            background: #f7f7f7;
+        }
+    }
+
+    .cellContent {
+        display: flex;
+        align-items: center;
+        padding: 2px 4px;
+    }
+
+    .input {
+        width: 100%;
+        min-width: 120px;
+        border: none;
+        background: transparent;
+        padding: 6px 4px;
+        font: inherit;
+
+        &:focus {
+            outline: 2px solid $accent;
+            outline-offset: -2px;
+        }
+    }
+
+    .bold {
+        font-weight: 700;
+    }
+
+    .italic {
+        font-style: italic;
+    }
+
+    .underline {
+        text-decoration: underline;
+    }
+
+    .bodyCell {
+        display: flex;
+        flex-direction: column;
+        position: relative;
+    }
+
+    .activeCell::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        border: 2px solid $accent;
+        box-shadow: 0 0 0 1px rgba(82, 182, 202, 0.25);
+        pointer-events: none;
+    }
+
+    .formatWindow {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        padding: 6px 10px;
+        background: #fff;
+        border: 1px solid #e1e1e1;
+        border-radius: 4px;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+    }
+
+    .formatWindowButtons {
+        display: flex;
+        gap: 4px;
+
+        .formatButton {
+            width: 26px;
+            height: 24px;
+            line-height: 22px;
+            font-size: 13px;
+        }
+    }
+
+    .formatButton {
+        width: 20px;
+        height: 18px;
+        padding: 0;
+        line-height: 16px;
+        font-size: 12px;
+        text-align: center;
+        color: #666;
+        background: #fff;
+        border: 1px solid #d4d4d4;
+        border-radius: 3px;
+        cursor: pointer;
+
+        &:hover {
+            border-color: $accent;
+            color: $accent;
+        }
+
+        &.active {
+            color: #fff;
+            background: $accent;
+            border-color: $accent;
+        }
+    }
+
+    .actionColumn {
+        width: 40px;
+        text-align: center;
+    }
+
+    .cornerCell,
+    .gutterCell {
+        width: 22px;
+        border: none !important;
+        background: transparent !important;
+        position: relative;
+    }
+
+    .headCell {
+        position: relative;
+    }
+
+    .toolbar {
+        display: flex;
+        gap: 10px;
+        margin-top: 12px;
+    }
+
+    .insertButton {
+        position: absolute;
+        width: 18px;
+        height: 18px;
+        padding: 0;
+        line-height: 16px;
+        font-size: 15px;
+        font-weight: bold;
+        text-align: center;
+        color: $accent;
+        background: #fff;
+        border: 1px solid $accent;
+        border-radius: 50%;
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 4;
+
+        &:hover {
+            color: #fff;
+            background: $accent;
+        }
+    }
+
+    .insertLineV,
+    .insertLineH {
+        position: absolute;
+        background: $accent;
+        pointer-events: none;
+    }
+
+    .colInsert {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 16px;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.1s ease-in-out;
+
+        &.left {
+            left: -8px;
+        }
+
+        &.right {
+            right: -8px;
+        }
+
+        .insertLineV {
+            top: 0;
+            bottom: 0;
+            left: 50%;
+            width: 2px;
+            transform: translateX(-50%);
+        }
+
+        .insertButton {
+            top: -9px;
+            left: 50%;
+            transform: translateX(-50%);
+        }
+    }
+
+    .rowInsert {
+        position: absolute;
+        left: 0;
+        right: 0;
+        height: 16px;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.1s ease-in-out;
+
+        &.top {
+            top: -8px;
+        }
+
+        &.bottom {
+            bottom: -8px;
+        }
+
+        .insertLineH {
+            left: 0;
+            right: 0;
+            top: 50%;
+            height: 2px;
+            transform: translateY(-50%);
+        }
+
+        .insertButton {
+            left: -2px;
+            top: 50%;
+            transform: translateY(-50%);
+        }
+    }
+
+    .headCell:hover > .colInsert,
+    .gutterCell:hover > .rowInsert {
+        opacity: 1;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/index.js
@@ -35,6 +35,7 @@ import TextEditor from './fields/TextEditor';
 import Url from './fields/Url';
 import Link from './fields/Link';
 import SingleIconSelection from './fields/SingleIconSelection';
+import Table from './fields/Table';
 import type {FormStoreInterface, Schema, Types} from './types';
 
 export {
@@ -73,6 +74,7 @@ export {
     Url,
     Link,
     SingleIconSelection,
+    Table,
 };
 export type {FormStoreInterface, Schema, Types};
 export default Form;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -99,6 +99,7 @@ import {
     Url,
     Link,
     SingleIconSelection,
+    Table,
 } from './containers/Form';
 import {textEditorRegistry} from './containers/TextEditor';
 import Form, {
@@ -163,6 +164,7 @@ const FIELD_TYPE_TIME = 'time';
 const FIELD_TYPE_URL = 'url';
 const FIELD_TYPE_LINK = 'link';
 const FIELD_TYPE_SINGLE_ICON_SELECTION = 'single_icon_selection';
+const FIELD_TYPE_TABLE = 'table';
 
 initializer.addUpdateConfigHook('sulu_admin', (config: Object, initialized: boolean) => {
     if (!initialized) {
@@ -271,6 +273,7 @@ function registerFieldTypes(fieldTypeOptions) {
     fieldRegistry.add(FIELD_TYPE_URL, Url);
     fieldRegistry.add(FIELD_TYPE_LINK, Link);
     fieldRegistry.add(FIELD_TYPE_SINGLE_ICON_SELECTION, SingleIconSelection);
+    fieldRegistry.add(FIELD_TYPE_TABLE, Table);
 
     registerFieldTypesWithOptions(fieldTypeOptions['selection'], Selection);
     registerFieldTypesWithOptions(fieldTypeOptions['single_selection'], SingleSelection);

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -260,5 +260,16 @@
     "sulu_admin.link_target_blank":  "_blank",
     "sulu_admin.link_target_self": "_self",
     "sulu_admin.link_target_parent": "_parent",
-    "sulu_admin.link_target_top": "_top"
+    "sulu_admin.link_target_top": "_top",
+    "sulu_admin.table.format_bold": "Fett",
+    "sulu_admin.table.format_italic": "Kursiv",
+    "sulu_admin.table.format_underline": "Unterstrichen",
+    "sulu_admin.table.insert_column": "Spalte einfügen",
+    "sulu_admin.table.insert_row": "Zeile einfügen",
+    "sulu_admin.table.fullscreen": "Vollbild",
+    "sulu_admin.table.column_title_placeholder": "Spaltentitel",
+    "sulu_admin.table.add_row": "Zeile",
+    "sulu_admin.table.add_column": "Spalte",
+    "sulu_admin.table.close": "Schließen",
+    "sulu_admin.table.edit_overlay_title": "Tabelle bearbeiten"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -260,5 +260,16 @@
     "sulu_admin.link_target_blank": "_blank",
     "sulu_admin.link_target_self": "_self",
     "sulu_admin.link_target_parent": "_parent",
-    "sulu_admin.link_target_top": "_top"
+    "sulu_admin.link_target_top": "_top",
+    "sulu_admin.table.format_bold": "Bold",
+    "sulu_admin.table.format_italic": "Italic",
+    "sulu_admin.table.format_underline": "Underline",
+    "sulu_admin.table.insert_column": "Insert column",
+    "sulu_admin.table.insert_row": "Insert row",
+    "sulu_admin.table.fullscreen": "Fullscreen",
+    "sulu_admin.table.column_title_placeholder": "Column title",
+    "sulu_admin.table.add_row": "Row",
+    "sulu_admin.table.add_column": "Column",
+    "sulu_admin.table.close": "Close",
+    "sulu_admin.table.edit_overlay_title": "Edit table"
 }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataMapper/TablePropertyMetadataMapperTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/SchemaMetadata/PropertyMetadataMapper/TablePropertyMetadataMapperTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Metadata\SchemaMetadata\PropertyMetadataMapper;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapper\TablePropertyMetadataMapper;
+
+class TablePropertyMetadataMapperTest extends TestCase
+{
+    private TablePropertyMetadataMapper $tablePropertyMetadataMapper;
+
+    protected function setUp(): void
+    {
+        $this->tablePropertyMetadataMapper = new TablePropertyMetadataMapper();
+    }
+
+    public function testMapPropertyMetadata(): void
+    {
+        $fieldMetadata = new FieldMetadata('specs');
+
+        $jsonSchema = $this->tablePropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
+
+        $this->assertArrayHasKey('anyOf', $jsonSchema);
+        $this->assertSame(['type' => 'null'], $jsonSchema['anyOf'][0]);
+        $this->assertSame('object', $jsonSchema['anyOf'][1]['type']);
+        $this->assertArrayHasKey('head', $jsonSchema['anyOf'][1]['properties']);
+        $this->assertArrayHasKey('body', $jsonSchema['anyOf'][1]['properties']);
+    }
+
+    public function testMapPropertyMetadataRequired(): void
+    {
+        $fieldMetadata = new FieldMetadata('specs');
+        $fieldMetadata->setRequired(true);
+
+        $jsonSchema = $this->tablePropertyMetadataMapper->mapPropertyMetadata($fieldMetadata)->toJsonSchema();
+
+        $this->assertSame('object', $jsonSchema['type']);
+        $this->assertArrayHasKey('head', $jsonSchema['properties']);
+        $this->assertArrayHasKey('body', $jsonSchema['properties']);
+        $this->assertSame('array', $jsonSchema['properties']['head']['type']);
+        $this->assertSame('array', $jsonSchema['properties']['body']['type']);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Related issues/PRs | #8907
| License | MIT

#### What's in this PR?

Ever since the CK Editor was restricted, I've been missing the ability to create simple tables.
To that end, I'd like to add the new “Table” property type—a way to create tables directly in the backend.
This could look something like the following POC.

See #8907

### Open To-Dos

- [ ] - Sulu Block support
- [ ] - Add documentation
- [ ] - Tests
- [ ] - Data is not yet loaded correctly into the view in the admin backend after saving
