### PR TITLE
Fix JavaScript tests failing with sanitize-html 2.17.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
         },
         "clearMocks": true,
         "transformIgnorePatterns": [
-            "node_modules/(?!(@ckeditor|array-move|lodash-es|vanilla-colorful|color-parse|color-name|color-convert)/)"
+            "node_modules/(?!(@ckeditor|array-move|lodash-es|vanilla-colorful|color-parse|color-name|color-convert|sanitize-html|htmlparser2|domhandler|domutils|dom-serializer|domelementtype|entities)/)"
         ],
         "testPathIgnorePatterns": [
             "vendor/friendsofsymfony"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The Jest transformIgnorePatterns allowlist in package.json now includes sanitize-html and the htmlparser2 package family. This lets Babel transform these ESM only packages to CommonJS when running the JavaScript tests. The sanitize-html entry itself is needed because the packages are installed nested under node_modules/sanitize-html and the ignore pattern would otherwise match at the first node_modules segment.

#### Why?

sanitize-html 2.17.6 updated its htmlparser2 dependency from version 10 to version 12. htmlparser2 12 and its related packages are published as ESM only. The Jest runtime cannot load ESM through require, so every test suite that imports sanitize-html fails with a SyntaxError. The repository has no lockfile, therefore every fresh npm install on CI pulls the new version and fails.