### PR TITLE
Fix Index searchable fields inside global blocks for article and page search

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
@@ -40,6 +40,11 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
         'single_media_selection',
     ];
 
+    /**
+     * @var array<string, array<string, FormMetadata>>
+     */
+    private array $globalBlockForms = [];
+
     public function __construct(
         private MetadataProviderInterface $formMetadataProvider,
     ) {
@@ -70,7 +75,7 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
         }
 
         $searchableFields = [];
-        $this->collectSearchableFields($metadata->getFlatFieldMetadata(), $searchableFields);
+        $this->collectSearchableFields($metadata->getFlatFieldMetadata(), $searchableFields, '', $locale);
 
         $document['content'] = $this->extractContent($templateData, $searchableFields);
 
@@ -101,7 +106,7 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
      * @param array<ItemMetadata> $items
      * @param array<string, array{type: string, role: string|null}> $fields
      */
-    private function collectSearchableFields(array $items, array &$fields, string $prefix = ''): void
+    private function collectSearchableFields(array $items, array &$fields, string $prefix, string $locale): void
     {
         foreach ($items as $item) {
             if (!$item instanceof FieldMetadata) {
@@ -128,15 +133,54 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
 
             if ('block' === $item->getType()) {
                 $blockPath = $prefix ? $prefix . '.' . $item->getName() : $item->getName();
-                foreach ($item->getTypes() as $type => $typeFormMetadata) {
+                foreach ($item->getTypes() as $typeFormMetadata) {
                     $this->collectSearchableFields(
-                        $typeFormMetadata->getItems(),
+                        $this->resolveTypeItems($typeFormMetadata, $locale),
                         $fields,
-                        $blockPath
+                        $blockPath,
+                        $locale
                     );
                 }
             }
         }
+    }
+
+    /**
+     * A global block type has no items of its own, so its referenced block form is resolved instead.
+     *
+     * @return array<ItemMetadata>
+     */
+    private function resolveTypeItems(FormMetadata $type, string $locale): array
+    {
+        $globalBlockTag = $type->getTagsByName('sulu.global_block')[0] ?? null;
+        if (null === $globalBlockTag) {
+            return $type->getItems();
+        }
+
+        $globalBlockName = $globalBlockTag->getAttribute('global_block');
+        if (!\is_string($globalBlockName)) {
+            return $type->getItems();
+        }
+
+        $globalBlockForm = $this->getGlobalBlockForms($locale)[$globalBlockName] ?? null;
+
+        return $globalBlockForm?->getItems() ?? $type->getItems();
+    }
+
+    /**
+     * @return array<string, FormMetadata>
+     */
+    private function getGlobalBlockForms(string $locale): array
+    {
+        if (!isset($this->globalBlockForms[$locale])) {
+            /** @var TypedFormMetadata $blockMetadata */
+            $blockMetadata = $this->formMetadataProvider->getMetadata('block', $locale, ['ignore_global_blocks' => true]);
+            /** @var array<string, FormMetadata> $forms */
+            $forms = $blockMetadata->getForms();
+            $this->globalBlockForms[$locale] = $forms;
+        }
+
+        return $this->globalBlockForms[$locale];
     }
 
     /**

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
@@ -40,11 +40,6 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
         'single_media_selection',
     ];
 
-    /**
-     * @var array<string, array<string, FormMetadata>>
-     */
-    private array $globalBlockForms = [];
-
     public function __construct(
         private MetadataProviderInterface $formMetadataProvider,
     ) {
@@ -162,25 +157,13 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
             return $type->getItems();
         }
 
-        $globalBlockForm = $this->getGlobalBlockForms($locale)[$globalBlockName] ?? null;
+        /** @var TypedFormMetadata $blockMetadata */
+        $blockMetadata = $this->formMetadataProvider->getMetadata('block', $locale, ['ignore_global_blocks' => true]);
+        /** @var array<string, FormMetadata> $forms */
+        $forms = $blockMetadata->getForms();
+        $globalBlockForm = $forms[$globalBlockName] ?? null;
 
         return $globalBlockForm?->getItems() ?? $type->getItems();
-    }
-
-    /**
-     * @return array<string, FormMetadata>
-     */
-    private function getGlobalBlockForms(string $locale): array
-    {
-        if (!isset($this->globalBlockForms[$locale])) {
-            /** @var TypedFormMetadata $blockMetadata */
-            $blockMetadata = $this->formMetadataProvider->getMetadata('block', $locale, ['ignore_global_blocks' => true]);
-            /** @var array<string, FormMetadata> $forms */
-            $forms = $blockMetadata->getForms();
-            $this->globalBlockForms[$locale] = $forms;
-        }
-
-        return $this->globalBlockForms[$locale];
     }
 
     /**

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
@@ -467,6 +467,81 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $this->assertSame(['Global block content'], $returnedData['content']);
     }
 
+    public function testVisitExtractsContentFromNestedGlobalBlocks(): void
+    {
+        // The article references an outer global block, which itself references an inner global block.
+        $outerGlobalBlockType = new FormMetadata();
+        $outerGlobalBlockType->setKey('outer_block');
+        $outerGlobalBlockType->addTag($this->createGlobalBlockTag('outer_block'));
+
+        $blockField = new FieldMetadata('main_content');
+        $blockField->setType('block');
+        $blockField->addType($outerGlobalBlockType);
+
+        $articleForm = new FormMetadata();
+        $articleForm->setKey('default');
+        $articleForm->addItem($blockField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $articleForm);
+
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        // The inner global block form holds the searchable field.
+        $contentField = new FieldMetadata('content');
+        $contentField->setType('text_editor');
+        $contentField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $innerGlobalBlockForm = new FormMetadata();
+        $innerGlobalBlockForm->setKey('inner_block');
+        $innerGlobalBlockForm->addItem($contentField);
+
+        // The outer global block form references the inner global block through a nested block field.
+        $innerGlobalBlockType = new FormMetadata();
+        $innerGlobalBlockType->setKey('inner_block');
+        $innerGlobalBlockType->addTag($this->createGlobalBlockTag('inner_block'));
+
+        $nestedBlockField = new FieldMetadata('nested');
+        $nestedBlockField->setType('block');
+        $nestedBlockField->addType($innerGlobalBlockType);
+
+        $outerGlobalBlockForm = new FormMetadata();
+        $outerGlobalBlockForm->setKey('outer_block');
+        $outerGlobalBlockForm->addItem($nestedBlockField);
+
+        $blockMetadata = new TypedFormMetadata();
+        $blockMetadata->addForm('outer_block', $outerGlobalBlockForm);
+        $blockMetadata->addForm('inner_block', $innerGlobalBlockForm);
+
+        $this->formMetadataProvider->getMetadata('block', 'en', ['ignore_global_blocks' => true])
+            ->willReturn($blockMetadata)
+            ->shouldBeCalled();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'main_content' => [
+                    [
+                        'type' => 'outer_block',
+                        'nested' => [
+                            [
+                                'type' => 'inner_block',
+                                'content' => '<p>Nested global block content</p>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['Nested global block content'], $returnedData['content']);
+    }
+
     public function testRoleImageSingleMediaSelectionSetsMediaId(): void
     {
         $imageField = new FieldMetadata('header_image');

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
@@ -412,6 +412,61 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         ];
     }
 
+    public function testVisitExtractsContentFromGlobalBlocks(): void
+    {
+        // A global block "ref" type carries the tag but no items (as produced by the metadata parser).
+        $globalBlockType = new FormMetadata();
+        $globalBlockType->setKey('text_content');
+        $globalBlockType->addTag($this->createGlobalBlockTag('text_content'));
+
+        $blockField = new FieldMetadata('main_content');
+        $blockField->setType('block');
+        $blockField->addType($globalBlockType);
+
+        $articleForm = new FormMetadata();
+        $articleForm->setKey('default');
+        $articleForm->addItem($blockField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $articleForm);
+
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $contentField = new FieldMetadata('content');
+        $contentField->setType('text_editor');
+        $contentField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $globalBlockForm = new FormMetadata();
+        $globalBlockForm->setKey('text_content');
+        $globalBlockForm->addItem($contentField);
+
+        $blockMetadata = new TypedFormMetadata();
+        $blockMetadata->addForm('text_content', $globalBlockForm);
+
+        $this->formMetadataProvider->getMetadata('block', 'en', ['ignore_global_blocks' => true])
+            ->willReturn($blockMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'main_content' => [
+                    [
+                        'type' => 'text_content',
+                        'content' => '<p>Global block content</p>',
+                    ],
+                ],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['Global block content'], $returnedData['content']);
+    }
+
     public function testRoleImageSingleMediaSelectionSetsMediaId(): void
     {
         $imageField = new FieldMetadata('header_image');
@@ -700,6 +755,15 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         if (null !== $role) {
             $tag->setAttributes(['role' => $role]);
         }
+
+        return $tag;
+    }
+
+    private function createGlobalBlockTag(string $blockName): TagMetadata
+    {
+        $tag = new TagMetadata();
+        $tag->setName('sulu.global_block');
+        $tag->setAttributes(['global_block' => $blockName]);
 
         return $tag;
     }

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
@@ -40,6 +40,11 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
         'single_media_selection',
     ];
 
+    /**
+     * @var array<string, array<string, FormMetadata>>
+     */
+    private array $globalBlockForms = [];
+
     public function __construct(
         private MetadataProviderInterface $formMetadataProvider,
     ) {
@@ -70,7 +75,7 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
         }
 
         $searchableFields = [];
-        $this->collectSearchableFields($metadata->getFlatFieldMetadata(), $searchableFields);
+        $this->collectSearchableFields($metadata->getFlatFieldMetadata(), $searchableFields, '', $locale);
 
         $document['content'] = $this->extractContent($templateData, $searchableFields);
 
@@ -101,7 +106,7 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
      * @param array<ItemMetadata> $items
      * @param array<string, array{type: string, role: string|null}> $fields
      */
-    private function collectSearchableFields(array $items, array &$fields, string $prefix = ''): void
+    private function collectSearchableFields(array $items, array &$fields, string $prefix, string $locale): void
     {
         foreach ($items as $item) {
             if (!$item instanceof FieldMetadata) {
@@ -128,15 +133,54 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
 
             if ('block' === $item->getType()) {
                 $blockPath = $prefix ? $prefix . '.' . $item->getName() : $item->getName();
-                foreach ($item->getTypes() as $type => $typeFormMetadata) {
+                foreach ($item->getTypes() as $typeFormMetadata) {
                     $this->collectSearchableFields(
-                        $typeFormMetadata->getItems(),
+                        $this->resolveTypeItems($typeFormMetadata, $locale),
                         $fields,
-                        $blockPath
+                        $blockPath,
+                        $locale
                     );
                 }
             }
         }
+    }
+
+    /**
+     * A global block type has no items of its own, so its referenced block form is resolved instead.
+     *
+     * @return array<ItemMetadata>
+     */
+    private function resolveTypeItems(FormMetadata $type, string $locale): array
+    {
+        $globalBlockTag = $type->getTagsByName('sulu.global_block')[0] ?? null;
+        if (null === $globalBlockTag) {
+            return $type->getItems();
+        }
+
+        $globalBlockName = $globalBlockTag->getAttribute('global_block');
+        if (!\is_string($globalBlockName)) {
+            return $type->getItems();
+        }
+
+        $globalBlockForm = $this->getGlobalBlockForms($locale)[$globalBlockName] ?? null;
+
+        return $globalBlockForm?->getItems() ?? $type->getItems();
+    }
+
+    /**
+     * @return array<string, FormMetadata>
+     */
+    private function getGlobalBlockForms(string $locale): array
+    {
+        if (!isset($this->globalBlockForms[$locale])) {
+            /** @var TypedFormMetadata $blockMetadata */
+            $blockMetadata = $this->formMetadataProvider->getMetadata('block', $locale, ['ignore_global_blocks' => true]);
+            /** @var array<string, FormMetadata> $forms */
+            $forms = $blockMetadata->getForms();
+            $this->globalBlockForms[$locale] = $forms;
+        }
+
+        return $this->globalBlockForms[$locale];
     }
 
     /**

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
@@ -40,11 +40,6 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
         'single_media_selection',
     ];
 
-    /**
-     * @var array<string, array<string, FormMetadata>>
-     */
-    private array $globalBlockForms = [];
-
     public function __construct(
         private MetadataProviderInterface $formMetadataProvider,
     ) {
@@ -162,25 +157,13 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
             return $type->getItems();
         }
 
-        $globalBlockForm = $this->getGlobalBlockForms($locale)[$globalBlockName] ?? null;
+        /** @var TypedFormMetadata $blockMetadata */
+        $blockMetadata = $this->formMetadataProvider->getMetadata('block', $locale, ['ignore_global_blocks' => true]);
+        /** @var array<string, FormMetadata> $forms */
+        $forms = $blockMetadata->getForms();
+        $globalBlockForm = $forms[$globalBlockName] ?? null;
 
         return $globalBlockForm?->getItems() ?? $type->getItems();
-    }
-
-    /**
-     * @return array<string, FormMetadata>
-     */
-    private function getGlobalBlockForms(string $locale): array
-    {
-        if (!isset($this->globalBlockForms[$locale])) {
-            /** @var TypedFormMetadata $blockMetadata */
-            $blockMetadata = $this->formMetadataProvider->getMetadata('block', $locale, ['ignore_global_blocks' => true]);
-            /** @var array<string, FormMetadata> $forms */
-            $forms = $blockMetadata->getForms();
-            $this->globalBlockForms[$locale] = $forms;
-        }
-
-        return $this->globalBlockForms[$locale];
     }
 
     /**

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
@@ -412,6 +412,61 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         ];
     }
 
+    public function testVisitExtractsContentFromGlobalBlocks(): void
+    {
+        // A global block "ref" type carries the tag but no items (as produced by the metadata parser).
+        $globalBlockType = new FormMetadata();
+        $globalBlockType->setKey('text_content');
+        $globalBlockType->addTag($this->createGlobalBlockTag('text_content'));
+
+        $blockField = new FieldMetadata('main_content');
+        $blockField->setType('block');
+        $blockField->addType($globalBlockType);
+
+        $pageForm = new FormMetadata();
+        $pageForm->setKey('default');
+        $pageForm->addItem($blockField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $pageForm);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $contentField = new FieldMetadata('content');
+        $contentField->setType('text_editor');
+        $contentField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $globalBlockForm = new FormMetadata();
+        $globalBlockForm->setKey('text_content');
+        $globalBlockForm->addItem($contentField);
+
+        $blockMetadata = new TypedFormMetadata();
+        $blockMetadata->addForm('text_content', $globalBlockForm);
+
+        $this->formMetadataProvider->getMetadata('block', 'en', ['ignore_global_blocks' => true])
+            ->willReturn($blockMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'main_content' => [
+                    [
+                        'type' => 'text_content',
+                        'content' => '<p>Global block content</p>',
+                    ],
+                ],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['Global block content'], $returnedData['content']);
+    }
+
     public function testRoleImageSingleMediaSelectionSetsMediaId(): void
     {
         $imageField = new FieldMetadata('header_image');
@@ -700,6 +755,15 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         if (null !== $role) {
             $tag->setAttributes(['role' => $role]);
         }
+
+        return $tag;
+    }
+
+    private function createGlobalBlockTag(string $blockName): TagMetadata
+    {
+        $tag = new TagMetadata();
+        $tag->setName('sulu.global_block');
+        $tag->setAttributes(['global_block' => $blockName]);
 
         return $tag;
     }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
@@ -467,6 +467,81 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $this->assertSame(['Global block content'], $returnedData['content']);
     }
 
+    public function testVisitExtractsContentFromNestedGlobalBlocks(): void
+    {
+        // The page references an outer global block, which itself references an inner global block.
+        $outerGlobalBlockType = new FormMetadata();
+        $outerGlobalBlockType->setKey('outer_block');
+        $outerGlobalBlockType->addTag($this->createGlobalBlockTag('outer_block'));
+
+        $blockField = new FieldMetadata('main_content');
+        $blockField->setType('block');
+        $blockField->addType($outerGlobalBlockType);
+
+        $pageForm = new FormMetadata();
+        $pageForm->setKey('default');
+        $pageForm->addItem($blockField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $pageForm);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        // The inner global block form holds the searchable field.
+        $contentField = new FieldMetadata('content');
+        $contentField->setType('text_editor');
+        $contentField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $innerGlobalBlockForm = new FormMetadata();
+        $innerGlobalBlockForm->setKey('inner_block');
+        $innerGlobalBlockForm->addItem($contentField);
+
+        // The outer global block form references the inner global block through a nested block field.
+        $innerGlobalBlockType = new FormMetadata();
+        $innerGlobalBlockType->setKey('inner_block');
+        $innerGlobalBlockType->addTag($this->createGlobalBlockTag('inner_block'));
+
+        $nestedBlockField = new FieldMetadata('nested');
+        $nestedBlockField->setType('block');
+        $nestedBlockField->addType($innerGlobalBlockType);
+
+        $outerGlobalBlockForm = new FormMetadata();
+        $outerGlobalBlockForm->setKey('outer_block');
+        $outerGlobalBlockForm->addItem($nestedBlockField);
+
+        $blockMetadata = new TypedFormMetadata();
+        $blockMetadata->addForm('outer_block', $outerGlobalBlockForm);
+        $blockMetadata->addForm('inner_block', $innerGlobalBlockForm);
+
+        $this->formMetadataProvider->getMetadata('block', 'en', ['ignore_global_blocks' => true])
+            ->willReturn($blockMetadata)
+            ->shouldBeCalled();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'main_content' => [
+                    [
+                        'type' => 'outer_block',
+                        'nested' => [
+                            [
+                                'type' => 'inner_block',
+                                'content' => '<p>Nested global block content</p>',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['Nested global block content'], $returnedData['content']);
+    }
+
     public function testRoleImageSingleMediaSelectionSetsMediaId(): void
     {
         $imageField = new FieldMetadata('header_image');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes #8905
| Related issues/PRs | #7503, #8272
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The website search content enhancers for articles and pages now resolve global block references when collecting searchable fields. When a block type carries the sulu.global_block tag the referenced block form is loaded and its items are walked instead of the empty type items. Nested global blocks are covered through the existing recursion. Resolved block forms are cached per locale to avoid repeated metadata lookups.

#### Why?

Fields tagged with sulu.search.field inside a global block were never written to the search content field. The indexer descended into the block type items, which stay empty for global blocks because the metadata parser only attaches a tag to the referenced type. As a result any content placed inside a global block was missing from the search index.