### PR TITLE
Add conflict for symfony/doctrine-bridge >= 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -170,6 +170,7 @@
         "scheb/2fa-google-authenticator": "< 6.10 || >= 9.0",
         "scheb/2fa-totp": "< 6.10 || >= 9.0",
         "scheb/2fa-trusted-device": "< 6.10 || >= 9.0",
+        "symfony/doctrine-bridge": ">= 8.0",
         "thecodingmachine/safe": "< 2.0.0"
     },
     "replace": {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The composer.json conflict section now excludes symfony/doctrine-bridge 8.0 and above. This keeps the bridge on the same Symfony 6.4 and 7.x version range that all other Symfony packages are constrained to. Composer resolves the bridge to 7.4 again for both stable and dev installations.

#### Why?

Sulu does not require symfony/doctrine-bridge directly, so it floats to 8.x through doctrine/doctrine-bundle. The bridge ships a console EntityValueResolver since 8.1 that implements an interface only available in symfony/console 8.1 and above. DoctrineBundle 3.3 dev probes this class with class_exists, which triggers a fatal autoload error when symfony/console is installed at 7.x. This currently breaks the PHP 8.5 dev stability job on the 3.0 branch.