### PR TITLE
Add title fallback for link type

### DIFF
--- a/packages/content/src/Application/ResourceLoader/Loader/LinkResourceLoader.php
+++ b/packages/content/src/Application/ResourceLoader/Loader/LinkResourceLoader.php
@@ -15,8 +15,9 @@ namespace Sulu\Content\Application\ResourceLoader\Loader;
 
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkItem;
 use Sulu\Bundle\MarkupBundle\Markup\Link\LinkProviderPoolInterface;
+use Sulu\Content\Application\ContentResolver\Value\ContentView;
 
-class LinkResourceLoader implements ResourceLoaderInterface
+class LinkResourceLoader implements ResourceLoaderContentViewEnhancementInterface
 {
     public const LINK_TYPE_EXTERNAL = 'external';
     public const RESOURCE_LOADER_KEY = 'link';
@@ -81,6 +82,17 @@ class LinkResourceLoader implements ResourceLoaderInterface
         }
 
         return $idsByProvider;
+    }
+
+    public function resolveContentViewEnhancement(mixed $resource): ContentView
+    {
+        $view = [];
+
+        if ($resource instanceof LinkItem) {
+            $view['resourceTitle'] = (string) $resource->getTitle();
+        }
+
+        return ContentView::create([], $view);
     }
 
     public static function getKey(): string

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -1212,6 +1212,8 @@ class ContentResolverTest extends SuluTestCase
         self::assertSame('external', $linkView['provider']);
         self::assertSame('https://sulu.io', $linkView['href']);
         self::assertSame('Sulu Website', $linkView['title']);
+        // external links have no resource title of their own
+        self::assertSame('', $linkView['resourceTitle']);
     }
 
     public function testResolveLinkInternal(): void
@@ -1271,7 +1273,71 @@ class ContentResolverTest extends SuluTestCase
         $linkView = $view['link'];
         self::assertSame('examples', $linkView['provider']);
         self::assertSame($linkedExample->getId(), $linkView['href']);
+        // editor-provided title and the linked resource's own title coexist
         self::assertSame('Linked Example', $linkView['title']);
+        self::assertSame('Linked Example', $linkView['resourceTitle']);
+    }
+
+    public function testResolveLinkInternalTitleFallback(): void
+    {
+        $linkedExample = static::createExample(
+            [
+                'en' => [
+                    'live' => [
+                        'template' => 'full-content',
+                        'title' => 'Fallback Target Title',
+                        'url' => '/fallback-target',
+                    ],
+                ],
+            ],
+            [
+                'create_route' => true,
+            ],
+        );
+
+        static::getEntityManager()->flush();
+
+        $example1 = static::createExample(
+            [
+                'en' => [
+                    'live' => [
+                        'template' => 'full-content',
+                        'title' => 'Lorem Ipsum',
+                        'url' => '/lorem-ipsum',
+                        'link' => [
+                            'provider' => 'examples',
+                            'href' => $linkedExample->getId(),
+                            // no title set in the admin -> should fall back to the linked example's title
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'create_route' => true,
+            ],
+        );
+
+        static::getEntityManager()->flush();
+
+        $dimensionContent = $this->contentAggregator->aggregate($example1, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        $content = $result['content'];
+
+        self::assertArrayHasKey('link', $content);
+        self::assertSame('/fallback-target', $content['link']);
+
+        /** @var array<string, mixed> $view */
+        $view = $result['view'];
+        self::assertArrayHasKey('link', $view);
+        /** @var array<string, mixed> $linkView */
+        $linkView = $view['link'];
+        self::assertSame('examples', $linkView['provider']);
+        self::assertSame($linkedExample->getId(), $linkView['href']);
+        // editor left the title empty, so no "title" is set; the linked resource's own
+        // title is exposed separately under "resourceTitle" by the LinkResourceLoader enhancement
+        self::assertArrayNotHasKey('title', $linkView);
+        self::assertSame('Fallback Target Title', $linkView['resourceTitle']);
     }
 
     public function testResolveNestedContentWithDraftStage(): void

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/LinkPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/LinkPropertyResolverTest.php
@@ -55,6 +55,8 @@ class LinkPropertyResolverTest extends TestCase
 
         $resolvableResource = $contentView->getContent();
         $this->assertInstanceOf(ResolvableResource::class, $resolvableResource);
+
+        // the title is enriched by LinkResourceLoader::resolveContentViewEnhancement(), not here
         $this->assertSame([
             'href' => 'http://example.com',
             'provider' => 'external',
@@ -98,6 +100,8 @@ class LinkPropertyResolverTest extends TestCase
         $resolvableResource = $contentView->getContent();
         $this->assertInstanceOf(ResolvableResource::class, $resolvableResource);
         $this->assertSame('article::1234-4567-7890', $resolvableResource->getId());
+
+        // the title is enriched by LinkResourceLoader::resolveContentViewEnhancement(), not here
         $this->assertSame([
             'href' => '1234-4567-7890',
             'provider' => 'article',

--- a/packages/content/tests/Unit/Content/Application/ResourceLoader/LinkResourceLoaderTest.php
+++ b/packages/content/tests/Unit/Content/Application/ResourceLoader/LinkResourceLoaderTest.php
@@ -110,4 +110,32 @@ class LinkResourceLoaderTest extends TestCase
             'external::https://sulu.io' => $link,
         ], $result);
     }
+
+    public function testResolveContentViewEnhancement(): void
+    {
+        $link = new LinkItem('123-123-123', 'Page Title', 'https://sulu.io/page', true);
+
+        $contentView = $this->loader->resolveContentViewEnhancement($link);
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['resourceTitle' => 'Page Title'], $contentView->getView());
+    }
+
+    public function testResolveContentViewEnhancementWithEmptyTitle(): void
+    {
+        $link = new LinkItem('https://sulu.io', '', 'https://sulu.io', true);
+
+        $contentView = $this->loader->resolveContentViewEnhancement($link);
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame(['resourceTitle' => ''], $contentView->getView());
+    }
+
+    public function testResolveContentViewEnhancementWithNonLinkItem(): void
+    {
+        $contentView = $this->loader->resolveContentViewEnhancement('not-a-link-item');
+
+        $this->assertSame([], $contentView->getContent());
+        $this->assertSame([], $contentView->getView());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no
| License | MIT
| Documentation PR | sulu/sulu-docs#925

#### What's in this PR?

Uses the page/article title for links when no custom title is set in the admin.

#### Why?

Right now view.link.title is just empty if you don't type a title, even though we already have the linked page's title  on the LinkItem. Felt wrong to leave it blank, so now it falls back to that