### PR TITLE
Do not throw when rolling back the tag name to id migration

### DIFF
--- a/packages/content/src/Infrastructure/Doctrine/Migrations/AbstractTagNameToIdMigration.php
+++ b/packages/content/src/Infrastructure/Doctrine/Migrations/AbstractTagNameToIdMigration.php
@@ -55,7 +55,8 @@ abstract class AbstractTagNameToIdMigration extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->throwIrreversibleMigrationException();
+        // This migration is not reversible: the original tag names cannot be
+        // restored from the ids. Intentionally a no-op instead of throwing.
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The `down()` method of `AbstractTagNameToIdMigration` no longer calls `throwIrreversibleMigrationException()`. It is now an empty method with a comment stating that the original tag names cannot be restored from the ids. This affects the three migrations that extend the base class, in the article, page and snippet packages.

#### Why?

Rolling back past this migration aborted with an exception, which blocked the whole down path even though the schema itself is untouched. The migration only rewrites data, so there is nothing to revert and nothing that would leave the database inconsistent.