### PR TITLE
Fix search indexing merging adjacent words when stripping HTML tags

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
@@ -338,6 +338,18 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
 
     private function stripHtml(string $html): string
     {
-        return \trim(\strip_tags($html));
+        // Only block-level tags (and <br>) should introduce a word boundary, so
+        // that words split across paragraphs, list items, table cells or line
+        // breaks stay separate, searchable tokens — while inline formatting
+        // inside a word (e.g. "<strong>") keeps the word together as one token.
+        $html = (string) \preg_replace('~</?(?:p|div|br|li|th|td|h[1-6])\b[^>]*>~i', ' ', $html);
+
+        // strip_tags removes the remaining inline tags but leaves entities as-is,
+        // so decode them afterwards ("&nbsp;" would otherwise survive and glue
+        // words together). Then collapse whitespace — including the non-breaking
+        // spaces produced by decoding — into single spaces.
+        $text = \html_entity_decode(\strip_tags($html), \ENT_QUOTES | \ENT_HTML5, 'UTF-8');
+
+        return \trim((string) \preg_replace('~[\s\x{a0}]+~u', ' ', $text));
     }
 }

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
@@ -173,6 +173,42 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $this->assertSame(['Hello world'], $returnedData['content']);
     }
 
+    public function testVisitStripsHtmlTagsWithoutMergingAdjacentWords(): void
+    {
+        $textField = new FieldMetadata('text');
+        $textField->setType('text_editor');
+        $textField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($textField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                // Block-level tags (<br>, </p><p>) must split words into separate
+                // tokens, otherwise only the first stays searchable. Inline tags
+                // (<strong>) must NOT split a word ("third" stays one token), and
+                // "&nbsp;" must decode to a real space instead of gluing words.
+                'text' => '<p>first<br>second</p><p>th<strong>ir</strong>d</p><p>a&nbsp;b</p>',
+            ],
+        ];
+
+        $data = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, $data);
+
+        $this->assertSame(['first second third a b'], $returnedData['content']);
+    }
+
     public function testVisitFiltersNonTextFieldTypes(): void
     {
         $titleField = new FieldMetadata('title');

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
@@ -338,6 +338,18 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
 
     private function stripHtml(string $html): string
     {
-        return \trim(\strip_tags($html));
+        // Only block-level tags (and <br>) should introduce a word boundary, so
+        // that words split across paragraphs, list items, table cells or line
+        // breaks stay separate, searchable tokens — while inline formatting
+        // inside a word (e.g. "<strong>") keeps the word together as one token.
+        $html = (string) \preg_replace('~</?(?:p|div|br|li|th|td|h[1-6])\b[^>]*>~i', ' ', $html);
+
+        // strip_tags removes the remaining inline tags but leaves entities as-is,
+        // so decode them afterwards ("&nbsp;" would otherwise survive and glue
+        // words together). Then collapse whitespace — including the non-breaking
+        // spaces produced by decoding — into single spaces.
+        $text = \html_entity_decode(\strip_tags($html), \ENT_QUOTES | \ENT_HTML5, 'UTF-8');
+
+        return \trim((string) \preg_replace('~[\s\x{a0}]+~u', ' ', $text));
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
@@ -173,6 +173,42 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $this->assertSame(['Hello world'], $returnedData['content']);
     }
 
+    public function testVisitStripsHtmlTagsWithoutMergingAdjacentWords(): void
+    {
+        $textField = new FieldMetadata('text');
+        $textField->setType('text_editor');
+        $textField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($textField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                // Block-level tags (<br>, </p><p>) must split words into separate
+                // tokens, otherwise only the first stays searchable. Inline tags
+                // (<strong>) must NOT split a word ("third" stays one token), and
+                // "&nbsp;" must decode to a real space instead of gluing words.
+                'text' => '<p>first<br>second</p><p>th<strong>ir</strong>d</p><p>a&nbsp;b</p>',
+            ],
+        ];
+
+        $data = ['content' => []];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, $data);
+
+        $this->assertSame(['first second third a b'], $returnedData['content']);
+    }
+
     public function testVisitFiltersNonTextFieldTypes(): void
     {
         $titleField = new FieldMetadata('title');


### PR DESCRIPTION
## What's in this PR?

`WebsitePageReindexContentEnhancer` and `WebsiteArticleReindexContentEnhancer`
strip HTML for the search index with `strip_tags()` alone. `strip_tags()`
removes tags without leaving a separator, so words separated only by tags —
e.g. `a<br>b` or `</p><p>` — get concatenated into one token.

## Why?

Given page content `<p>Suchbegriff_1<br>Suchbegriff_2</p><p>Suchbegriff_3</p>`
the index stored a single token `Suchbegriff_1Suchbegriff_2Suchbegriff_3`.
Only `Suchbegriff_1` was findable (as a prefix); `Suchbegriff_2` and
`Suchbegriff_3` were unsearchable.

## Fix

Insert a space before every tag before stripping, then collapse whitespace, so
each word stays its own token. Regression tests added to both packages.