### PR TITLE
Fix account parent serialized as object instead of scalar id

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Api/Account.php
+++ b/src/Sulu/Bundle/ContactBundle/Api/Account.php
@@ -194,9 +194,6 @@ class Account extends ApiWrapper
      *
      * @return self|null
      */
-    #[VirtualProperty]
-    #[SerializedName('parent')]
-    #[Groups(['fullAccount'])]
     public function getParent()
     {
         $account = $this->entity->getParent();
@@ -205,6 +202,14 @@ class Account extends ApiWrapper
         }
 
         return null;
+    }
+
+    #[VirtualProperty]
+    #[SerializedName('parent')]
+    #[Groups(['fullAccount'])]
+    public function getParentId(): ?int
+    {
+        return $this->getParent()?->getId();
     }
 
     /**

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Controller/AccountControllerTest.php
@@ -490,7 +490,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertEquals('ExampleCompany', $response->name);
         $this->assertEquals('A small notice', $response->note);
         $this->assertEquals(1, $response->depth);
-        $this->assertEquals($account->getId(), $response->parent->id);
+        $this->assertEquals($account->getId(), $response->parent);
         $this->assertEquals('erika.mustermann@muster.at', $response->contactDetails->emails[0]->email);
         $this->assertEquals('erika.mustermann@muster.de', $response->contactDetails->emails[1]->email);
         $this->assertEquals('123456789', $response->contactDetails->phones[0]->phone);
@@ -1734,7 +1734,7 @@ class AccountControllerTest extends SuluTestCase
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertEquals('ExampleCompany', $response->name);
-        $this->assertEquals($account->getId(), $response->parent->id);
+        $this->assertEquals($account->getId(), $response->parent);
         $this->assertEquals('erika.mustermann@muster.at', $response->contactDetails->emails[0]->email);
         $this->assertEquals('123456789', $response->contactDetails->phones[0]->phone);
         $this->assertEquals('123456789-1', $response->contactDetails->faxes[0]->fax);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | #8276
| License | MIT
| Documentation PR | 

#### What's in this PR?

`Sulu\Bundle\ContactBundle\Api\Account::getParent()` still serialized the account `parent` as a full nested account object, while the matching `single_account_selection` admin field and the write path expect a scalar id.

This PR aligns the read format with the write format by following the same pattern already used in the codebase for similar relations (`Contact::getAccount()`/`getAccountId()` and `Category::getParent()`/`getParentId()`):

- `getParent()` stays as an internal getter returning the account object (no serialization annotations anymore).
- A new `getParentId(): ?int` carries the `#[VirtualProperty] #[SerializedName('parent')] #[Groups(['fullAccount'])]` annotations and returns the scalar id.

As a result the serialized `parent` value changes from a nested object to a scalar id, which is what the `mainContact` property (`getMainContact(): ?int`) and the account write path already do.

The two functional assertions that read `$response->parent->id` are updated to read the scalar `$response->parent`. Note the account is already sent as a scalar (`'parent' => $account->getId()`) in these tests, so only the read side was inconsistent.

#### Why?

On a Sulu 3.0.7/3.0.8 install, editing an account and setting a "Parent Company" (`parent`, a `single_account_selection`) breaks the field on reload.

Steps to reproduce:

1. Create two accounts.
2. Set one account as the "Parent Company" of the other and save.
3. Reload the child account edit form.

The `parent` field then issues a request to `GET /admin/api/accounts/[object Object]` (the object is stringified as the id), which raises on the PHP side:

```
TypeError: Sulu\Bundle\ContactBundle\Entity\AccountRepository::findAccountById():
Argument #1 ($id) must be of type int, string given,
called in .../ContactBundle/Contact/AccountManager.php on line 193
```

and the field keeps reloading in a loop.

Root cause: #8276 removed the deprecated object data format for entity selections. It switched the write path (`AccountController::setParent()` now accepts a scalar id), converted `Contact::getAccount()` to `getAccountId(): ?int`, and removed the object tolerance from the `SingleSelection` admin field. The `parent` property was used as the example in the `UPGRADE-3.x.md` entry, but `Account::getParent()` was left serializing an object, so its output no longer matches what the field and the write path expect. The `mainContact` property works because `getMainContact()` already returns a scalar id.
