### PR TITLE
Fix PHPStan errors and permission tests on lowest dependencies

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29827,6 +29827,18 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/FormatControllerTest.php
 
 		-
+			message: '#^Cannot call method encodePassword\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerMovePermissionTest.php
+
+		-
+			message: '#^Instanceof between Symfony\\Component\\PasswordHasher\\Hasher\\PasswordHasherFactory and Symfony\\Component\\PasswordHasher\\Hasher\\PasswordHasherFactoryInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerMovePermissionTest.php
+
+		-
 			message: '#^Access to an undefined property object\:\:\$categories\.$#'
 			identifier: property.notFound
 			count: 1
@@ -46211,6 +46223,18 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Bundle/PreviewBundle/Tests/Functional/Preview/Renderer/PreviewRendererTest.php
+
+		-
+			message: '#^Cannot call method encodePassword\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerPermissionTest.php
+
+		-
+			message: '#^Instanceof between Symfony\\Component\\PasswordHasher\\Hasher\\PasswordHasherFactory and Symfony\\Component\\PasswordHasher\\Hasher\\PasswordHasherFactoryInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerPermissionTest.php
 
 		-
 			message: '#^Cannot access offset ''lastVisit'' on mixed\.$#'
@@ -71656,6 +71680,12 @@ parameters:
 			message: '#^Cannot call method getValue\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 1
+			path: src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+
+		-
+			message: '#^Cannot cast mixed to int\.$#'
+			identifier: cast.int
+			count: 2
 			path: src/Sulu/Component/Content/SmartContent/QueryBuilder.php
 
 		-

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerMovePermissionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerMovePermissionTest.php
@@ -126,10 +126,14 @@ class MediaControllerMovePermissionTest extends SuluTestCase
 
         $passwordHasherFactory = self::getContainer()->get('sulu_security.encoder_factory');
         if ($passwordHasherFactory instanceof PasswordHasherFactoryInterface) {
-            $user->setPassword($passwordHasherFactory->getPasswordHasher($user)->hash($username));
+            $hasher = $passwordHasherFactory->getPasswordHasher($user);
+            $password = $hasher->hash($username);
         } else {
-            $user->setPassword($passwordHasherFactory->getEncoder($user)->encodePassword($username, $user->getSalt()));
+            $encoder = $passwordHasherFactory->getEncoder($user);
+            $password = $encoder->encodePassword($username, $user->getSalt());
         }
+
+        $user->setPassword($password);
 
         $userRole = new UserRole();
         $userRole->setUser($user);

--- a/src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerPermissionTest.php
+++ b/src/Sulu/Bundle/PreviewBundle/Tests/Functional/UserInterface/Controller/PreviewLinkControllerPermissionTest.php
@@ -22,6 +22,7 @@ use Sulu\Bundle\TestBundle\Kernel\SuluKernelBrowser;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Component\DocumentManager\DocumentManagerInterface;
 use Sulu\Component\Security\Authentication\RoleInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 
 use function Symfony\Component\String\u;
 
@@ -226,8 +227,16 @@ class PreviewLinkControllerPermissionTest extends SuluTestCase
         $user->setSalt('');
         $user->setLocale('en');
 
-        $passwordHasher = static::getContainer()->get('sulu_security.encoder_factory')->getPasswordHasher($user);
-        $user->setPassword($passwordHasher->hash($username));
+        $passwordHasherFactory = static::getContainer()->get('sulu_security.encoder_factory');
+        if ($passwordHasherFactory instanceof PasswordHasherFactoryInterface) {
+            $hasher = $passwordHasherFactory->getPasswordHasher($user);
+            $password = $hasher->hash($username);
+        } else {
+            $encoder = $passwordHasherFactory->getEncoder($user);
+            $password = $encoder->encodePassword($username, $user->getSalt());
+        }
+
+        $user->setPassword($password);
 
         $userRole = new UserRole();
         $userRole->setUser($user);

--- a/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
+++ b/src/Sulu/Component/Content/SmartContent/QueryBuilder.php
@@ -318,6 +318,8 @@ class QueryBuilder extends ContentQueryBuilder
 
     /**
      * build tags where clauses.
+     *
+     * @return string
      */
     protected function buildTagsWhere($tags, $operator, $languageCode)
     {
@@ -365,6 +367,8 @@ class QueryBuilder extends ContentQueryBuilder
 
     /**
      * build categories where clauses.
+     *
+     * @return string
      */
     protected function buildCategoriesWhere($categories, $operator, $languageCode)
     {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The `createUser` helper in `PreviewLinkControllerPermissionTest` now picks the password hasher API based on the factory it receives and falls back to the legacy encoder API when the password hasher component is not installed. The equivalent helper in `MediaControllerMovePermissionTest` was aligned with the shape already used in `MediaStreamControllerAdminTest`. The two where clause builders in the smart content `QueryBuilder` declare `@return string` so the unit test can rely on the return type. The remaining analysis errors are covered by the PHPStan baseline.

#### Why?

The `2.6` branch is currently red on two jobs. The `PHP 8.2` job that installs the lowest dependencies fails because the test calls `getPasswordHasher()` on the legacy `EncoderFactory`, which does not offer that method. The `PHP Lint` job fails with seven PHPStan errors. PHPStan resolves the hasher factory against the highest installed dependencies, so the compatibility branch reads as dead code and needs a baseline entry.