### PR TITLE
Fix preview webspace selection for nested localizations

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/Preview.js
@@ -81,15 +81,20 @@ class Preview extends React.Component<Props> {
         const {formStore: {locale}} = this.props;
         const currentLocale = locale?.get();
 
+        const supportsLocale = (localizations) => localizations.some(
+            (localization) => localization.locale === currentLocale
+                || (localization.children && supportsLocale(localization.children))
+        );
+
         return webspaceStore.grantedWebspaces
             .filter((webspace) => {
                 // Filter webspaces that support the current locale
                 if (!currentLocale || !webspace.localizations) {
                     return true;
                 }
-                return webspace.localizations.some(
-                    (localization) => localization.locale === currentLocale
-                );
+                // Localizations are a nested tree (e.g. "de" -> "de_ch"), so the
+                // check needs to recurse into the child localizations.
+                return supportsLocale(webspace.localizations);
             })
             .map((webspace): Object => ({
                 label: webspace.name,

--- a/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
+++ b/src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js
@@ -640,3 +640,36 @@ test('Fall back to first webspace when mainWebspace is not in webspace options',
 
     expect(PreviewStore).toHaveBeenCalledWith('articles', undefined, undefined, 'sulu_io', undefined);
 });
+
+test('Use mainWebspace when the current locale is a nested localization', () => {
+    const locale = observable.box('de_ch');
+    const resourceStore = new ResourceStore('articles', 1, {locale});
+    const formStore = new ResourceFormStore(resourceStore, 'articles');
+
+    // $FlowFixMe
+    formStore.data = {mainWebspace: 'example'};
+
+    const grantedWebspaces = webspaceStore.grantedWebspaces;
+    // $FlowFixMe
+    webspaceStore.grantedWebspaces = [
+        {
+            key: 'example',
+            name: 'Example',
+            localizations: [
+                {locale: 'de', children: [{locale: 'de_ch'}, {locale: 'de_de'}]},
+                {locale: 'en'},
+            ],
+        },
+    ];
+
+    const router = new Router({});
+
+    try {
+        mount(<Preview formStore={formStore} router={router} />);
+
+        expect(PreviewStore).toHaveBeenCalledWith('articles', undefined, locale, 'example', undefined);
+    } finally {
+        // $FlowFixMe
+        webspaceStore.grantedWebspaces = grantedWebspaces;
+    }
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #8423
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The `webspaceOptions` getter in the preview container now recurses into the child localizations of each webspace when it checks whether a webspace supports the current locale. Before this change the check only compared the top level localizations. A new test covers the case where the current locale is a nested localization such as `de_ch`.

#### Why?

Webspace localizations are stored as a nested tree where country variants like `de_ch` are children of their language localization. The locale filter added in #8423 only looked at the top level entries, so previewing an article in a nested locale returned no webspace and the render failed with a type error in `findPortalInformationsByWebspaceKeyAndLocale`. This broke preview for every country specific locale while top level locales such as `de` kept working.