### PR TITLE
Apply disabled_condition consistently across toolbar actions

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js
@@ -156,6 +156,19 @@ test('Return enabled item config', () => {
     }));
 });
 
+test('Return item config is disabled with disabled_condition', () => {
+    const copyLocaleToolbarAction = createCopyLocaleToolbarAction(
+        ['en', 'de'],
+        {disabled_condition: 'true == true'}
+    );
+    copyLocaleToolbarAction.resourceFormStore.resourceStore.id = 5;
+
+    expect(copyLocaleToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+        label: 'sulu_admin.copy_locale',
+    }));
+});
+
 test('Return no item config if deprecated display_condition is not met', () => {
     const copyLocaleToolbarAction = createCopyLocaleToolbarAction(
         ['en', 'de'],

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyToolbarAction.test.js
@@ -96,6 +96,17 @@ test('Return  item config with enabled button if form store contains an id', () 
     }));
 });
 
+test('Return item config with disabled button if form store contains an id but has disabled_condition', () => {
+    const copyToolbarAction = createCopyToolbarAction({
+        disabled_condition: 'true == true',
+    });
+    copyToolbarAction.resourceFormStore.resourceStore.id = 123;
+
+    expect(copyToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
 test('Return item config if passed visible_condition is met', () => {
     const copyToolbarAction = createCopyToolbarAction({visible_condition: '_permission.edit'});
     copyToolbarAction.resourceFormStore.resourceStore.data._permission = {edit: true};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js
@@ -94,6 +94,21 @@ test('Return enabled item config', () => {
     }));
 });
 
+test('Return disabled item config when disabled_condition is set', () => {
+    const deleteDraftToolbarAction = createDeleteDraftToolbarAction({
+        disabled_condition: 'true == true',
+    });
+    deleteDraftToolbarAction.resourceFormStore.resourceStore.id = 5;
+    deleteDraftToolbarAction.resourceFormStore.resourceStore.data.published = true;
+    deleteDraftToolbarAction.resourceFormStore.resourceStore.data.publishedState = false;
+
+    expect(deleteDraftToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+        label: 'sulu_page.delete_draft',
+        type: 'button',
+    }));
+});
+
 test('Return no item config if deprecated display_condition is not met', () => {
     const deleteDraftToolbarAction = createDeleteDraftToolbarAction({display_condition: '_permission.live'});
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js
@@ -136,6 +136,16 @@ test('Return item config with enabled button if more than one contentLocale and 
     }));
 });
 
+test('Return item config with enabled button if has disabled_condition met', () => {
+    const deleteToolbarAction = createDeleteToolbarAction({delete_locale: true, disabled_condition: 'true == true'});
+    deleteToolbarAction.resourceFormStore.resourceStore.id = '123-123-123';
+    deleteToolbarAction.resourceFormStore.resourceStore.data = {contentLocales: ['de', 'en']};
+
+    expect(deleteToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
 test('Return item config with disabled button if only one contentLocale is available', () => {
     const deleteToolbarAction = createDeleteToolbarAction({delete_locale: true});
     deleteToolbarAction.resourceFormStore.resourceStore.id = '123-123-123';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/PublishToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/PublishToolbarAction.test.js
@@ -76,6 +76,16 @@ test('Return item config with enabled button when resource is not published and 
     }));
 });
 
+test('Return item config with disabled button when has disabled_condition met', () => {
+    const publishToolbarAction = createPublishToolbarAction({disabled_condition: 'true == true'});
+    publishToolbarAction.resourceFormStore.resourceStore.dirty = false;
+    publishToolbarAction.resourceFormStore.resourceStore.data.publishedState = false;
+
+    expect(publishToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
 test('Return item config with disabled button when resource is not published but form is not dirty', () => {
     const publishToolbarAction = createPublishToolbarAction();
     publishToolbarAction.resourceFormStore.resourceStore.dirty = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/ReloadFormStoreToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/ReloadFormStoreToolbarAction.test.js
@@ -112,6 +112,23 @@ test('Return correct toolbar item config', () => {
 
     expect(config).toEqual({
         type: 'button',
+        disabled: false,
+        label: 'Reload',
+        icon: 'su-sync',
+        onClick: expect.any(Function),
+    });
+});
+
+test('Return correct toolbar item config but with disabled_condition met', () => {
+    const action = createReloadFormStoreToolbarAction({
+        label: 'Reload',
+        disabled_condition: 'true == true',
+    });
+    const config = action.getToolbarItemConfig();
+
+    expect(config).toEqual({
+        type: 'button',
+        disabled: true,
         label: 'Reload',
         icon: 'su-sync',
         onClick: expect.any(Function),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveToolbarAction.test.js
@@ -79,6 +79,15 @@ test('Return item config with enabled button when dirty flag is set', () => {
     }));
 });
 
+test('Return item config with enabled button when dirty flag is set but disabled_ condition is met', () => {
+    const saveToolbarAction = createSaveToolbarAction( {disabled_condition: 'true == true'});
+    saveToolbarAction.resourceFormStore.resourceStore.dirty = true;
+
+    expect(saveToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
 test('Return item config with loading button when saving flag is set', () => {
     const saveToolbarAction = createSaveToolbarAction();
     saveToolbarAction.resourceFormStore.resourceStore.saving = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js
@@ -81,6 +81,21 @@ test('Return item config with enabled button when dirty flag is set', () => {
     }));
 });
 
+test('Return item config with disabled button when dirty flag is set but disabled_condition is met', () => {
+    const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction(
+        {
+            condition: 'true',
+            formKey: 'test',
+            disabled_condition: 'true == true',
+        }
+    );
+    saveWithFormDialogToolbarAction.resourceFormStore.resourceStore.dirty = true;
+
+    expect(saveWithFormDialogToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+    }));
+});
+
 test('Return item config with loading button when saving flag is set', () => {
     const saveWithFormDialogToolbarAction = createSaveWithFormDialogToolbarAction({condition: 'true', formKey: 'test'});
     saveWithFormDialogToolbarAction.resourceFormStore.resourceStore.saving = true;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js
@@ -93,6 +93,20 @@ test('Return enabled item config', () => {
     }));
 });
 
+test('Return item config with disabled_condition is met', () => {
+    const setUnpublishedToolbarAction = createSetUnpublishedToolbarAction(
+        {disabled_condition: 'true == true'}
+    );
+    setUnpublishedToolbarAction.resourceFormStore.resourceStore.id = 5;
+    setUnpublishedToolbarAction.resourceFormStore.resourceStore.data.published = true;
+    setUnpublishedToolbarAction.resourceFormStore.resourceStore.data.publishedState = false;
+
+    expect(setUnpublishedToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        disabled: true,
+        label: 'sulu_page.unpublish',
+    }));
+});
+
 test('Return item config if passed visible_condition is met', () => {
     const setUnpublishedToolbarAction = createSetUnpublishedToolbarAction({visible_condition: '_permission.edit'});
     setUnpublishedToolbarAction.resourceFormStore.resourceStore.data._permission = {edit: true};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TogglerToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TogglerToolbarAction.test.js
@@ -71,7 +71,7 @@ function createTogglerToolbarAction(resourceKey, options: {[key: string]: mixed}
     return new TogglerToolbarAction(resourceFormStore, form, router, [], options, resourceStore);
 }
 
-test('Return item config with correct type, label, loading and value', () => {
+test('Return item config with correct type, label, loading, disabled and value', () => {
     const toolbarAction = createTogglerToolbarAction('test', {label: 'sulu_admin.publish', property: 'published'});
     toolbarAction.resourceFormStore.resourceStore.loading = false;
     toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
@@ -79,6 +79,26 @@ test('Return item config with correct type, label, loading and value', () => {
 
     expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
         type: 'toggler',
+        disabled: false,
+        label: 'sulu_admin.publish',
+        loading: false,
+        value: false,
+    }));
+});
+
+test('Return item config with correct type, label, loading, disabled and value but with disabled_condtion met', () => {
+    const toolbarAction = createTogglerToolbarAction('test', {
+        label: 'sulu_admin.publish',
+        property: 'published',
+        disabled_condition: 'true == true',
+    });
+    toolbarAction.resourceFormStore.resourceStore.loading = false;
+    toolbarAction.resourceFormStore.resourceStore.data.id = 1234;
+    toolbarAction.resourceFormStore.resourceStore.data.published = false;
+
+    expect(toolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
+        type: 'toggler',
+        disabled: true,
         label: 'sulu_admin.publish',
         loading: false,
         value: false,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js
@@ -128,6 +128,24 @@ test('Return correct toolbar item config', () => {
 
     expect(config).toEqual({
         type: 'button',
+        disabled: false,
+        label: 'Update',
+        icon: 'su-pen',
+        onClick: expect.any(Function),
+        loading: false,
+    });
+});
+
+test('Return correct toolbar item config but with disabled_condition met', () => {
+    const action = createUpdateFormStoreToolbarAction({
+        label: 'Update',
+        disabled_condition: 'true == true',
+    });
+    const config = action.getToolbarItemConfig();
+
+    expect(config).toEqual({
+        type: 'button',
+        disabled: true,
         label: 'Update',
         icon: 'su-pen',
         onClick: expect.any(Function),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
@@ -1,5 +1,6 @@
 // @flow
 import {computed, toJS} from 'mobx';
+import jexl from 'jexl';
 import ResourceStore from '../../../stores/ResourceStore';
 import {ResourceFormStore, FormInspector, conditionDataProviderRegistry} from '../../../containers/Form';
 import Router from '../../../services/Router';
@@ -60,5 +61,17 @@ export default class AbstractFormToolbarAction {
 
     destroy() {
 
+    }
+
+    isDisabled(): boolean {
+        const {
+            disabled_condition: disabledCondition,
+        } = this.options;
+
+        try {
+            return disabledCondition ? jexl.evalSync(disabledCondition, this.conditionData) : false;
+        } catch (e) {
+            return false;
+        }
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyLocaleToolbarAction.js
@@ -98,13 +98,11 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
             visible_condition: visibleCondition,
         } = this.options;
 
-        const {id} = this.resourceFormStore;
-
         const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {
-                disabled: !id,
+                disabled: this.isDisabled(),
                 icon: 'su-copy',
                 label: translate('sulu_admin.copy_locale'),
                 onClick: action(() => {
@@ -177,4 +175,10 @@ export default class CopyLocaleToolbarAction extends AbstractFormToolbarAction {
             locales: this.locales?.filter((locale) => locale !== this.resourceFormStore.locale?.get()),
         });
     };
+
+    isDisabled(): boolean {
+        const disabled = super.isDisabled();
+
+        return disabled || !this.resourceFormStore.id;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/CopyToolbarAction.js
@@ -33,12 +33,11 @@ export default class CopyToolbarAction extends AbstractFormToolbarAction {
             visible_condition: visibleCondition,
         } = this.options;
 
-        const {id} = this.resourceFormStore;
         const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {
-                disabled: !id,
+                disabled: this.isDisabled(),
                 icon: 'su-copy',
                 label: translate('sulu_admin.create_copy'),
                 onClick: action(() => {
@@ -81,4 +80,10 @@ export default class CopyToolbarAction extends AbstractFormToolbarAction {
     @action handleCopyDialogClose = () => {
         this.showCopyDialog = false;
     };
+
+    isDisabled(): boolean {
+        const disabled = super.isDisabled();
+
+        return disabled || !this.resourceFormStore.id;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteDraftToolbarAction.js
@@ -76,14 +76,11 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
             visible_condition: visibleCondition,
         } = this.options;
 
-        const {id, data} = this.resourceFormStore;
-        const {published, publishedState} = data;
-
         const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {
-                disabled: !id || !published || publishedState,
+                disabled: this.isDisabled(),
                 label: translate('sulu_page.delete_draft'),
                 onClick: action(() => {
                     this.showDeleteDraftDialog = true;
@@ -132,4 +129,13 @@ export default class DeleteDraftToolbarAction extends AbstractFormToolbarAction 
     @action handleDeleteDraftDialogClose = () => {
         this.showDeleteDraftDialog = false;
     };
+
+    isDisabled(): boolean {
+        const disabled = super.isDisabled();
+
+        const {id, data} = this.resourceFormStore;
+        const {published, publishedState} = data;
+
+        return disabled || !id || !published || publishedState;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/DeleteToolbarAction.js
@@ -182,23 +182,16 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
             visible_condition: visibleCondition,
         } = this.options;
 
-        const {id} = this.resourceFormStore;
-
         const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (!visibleConditionFulfilled) {
             return;
         }
 
-        const isOnlyOneContentLocale = jexl.evalSync(
-            'contentLocales && contentLocales|length == 1',
-            this.conditionData
-        );
-
         if (deleteLocaleOption) {
             // Delete locale mode
             return {
-                disabled: !id || !!isOnlyOneContentLocale,
+                disabled: this.isDisabled(),
                 icon: 'su-trash-alt',
                 label: translate('sulu_admin.delete_locale'),
                 onClick: action(() => {
@@ -208,22 +201,8 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
                 type: 'button',
             };
         } else {
-            // Regular delete mode
-            if (!id) {
-                return {
-                    disabled: true,
-                    icon: 'su-trash-alt',
-                    label: translate('sulu_admin.delete'),
-                    onClick: action(() => {
-                        this.deleteLocale = false;
-                        this.showDialog = true;
-                    }),
-                    type: 'button',
-                };
-            }
-
             return {
-                disabled: false,
+                disabled: this.isDisabled(),
                 icon: 'su-trash-alt',
                 label: translate('sulu_admin.delete'),
                 onClick: action(() => {
@@ -319,4 +298,23 @@ export default class DeleteToolbarAction extends AbstractFormToolbarAction {
                 })
             );
     };
+
+    isDisabled(): boolean {
+        const disabled = super.isDisabled();
+
+        const {id} = this.resourceFormStore;
+
+        const deleteLocaleOption = this.options.delete_locale ?? false;
+
+        const isOnlyOneContentLocale = jexl.evalSync(
+            'contentLocales && contentLocales|length == 1',
+            this.conditionData
+        );
+
+        if (deleteLocaleOption) {
+            return disabled || !id || !!isOnlyOneContentLocale;
+        }
+
+        return id ? disabled : true;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/PublishToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/PublishToolbarAction.js
@@ -9,19 +9,25 @@ export default class PublishToolbarAction extends AbstractFormToolbarAction {
             visible_condition: visibleCondition,
         } = this.options;
 
-        const {dirty, data} = this.resourceFormStore;
-
         const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {
                 label: translate('sulu_admin.publish'),
-                disabled: dirty || data.publishedState === undefined || !!data.publishedState,
+                disabled: this.isDisabled(),
                 onClick: () => {
                     this.form.submit({action: 'publish'});
                 },
                 type: 'button',
             };
         }
+    }
+
+    isDisabled(): boolean {
+        const disabled = super.isDisabled();
+
+        const {dirty, data} = this.resourceFormStore;
+
+        return disabled || dirty || data.publishedState === undefined || !!data.publishedState;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/ReloadFormStoreToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/ReloadFormStoreToolbarAction.js
@@ -137,6 +137,7 @@ export default class ReloadFormStoreToolbarAction extends AbstractFormToolbarAct
     getToolbarItemConfig() {
         return {
             type: 'button',
+            disabled: this.isDisabled(),
             label: this.label,
             icon: this.icon,
             onClick: this.handleClick,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveToolbarAction.js
@@ -11,7 +11,7 @@ export default class SaveToolbarAction extends AbstractFormToolbarAction {
             options: submitOptions,
         } = this.options;
 
-        const {dirty, saving} = this.resourceFormStore;
+        const {saving} = this.resourceFormStore;
 
         if (typeof label !== 'string') {
             throw new Error('The "label" option must be a string!');
@@ -25,7 +25,7 @@ export default class SaveToolbarAction extends AbstractFormToolbarAction {
 
         if (visibleConditionFulfilled) {
             return {
-                disabled: !dirty,
+                disabled: this.isDisabled(),
                 icon: 'su-save',
                 label: translate(label),
                 loading: saving,
@@ -35,5 +35,11 @@ export default class SaveToolbarAction extends AbstractFormToolbarAction {
                 type: 'button',
             };
         }
+    }
+
+    isDisabled(): boolean {
+        const disabled = super.isDisabled();
+
+        return disabled || !this.resourceFormStore.dirty;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SaveWithFormDialogToolbarAction.js
@@ -85,7 +85,7 @@ export default class SaveWithFormDialogToolbarAction extends AbstractFormToolbar
 
     getToolbarItemConfig() {
         return {
-            disabled: !this.resourceFormStore.dirty,
+            disabled: this.isDisabled(),
             icon: 'su-save',
             label: translate('sulu_admin.save'),
             loading: this.resourceFormStore.saving,
@@ -107,5 +107,11 @@ export default class SaveWithFormDialogToolbarAction extends AbstractFormToolbar
 
     destroy() {
         this.dialogFormStore.destroy();
+    }
+
+    isDisabled(): boolean {
+        const disabled = super.isDisabled();
+
+        return disabled || !this.resourceFormStore.dirty;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/SetUnpublishedToolbarAction.js
@@ -76,14 +76,11 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
             visible_condition: visibleCondition,
         } = this.options;
 
-        const {id, data} = this.resourceFormStore;
-        const {published} = data;
-
         const visibleConditionFulfilled = !visibleCondition || jexl.evalSync(visibleCondition, this.conditionData);
 
         if (visibleConditionFulfilled) {
             return {
-                disabled: !id || !published,
+                disabled: this.isDisabled(),
                 label: translate('sulu_page.unpublish'),
                 onClick: action(() => {
                     this.showUnpublishDialog = true;
@@ -132,4 +129,13 @@ export default class SetUnpublishedToolbarAction extends AbstractFormToolbarActi
     @action handleUnpublishDialogClose = () => {
         this.showUnpublishDialog = false;
     };
+
+    isDisabled(): boolean {
+        const disabled = super.isDisabled();
+
+        const {id, data} = this.resourceFormStore;
+        const {published} = data;
+
+        return disabled || !id || !published;
+    }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TogglerToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TogglerToolbarAction.js
@@ -65,6 +65,7 @@ export default class TogglerToolbarAction extends AbstractFormToolbarAction {
 
         return {
             type: 'toggler',
+            disabled: this.isDisabled(),
             onClick: this.handleTogglerClick,
             label: this.label,
             loading: this.loading,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/TypeToolbarAction.js
@@ -1,5 +1,4 @@
 // @flow
-import jexl from 'jexl';
 import React from 'react';
 import {observable, action} from 'mobx';
 import Dialog from '../../../components/Dialog';
@@ -18,15 +17,12 @@ export default class TypeToolbarAction extends AbstractFormToolbarAction {
         }
 
         const {
-            disabled_condition: disabledCondition,
             sort_by: sortBy,
         } = this.options;
 
         if (sortBy !== undefined && typeof sortBy !== 'string') {
             throw new Error('The "sort_by" option must be a string if given!');
         }
-
-        const isDisabled = disabledCondition ? jexl.evalSync(disabledCondition, this.conditionData) : false;
 
         const sortedTypes = sortBy
             ? formTypes.sort((t1, t2) => String(t1[sortBy]).localeCompare(String(t2[sortBy])))
@@ -48,7 +44,7 @@ export default class TypeToolbarAction extends AbstractFormToolbarAction {
             }),
             loading: this.resourceFormStore.typesLoading,
             value: this.resourceFormStore.type,
-            disabled: isDisabled,
+            disabled: this.isDisabled(),
             options: sortedTypes.map((type) => ({
                 value: type.key,
                 label: type.title,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/UpdateFormStoreToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/UpdateFormStoreToolbarAction.js
@@ -179,6 +179,7 @@ export default class UpdateFormStoreToolbarAction extends AbstractFormToolbarAct
             icon: this.icon,
             onClick: this.handleClick,
             loading: this.loading,
+            disabled: this.isDisabled(),
         };
     }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

This PR applies configurable disabled_condition evaluation to all (non deprecated) form action toolbars.
Additionally it refactores the logic for the disabled config flag into a separat method and so cleans up some of the more bloated getToolbarItemConfig

#### Why?

When reusing existing toolbar actions, sometimes an additional disabled_condition needs to be set. Since not all ToolbarAction evaluated the disabled_condition, there is the need to extend the existing toolbaraction with the additional logic. 
This simplifies the step, since the disabled_condition can be set via PHP.

I intentionally did not refactor or add the visibility_condition for now, since I was unsure, if this would be better suited in another PR.