### PR TITLE
Add configurable Field-Types for the AIApplication

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81097,6 +81097,18 @@ parameters:
 			path: src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
 
 		-
+			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 1
+			path: src/Sulu/Component/Persistence/RelationTrait.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: src/Sulu/Component/Persistence/RelationTrait.php
+
+		-
 			message: '#^Property Sulu\\Component\\Persistence\\Tests\\Unit\\EventSubscriber\\ORM\\MetadataSubscriberTest\:\:\$classMetadata with generic class Doctrine\\ORM\\Mapping\\ClassMetadata does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
@@ -18,6 +18,8 @@ type Props = {|
         formKey: string,
         route: string,
     },
+    htmlFieldTypes: Array<string>,
+    textFieldTypes: Array<string>,
     translation: {
         enabled: boolean,
         route: string,
@@ -44,6 +46,11 @@ type Props = {|
  */
 @observer
 export default class AiApplication extends Component<Props> {
+    static defaultProps = {
+        htmlFieldTypes: ['text_editor'],
+        textFieldTypes: ['text_line', 'text_area'],
+    };
+
     @observable selectedComponent: {
         dataPath: string,
         formInspector: FormInspector,
@@ -212,19 +219,24 @@ export default class AiApplication extends Component<Props> {
     }
 
     @computed get delta() {
-        if (this.selectedComponent?.schemaType === 'text_line') {
-            return 5;
-        }
-
-        if (this.selectedComponent?.schemaType === 'text_area') {
-            return 5;
-        }
-
-        if (this.selectedComponent?.schemaType === 'text_editor') {
+        const schemaType = this.selectedComponent?.schemaType;
+        if (schemaType && this.props.htmlFieldTypes.includes(schemaType)) {
             return 50;
         }
 
         return 5;
+    }
+
+    canonicalFieldType(schemaType: string): 'text_line' | 'text_area' | 'text_editor' {
+        if (this.props.htmlFieldTypes.includes(schemaType)) {
+            return 'text_editor';
+        }
+
+        if (schemaType === 'text_area') {
+            return 'text_area';
+        }
+
+        return 'text_line';
     }
 
     @action handleWritingAssistantOpen = () => {
@@ -312,9 +324,13 @@ export default class AiApplication extends Component<Props> {
         }
 
         const schemaType = this.selectedComponent?.schemaType || 'text_line';
-        if (schemaType !== 'text_line' && schemaType !== 'text_area' && schemaType !== 'text_editor') {
+        if (!this.props.textFieldTypes.includes(schemaType)
+            && !this.props.htmlFieldTypes.includes(schemaType)
+        ) {
             return null;
         }
+
+        const canonicalType = this.canonicalFieldType(schemaType);
 
         return (
             <div style={this.position}>
@@ -353,7 +369,7 @@ export default class AiApplication extends Component<Props> {
                         onDialogClose={this.handleWritingAssistantClose}
                         resourceId={this.selectedComponent.formInspector.id}
                         resourceKey={this.selectedComponent.formInspector.resourceKey}
-                        type={schemaType}
+                        type={canonicalType}
                         url={this.writingAssistantUrl}
                         value={this.selectedText}
                         webspaceKey={this.selectedComponent.formInspector.options?.webspace}
@@ -379,7 +395,7 @@ export default class AiApplication extends Component<Props> {
                         resourceKey={this.selectedComponent.formInspector.resourceKey}
                         sourceLanguages={this.props.translation.sourceLanguages}
                         targetLanguages={this.props.translation.targetLanguages}
-                        type={schemaType}
+                        type={canonicalType}
                         url={this.translationUrl}
                         value={this.selectedText}
                         webspaceKey={this.selectedComponent.formInspector.options?.webspace}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/AiApplication.js
@@ -220,7 +220,7 @@ export default class AiApplication extends Component<Props> {
 
     @computed get delta() {
         const schemaType = this.selectedComponent?.schemaType;
-        if (schemaType && this.props.htmlFieldTypes.includes(schemaType)) {
+        if (schemaType && this.canonicalFieldType(schemaType) === 'text_editor') {
             return 50;
         }
 
@@ -228,12 +228,12 @@ export default class AiApplication extends Component<Props> {
     }
 
     canonicalFieldType(schemaType: string): 'text_line' | 'text_area' | 'text_editor' {
-        if (this.props.htmlFieldTypes.includes(schemaType)) {
-            return 'text_editor';
+        if (schemaType === 'text_line' || schemaType === 'text_area' || schemaType === 'text_editor') {
+            return schemaType;
         }
 
-        if (schemaType === 'text_area') {
-            return 'text_area';
+        if (this.props.htmlFieldTypes.includes(schemaType)) {
+            return 'text_editor';
         }
 
         return 'text_line';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
@@ -180,6 +180,18 @@ describe('AiApplication', () => {
         expect(instance.canonicalFieldType('text_line')).toBe('text_line');
     });
 
+    test('canonicalFieldType maps canonical types to themselves regardless of configuration', () => {
+        const instance = new AiApplication({
+            ...props,
+            htmlFieldTypes: ['configurable_text_editor'],
+            textFieldTypes: ['custom_line'],
+        });
+
+        expect(instance.canonicalFieldType('text_editor')).toBe('text_editor');
+        expect(instance.canonicalFieldType('text_area')).toBe('text_area');
+        expect(instance.canonicalFieldType('text_line')).toBe('text_line');
+    });
+
     test('handles scroll and resize events', () => {
         render(<AiApplication {...props} />);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
@@ -96,6 +96,88 @@ describe('AiApplication', () => {
         expect(screen.getByTitle('sulu_admin.writing_assistant')).toBeInTheDocument();
     });
 
+    test('does not render for an unknown schemaType by default', () => {
+        const {container} = render(<AiApplication {...props} />);
+
+        const mockElement = document.createElement('div');
+        Object.defineProperty(mockElement, 'parentElement', {
+            // $FlowFixMe
+            value: {
+                getBoundingClientRect: jest.fn().mockReturnValue({
+                    top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0,
+                }),
+            },
+        });
+
+        const event = new Event('sulu.focus');
+        Object.defineProperty(event, 'target', {value: mockElement});
+        // $FlowFixMe
+        Object.defineProperty(event, 'detail', {
+            value: {
+                formInspector: {locale: {get: () => 'en'}},
+                getValue: jest.fn(),
+                schemaPath: 'schemaPath',
+                schemaType: 'configurable_text_editor',
+                setValue: jest.fn(),
+            },
+        });
+
+        fireEvent(document, event);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    test('renders FeatureBadge for custom htmlFieldTypes', () => {
+        render(
+            <AiApplication
+                {...props}
+                htmlFieldTypes={['text_editor', 'configurable_text_editor']}
+            />
+        );
+
+        const mockElement = document.createElement('div');
+        Object.defineProperty(mockElement, 'parentElement', {
+            // $FlowFixMe
+            value: {
+                getBoundingClientRect: jest.fn().mockReturnValue({
+                    top: 0, right: 0, bottom: 0, left: 0, width: 0, height: 0,
+                }),
+            },
+        });
+
+        const event = new Event('sulu.focus');
+        Object.defineProperty(event, 'target', {value: mockElement});
+        // $FlowFixMe
+        Object.defineProperty(event, 'detail', {
+            value: {
+                formInspector: {locale: {get: () => 'en'}},
+                getValue: jest.fn(),
+                schemaPath: 'schemaPath',
+                schemaType: 'configurable_text_editor',
+                setValue: jest.fn(),
+            },
+        });
+
+        fireEvent(document, event);
+
+        expect(screen.getByTitle('sulu_admin.translator')).toBeInTheDocument();
+        expect(screen.getByTitle('sulu_admin.writing_assistant')).toBeInTheDocument();
+    });
+
+    test('canonicalFieldType classifies custom html types as text_editor', () => {
+        const instance = new AiApplication({
+            ...props,
+            htmlFieldTypes: ['text_editor', 'configurable_text_editor'],
+            textFieldTypes: ['text_line', 'text_area', 'custom_line'],
+        });
+
+        expect(instance.canonicalFieldType('configurable_text_editor')).toBe('text_editor');
+        expect(instance.canonicalFieldType('text_editor')).toBe('text_editor');
+        expect(instance.canonicalFieldType('text_area')).toBe('text_area');
+        expect(instance.canonicalFieldType('custom_line')).toBe('text_line');
+        expect(instance.canonicalFieldType('text_line')).toBe('text_line');
+    });
+
     test('handles scroll and resize events', () => {
         render(<AiApplication {...props} />);
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/AiApplication/tests/AiApplication.test.js
@@ -25,6 +25,8 @@ describe('AiApplication', () => {
                 formKey: 'formKey',
                 route: 'feedbackRoute',
             },
+            htmlFieldTypes: ['text_editor'],
+            textFieldTypes: ['text_line', 'text_area'],
             translation: {
                 enabled: true,
                 route: 'translationRoute',

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -465,6 +465,8 @@ initializer.addUpdateConfigHook('sulu_ai', (config: Object, initialized: boolean
 
     render(<AiApplication
         feedback={config['feedback']}
+        htmlFieldTypes={config['html_field_types'] || ['text_editor']}
+        textFieldTypes={config['text_field_types'] || ['text_line', 'text_area']}
         translation={config['translation']}
         writingAssistant={config['writing_assistant']}
     />, div);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/index.js
@@ -465,8 +465,8 @@ initializer.addUpdateConfigHook('sulu_ai', (config: Object, initialized: boolean
 
     render(<AiApplication
         feedback={config['feedback']}
-        htmlFieldTypes={config['html_field_types'] || ['text_editor']}
-        textFieldTypes={config['text_field_types'] || ['text_line', 'text_area']}
+        htmlFieldTypes={config['html_field_types']}
+        textFieldTypes={config['text_field_types']}
         translation={config['translation']}
         writingAssistant={config['writing_assistant']}
     />, div);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no yes
| BC breaks? | no yes
| Deprecations? | no yes <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Replaces the hardcoded text_line/text_area/text_editor check in AiApplication with textFieldTypes and htmlFieldTypes props sourced from the sulu_ai admin config (with defaults preserving current behavior). Third-party editor field types such as configurable_text_editor can now opt into the writing assistant and translator toolbar by configuring sulu_ai.html_field_types. A canonicalFieldType helper maps custom types back to the three canonical values so WritingAssistant, Translator and Message do not need changes.

#### Why?

This should be extensible.
