### PR TITLE
Fix shadow and ghost locale regressions

### DIFF
--- a/packages/article/src/Application/MessageHandler/ApplyWorkflowTransitionArticleMessageHandler.php
+++ b/packages/article/src/Application/MessageHandler/ApplyWorkflowTransitionArticleMessageHandler.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Article\Application\MessageHandler;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Article\Application\Message\ApplyWorkflowTransitionArticleMessage;
 use Sulu\Article\Domain\Event\ArticleWorkflowTransitionAppliedEvent;
 use Sulu\Article\Domain\Model\ArticleInterface;
@@ -29,33 +30,81 @@ final class ApplyWorkflowTransitionArticleMessageHandler
     public function __construct(
         private ArticleRepositoryInterface $articleRepository,
         private ContentWorkflowInterface $contentWorkflow,
-        private DomainEventCollectorInterface $domainEventCollector
+        private EntityManagerInterface $entityManager,
+        private DomainEventCollectorInterface $domainEventCollector,
     ) {
     }
 
     public function __invoke(ApplyWorkflowTransitionArticleMessage $message): ArticleInterface
     {
-        $article = $this->articleRepository->getOneBy(
+        $locale = $message->getLocale();
+
+        $article = $this->loadArticle($message, [$locale]);
+
+        // The shadow source and dependent locales are only known once this locale is loaded.
+        $relatedLocales = $this->resolveRelatedLocales($article, $locale);
+        if ([] !== $relatedLocales) {
+            // Drop the identity-map collection (filled by a preceding ModifyArticleMessage) so the
+            // wider query re-hydrates it with all locales.
+            $this->entityManager->refresh($article);
+
+            $article = $this->loadArticle($message, [$locale, ...$relatedLocales]);
+        }
+
+        $this->contentWorkflow->apply(
+            $article,
+            ['locale' => $locale],
+            $message->getTransitionName()
+        );
+
+        $this->domainEventCollector->collect(new ArticleWorkflowTransitionAppliedEvent($article, $message->getTransitionName(), $locale));
+
+        return $article;
+    }
+
+    /**
+     * @param string[] $locales
+     */
+    private function loadArticle(ApplyWorkflowTransitionArticleMessage $message, array $locales): ArticleInterface
+    {
+        return $this->articleRepository->getOneBy(
             $message->getIdentifier(),
             [
                 ArticleRepositoryInterface::SELECT_ARTICLE_CONTENT => [
                     'selects' => [DimensionContentQueryEnhancer::GROUP_SELECT_CONTENT_ADMIN => true],
                     'dimensionAttributes' => [
-                        'locale' => $message->getLocale(),
+                        'locale' => $locales,
                         'stage' => [DimensionContentInterface::STAGE_DRAFT, DimensionContentInterface::STAGE_LIVE],
                     ],
                 ],
             ]
         );
+    }
 
-        $this->contentWorkflow->apply(
-            $article,
-            ['locale' => $message->getLocale()],
-            $message->getTransitionName()
-        );
+    /**
+     * Resolve the shadow source and dependent locales so the caller can re-load the article
+     * with them hydrated before the publish subscriber aggregates the source locale.
+     *
+     * @return string[]
+     */
+    private function resolveRelatedLocales(ArticleInterface $article, string $locale): array
+    {
+        foreach ($article->getDimensionContents() as $dimensionContent) {
+            if (DimensionContentInterface::STAGE_DRAFT !== $dimensionContent->getStage()
+                || null !== $dimensionContent->getLocale()
+            ) {
+                continue;
+            }
 
-        $this->domainEventCollector->collect(new ArticleWorkflowTransitionAppliedEvent($article, $message->getTransitionName(), $message->getLocale()));
+            $relatedLocales = $dimensionContent->getShadowLocalesForLocale($locale);
+            $sourceLocale = ($dimensionContent->getShadowLocales() ?? [])[$locale] ?? null;
+            if (null !== $sourceLocale) {
+                $relatedLocales[] = $sourceLocale;
+            }
 
-        return $article;
+            return \array_values(\array_unique($relatedLocales));
+        }
+
+        return [];
     }
 }

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -211,6 +211,7 @@ final class SuluArticleBundle extends AbstractBundle
             ->args([
                 new Reference('sulu_article.article_repository'),
                 new Reference('sulu_content.content_workflow'),
+                new Reference('doctrine.orm.entity_manager'),
                 new Reference('sulu_activity.domain_event_collector'),
             ])
             ->tag('messenger.message_handler');

--- a/packages/article/tests/Functional/Integration/ArticleShadowPublishTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleShadowPublishTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Tests\Functional\Integration;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Article\Domain\Model\ArticleDimensionContent;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Route\Domain\Value\RequestAttributeEnum;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+#[CoversNothing]
+class ArticleShadowPublishTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient(
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+        );
+
+        $requestContext = self::getContainer()->get('router.request_context');
+        $requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, 'sulu-io');
+    }
+
+    public function testPublishShadowLocaleSucceeds(): void
+    {
+        self::purgeDatabase();
+
+        $this->client->request(
+            'POST',
+            '/admin/api/articles?locale=en&action=publish',
+            [], [], [],
+            \json_encode([
+                'template' => 'article',
+                'title' => 'Source EN',
+                'url' => '/source-en',
+                'mainWebspace' => 'sulu-io',
+            ]) ?: null,
+        );
+        self::assertSame(201, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        /** @var array{id: string} $content */
+        $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $id = $content['id'];
+
+        $this->client->request(
+            'PUT',
+            '/admin/api/articles/' . $id . '?locale=de',
+            [], [], [],
+            \json_encode([
+                'template' => 'article',
+                'title' => 'Source EN',
+                'url' => '/quelle-de',
+                'mainWebspace' => 'sulu-io',
+                'shadowOn' => true,
+                'shadowLocale' => 'en',
+            ]) ?: null,
+        );
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        // Publishing the shadow used to fail because the source locale's content was not loaded.
+        $this->client->request(
+            'PUT',
+            '/admin/api/articles/' . $id . '?locale=de&action=publish',
+            [], [], [],
+            \json_encode([
+                'template' => 'article',
+                'title' => 'Source EN',
+                'url' => '/quelle-de',
+                'mainWebspace' => 'sulu-io',
+                'shadowOn' => true,
+                'shadowLocale' => 'en',
+            ]) ?: null,
+        );
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        $liveDe = $this->getLiveDimensionContent($id, 'de');
+        self::assertNotNull($liveDe, 'Expected a published (live) DE dimension content.');
+        self::assertSame('en', $liveDe['shadowLocale']);
+        self::assertSame('article', $liveDe['templateKey']);
+        self::assertNotNull($liveDe['workflowPublished']);
+        /** @var array<string, mixed> $templateData */
+        $templateData = $liveDe['templateData'];
+        self::assertSame('Source EN', $templateData['title'] ?? null);
+    }
+
+    public function testRepublishingSourceUpdatesLiveShadowDependent(): void
+    {
+        self::purgeDatabase();
+
+        $this->client->request(
+            'POST',
+            '/admin/api/articles?locale=en&action=publish',
+            [], [], [],
+            \json_encode(['template' => 'article', 'title' => 'Source EN', 'url' => '/source-en', 'mainWebspace' => 'sulu-io']) ?: null,
+        );
+        self::assertSame(201, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        /** @var array{id: string} $content */
+        $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $id = $content['id'];
+
+        $shadowData = ['template' => 'article', 'title' => 'Source EN', 'url' => '/quelle-de', 'mainWebspace' => 'sulu-io', 'shadowOn' => true, 'shadowLocale' => 'en'];
+        $this->client->request('PUT', '/admin/api/articles/' . $id . '?locale=de', [], [], [], \json_encode($shadowData) ?: null);
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        $this->client->request('PUT', '/admin/api/articles/' . $id . '?locale=de&action=publish', [], [], [], \json_encode($shadowData) ?: null);
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        $liveDe = $this->getLiveDimensionContent($id, 'de');
+        self::assertNotNull($liveDe);
+        /** @var array<string, mixed> $templateData */
+        $templateData = $liveDe['templateData'];
+        self::assertSame('Source EN', $templateData['title'] ?? null);
+
+        // Republishing the source must update the shadow dependent's live content, not duplicate it.
+        $this->client->request(
+            'PUT',
+            '/admin/api/articles/' . $id . '?locale=en&action=publish',
+            [], [], [],
+            \json_encode(['template' => 'article', 'title' => 'Source EN Updated', 'url' => '/source-en', 'mainWebspace' => 'sulu-io']) ?: null,
+        );
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        $liveDe = $this->getLiveDimensionContent($id, 'de');
+        self::assertNotNull($liveDe);
+        self::assertSame('en', $liveDe['shadowLocale']);
+        /** @var array<string, mixed> $templateData */
+        $templateData = $liveDe['templateData'];
+        self::assertSame('Source EN Updated', $templateData['title'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getLiveDimensionContent(string $articleId, string $locale): ?array
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+
+        /** @var array<string, mixed>|null $row */
+        $row = $entityManager->createQueryBuilder()
+            ->from(ArticleDimensionContent::class, 'dimensionContent')
+            ->select(
+                'dimensionContent.stage',
+                'dimensionContent.locale',
+                'dimensionContent.templateKey',
+                'dimensionContent.workflowPublished',
+                'dimensionContent.shadowLocale',
+                'dimensionContent.templateData',
+            )
+            ->where('IDENTITY(dimensionContent.article) = :articleId')
+            ->andWhere('dimensionContent.stage = :stage')
+            ->andWhere('dimensionContent.locale = :locale')
+            ->andWhere('dimensionContent.version = 0')
+            ->setParameter('articleId', $articleId)
+            ->setParameter('stage', 'live')
+            ->setParameter('locale', $locale)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $row;
+    }
+}

--- a/packages/content/config/services.php
+++ b/packages/content/config/services.php
@@ -159,7 +159,10 @@ return static function(ContainerConfigurator $container) {
     $services->alias(ContentWorkflowInterface::class, 'sulu_content.content_workflow');
 
     $services->set('sulu_content.publish_transition_subscriber', PublishTransitionSubscriber::class)
-        ->args([new Reference('sulu_content.content_copier')])
+        ->args([
+            new Reference('sulu_content.content_copier'),
+            new Reference('sulu_content.content_aggregator'),
+        ])
         ->tag('kernel.event_subscriber');
 
     $services->set('sulu_content.remove_draft_transition_subscriber', RemoveDraftTransitionSubscriber::class)

--- a/packages/content/src/Application/ContentHash/ContentHashChecker.php
+++ b/packages/content/src/Application/ContentHash/ContentHashChecker.php
@@ -51,9 +51,12 @@ class ContentHashChecker
             $dimensionContentClass,
         ))->getDimensionContent($dimensionAttributes);
 
-        if (!$dimensionContent instanceof DimensionContentInterface
-            || $expectedHash !== $this->hasher->hash($dimensionContent)
-        ) {
+        if (!$dimensionContent instanceof DimensionContentInterface) {
+            // No persisted content for this locale yet, so there is nothing to lock against.
+            return;
+        }
+
+        if ($expectedHash !== $this->hasher->hash($dimensionContent)) {
             throw new InvalidHashException($contentRichEntity::class, $identifier);
         }
     }

--- a/packages/content/src/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
+++ b/packages/content/src/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriber.php
@@ -13,13 +13,17 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Application\ContentWorkflow\Subscriber;
 
+use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentCopier\ContentCopierInterface;
 use Sulu\Content\Application\ContentWorkflow\ContentWorkflowInterface;
+use Sulu\Content\Domain\Exception\ContentNotFoundException;
+use Sulu\Content\Domain\Exception\ShadowSourceNotPublishedException;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\RoutableInterface;
 use Sulu\Content\Domain\Model\ShadowInterface;
+use Sulu\Content\Domain\Model\TemplateInterface;
 use Sulu\Content\Domain\Model\WorkflowInterface;
 use Sulu\Route\Domain\Model\Route;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -32,8 +36,10 @@ use Symfony\Component\Workflow\Event\TransitionEvent;
  */
 class PublishTransitionSubscriber implements EventSubscriberInterface
 {
-    public function __construct(private ContentCopierInterface $contentCopier)
-    {
+    public function __construct(
+        private ContentCopierInterface $contentCopier,
+        private ContentAggregatorInterface $contentAggregator,
+    ) {
     }
 
     public function onPublish(TransitionEvent $transitionEvent): void
@@ -119,6 +125,18 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
         $sourceDimensionAttributes['locale'] = $shadowLocale;
         $sourceDimensionAttributes['stage'] = DimensionContentInterface::STAGE_LIVE;
 
+        // Resolve the source content up front to fail with a translatable error when its locale is
+        // not published yet, instead of crashing later in the copy.
+        try {
+            $sourceDimensionContent = $this->contentAggregator->aggregate($contentRichEntity, $sourceDimensionAttributes);
+        } catch (ContentNotFoundException $exception) {
+            throw new ShadowSourceNotPublishedException($locale, $shadowLocale, $exception);
+        }
+
+        if ($sourceDimensionContent instanceof TemplateInterface && null === $sourceDimensionContent->getTemplateKey()) {
+            throw new ShadowSourceNotPublishedException($locale, $shadowLocale);
+        }
+
         $data = [
             // @see \Sulu\Content\Application\ContentDataMapper\DataMapper\ShadowDataMapper::map
             'shadowOn' => true,
@@ -134,9 +152,8 @@ class PublishTransitionSubscriber implements EventSubscriberInterface
             }
         }
 
-        $this->contentCopier->copy(
-            $contentRichEntity,
-            $sourceDimensionAttributes,
+        $this->contentCopier->copyFromDimensionContent(
+            $sourceDimensionContent,
             $contentRichEntity,
             $targetDimensionAttributes,
             ['data' => $data]

--- a/packages/content/src/Domain/Exception/ShadowSourceNotPublishedException.php
+++ b/packages/content/src/Domain/Exception/ShadowSourceNotPublishedException.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Domain\Exception;
+
+use Sulu\Component\Rest\Exception\TranslationErrorMessageExceptionInterface;
+
+class ShadowSourceNotPublishedException extends \Exception implements TranslationErrorMessageExceptionInterface
+{
+    public const EXCEPTION_CODE_SHADOW_SOURCE_NOT_PUBLISHED = 1107;
+
+    public function __construct(
+        private string $locale,
+        private string $shadowLocale,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct(
+            \sprintf(
+                'The shadow locale "%s" cannot be published because its source locale "%s" has not been published yet.',
+                $this->locale,
+                $this->shadowLocale,
+            ),
+            self::EXCEPTION_CODE_SHADOW_SOURCE_NOT_PUBLISHED,
+            $previous,
+        );
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function getShadowLocale(): string
+    {
+        return $this->shadowLocale;
+    }
+
+    public function getMessageTranslationKey(): string
+    {
+        return 'sulu_content.shadow_source_not_published';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getMessageTranslationParameters(): array
+    {
+        return [
+            '{locale}' => $this->locale,
+            '{shadowLocale}' => $this->shadowLocale,
+        ];
+    }
+}

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
@@ -16,6 +16,7 @@ namespace Sulu\Content\Infrastructure\Symfony\HttpKernel;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverInterface;
 use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataAwareInterface;
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
+use Sulu\Content\Domain\Exception\ShadowSourceNotPublishedException;
 use Sulu\Content\Infrastructure\Doctrine\EventListener\RouteCleanupListener;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\ExcerptFormPass;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\ResourceLoaderCacheCompilerPass;
@@ -96,6 +97,19 @@ final class SuluContentBundle extends AbstractBundle
                     'forms' => [
                         'directories' => [
                             \dirname(__DIR__, 4) . '/config/forms',
+                        ],
+                    ],
+                ]
+            );
+        }
+
+        if ($builder->hasExtension('fos_rest')) {
+            $builder->prependExtensionConfig(
+                'fos_rest',
+                [
+                    'exception' => [
+                        'codes' => [
+                            ShadowSourceNotPublishedException::class => 400,
                         ],
                     ],
                 ]

--- a/packages/content/tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentWorkflow/Subscriber/PublishTransitionSubscriberTest.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace Sulu\Content\Tests\Unit\Content\Application\ContentWorkflow\Subscriber;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentCopier\ContentCopierInterface;
 use Sulu\Content\Application\ContentWorkflow\ContentWorkflowInterface;
 use Sulu\Content\Application\ContentWorkflow\Subscriber\PublishTransitionSubscriber;
+use Sulu\Content\Domain\Exception\ContentNotFoundException;
+use Sulu\Content\Domain\Exception\ShadowSourceNotPublishedException;
 use Sulu\Content\Domain\Model\ContentRichEntityInterface;
 use Sulu\Content\Domain\Model\DimensionContentCollectionInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
@@ -33,9 +37,13 @@ class PublishTransitionSubscriberTest extends TestCase
     use ProphecyTrait;
 
     public function createContentPublisherSubscriberInstance(
-        ContentCopierInterface $contentCopier
+        ContentCopierInterface $contentCopier,
+        ?ContentAggregatorInterface $contentAggregator = null
     ): PublishTransitionSubscriber {
-        return new PublishTransitionSubscriber($contentCopier);
+        return new PublishTransitionSubscriber(
+            $contentCopier,
+            $contentAggregator ?? $this->prophesize(ContentAggregatorInterface::class)->reveal()
+        );
     }
 
     public function testGetSubscribedEvents(): void
@@ -283,10 +291,17 @@ class PublishTransitionSubscriberTest extends TestCase
         )
             ->willReturn($versionDimensionContent->reveal());
 
+        $contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
+        $sourceDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $sourceDimensionContent->willImplement(TemplateInterface::class);
+        $sourceDimensionContent->getTemplateKey()->willReturn('default');
+        $contentAggregator->aggregate($contentRichEntity->reveal(), $sourceDimensionAttributes)
+            ->willReturn($sourceDimensionContent->reveal())
+            ->shouldBeCalled();
+
         $resolvedCopiedContent = $this->prophesize(DimensionContentInterface::class);
-        $contentCopier->copy(
-            $contentRichEntity->reveal(),
-            $sourceDimensionAttributes,
+        $contentCopier->copyFromDimensionContent(
+            $sourceDimensionContent->reveal(),
             $contentRichEntity->reveal(),
             $targetDimensionAttributes,
             [
@@ -299,7 +314,104 @@ class PublishTransitionSubscriberTest extends TestCase
             ->willReturn($resolvedCopiedContent->reveal())
             ->shouldBeCalled();
 
-        $contentPublishSubscriber = $this->createContentPublisherSubscriberInstance($contentCopier->reveal());
+        $contentPublishSubscriber = $this->createContentPublisherSubscriberInstance(
+            $contentCopier->reveal(),
+            $contentAggregator->reveal()
+        );
+
+        $contentPublishSubscriber->onPublish($event);
+    }
+
+    public function testOnPublishShadowWithUnpublishedSourceThrows(): void
+    {
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(WorkflowInterface::class);
+        $dimensionContent->willImplement(ShadowInterface::class);
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
+        $dimensionAttributes = ['locale' => 'en', 'stage' => 'draft'];
+
+        $dimensionContent->getLocale()->willReturn('en');
+        $dimensionContent->getShadowLocale()->willReturn('de');
+        $dimensionContent->getWorkflowPublished()->willReturn(null);
+        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldBeCalled();
+
+        $event = new TransitionEvent($dimensionContent->reveal(), new Marking());
+        $event->setContext([
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
+        ]);
+
+        $contentCopier = $this->prophesize(ContentCopierInterface::class);
+        $contentCopier->copyFromDimensionContentCollection(Argument::cetera())
+            ->willReturn($this->prophesize(DimensionContentInterface::class)->reveal());
+        // The shadow source must not be copied when it has no published template.
+        $contentCopier->copyFromDimensionContent(Argument::cetera())->shouldNotBeCalled();
+
+        $sourceDimensionAttributes = ['locale' => 'de', 'stage' => 'live'];
+
+        // Source live content exists (e.g. an unlocalized live of the page) but carries no template.
+        $contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
+        $sourceDimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $sourceDimensionContent->willImplement(TemplateInterface::class);
+        $sourceDimensionContent->getTemplateKey()->willReturn(null);
+        $contentAggregator->aggregate($contentRichEntity->reveal(), $sourceDimensionAttributes)
+            ->willReturn($sourceDimensionContent->reveal())
+            ->shouldBeCalled();
+
+        $contentPublishSubscriber = $this->createContentPublisherSubscriberInstance(
+            $contentCopier->reveal(),
+            $contentAggregator->reveal()
+        );
+
+        $this->expectException(ShadowSourceNotPublishedException::class);
+
+        $contentPublishSubscriber->onPublish($event);
+    }
+
+    public function testOnPublishShadowWithMissingSourceThrows(): void
+    {
+        $dimensionContent = $this->prophesize(DimensionContentInterface::class);
+        $dimensionContent->willImplement(WorkflowInterface::class);
+        $dimensionContent->willImplement(ShadowInterface::class);
+        $dimensionContentCollection = $this->prophesize(DimensionContentCollectionInterface::class);
+        $contentRichEntity = $this->prophesize(ContentRichEntityInterface::class);
+        $dimensionAttributes = ['locale' => 'en', 'stage' => 'draft'];
+
+        $dimensionContent->getLocale()->willReturn('en');
+        $dimensionContent->getShadowLocale()->willReturn('de');
+        $dimensionContent->getWorkflowPublished()->willReturn(null);
+        $dimensionContent->setWorkflowPublished(Argument::cetera())->shouldBeCalled();
+
+        $event = new TransitionEvent($dimensionContent->reveal(), new Marking());
+        $event->setContext([
+            ContentWorkflowInterface::DIMENSION_CONTENT_COLLECTION_CONTEXT_KEY => $dimensionContentCollection->reveal(),
+            ContentWorkflowInterface::DIMENSION_ATTRIBUTES_CONTEXT_KEY => $dimensionAttributes,
+            ContentWorkflowInterface::CONTENT_RICH_ENTITY_CONTEXT_KEY => $contentRichEntity->reveal(),
+        ]);
+
+        $contentCopier = $this->prophesize(ContentCopierInterface::class);
+        $contentCopier->copyFromDimensionContentCollection(Argument::cetera())
+            ->willReturn($this->prophesize(DimensionContentInterface::class)->reveal());
+        $contentCopier->copyFromDimensionContent(Argument::cetera())->shouldNotBeCalled();
+
+        $sourceDimensionAttributes = ['locale' => 'de', 'stage' => 'live'];
+
+        // The source has no live content at all.
+        $contentRichEntity->getId()->willReturn('some-uuid');
+        $contentRichEntity->getDimensionContents()->willReturn(new ArrayCollection([]));
+        $contentAggregator = $this->prophesize(ContentAggregatorInterface::class);
+        $contentAggregator->aggregate($contentRichEntity->reveal(), $sourceDimensionAttributes)
+            ->willThrow(new ContentNotFoundException($contentRichEntity->reveal(), $sourceDimensionAttributes))
+            ->shouldBeCalled();
+
+        $contentPublishSubscriber = $this->createContentPublisherSubscriberInstance(
+            $contentCopier->reveal(),
+            $contentAggregator->reveal()
+        );
+
+        $this->expectException(ShadowSourceNotPublishedException::class);
 
         $contentPublishSubscriber->onPublish($event);
     }

--- a/packages/content/translations/admin.de.json
+++ b/packages/content/translations/admin.de.json
@@ -1,4 +1,5 @@
 {
+    "sulu_content.shadow_source_not_published": "Diese Seite kann nicht als Shadow von \"{shadowLocale}\" veröffentlicht werden, da \"{shadowLocale}\" noch nicht veröffentlicht wurde. Bitte veröffentlichen Sie zuerst \"{shadowLocale}\".",
     "sulu_content.seo": "SEO",
     "sulu_content.excerpt": "Auszug & Taxonomien",
     "sulu_content.taxonomies": "Taxonomien",

--- a/packages/content/translations/admin.en.json
+++ b/packages/content/translations/admin.en.json
@@ -1,4 +1,5 @@
 {
+    "sulu_content.shadow_source_not_published": "This page cannot be published as a shadow of \"{shadowLocale}\" because \"{shadowLocale}\" has not been published yet. Please publish \"{shadowLocale}\" first.",
     "sulu_content.seo": "SEO",
     "sulu_content.excerpt": "Excerpt & Taxonomies",
     "sulu_content.taxonomies": "Taxonomies",

--- a/packages/page/src/Application/ContentNormalizer/DefaultTemplateNormalizer.php
+++ b/packages/page/src/Application/ContentNormalizer/DefaultTemplateNormalizer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Application\ContentNormalizer;
+
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Content\Application\ContentNormalizer\Normalizer\NormalizerInterface;
+use Sulu\Page\Domain\Model\PageDimensionContentInterface;
+use Sulu\Page\Domain\Model\PageInterface;
+
+/**
+ * @internal this class is internal and should not be extended from or used in another context
+ */
+final class DefaultTemplateNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        private WebspaceManagerInterface $webspaceManager,
+    ) {
+    }
+
+    public function enhance(object $object, array $normalizedData): array
+    {
+        if (!$object instanceof PageDimensionContentInterface) {
+            return $normalizedData;
+        }
+
+        if (!empty($normalizedData['template'])) {
+            return $normalizedData;
+        }
+
+        $page = $object->getResource();
+
+        $webspace = $this->webspaceManager->findWebspaceByKey($page->getWebspaceKey());
+        $defaultTemplate = $webspace?->getDefaultTemplate(PageInterface::TEMPLATE_TYPE);
+
+        if (null !== $defaultTemplate && '' !== $defaultTemplate) {
+            $normalizedData['template'] = $defaultTemplate;
+        }
+
+        return $normalizedData;
+    }
+
+    public function getIgnoredAttributes(object $object): array
+    {
+        return [];
+    }
+}

--- a/packages/page/src/Application/MessageHandler/ApplyWorkflowTransitionPageMessageHandler.php
+++ b/packages/page/src/Application/MessageHandler/ApplyWorkflowTransitionPageMessageHandler.php
@@ -82,6 +82,9 @@ final class ApplyWorkflowTransitionPageMessageHandler
     }
 
     /**
+     * Resolve the shadow source and dependent locales so the caller can re-load the page
+     * with them hydrated before the publish subscriber aggregates the source locale.
+     *
      * @return string[]
      */
     private function resolveRelatedLocales(PageInterface $page, string $locale): array

--- a/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
+++ b/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
@@ -239,6 +239,8 @@ class PageAdmin extends Admin
 
             // Excerpt tab for content AND external pages
             $excerptTabCondition = "(linkOn == false || (linkData.provider != 'page')) && shadowOn == false";
+
+            $localePersistedCondition = 'availableLocales && locale in availableLocales';
             /** @var PreviewFormViewBuilder $viewBuilder */
             foreach ($viewBuilders as $viewBuilder) {
                 if (PageAdmin::ADD_FORM_VIEW . '.content' === $viewBuilder->getName()) {
@@ -261,7 +263,7 @@ class PageAdmin extends Admin
                     $viewBuilder
                         ->disablePreviewWebspaceChooser()
                         ->addRouterAttributesToFormRequest($routerAttributesToFormRequest)
-                        ->setTabCondition($contentTabCondition)
+                        ->setTabCondition($contentTabCondition . ' && ' . $localePersistedCondition)
                         ->setPreviewCondition($previewCondition);
                 }
 
@@ -271,14 +273,19 @@ class PageAdmin extends Admin
                         ->addRouterAttributesToFormRequest($routerAttributesToFormRequest)
                         ->addRouterAttributesToFormMetadata($routerAttributesToFormMetadata)
                         ->setPreviewCondition($previewCondition)
-                        ->setTabCondition($excerptTabCondition);
+                        ->setTabCondition($excerptTabCondition . ' && ' . $localePersistedCondition);
                 }
 
                 if (PageAdmin::EDIT_FORM_VIEW . '.settings' === $viewBuilder->getName()) {
                     $viewBuilder
                         ->disablePreviewWebspaceChooser()
                         ->addRouterAttributesToFormRequest($routerAttributesToFormRequest)
+                        ->setTabCondition($localePersistedCondition)
                         ->setPreviewCondition($previewCondition);
+                }
+
+                if (PageAdmin::EDIT_FORM_VIEW . '.insights' === $viewBuilder->getName()) {
+                    $viewBuilder->setTabCondition($localePersistedCondition);
                 }
 
                 $viewCollection->add($viewBuilder);
@@ -304,7 +311,7 @@ class PageAdmin extends Admin
                     ->setPreviewResourceKey(PageInterface::RESOURCE_KEY)
                     ->setFormKey('permission_details')
                     ->addRequestParameters(['resourceKey' => PageInterface::RESOURCE_KEY])
-                    ->setTabCondition('_permissions.security')
+                    ->setTabCondition('_permissions.security && ' . $localePersistedCondition)
                     ->setTabTitle('sulu_security.permissions')
                     ->addToolbarActions([
                         new SaveWithFormDialogToolbarAction(

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -16,6 +16,7 @@ namespace Sulu\Page\Infrastructure\Symfony\HttpKernel;
 use Sulu\Bundle\PersistenceBundle\DependencyInjection\PersistenceExtensionTrait;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Content\Infrastructure\Sulu\Preview\ContentObjectProvider;
+use Sulu\Page\Application\ContentNormalizer\DefaultTemplateNormalizer;
 use Sulu\Page\Application\Mapper\PageContentMapper;
 use Sulu\Page\Application\Mapper\PageMapperInterface;
 use Sulu\Page\Application\MessageHandler\ApplyWorkflowTransitionPageMessageHandler;
@@ -264,6 +265,13 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('sulu_content.content_persister'),
             ])
             ->tag('sulu_page.page_mapper');
+
+        $services->set('sulu_page.default_template_normalizer')
+            ->class(DefaultTemplateNormalizer::class)
+            ->args([
+                new Reference('sulu_core.webspace.webspace_manager'),
+            ])
+            ->tag('sulu_content.normalizer', ['priority' => 127]);
 
         // DataMapper service
         $services->set('sulu_page.navigation_context_data_mapper')

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Admin/PageAdminViewTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Admin/PageAdminViewTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Sulu\Admin;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
+
+/**
+ * A not-yet-saved locale must only expose the content tab; every other tab is revealed once the
+ * locale has its own draft (and therefore a templateKey), mirroring the "create page" flow. This
+ * prevents enabling a shadow on a locale that has no template yet.
+ */
+class PageAdminViewTest extends SuluTestCase
+{
+    private const LOCALE_PERSISTED_CONDITION = 'availableLocales && locale in availableLocales';
+
+    private ViewRegistry $viewRegistry;
+
+    protected function setUp(): void
+    {
+        $this->viewRegistry = self::getContainer()->get('sulu_admin.view_registry');
+    }
+
+    public function testContentTabIsAvailableForUnsavedLocale(): void
+    {
+        $condition = $this->viewRegistry
+            ->findViewByName(PageAdmin::EDIT_FORM_VIEW . '.content')
+            ->getOption('tabCondition');
+
+        $this->assertIsString($condition);
+        $this->assertStringNotContainsString(
+            self::LOCALE_PERSISTED_CONDITION,
+            $condition,
+            'The content tab must stay available for a not-yet-saved locale.',
+        );
+    }
+
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function nonContentTabProvider(): iterable
+    {
+        yield 'seo' => ['seo'];
+        yield 'excerpt' => ['excerpt'];
+        yield 'settings' => ['settings'];
+        yield 'insights' => ['insights'];
+        yield 'permissions' => ['permissions'];
+    }
+
+    #[DataProvider('nonContentTabProvider')]
+    public function testNonContentTabRequiresPersistedLocale(string $tab): void
+    {
+        $condition = $this->viewRegistry
+            ->findViewByName(PageAdmin::EDIT_FORM_VIEW . '.' . $tab)
+            ->getOption('tabCondition');
+
+        $this->assertIsString($condition, \sprintf('Tab "%s" must have a tabCondition.', $tab));
+        $this->assertStringContainsString(
+            self::LOCALE_PERSISTED_CONDITION,
+            $condition,
+            \sprintf('Tab "%s" must only be shown once the locale has been saved.', $tab),
+        );
+    }
+}

--- a/packages/page/tests/Functional/Integration/PageDefaultTemplateTest.php
+++ b/packages/page/tests/Functional/Integration/PageDefaultTemplateTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Model\PageInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * Loading a not-yet-translated ("ghost") page locale must return the webspace's default template
+ * instead of null, so the admin form is pre-filled and sends a valid template on save. This mirrors
+ * the Sulu 2.x read behaviour and is provided by the DefaultTemplateNormalizer.
+ */
+#[CoversNothing]
+class PageDefaultTemplateTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient(
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+        );
+    }
+
+    private function createHomepage(string $uuid, string $webspaceKey): PageInterface
+    {
+        $homepage = new Page($uuid);
+        $homepage->setLft(0);
+        $homepage->setRgt(1);
+        $homepage->setDepth(0);
+        $homepage->setWebspaceKey($webspaceKey);
+        self::getEntityManager()->persist($homepage);
+        self::getEntityManager()->flush();
+
+        return $homepage;
+    }
+
+    public function testGhostLocaleReturnsWebspaceDefaultTemplate(): void
+    {
+        self::purgeDatabase();
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
+
+        // 1. Create the page in EN with the "default" template.
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&parentId=%s&webspace=sulu-io', $homepage->getId()),
+            [], [], [],
+            \json_encode(['template' => 'default', 'title' => 'Source EN', 'url' => '/source-en']) ?: null,
+        );
+        self::assertSame(201, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        /** @var array{id: string} $content */
+        $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $id = $content['id'];
+
+        // 2. Open DE - a ghost of EN that has no own content yet.
+        $this->client->request('GET', '/admin/api/pages/' . $id . '?locale=de&webspace=sulu-io');
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+
+        /** @var array{template?: string|null, ghostLocale?: string|null} $data */
+        $data = \json_decode((string) $this->client->getResponse()->getContent(), true);
+
+        // It is a ghost of EN and carries the webspace's default page template ("default" for sulu-io),
+        // instead of the null it would otherwise have for a not-yet-translated locale.
+        self::assertSame('en', $data['ghostLocale'] ?? null, 'DE is expected to be a ghost of EN.');
+        self::assertSame('default', $data['template'] ?? null, 'Expected the webspace default template, not null.');
+    }
+}

--- a/packages/page/tests/Functional/Integration/PageNewLocaleHashTest.php
+++ b/packages/page/tests/Functional/Integration/PageNewLocaleHashTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Page\Domain\Model\Page;
+use Sulu\Page\Domain\Model\PageInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * Saving a brand-new locale (a ghost of an existing one) must not fail with an optimistic-locking
+ * conflict. The form loads the new locale as a ghost and receives an "_hash" generated from the
+ * ghost source's content; that hash can never match the (non-existent) target locale, so the hash
+ * check must be skipped when the targeted locale has no content of its own yet.
+ */
+#[CoversNothing]
+class PageNewLocaleHashTest extends SuluTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createAuthenticatedClient(
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json'],
+        );
+    }
+
+    private function createHomepage(string $uuid, string $webspaceKey): PageInterface
+    {
+        $homepage = new Page($uuid);
+        $homepage->setLft(0);
+        $homepage->setRgt(1);
+        $homepage->setDepth(0);
+        $homepage->setWebspaceKey($webspaceKey);
+        self::getEntityManager()->persist($homepage);
+        self::getEntityManager()->flush();
+
+        return $homepage;
+    }
+
+    public function testSaveNewGhostLocaleWithHashSucceeds(): void
+    {
+        self::purgeDatabase();
+        $homepage = $this->createHomepage('0199ee04-c220-784e-a6fa-ac985870f2d5', 'sulu-io');
+
+        // 1. Create the page in EN.
+        $this->client->request(
+            'POST',
+            \sprintf('/admin/api/pages?locale=en&parentId=%s&webspace=sulu-io', $homepage->getId()),
+            [], [], [],
+            \json_encode(['template' => 'default', 'title' => 'Source EN', 'url' => '/source-en']) ?: null,
+        );
+        self::assertSame(201, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        /** @var array{id: string} $content */
+        $content = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        $id = $content['id'];
+
+        // 2. Open DE - a ghost of EN. The response carries an "_hash" built from the ghost source.
+        $this->client->request('GET', '/admin/api/pages/' . $id . '?locale=de&webspace=sulu-io');
+        self::assertSame(200, $this->client->getResponse()->getStatusCode(), (string) $this->client->getResponse()->getContent());
+        /** @var array{_hash?: string, ghostLocale?: string} $ghost */
+        $ghost = \json_decode((string) $this->client->getResponse()->getContent(), true);
+        self::assertSame('en', $ghost['ghostLocale'] ?? null, 'DE is expected to be a ghost of EN.');
+        $hash = $ghost['_hash'] ?? null;
+        self::assertIsString($hash, 'The ghost response must carry an "_hash".');
+
+        // 3. Save DE for the first time, sending back the ghost hash. This used to fail with
+        //    409 "InvalidHashException" because DE has no own content to lock against yet.
+        $this->client->request(
+            'PUT',
+            '/admin/api/pages/' . $id . '?locale=de&action=draft&webspace=sulu-io',
+            [], [], [],
+            \json_encode([
+                '_hash' => $hash,
+                'template' => 'default',
+                'title' => 'No copy DE',
+                'url' => '/no-copy-de',
+            ]) ?: null,
+        );
+
+        $response = $this->client->getResponse();
+        self::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        /** @var array{title?: string, availableLocales?: array<int, string>} $saved */
+        $saved = \json_decode((string) $response->getContent(), true);
+        self::assertSame('No copy DE', $saved['title'] ?? null);
+        self::assertContains('de', $saved['availableLocales'] ?? []);
+    }
+}

--- a/packages/page/tests/Functional/Integration/responses/page_get_ghost_locale.json
+++ b/packages/page/tests/Functional/Integration/responses/page_get_ghost_locale.json
@@ -42,7 +42,7 @@
     "shadowLocales": [],
     "shadowOn": false,
     "stage": "draft",
-    "template": null,
+    "template": "default",
     "title": null,
     "version" : 0,
     "webspace": "sulu-io",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

This PR fixes several regressions that surface when working with a locale that has no persisted content yet, either a shadow locale or a not yet translated ghost locale. The publish path now loads the shadow source locale before the workflow runs, so shadow articles publish correctly across locales and a shadow whose source is not yet published returns a translated 400 response instead of crashing. The admin read path now returns the webspace default template for a ghost locale and no longer blocks the first save of a new locale with a false optimistic lock conflict. The page settings and permission tabs now stay hidden until the locale is actually saved.

#### Why?

A shadow or ghost locale has no dimension content of its own, so code paths that assumed persisted content failed in different ways. Publishing could crash, the first save of a new locale hit a false optimistic lock conflict, and a ghost locale returned a null template to the admin form. The shadow article publish fix is the article counterpart of the page fix already merged in #8886.