### PR TITLE
Remove RequestParameterTraits from some controllers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32797,6 +32797,18 @@ parameters:
 			path: src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
 
 		-
+			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 1
+			path: src/Sulu/Component/Persistence/RelationTrait.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: src/Sulu/Component/Persistence/RelationTrait.php
+
+		-
 			message: '#^Parameter \#1 \$objects of class Sulu\\Component\\Persistence\\EventSubscriber\\ORM\\MetadataSubscriber constructor expects array\<string, array\<string, array\{model\?\: class\-string\<object\>, repository\?\: class\-string\<Doctrine\\ORM\\EntityRepository\<object\>\>\}\>\>, array\{sulu\: array\{contact\: array\{model\: ''stdClass'', repository\: ''Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactRepository''\}, member\: array\{model\: ''Closure''\}, user\: array\{model\: class\-string\<stdClass\>\}\}\} given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
+++ b/src/Sulu/Bundle/ActivityBundle/UserInterface/Controller/ActivityController.php
@@ -24,7 +24,6 @@ use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\PaginatedRepresentation;
-use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Rest\RestHelperInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -37,8 +36,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ActivityController extends AbstractRestController implements SecuredControllerInterface
 {
-    use RequestParametersTrait;
-
     /**
      * @param class-string $activityClass
      * @param array<string, int> $permissions Inject `sulu_security.permissions` parameter
@@ -83,11 +80,11 @@ class ActivityController extends AbstractRestController implements SecuredContro
         $translationLocale = $user->getLocale();
 
         /** @var string|null $resourceLocale */
-        $resourceLocale = $this->getRequestParameter($request, 'locale');
+        $resourceLocale = $this->getLocale($request);
         /** @var string|null $resourceId */
-        $resourceId = $this->getRequestParameter($request, 'resourceId');
+        $resourceId = $request->query->get('resourceId');
         /** @var string|null $resourceKey */
-        $resourceKey = $this->getRequestParameter($request, 'resourceKey');
+        $resourceKey = $request->query->get('resourceKey');
 
         $this->addResourceSecurityContextCondition($listBuilder, $fieldDescriptors, $user);
         $this->addResourceObjectSecurityCondition($listBuilder, $fieldDescriptors, $user);

--- a/src/Sulu/Bundle/MediaBundle/Controller/FormatController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/FormatController.php
@@ -14,15 +14,13 @@ namespace Sulu\Bundle\MediaBundle\Controller;
 use FOS\RestBundle\View\ViewHandlerInterface;
 use Sulu\Bundle\MediaBundle\Media\FormatManager\FormatManagerInterface;
 use Sulu\Component\Rest\AbstractRestController;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
-use Sulu\Component\Rest\RequestParametersTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class FormatController extends AbstractRestController
 {
-    use RequestParametersTrait;
-
     public function __construct(
         ViewHandlerInterface $viewHandler,
         private FormatManagerInterface $formatManager
@@ -35,7 +33,7 @@ class FormatController extends AbstractRestController
      */
     public function cgetAction(Request $request)
     {
-        $locale = $this->getRequestParameter($request, 'locale', true);
+        $locale = $this->getLocale($request) ?: throw new MissingParameterException(self::class, 'locale');
 
         return $this->handleView($this->view(
             new CollectionRepresentation(

--- a/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewController.php
+++ b/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewController.php
@@ -12,7 +12,7 @@
 namespace Sulu\Bundle\PreviewBundle\UserInterface\Controller;
 
 use Sulu\Bundle\PreviewBundle\Preview\Preview;
-use Sulu\Component\Rest\RequestParametersTrait;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,8 +26,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class PreviewController
 {
-    use RequestParametersTrait;
-
     public function __construct(
         private Preview $preview,
         private TokenStorageInterface $tokenStorage,
@@ -37,8 +35,8 @@ class PreviewController
 
     public function startAction(Request $request): Response
     {
-        $id = $this->getRequestParameter($request, 'id', true);
-        $provider = $this->getRequestParameter($request, 'provider', true);
+        $id = $request->query->getString('id') ?: throw new MissingParameterException(self::class, 'id');
+        $provider = $request->query->getString('provider') ?: throw new MissingParameterException(self::class, 'provider');
         $options = $this->getOptionsFromRequest($request);
 
         return new JsonResponse(
@@ -50,9 +48,9 @@ class PreviewController
 
     public function renderAction(Request $request): Response
     {
-        $provider = $this->getRequestParameter($request, 'provider', true);
-        $id = $this->getRequestParameter($request, 'id', true);
-        $token = $this->getRequestParameter($request, 'token', true);
+        $provider = $request->query->getString('provider') ?: throw new MissingParameterException(self::class, 'provider');
+        $id = $request->query->getString('id') ?: throw new MissingParameterException(self::class, 'id');
+        $token = $request->query->getString('token') ?: throw new MissingParameterException(self::class, 'token');
 
         $options = $this->getOptionsFromRequest($request);
 
@@ -69,11 +67,18 @@ class PreviewController
 
     public function updateAction(Request $request): Response
     {
-        $provider = $this->getRequestParameter($request, 'provider', true);
-        $id = $this->getRequestParameter($request, 'id', true);
-        $token = $this->getRequestParameter($request, 'token', true);
+        $provider = $request->query->getString('provider') ?: throw new MissingParameterException(self::class, 'provider');
+        $id = $request->query->getString('id') ?: throw new MissingParameterException(self::class, 'id');
+        $token = $request->query->getString('token') ?: throw new MissingParameterException(self::class, 'token');
+
+        $payload = $request->getPayload();
+
+        if (!$payload->has('data')) {
+            throw new MissingParameterException(self::class, 'data');
+        }
+
         /** @var array<string, mixed> $data */
-        $data = (array) $this->getRequestParameter($request, 'data', true);
+        $data = $payload->all('data');
 
         $options = $this->getOptionsFromRequest($request);
 
@@ -92,13 +97,25 @@ class PreviewController
 
     public function updateContextAction(Request $request): Response
     {
-        $id = $this->getRequestParameter($request, 'id', true);
-        $provider = $this->getRequestParameter($request, 'provider', true);
-        $token = $this->getRequestParameter($request, 'token', true);
+        $provider = $request->query->getString('provider') ?: throw new MissingParameterException(self::class, 'provider');
+        $id = $request->query->getString('id') ?: throw new MissingParameterException(self::class, 'id');
+        $token = $request->query->getString('token') ?: throw new MissingParameterException(self::class, 'token');
+
+        $payload = $request->getPayload();
+
+        if (!$payload->has('context')) {
+            throw new MissingParameterException(self::class, 'context');
+        }
+
+        if (!$payload->has('data')) {
+            throw new MissingParameterException(self::class, 'data');
+        }
+
         /** @var array<string, mixed> $context */
-        $context = (array) $this->getRequestParameter($request, 'context', true);
+        $context = $payload->all('context');
+
         /** @var array<string, mixed> $data */
-        $data = $this->getRequestParameter($request, 'data', true);
+        $data = $payload->all('data');
 
         $options = $this->getOptionsFromRequest($request);
 
@@ -118,7 +135,9 @@ class PreviewController
 
     public function stopAction(Request $request): Response
     {
-        $this->preview->stop($this->getRequestParameter($request, 'token', true));
+        $token = $request->query->getString('token') ?: throw new MissingParameterException(self::class, 'token');
+
+        $this->preview->stop($token);
 
         return new JsonResponse();
     }

--- a/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewLinkController.php
+++ b/src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewLinkController.php
@@ -17,7 +17,6 @@ use Sulu\Bundle\PreviewBundle\Domain\Repository\PreviewLinkRepositoryInterface;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
-use Sulu\Component\Rest\RequestParametersTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -27,8 +26,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class PreviewLinkController extends AbstractRestController
 {
-    use RequestParametersTrait;
-
     public function __construct(
         private PreviewLinkRepositoryInterface $previewLinkRepository,
         private PreviewLinkManagerInterface $previewLinkManager,
@@ -40,8 +37,8 @@ class PreviewLinkController extends AbstractRestController
 
     public function getAction(Request $request, string $resourceId): Response
     {
-        $resourceKey = $this->getRequestParameter($request, 'resourceKey', true);
-        $locale = $this->getRequestParameter($request, 'locale', true);
+        $resourceKey = $request->query->getString('resourceKey') ?: throw new MissingParameterException(self::class, 'resourceKey');
+        $locale = $this->getLocale($request) ?: throw new MissingParameterException(self::class, 'locale');
 
         $previewLink = $this->previewLinkRepository->findByResource($resourceKey, $resourceId, $locale);
         if (!$previewLink) {
@@ -54,12 +51,12 @@ class PreviewLinkController extends AbstractRestController
     public function postTriggerAction(Request $request, string $resourceId): Response
     {
         $action = $request->query->getString('action') ?: throw new MissingParameterException(self::class, 'action');
+        $resourceKey = $request->query->getString('resourceKey') ?: throw new MissingParameterException(self::class, 'resourceKey');
+        $locale = $this->getLocale($request) ?: throw new MissingParameterException(self::class, 'locale');
 
         try {
             switch ($action) {
                 case 'generate':
-                    $resourceKey = $this->getRequestParameter($request, 'resourceKey', true);
-                    $locale = $this->getRequestParameter($request, 'locale', true);
                     $options = $request->query->all();
                     unset($options['action'], $options['resourceKey'], $options['provider'], $options['locale']);
 
@@ -67,9 +64,6 @@ class PreviewLinkController extends AbstractRestController
 
                     return $this->handleView($this->view($previewLink, 201));
                 case 'revoke':
-                    $resourceKey = $this->getRequestParameter($request, 'resourceKey', true);
-                    $locale = $this->getRequestParameter($request, 'locale', true);
-
                     $this->previewLinkManager->revoke($resourceKey, $resourceId, $locale);
 
                     return $this->handleView($this->view(null, 204));

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -19,13 +19,13 @@ use Sulu\Bundle\SecurityBundle\UserManager\UserManager;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\Exception\MissingArgumentException;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\PaginatedRepresentation;
-use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Rest\RestHelperInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\SecuredControllerInterface;
@@ -37,8 +37,6 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class UserController extends AbstractRestController implements SecuredControllerInterface
 {
-    use RequestParametersTrait;
-
     /**
      * @param class-string $userClass
      */
@@ -137,7 +135,7 @@ class UserController extends AbstractRestController implements SecuredController
     {
         try {
             $this->checkArguments($request);
-            $locale = $this->getRequestParameter($request, 'locale', true);
+            $locale = $request->getPayload()->getString('locale') ?: throw new MissingParameterException(self::class, 'locale');
             $data = $request->request->all();
             $data['contactId'] = $request->query->get('contactId');
             $user = $this->userManager->save($data, $locale);
@@ -193,7 +191,7 @@ class UserController extends AbstractRestController implements SecuredController
     {
         try {
             $this->checkArguments($request);
-            $locale = $this->getRequestParameter($request, 'locale', true);
+            $locale = $request->getPayload()->getString('locale') ?: throw new MissingParameterException(self::class, 'locale');
             $user = $this->userManager->save($request->request->all(), $locale, $id);
             $view = $this->view($user, 200);
         } catch (EntityNotFoundException $exc) {
@@ -217,7 +215,7 @@ class UserController extends AbstractRestController implements SecuredController
     public function patchAction(Request $request, $id)
     {
         try {
-            $locale = $this->getRequestParameter($request, 'locale');
+            $locale = $request->getPayload()->getString('locale') ?: null;
             $user = $this->userManager->save($request->request->all(), $locale, $id, true);
             $view = $this->view($user, 200);
         } catch (EntityNotFoundException $exc) {
@@ -253,18 +251,22 @@ class UserController extends AbstractRestController implements SecuredController
      */
     // TODO: Use schema validation see:
     // https://github.com/sulu-io/sulu/issues/1136
-    private function checkArguments(Request $request)
+    private function checkArguments(Request $request): void
     {
-        if (null == $request->get('username')) {
+        $payload = $request->getPayload();
+        $contactId = $request->query->get('contactId') ?? $payload->get('contactId');
+
+        if (null == $payload->get('username')) {
             throw new MissingArgumentException($this->userClass, 'username');
         }
-        if ($request->isMethod('POST') && null === $request->get('password')) {
+        if ($request->isMethod('POST') && null === $payload->get('password')) {
             throw new MissingArgumentException($this->userClass, 'password');
         }
-        if (null == $request->get('locale')) {
+        if (null == $payload->get('locale')) {
             throw new MissingArgumentException($this->userClass, 'locale');
         }
-        if (null == $request->get('contact') && null == $request->get('contactId')) {
+        // "contact" is an array, so `get` can not be used here as `InputBag::get` only allows scalar values
+        if ([] === $payload->all('contact') && null == $contactId) {
             throw new MissingArgumentException($this->userClass, 'contact');
         }
     }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/UserControllerTest.php
@@ -21,11 +21,15 @@ use Sulu\Bundle\SecurityBundle\Entity\Permission;
 use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
+use Sulu\Bundle\TestBundle\Testing\AssertSnapshotTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
 
 class UserControllerTest extends SuluTestCase
 {
+    use AssertSnapshotTrait;
+
     /**
      * @var EntityManager
      */
@@ -274,6 +278,7 @@ class UserControllerTest extends SuluTestCase
             ]
         );
 
+        $this->assertResponseIsSuccessful();
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals('manager', $response->username);
@@ -336,6 +341,7 @@ class UserControllerTest extends SuluTestCase
             '/api/users/' . $response->id
         );
 
+        $this->assertResponseIsSuccessful();
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals('manager', $response->username);
@@ -368,10 +374,12 @@ class UserControllerTest extends SuluTestCase
                 ],
             ]
         );
-        $response = \json_decode($this->client->getResponse()->getContent());
 
-        $this->assertHttpStatusCode(400, $this->client->getResponse());
-        $this->assertStringContainsString('username', $response->message);
+        $this->assertResponseSnapshot(
+            'user_post_missing_username.json',
+            $this->client->getResponse(),
+            Response::HTTP_BAD_REQUEST,
+        );
     }
 
     public function testPostWithMissingPassword(): void
@@ -398,10 +406,11 @@ class UserControllerTest extends SuluTestCase
                 ],
             ]
         );
-        $response = \json_decode($this->client->getResponse()->getContent());
-
-        $this->assertHttpStatusCode(400, $this->client->getResponse());
-        $this->assertStringContainsString('password', $response->message);
+        $this->assertResponseSnapshot(
+            'user_post_missing_password.json',
+            $this->client->getResponse(),
+            Response::HTTP_BAD_REQUEST,
+        );
     }
 
     public function testPostWithNotUniqueEmail(): void
@@ -619,6 +628,7 @@ class UserControllerTest extends SuluTestCase
                 'locale' => 'en',
             ]
         );
+        $this->assertResponseIsSuccessful();
         $response = \json_decode($this->client->getResponse()->getContent());
         $this->assertEquals('en', $response->locale);
 
@@ -633,6 +643,8 @@ class UserControllerTest extends SuluTestCase
                 'username' => 'newusername',
             ]
         );
+
+        $this->assertResponseIsSuccessful();
         $response = \json_decode($this->client->getResponse()->getContent());
         $this->assertEquals('newusername', $response->username);
 
@@ -652,6 +664,7 @@ class UserControllerTest extends SuluTestCase
             'GET',
             '/api/users/' . $this->user1->getId()
         );
+        $this->assertResponseIsSuccessful();
         $response = \json_decode($this->client->getResponse()->getContent());
 
         $this->assertEquals('en', $response->locale);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/snapshots/user_post_missing_password.json
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/snapshots/user_post_missing_password.json
@@ -1,0 +1,4 @@
+{
+    "code": 0,
+    "message": "The \"Sulu\\Bundle\\SecurityBundle\\Entity\\User\"-entity requires a \"password\"-argument"
+}

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/snapshots/user_post_missing_username.json
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/snapshots/user_post_missing_username.json
@@ -1,0 +1,4 @@
+{
+    "code": 0,
+    "message": "The \"Sulu\\Bundle\\SecurityBundle\\Entity\\User\"-entity requires a \"username\"-argument"
+}

--- a/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+++ b/src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
@@ -108,7 +108,7 @@ class UserManager implements UserManagerInterface
      * Creates a new user with the given data.
      *
      * @param array $data
-     * @param string $locale
+     * @param string|null $locale
      * @param null|int $id
      * @param bool $patch
      * @param bool $flush


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | technically
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #8216 
| License | MIT
| Documentation PR | -

#### What's in this PR?
Removing some of the usage of the `RequestParametersTrait`

#### Why?
Symfony 8 doesn't support this anymore.

#### Example Usage
If you're extending these Controllers and still need the trait, use it in your extended class (but it's still deprecated)