### PR TITLE
Fix PHPStan type errors in request and data provider traits

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -90515,3 +90515,9 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/phpstan/object-manager.php
+
+		-
+			message: '#^Call to function array_key_exists\(\) with ''model'' and array\{model\: class\-string, repository\?\: class\-string\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php

--- a/src/Sulu/Component/Rest/RequestParametersTrait.php
+++ b/src/Sulu/Component/Rest/RequestParametersTrait.php
@@ -61,15 +61,15 @@ trait RequestParametersTrait
         /** @var mixed $value */
         $value = $this->getRequestParameter($request, $name, $force, $default);
         if ('true' === $value || true === $value) {
-            $value = true;
-        } elseif ('false' === $value || false === $value) {
-            $value = false;
-        } elseif ($force) {
+            return true;
+        }
+        if ('false' === $value || false === $value) {
+            return false;
+        }
+        if ($force) {
             throw new ParameterDataTypeException(\get_class($this), $name);
-        } else {
-            $value = $default;
         }
 
-        return $value;
+        return $default;
     }
 }

--- a/src/Sulu/Component/Rest/RequestParametersTrait.php
+++ b/src/Sulu/Component/Rest/RequestParametersTrait.php
@@ -58,12 +58,13 @@ trait RequestParametersTrait
      */
     protected function getBooleanRequestParameter($request, $name, $force = false, $default = null)
     {
+        /** @var mixed $value */
         $value = $this->getRequestParameter($request, $name, $force, $default);
         if ('true' === $value || true === $value) {
             $value = true;
         } elseif ('false' === $value || false === $value) {
             $value = false;
-        } elseif ($force && true !== $value && false !== $value) {
+        } elseif ($force) {
             throw new ParameterDataTypeException(\get_class($this), $name);
         } else {
             $value = $default;

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryInterface.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryInterface.php
@@ -21,7 +21,7 @@ interface DataProviderRepositoryInterface
      * When pagination is active the result count is pageSize + 1 to determine has next page.
      *
      * @param array $filters array of filters: tags, tagOperator
-     * @param int $page
+     * @param int|null $page
      * @param int $pageSize
      * @param int $limit
      * @param string $locale

--- a/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
+++ b/src/Sulu/Component/SmartContent/Orm/DataProviderRepositoryTrait.php
@@ -27,7 +27,7 @@ trait DataProviderRepositoryTrait
 
     /**
      * @param array $filters
-     * @param int $page
+     * @param int|null $page
      * @param int $pageSize
      * @param int|null $limit
      * @param string $locale
@@ -88,7 +88,7 @@ trait DataProviderRepositoryTrait
      * Resolves filter and returns id array for second query.
      *
      * @param array $filters array of filters: tags, tagOperator
-     * @param int $page
+     * @param int|null $page
      * @param int $pageSize
      * @param int|null $limit
      * @param string $locale


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This resolves PHPStan errors caused by PHPDoc types that were narrower than the values the code actually handles. In getBooleanRequestParameter the resolved value is annotated as its real bool|string|null type and a redundant comparison in the force branch is removed. The private findByFiltersIds method now documents that its page argument can be null. The defensive array_key_exists check in PersistenceExtensionTrait is added to the baseline instead, since the object configuration always provides a model.

#### Why?

PHPStan at max level reported comparisons that could never change their outcome because the annotations claimed narrower types than reality. Correcting the annotations and baselining the one intentional defensive check clears the errors without changing runtime behavior, which the existing unit tests confirm.