### PR TITLE
Marking `form_of_address` property as deprecated

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,5 +1,11 @@
 # Upgrade
 
+## 3.0.9
+
+### `form_of_address` configuration is now deprecated
+
+To change the default forms of address override the `Sulu\Bundle\ContactBundle\Provider\FormOfAddressProvider` service.
+
 ## 3.0.8
 
 ### AbstractTagNameToIdMigration moved to Infrastructure Layer

--- a/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/ContactBundle/DependencyInjection/Configuration.php
@@ -15,6 +15,7 @@ use Sulu\Bundle\ContactBundle\Entity\Account;
 use Sulu\Bundle\ContactBundle\Entity\AccountRepository;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\ContactBundle\Entity\ContactRepository;
+use Sulu\Bundle\ContactBundle\Provider\FormOfAddressProviderInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -63,6 +64,11 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('form_of_address')
+                    ->setDeprecated(
+                        'sulu/sulu',
+                        '3.1',
+                        'This property is deprecated. Use the ' . FormOfAddressProviderInterface::class . ' instead',
+                    )
                     ->useAttributeAsKey('title')
                     ->prototype('array')
                         ->addDefaultsIfNotSet()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Marking the container parameter `form_of_address` as deprecated.

#### Why?
It's used nowhere. In the endpoint that provides the form of address the `FormOfAddressProvider` class is being used.
