### PR TITLE
Redirect the homepage of a prefixed portal when it has a trailing slash

### DIFF
--- a/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
+++ b/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
@@ -66,7 +66,17 @@ final readonly class RouteCollectionForRequestRouteLoader implements RouteCollec
                     // Important: This fix is only possible because we check that the matchType
                     // ResourceLocator is not set for homepage, because it is an empty string
                     // and the constructor of the RequestAttributes filters the given attributes via array_filter
-                    $slug = $suluAttribute->getAttribute('resourceLocator') ?? '/';
+                    $resourceLocator = $suluAttribute->getAttribute('resourceLocator');
+
+                    // The homepage of a portal whose url carries a prefix (e.g. "{host}/{localization}")
+                    // has no resourceLocator. Requesting it with a trailing slash gives "/" instead, which
+                    // is not its canonical url: no route may match, so that the RedirectExceptionSubscriber
+                    // redirects to the url without the trailing slash.
+                    if ('/' === $resourceLocator && '' !== ($suluAttribute->getAttribute('resourceLocatorPrefix') ?? '')) {
+                        return new RouteCollection();
+                    }
+
+                    $slug = $resourceLocator ?? '/';
 
                     if ($slug) {
                         $request->attributes->set(RequestAttributeEnum::SLUG->value, $slug);

--- a/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
@@ -18,6 +18,9 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
+use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Route\Application\Routing\Matcher\RouteCollectionForRequestRouteLoader;
 use Sulu\Route\Application\Routing\Matcher\RouteDefaultsProviderInterface;
 use Sulu\Route\Domain\Model\Route;
@@ -96,6 +99,62 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
         $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
 
         $this->assertCount(0, $routeCollection);
+    }
+
+    public function testGetRouteCollectionForRequestHomepageWithTrailingSlashDoesNotMatch(): void
+    {
+        $request = Request::create('/de/');
+        $request->attributes->set('_sulu', $this->createSuluAttributes('/', '/de'));
+
+        $this->routeRepository->findFirstBy(Argument::cetera())->shouldNotBeCalled();
+        $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
+
+        $this->assertCount(0, $routeCollection);
+    }
+
+    public function testGetRouteCollectionForRequestHomepageOfPrefixedPortalMatches(): void
+    {
+        // the homepage has no resourceLocator, the RequestAttributes filter out its empty string
+        $request = Request::create('/de');
+        $request->attributes->set('_sulu', $this->createSuluAttributes(null, '/de'));
+
+        $routeModel = new Route('resource_key_example', '1', 'en', '/', 'the_site');
+        static::setPrivateProperty($routeModel, 'id', 1);
+
+        $this->routeRepository->findFirstBy(['webspaceOrNull' => 'the_site', 'locale' => 'en', 'slug' => '/'], Argument::cetera())
+            ->willReturn($routeModel);
+        $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
+
+        $this->assertCount(1, $routeCollection);
+    }
+
+    public function testGetRouteCollectionForRequestHomepageOfPortalWithoutPrefixMatches(): void
+    {
+        // without a prefix "/" is the canonical homepage url, it must keep matching
+        $request = Request::create('/');
+        $request->attributes->set('_sulu', $this->createSuluAttributes('/', null));
+
+        $routeModel = new Route('resource_key_example', '1', 'en', '/', 'the_site');
+        static::setPrivateProperty($routeModel, 'id', 1);
+
+        $this->routeRepository->findFirstBy(['webspaceOrNull' => 'the_site', 'locale' => 'en', 'slug' => '/'], Argument::cetera())
+            ->willReturn($routeModel);
+        $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
+
+        $this->assertCount(1, $routeCollection);
+    }
+
+    private function createSuluAttributes(?string $resourceLocator, ?string $resourceLocatorPrefix): RequestAttributes
+    {
+        $portalInformation = $this->prophesize(PortalInformation::class);
+        $portalInformation->getWebspaceKey()->willReturn('the_site');
+
+        return new RequestAttributes([
+            'portalInformation' => $portalInformation->reveal(),
+            'matchType' => RequestAnalyzerInterface::MATCH_TYPE_FULL,
+            'resourceLocator' => $resourceLocator,
+            'resourceLocatorPrefix' => $resourceLocatorPrefix,
+        ]);
     }
 
     public function testGetRouteCollectionForRequestMatch(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8728
| License | MIT
| Documentation PR | -

#### What's in this PR?

`/de/` returned a `200` instead of redirecting to `/de`. Sub pages already redirected, only the homepage did not.

`RouteCollectionForRequestRouteLoader` resolves the slug like this:

```php
// Important: This fix is only possible because we check that the matchType
// ResourceLocator is not set for homepage, because it is an empty string
// and the constructor of the RequestAttributes filters the given attributes via array_filter
$slug = $suluAttribute->getAttribute('resourceLocator') ?? '/';
```

For `/de/` the `resourceLocator` is `"/"` — not an empty string, so it survives the `array_filter` and becomes the slug. The homepage route matches, no `NotFoundHttpException` is thrown, and `RedirectExceptionSubscriber::redirectTrailingSlashOrHtml()` never runs since it only reacts to a 404. For `/de/foo/` the `resourceLocator` is `"/foo/"`, no route matches, and the redirect happens as expected.

So the loader now returns an empty `RouteCollection` for that url, and the existing subscriber issues the `301` to `/de`.

#### Why not simply reject a `"/"` slug?

Because a portal whose url carries no prefix (`{host}`) has `/` as its canonical homepage url, and there `resourceLocator` *is* `"/"`. I mirrored `PortalInformationRequestProcessor::getResourceLocatorFromRequest()` in a script to check every shape before writing the guard:

| portal url | request | `resourceLocator` | `resourceLocatorPrefix` | rejected? |
| --- | --- | --- | --- | --- |
| `{host}/{localization}` | `/de` | `null` | `/de` | no |
| `{host}/{localization}` | `/de/` | `/` | `/de` | **yes** |
| `{host}/{localization}` | `/de/foo` | `/foo` | `/de` | no |
| `{host}/{localization}` | `/de/foo/` | `/foo/` | `/de` | no |
| `{host}` | `/` | `/` | `null` | no |
| `{host}` | `/foo/` | `/foo/` | `null` | no |

Hence the guard is `'/' === $resourceLocator && '' !== $prefix`.

#### Notes for reviewers

- `testGetRouteCollectionForRequestHomepageWithTrailingSlashDoesNotMatch` fails without the fix. The two other added tests (homepage of a prefixed portal, homepage of a portal without prefix) pass before and after: they are there to pin down the cases the guard must *not* touch.
- `packages/route` unit tests go from 78 to 81, no other change. php-cs-fixer clean, no PHP 8.5 deprecation.
- **I could not verify the `301` end to end**, that would need a full Sulu application with a database. I read `RedirectExceptionSubscriber` and checked it computes `'/' . trim('/de' . '/', '/') === '/de'`, which differs from the path info, so it should redirect — but that is reasoning, not observation. Happy to add a functional test if you point me at the right place.
