### PR TITLE
Move jest polyfill setup to own script, remove unused jest-canvas-mock package

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
         },
         "setupFiles": [
             "jest-canvas-mock",
-            "regenerator-runtime/runtime"
+            "regenerator-runtime/runtime",
+            "./tests/js/polyfills-for-jest.js"
         ],
         "setupFilesAfterEnv": [
             "./tests/js/testSetup.config.js"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
         "glob": "^10.3.10",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.2.0",
-        "jest-canvas-mock": "^2.1.1",
         "jest-environment-jsdom": "^30.2.0",
         "mini-css-extract-plugin": "^2.7.1",
         "mobx": "^4.0.0",
@@ -102,7 +101,6 @@
             "fos-jsrouting/router": "<rootDir>/tests/js/mocks/fos-jsrouting-router.js"
         },
         "setupFiles": [
-            "jest-canvas-mock",
             "regenerator-runtime/runtime",
             "./tests/js/polyfills-for-jest.js"
         ],

--- a/tests/js/polyfills-for-jest.js
+++ b/tests/js/polyfills-for-jest.js
@@ -1,0 +1,14 @@
+// @flow
+// eslint-disable-next-line import/no-nodejs-modules
+import {TextDecoder, TextEncoder} from 'util';
+import 'core-js/features/string/replace-all';
+
+Object.defineProperty(window, 'TextDecoder', {
+    writable: true,
+    value: TextDecoder,
+});
+
+Object.defineProperty(window, 'TextEncoder', {
+    writable: true,
+    value: TextEncoder,
+});

--- a/tests/js/testSetup.config.js
+++ b/tests/js/testSetup.config.js
@@ -1,23 +1,10 @@
 // @flow
-// eslint-disable-next-line import/no-nodejs-modules
-import {TextDecoder, TextEncoder} from 'util';
-import 'core-js/features/string/replace-all';
 import Enzyme from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import {isObservableArray, toJS} from 'mobx';
 import '@testing-library/jest-dom';
 
 Enzyme.configure({adapter: new Adapter()});
-
-Object.defineProperty(window, 'TextDecoder', {
-    writable: true,
-    value: TextDecoder,
-});
-
-Object.defineProperty(window, 'TextEncoder', {
-    writable: true,
-    value: TextEncoder,
-});
 
 function mobxAwareEqualityTester(a, b, customTesters) {
     const isAObservable = isObservableArray(a);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #6343 
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Move jest polyfills setup to own script.

#### Why?

This prepares some compatibility fixes for React 18 where TextEncoder under Jest need be set before Jest.

Still React 18 would show:

<details><summary>React 18 Warning</summary>

```js
    console.error
      Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot
```

</details>