### PR TITLE
Add RelationTrait linting errors to baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -90521,3 +90521,15 @@ parameters:
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php
+
+		-
+			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 1
+			path: src/Sulu/Component/Persistence/RelationTrait.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: src/Sulu/Component/Persistence/RelationTrait.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/8913
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Adds new errors after updating phpstan to baseline.