### PR TITLE
Fix navigation for link pages with an unresolvable target

### DIFF
--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -23,6 +23,7 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Content\Application\ContentAggregator\ContentAggregatorInterface;
 use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
+use Sulu\Content\Domain\Model\LinkInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Model\PageDimensionContentInterface;
@@ -222,7 +223,12 @@ final class NavigationRepository implements NavigationRepositoryInterface
     ): array {
         $result = [];
         foreach ($pages as $page) {
-            $result[] = $this->resolvePageContent($page, $locale, $properties);
+            $normalizedContent = $this->resolvePageContent($page, $locale, $properties);
+            if (null === $normalizedContent) {
+                continue;
+            }
+
+            $result[] = $normalizedContent;
         }
 
         return $result;
@@ -338,6 +344,10 @@ final class NavigationRepository implements NavigationRepositoryInterface
         foreach ($pageUuids as $pageUuid) {
             $page = $pagesByUuid[$pageUuid];
             $normalizedContent = $this->resolvePageContent($page, $locale, $properties);
+            if (null === $normalizedContent) {
+                continue;
+            }
+
             $normalizedContent['children'] = $this->normalizePageTreeNodes(
                 $childPageUuidsByParent[$pageUuid] ?? [],
                 $pagesByUuid,
@@ -355,14 +365,16 @@ final class NavigationRepository implements NavigationRepositoryInterface
     /**
      * @param array<string, string> $properties
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed>|null
      */
-    private function resolvePageContent(PageInterface $page, string $locale, array $properties): array
+    private function resolvePageContent(PageInterface $page, string $locale, array $properties): ?array
     {
         $pageDimensionContent = $this->contentAggregator->aggregate($page, [
             'locale' => $locale,
             'stage' => DimensionContentInterface::STAGE_LIVE,
         ]);
+
+        $urlKeys = \array_keys($properties, 'url', true);
 
         // prefix all properties with "nav." to only resolve navigation related content
         foreach ($properties as $key => $value) {
@@ -378,9 +390,45 @@ final class NavigationRepository implements NavigationRepositoryInterface
 
         $result = $resolvedContent['nav'];
 
+        if ($this->isUnresolvedInternalPageLink($pageDimensionContent, $result, $urlKeys)) {
+            return null;
+        }
+
         $result['targetType'] = $result['targetType'] ?? PageLinkProvider::ALIAS;
 
         return $result;
+    }
+
+    /**
+     * @param DimensionContentInterface<PageInterface> $dimensionContent
+     * @param array<string, mixed> $result
+     * @param array<int, string> $urlKeys
+     */
+    private function isUnresolvedInternalPageLink(
+        DimensionContentInterface $dimensionContent,
+        array $result,
+        array $urlKeys,
+    ): bool {
+        if (!$dimensionContent instanceof LinkInterface) {
+            return false;
+        }
+
+        if (PageLinkProvider::ALIAS !== ($dimensionContent->getLinkData()['provider'] ?? null)) {
+            return false;
+        }
+
+        if ([] === $urlKeys) {
+            return false;
+        }
+
+        foreach ($urlKeys as $urlKey) {
+            $url = $result[$urlKey] ?? null;
+            if (null !== $url && '' !== $url) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
+++ b/packages/page/src/Infrastructure/Doctrine/Repository/NavigationRepository.php
@@ -390,7 +390,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
 
         $result = $resolvedContent['nav'];
 
-        if ($this->isUnresolvedInternalPageLink($pageDimensionContent, $result, $urlKeys)) {
+        if ($this->isUnresolvedLink($pageDimensionContent, $result, $urlKeys)) {
             return null;
         }
 
@@ -404,7 +404,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
      * @param array<string, mixed> $result
      * @param array<int, string> $urlKeys
      */
-    private function isUnresolvedInternalPageLink(
+    private function isUnresolvedLink(
         DimensionContentInterface $dimensionContent,
         array $result,
         array $urlKeys,
@@ -413,7 +413,7 @@ final class NavigationRepository implements NavigationRepositoryInterface
             return false;
         }
 
-        if (PageLinkProvider::ALIAS !== ($dimensionContent->getLinkData()['provider'] ?? null)) {
+        if (null === ($dimensionContent->getLinkData()['provider'] ?? null)) {
             return false;
         }
 
@@ -422,13 +422,34 @@ final class NavigationRepository implements NavigationRepositoryInterface
         }
 
         foreach ($urlKeys as $urlKey) {
-            $url = $result[$urlKey] ?? null;
+            $url = $this->findResolvedValue($result, $urlKey);
             if (null !== $url && '' !== $url) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    /**
+     * The content resolver nests dotted property names, so "link.url" is resolved
+     * into $result['link']['url'].
+     *
+     * @param array<string, mixed> $result
+     */
+    private function findResolvedValue(array $result, string $key): mixed
+    {
+        $value = $result;
+
+        foreach (\explode('.', $key) as $segment) {
+            if (!\is_array($value) || !\array_key_exists($segment, $value)) {
+                return null;
+            }
+
+            $value = $value[$segment];
+        }
+
+        return $value;
     }
 
     /**

--- a/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/ContentResolver/PageLinkDimensionContentEnhancer.php
@@ -124,6 +124,10 @@ class PageLinkDimensionContentEnhancer implements DimensionContentEnhancerInterf
             $url = $this->appendQueryAndAnchor($url, $linkData);
         }
 
+        if (null === $targetDimensionContent->getLocale()) {
+            return $pageDimensionContent;
+        }
+
         $enhancedDimensionContent->setTemplateData([
             ...$enhancedDimensionContent->getTemplateData(),
             ...[

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -31,6 +31,8 @@ class NavigationRepositoryLinkTest extends SuluTestCase
 
     private static string $internalLinkPageUuid;
 
+    private static string $mediaLinkPageUuid;
+
     /**
      * @return array<string, string>
      */
@@ -165,6 +167,79 @@ class NavigationRepositoryLinkTest extends SuluTestCase
                 ],
             ],
         ]);
+
+        // Created last so it cannot shift the positional indexes the tests above rely on.
+        $mediaLinkPage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Media Link Page',
+                    'url' => '/media-link',
+                    'template' => 'default',
+                    'navigationContexts' => ['main'],
+                    'linkOn' => true,
+                    'linkData' => [
+                        'href' => 999999,
+                        'provider' => 'media',
+                    ],
+                    'parentId' => $homepage->getId(),
+                ],
+            ],
+        ]);
+        self::$mediaLinkPageUuid = $mediaLinkPage->getUuid();
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $navigation
+     *
+     * @return array<string, mixed>|null
+     */
+    private function findByUuid(array $navigation, string $uuid): ?array
+    {
+        foreach ($navigation as $item) {
+            if ($uuid === ($item['uuid'] ?? null)) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    public function testGetNavigationFlatKeepsValidInternalLinkWhenUrlIsMappedToNestedProperty(): void
+    {
+        $properties = $this->getDefaultProperties();
+        unset($properties['url']);
+        $properties['link.url'] = 'url';
+
+        $navigation = $this->navigationRepository->getNavigationFlat(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            1,
+            $properties
+        );
+
+        $internalLinkNav = $this->findByUuid($navigation, self::$internalLinkPageUuid);
+        $this->assertNotNull($internalLinkNav, 'valid internal link was dropped when its url is mapped to a nested property');
+
+        /** @var array<string, mixed> $link */
+        $link = $internalLinkNav['link'];
+        $this->assertSame('/target-page', $link['url']);
+    }
+
+    public function testGetNavigationFlatExcludesLinkWithUnresolvableMediaTarget(): void
+    {
+        $navigation = $this->navigationRepository->getNavigationFlat(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            1,
+            $this->getDefaultProperties()
+        );
+
+        $uuids = \array_map(static fn (array $item) => $item['uuid'], $navigation);
+        $this->assertNotContains(self::$mediaLinkPageUuid, $uuids);
     }
 
     public function testGetNavigationFlat(): void

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryLinkTest.php
@@ -189,7 +189,7 @@ class NavigationRepositoryLinkTest extends SuluTestCase
     }
 
     /**
-     * @param array<int, array<string, mixed>> $navigation
+     * @param array<string, mixed>[] $navigation
      *
      * @return array<string, mixed>|null
      */

--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryUnpublishedLinkTargetTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryUnpublishedLinkTargetTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Functional\Infrastructure\Doctrine\Repository;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Domain\Model\WorkflowInterface;
+use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
+use Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage;
+use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
+use Sulu\Page\Infrastructure\Sulu\Content\PageLinkProvider;
+use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * Regression test for an internal link page that points to a page which was
+ * published and then unpublished. Resolving the navigation must not fail even
+ * though the link target has no published content anymore.
+ *
+ * @see https://github.com/sulu/SuluHeadlessBundle/issues/164
+ */
+#[CoversNothing]
+class NavigationRepositoryUnpublishedLinkTargetTest extends SuluTestCase
+{
+    use CreatePageTrait;
+
+    private NavigationRepositoryInterface $navigationRepository;
+
+    private static string $internalLinkPageUuid;
+
+    private static string $targetPageUuid;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->navigationRepository = $this->getContainer()->get('sulu_page.navigation_repository');
+
+        /** @var RequestContext $requestContext */
+        $requestContext = self::getContainer()->get('router')->getContext();
+        $requestContext->setParameter('webspace', 'sulu-io');
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::purgeDatabase();
+        self::bootKernel();
+
+        $homepage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Homepage',
+                    'url' => '/',
+                    'template' => 'default',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        // Target page is published so that live dimensions (including the
+        // unlocalized base) are created, then unpublished below.
+        $targetPage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Target Page',
+                    'url' => '/target-page',
+                    'template' => 'default',
+                    'navigationContexts' => [],
+                    'parentId' => $homepage->getId(),
+                ],
+            ],
+        ]);
+        self::$targetPageUuid = $targetPage->getUuid();
+
+        $internalLinkPage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Internal Link Page',
+                    'url' => '/internal-link',
+                    'template' => 'default',
+                    'navigationContexts' => ['main'],
+                    'linkOn' => true,
+                    'linkData' => [
+                        'href' => $targetPage->getUuid(),
+                        'provider' => PageLinkProvider::ALIAS,
+                    ],
+                    'parentId' => $homepage->getId(),
+                ],
+            ],
+        ]);
+        self::$internalLinkPageUuid = $internalLinkPage->getUuid();
+
+        // Unpublish the target page: its localized live content is removed while the
+        // link page keeps pointing at it. Aggregating the target for the live stage
+        // now yields a dimension content without a locale.
+        self::unpublishPage($targetPage->getUuid(), 'en');
+    }
+
+    private static function unpublishPage(string $uuid, string $locale): void
+    {
+        $messageBus = self::getContainer()->get('sulu_message_bus');
+
+        $messageBus->dispatch(
+            new Envelope(
+                new ApplyWorkflowTransitionPageMessage(
+                    identifier: ['uuid' => $uuid],
+                    locale: $locale,
+                    transitionName: WorkflowInterface::WORKFLOW_TRANSITION_UNPUBLISH
+                ),
+                [new EnableFlushStamp()]
+            )
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getDefaultProperties(): array
+    {
+        return [
+            'uuid' => 'object.resource.id',
+            'title' => 'title',
+            'url' => 'url',
+            'template' => 'object.templateKey',
+            'linkProvider' => 'object.linkData[provider]',
+        ];
+    }
+
+    public function testGetNavigationTreeExcludesInternalLinkWithUnpublishedTarget(): void
+    {
+        $navigation = $this->navigationRepository->getNavigationTree(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            2,
+            $this->getDefaultProperties()
+        );
+
+        // Resolving the navigation must not fail (regression: it previously threw a
+        // TypeError because the unpublished target has no locale).
+        /** @var array<string, mixed> $homepageNav */
+        $homepageNav = $navigation[0];
+        $this->assertSame('Homepage', $homepageNav['title']);
+
+        // The internal link page points at an unpublished page and therefore cannot
+        // resolve to a url, so it is dropped from the navigation entirely.
+        /** @var array<int, array<string, mixed>> $homepageChildren */
+        $homepageChildren = $homepageNav['children'];
+        $childUuids = \array_map(static fn (array $item) => $item['uuid'], $homepageChildren);
+        $this->assertNotContains(self::$internalLinkPageUuid, $childUuids);
+        $this->assertNotContains(self::$targetPageUuid, $childUuids);
+    }
+
+    public function testGetNavigationFlatExcludesInternalLinkWithUnpublishedTarget(): void
+    {
+        $navigation = $this->navigationRepository->getNavigationFlat(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            2,
+            $this->getDefaultProperties()
+        );
+
+        $uuids = \array_map(static fn (array $item) => $item['uuid'], $navigation);
+        $this->assertNotContains(self::$internalLinkPageUuid, $uuids);
+        $this->assertNotContains(self::$targetPageUuid, $uuids);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | https://github.com/sulu/SuluHeadlessBundle/issues/164
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Navigation no longer breaks when a link page points to a target that cannot be resolved. The link enhancer now skips resolution when the target has no localized content, which previously threw a TypeError. A link page whose url cannot be resolved is dropped from the navigation instead of rendering with an empty url. This covers every link provider, so an internal page link to an unpublished page behaves the same as a media link to a deleted media.

#### Why?

Unpublishing the target of an internal link page made the navigation API throw a TypeError because the aggregated target has no locale. On the Twig side sulu_content_path() then failed on the null url. Any link provider can fail to resolve its target, so the fix is not limited to internal page links. See sulu/SuluHeadlessBundle#164.