### PR TITLE
Use correct request bags in KeywordController

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7237,18 +7237,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
 
 		-
-			message: '#^Parameter \#1 \$keyword of method Sulu\\Bundle\\CategoryBundle\\Entity\\KeywordInterface\:\:setKeyword\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
-
-		-
-			message: '#^Parameter \#1 \$locale of method Sulu\\Bundle\\CategoryBundle\\Entity\\KeywordInterface\:\:setLocale\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
-
-		-
 			message: '#^Parameter \#2 \$category of method Sulu\\Bundle\\CategoryBundle\\Category\\KeywordManagerInterface\:\:delete\(\) expects Sulu\\Bundle\\CategoryBundle\\Entity\\CategoryInterface, Sulu\\Bundle\\CategoryBundle\\Entity\\CategoryInterface\|null given\.$#'
 			identifier: argument.type
 			count: 2
@@ -7262,18 +7250,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$fieldDescriptors of method Sulu\\Component\\Rest\\RestHelperInterface\:\:initializeListBuilder\(\) expects array\<Sulu\\Component\\Rest\\ListBuilder\\FieldDescriptorInterface\>, array\<Sulu\\Component\\Rest\\ListBuilder\\FieldDescriptorInterface\>\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
-
-		-
-			message: '#^Parameter \#3 \$force of method Sulu\\Bundle\\CategoryBundle\\Category\\KeywordManagerInterface\:\:save\(\) expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -7671,7 +7647,7 @@ parameters:
 		-
 			message: '#^Binary operation "\." between non\-falsy\-string and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 11
+			count: 16
 			path: src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
 
 		-
@@ -32879,7 +32855,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
-
 		-
 			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
 			identifier: equal.alwaysTrue

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -128,8 +128,8 @@ class KeywordController extends AbstractRestController implements SecuredControl
         /** @var KeywordInterface $keyword */
         $keyword = $this->keywordRepository->createNew();
         $category = $this->categoryRepository->findCategoryById($categoryId);
-        $keyword->setKeyword($request->request->getString('keyword'));
-        $keyword->setLocale($request->request->getString('locale'));
+        $keyword->setKeyword($request->getPayload()->getString('keyword'));
+        $keyword->setLocale($this->getLocale($request));
 
         $keyword = $this->keywordManager->save($keyword, $category);
 
@@ -167,7 +167,7 @@ class KeywordController extends AbstractRestController implements SecuredControl
             $force = $request->query->getString('force');
         }
         $category = $this->categoryRepository->findCategoryById($categoryId);
-        $keyword->setKeyword($request->request->getString('keyword'));
+        $keyword->setKeyword($request->getPayload()->getString('keyword'));
 
         $keyword = $this->keywordManager->save($keyword, $category, $force);
 

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -86,7 +86,7 @@ class KeywordController extends AbstractRestController implements SecuredControl
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptor);
 
         /** @var string $locale */
-        $locale = $request->get('locale');
+        $locale = $this->getLocale($request);
         $categoryTranslation = $category->findTranslationByLocale($locale);
 
         if (false == $categoryTranslation) {
@@ -128,8 +128,8 @@ class KeywordController extends AbstractRestController implements SecuredControl
         /** @var KeywordInterface $keyword */
         $keyword = $this->keywordRepository->createNew();
         $category = $this->categoryRepository->findCategoryById($categoryId);
-        $keyword->setKeyword($request->get('keyword'));
-        $keyword->setLocale($request->get('locale'));
+        $keyword->setKeyword($request->request->getString('keyword'));
+        $keyword->setLocale($request->request->getString('locale'));
 
         $keyword = $this->keywordManager->save($keyword, $category);
 
@@ -162,9 +162,12 @@ class KeywordController extends AbstractRestController implements SecuredControl
             return $this->handleView($this->view(null, 404));
         }
 
-        $force = $request->get('force');
+        $force = null;
+        if ($request->query->has('force')) {
+            $force = $request->query->getString('force');
+        }
         $category = $this->categoryRepository->findCategoryById($categoryId);
-        $keyword->setKeyword($request->get('keyword'));
+        $keyword->setKeyword($request->request->getString('keyword'));
 
         $keyword = $this->keywordManager->save($keyword, $category, $force);
 
@@ -203,7 +206,7 @@ class KeywordController extends AbstractRestController implements SecuredControl
     {
         $category = $this->categoryRepository->findCategoryById($categoryId);
 
-        $ids = \array_filter(\explode(',', $request->get('ids')));
+        $ids = \array_filter(\explode(',', $request->query->getString('ids')));
         foreach ($ids as $id) {
             $keyword = $this->keywordRepository->findById($id);
             $this->keywordManager->delete($keyword, $category);

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -22,6 +22,7 @@ use Sulu\Bundle\CategoryBundle\Entity\KeywordRepositoryInterface;
 use Sulu\Bundle\CategoryBundle\Exception\KeywordIsMultipleReferencedException;
 use Sulu\Bundle\CategoryBundle\Exception\KeywordNotUniqueException;
 use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\PaginatedRepresentation;
@@ -77,8 +78,10 @@ class KeywordController extends AbstractRestController implements SecuredControl
         $listBuilder = $this->listBuilderFactory->create($this->keywordClass);
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptor);
 
-        /** @var string $locale */
         $locale = $this->getLocale($request);
+        if (null === $locale) {
+            throw new MissingParameterException(self::class, 'locale');
+        }
         $categoryTranslation = $category->findTranslationByLocale($locale);
 
         if (false == $categoryTranslation) {
@@ -117,11 +120,16 @@ class KeywordController extends AbstractRestController implements SecuredControl
      */
     public function postAction($categoryId, Request $request)
     {
+        $locale = $this->getLocale($request);
+        if (null === $locale) {
+            throw new MissingParameterException(self::class, 'locale');
+        }
+
         /** @var KeywordInterface $keyword */
         $keyword = $this->keywordRepository->createNew();
         $category = $this->categoryRepository->findCategoryById($categoryId);
         $keyword->setKeyword($request->getPayload()->getString('keyword'));
-        $keyword->setLocale($this->getLocale($request));
+        $keyword->setLocale($locale);
 
         $keyword = $this->keywordManager->save($keyword, $category);
 

--- a/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/KeywordController.php
@@ -58,14 +58,6 @@ class KeywordController extends AbstractRestController implements SecuredControl
         private string $keywordClass
     ) {
         parent::__construct($viewHandler);
-        $this->restHelper = $restHelper;
-        $this->listBuilderFactory = $listBuilderFactory;
-        $this->fieldDescriptorFactory = $fieldDescriptorFactory;
-        $this->keywordManager = $keywordManager;
-        $this->keywordRepository = $keywordRepository;
-        $this->categoryRepository = $categoryRepository;
-        $this->entityManager = $entityManager;
-        $this->keywordClass = $keywordClass;
     }
 
     /**

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Functional/Controller/KeywordControllerTest.php
@@ -148,8 +148,8 @@ class KeywordControllerTest extends SuluTestCase
     {
         $this->client->jsonRequest(
             'POST',
-            '/api/categories/' . ($categoryId ?: $this->category1->getId()) . '/keywords',
-            ['locale' => $locale, 'keyword' => $keyword]
+            '/api/categories/' . ($categoryId ?: $this->category1->getId()) . '/keywords?locale=' . $locale,
+            ['keyword' => $keyword]
         );
 
         $result = \json_decode($this->client->getResponse()->getContent(), true);
@@ -168,8 +168,8 @@ class KeywordControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/categories/' . $this->category1->getId() . '/keywords',
-            ['locale' => $locale, 'keyword' => $keyword]
+            '/api/categories/' . $this->category1->getId() . '/keywords?locale=' . $locale,
+            ['keyword' => $keyword]
         );
 
         $result = \json_decode($this->client->getResponse()->getContent(), true);
@@ -184,8 +184,8 @@ class KeywordControllerTest extends SuluTestCase
     {
         $this->client->jsonRequest(
             'POST',
-            '/api/categories/' . $this->category1->getId() . '/keywords',
-            ['locale' => 'it', 'keyword' => 'my-keyword']
+            '/api/categories/' . $this->category1->getId() . '/keywords?locale=it',
+            ['keyword' => 'my-keyword']
         );
 
         $result = \json_decode($this->client->getResponse()->getContent(), true);
@@ -202,8 +202,8 @@ class KeywordControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/categories/' . $this->category2->getId() . '/keywords',
-            ['locale' => $locale, 'keyword' => $keyword]
+            '/api/categories/' . $this->category2->getId() . '/keywords?locale=' . $locale,
+            ['keyword' => $keyword]
         );
 
         $result = \json_decode($this->client->getResponse()->getContent(), true);
@@ -222,8 +222,8 @@ class KeywordControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/categories/' . $this->category2->getId() . '/keywords',
-            ['locale' => $locale, 'keyword' => $keyword]
+            '/api/categories/' . $this->category2->getId() . '/keywords?locale=' . $locale,
+            ['keyword' => $keyword]
         );
 
         $result = \json_decode($this->client->getResponse()->getContent(), true);
@@ -241,7 +241,7 @@ class KeywordControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/categories/' . $this->category1->getId() . '/keywords/' . $first['id'],
+            '/api/categories/' . $this->category1->getId() . '/keywords/' . $first['id'] . '?locale=' . $locale,
             ['keyword' => $keyword]
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #8216 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?
Replacing `request->get` with appropriate parameter bags.

#### Why?
Symfony 8 Support
