### PR TITLE
Fix Index search fields in sectioned global blocks

### DIFF
--- a/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
+++ b/src/Sulu/Bundle/PageBundle/Search/Metadata/StructureProvider.php
@@ -434,7 +434,7 @@ EOT;
             return $component->getChildren();
         }
 
-        return $result->getChildren();
+        return $result->getProperties();
     }
 
     private function createIndexNameField(Metadata $documentMetadata, $indexName, $decorate)

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/blocks/searchable_section_block.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/blocks/searchable_section_block.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>searchable_section_block</key>
+
+    <meta>
+        <title lang="en">Searchable Section Block</title>
+        <title lang="de">Searchable Section Block</title>
+    </meta>
+
+    <properties>
+        <section name="content">
+            <properties>
+                <property name="headline" type="text_line" mandatory="true">
+                    <meta>
+                        <title lang="en">Headline</title>
+                        <title lang="de">Überschrift</title>
+                    </meta>
+
+                    <tag name="sulu.search.field" type="string" />
+                </property>
+            </properties>
+        </section>
+    </properties>
+</template>

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/global_block_section.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/global_block_section.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>global_block_section</key>
+
+    <view>default</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <cacheLifetime>2400</cacheLifetime>
+
+    <meta>
+        <title lang="en">Global Block Section</title>
+        <title lang="de">Global Block Section</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <block name="blocks" minOccurs="0">
+            <types>
+                <type ref="searchable_section_block" />
+            </types>
+        </block>
+    </properties>
+</template>

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Search/SaveDocumentTest.php
@@ -14,6 +14,7 @@ namespace Sulu\Bundle\PageBundle\Tests\Functional\Search;
 use Composer\InstalledVersions;
 use Massive\Bundle\SearchBundle\Search\Field;
 use Massive\Bundle\SearchBundle\Search\QueryHit;
+use Massive\Bundle\SearchBundle\Search\SearchManagerInterface;
 use Massive\Bundle\SearchBundle\Search\SearchResult;
 use Sulu\Bundle\PageBundle\Document\PageDocument;
 use Sulu\Bundle\SearchBundle\Search\Document;
@@ -72,6 +73,42 @@ class SaveDocumentTest extends BaseTestCase
         $searches = [
             'Places' => 1,
             'Basel' => 1,
+            'Dornbirn' => 1,
+        ];
+
+        foreach ($searches as $search => $count) {
+            $res = $searchManager->createSearch($search)->locale('de')->index('page_sulu_io')->execute();
+            $this->assertCount($count, $res, 'Searching for: ' . $search);
+        }
+    }
+
+    public function testSaveDocumentWithSectionedGlobalBlock(): void
+    {
+        $document = new PageDocument();
+        $document->setTitle('Global Places');
+        $document->setStructureType('global_block_section');
+        $document->setResourceSegment('/global-places');
+        $document->setWorkflowStage(WorkflowStage::PUBLISHED);
+        $document->getStructure()->bind([
+            'blocks' => [
+                [
+                    'type' => 'searchable_section_block',
+                    'headline' => 'Dornbirn',
+                ],
+            ],
+        ], false);
+        $document->setParent($this->homeDocument);
+
+        $this->documentManager->persist($document, 'de');
+        $this->documentManager->flush();
+
+        $searchManager = $this->getSearchManager();
+        $this->assertInstanceOf(SearchManagerInterface::class, $searchManager);
+
+        // "Dornbirn" only exists in the search field nested inside the global block's <section>,
+        // so finding it proves the sectioned global block is indexed.
+        $searches = [
+            'Global Places' => 1,
             'Dornbirn' => 1,
         ];
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Unit/Search/Metadata/StructureProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Unit/Search/Metadata/StructureProviderTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\PageBundle\Tests\Unit\Search\Metadata;
+
+use Massive\Bundle\SearchBundle\Search\Factory;
+use Massive\Bundle\SearchBundle\Search\Metadata\ClassMetadata;
+use Massive\Bundle\SearchBundle\Search\Metadata\ComplexMetadata;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\PageBundle\Search\Metadata\StructureProvider;
+use Sulu\Component\Content\Extension\ExtensionManagerInterface;
+use Sulu\Component\Content\Metadata\BlockMetadata;
+use Sulu\Component\Content\Metadata\ComponentMetadata;
+use Sulu\Component\Content\Metadata\Factory\StructureMetadataFactoryInterface;
+use Sulu\Component\Content\Metadata\PropertyMetadata;
+use Sulu\Component\Content\Metadata\SectionMetadata;
+use Sulu\Component\Content\Metadata\StructureMetadata;
+use Sulu\Component\DocumentManager\Metadata;
+use Sulu\Component\DocumentManager\Metadata\MetadataFactory;
+
+class StructureProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<MetadataFactory>
+     */
+    private $metadataFactory;
+
+    /**
+     * @var ObjectProphecy<StructureMetadataFactoryInterface>
+     */
+    private $structureFactory;
+
+    /**
+     * @var ObjectProphecy<ExtensionManagerInterface>
+     */
+    private $extensionManager;
+
+    /**
+     * @var StructureProvider
+     */
+    private $provider;
+
+    public function setUp(): void
+    {
+        $this->metadataFactory = $this->prophesize(MetadataFactory::class);
+        $this->structureFactory = $this->prophesize(StructureMetadataFactoryInterface::class);
+        $this->extensionManager = $this->prophesize(ExtensionManagerInterface::class);
+
+        $this->provider = new StructureProvider(
+            new Factory(),
+            $this->metadataFactory->reveal(),
+            $this->structureFactory->reveal(),
+            $this->extensionManager->reveal()
+        );
+    }
+
+    /**
+     * A "sulu.search.field" tagged property that lives inside a <section> of a referenced
+     * global block must still be indexed. Flat global blocks were fixed by #8272, but
+     * sectioned/nested ones regressed because getChildren() returns the raw section wrapper
+     * instead of the flattened model properties.
+     */
+    public function testGlobalBlockWithSectionedSearchFieldIsIndexed(): void
+    {
+        // referenced global block "editorial": the searchable field is wrapped in a <section>
+        $searchProperty = new PropertyMetadata('headline');
+        $searchProperty->setType('text_line');
+        $searchProperty->addTag(['name' => 'sulu.search.field', 'attributes' => []]);
+
+        $section = new SectionMetadata('header');
+        $section->addChild($searchProperty);
+
+        $blockStructure = new StructureMetadata('editorial');
+        $blockStructure->setChildren(['header' => $section]);
+        $blockStructure->burnProperties();
+
+        $this->structureFactory->getStructureMetadata('block', 'editorial')
+            ->willReturn($blockStructure);
+
+        // page template: a block property whose type references the global block (<type ref="editorial"/>)
+        $globalBlockComponent = new ComponentMetadata('editorial');
+        $globalBlockComponent->addTag([
+            'name' => 'sulu.global_block',
+            'attributes' => ['global_block' => 'editorial'],
+        ]);
+
+        $block = new BlockMetadata('blocks');
+        $block->setType('block');
+        $block->addComponent($globalBlockComponent);
+
+        $structure = $this->prophesize(StructureMetadata::class);
+        $structure->getProperties()->willReturn(['blocks' => $block]);
+
+        $documentMetadata = $this->prophesize(Metadata::class);
+        $documentMetadata->getClass()->willReturn(\stdClass::class);
+        $documentMetadata->getReflectionClass()->willReturn(new \ReflectionClass(\stdClass::class));
+
+        $classMetadata = $this->provider->getMetadata(
+            $documentMetadata->reveal(),
+            $structure->reveal()
+        );
+
+        $this->assertInstanceOf(ClassMetadata::class, $classMetadata);
+        $fieldMapping = $classMetadata->getIndexMetadata('_default')->getFieldMapping();
+
+        $this->assertArrayHasKey('blocks', $fieldMapping, 'The global block was not indexed at all.');
+
+        $blockMapping = $fieldMapping['blocks'];
+        $this->assertIsArray($blockMapping);
+        $this->assertSame('complex', $blockMapping['type']);
+
+        $complexMapping = $blockMapping['mapping'];
+        $this->assertInstanceOf(ComplexMetadata::class, $complexMapping);
+
+        $nestedMapping = $complexMapping->getFieldMapping();
+        $this->assertIsArray($nestedMapping);
+        $this->assertArrayHasKey(
+            'editorial_headline',
+            $nestedMapping,
+            'The searchable field nested inside the global block section was not indexed.'
+        );
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/8905
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The search metadata provider now reads the flattened model properties of a referenced global block instead of its raw children. This way properties tagged with sulu.search.field that live inside a section of a global block are included in the search index mapping. A unit test and a functional test cover the sectioned global block case.

#### Why?

Search fields defined inside a section of a global block were not indexed. The provider iterated over the raw children of the block structure and received the section wrapper instead of the properties inside it. As a result the tagged properties were never mapped and content in sectioned global blocks could not be found via search.