### PR TITLE
Null unresolved resources when the resolved map is empty

### DIFF
--- a/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
+++ b/packages/content/src/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacer.php
@@ -82,9 +82,11 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
             return $this->replaceUnresolvedWithNull($content);
         }
 
-        if (0 === \count($resolvedResources)) {
-            return $content;
-        }
+        // No `0 === \count($resolvedResources)` early-return: an empty map also occurs when every resolvable
+        // failed to load (e.g. a link to an unpublished/absent page), and those unresolved resources must
+        // still be nulled and compacted below. Returning $content untouched would leak a ResolvableResource
+        // object to the template layer (uncastable to string) — inconsistent with the $depth > $maxDepth
+        // branch above, which already nulls unresolved resources.
 
         $onlyResolvableResources = true;
         foreach ($content as $key => $value) {
@@ -229,10 +231,8 @@ class ResolvableResourceReplacer implements ResolvableResourceReplacerInterface
         int $depth,
         int $maxDepth
     ): array {
-        if (0 === \count($resolvedResources)) {
-            return $view;
-        }
-
+        // See replaceRecursively(): no early-return on an empty map — unresolved resources must be nulled
+        // and compacted rather than left in place, so we always walk.
         /** @var array<string, mixed> $result */
         $result = $this->replaceInViewRecursively($view, $resolvedResources, $depth, $maxDepth);
 

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/ResolvableResourceReplacer/ResolvableResourceReplacerTest.php
@@ -182,6 +182,10 @@ class ResolvableResourceReplacerTest extends TestCase
 
     public function testReplaceWithEmptyResolvedResources(): void
     {
+        // An empty $resolvedResources map also occurs when every resolvable failed to load (e.g. a link to
+        // an unpublished/absent page). The unresolved resource must be nulled rather than left in place,
+        // otherwise it reaches the template layer and throws "could not be converted to string". This
+        // matches the depth-exceeded path (testReplaceWithMaxDepthExceeded) and the partial-resolution path.
         $resolvableResource = new ResolvableResource(
             '123',
             'page',
@@ -193,7 +197,10 @@ class ResolvableResourceReplacerTest extends TestCase
             'pages'
         );
 
-        $content = ['page' => $resolvableResource];
+        $content = [
+            'title' => 'Test',
+            'page' => $resolvableResource,
+        ];
         $resolvedResources = [];
 
         $result = $this->replacer->replaceResolvableResourcesWithResolvedValues(
@@ -203,10 +210,36 @@ class ResolvableResourceReplacerTest extends TestCase
             5
         );
 
-        self::assertSame($resolvableResource, $result['content']['page']);
+        self::assertSame('Test', $result['content']['title']);
+        self::assertNull($result['content']['page']);
 
         $tags = $this->referenceStore->getAll();
         self::assertEmpty($tags);
+    }
+
+    public function testReplaceNullsUnresolvedLinkNestedInBlockCollection(): void
+    {
+        // Regression for a real-world crash: a `link` field pointing at an unpublished page, nested inside a
+        // block's CTA collection, with no other resource on the page resolving (empty $resolvedResources).
+        // Before the fix the ResolvableResource survived to the template and threw during string conversion.
+        $link = new ResolvableResource('page::7509', 'link', -50);
+
+        $content = [
+            'blocks' => [
+                [
+                    'type' => 'app-cta',
+                    'ctas' => [
+                        ['headline' => 'CTA', 'link' => $link],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->replacer->replaceResolvableResourcesWithResolvedValues($content, [], 1, 5);
+
+        $cta = $result['content']['blocks'][0]['ctas'][0];
+        self::assertSame('CTA', $cta['headline']);
+        self::assertNull($cta['link']);
     }
 
     public function testReplaceWithComplexNestedStructure(): void
@@ -958,14 +991,16 @@ class ResolvableResourceReplacerTest extends TestCase
         self::assertContains('tags-4', $refs);
     }
 
-    public function testReplaceResolvableResourcesInViewReturnsEarlyWithNoResolvedResources(): void
+    public function testReplaceResolvableResourcesInViewDropsUnresolvedWithNoResolvedResources(): void
     {
+        // Mirror the content side: with no resolved resources an unresolved list entry is dropped
+        // (consistent with the partial-resolution path), not left in place as a surviving object.
         $tag = new ResolvableResource(3, 'tag', 0);
         $view = ['tags' => [$tag]];
 
         $result = $this->replacer->replaceResolvableResourcesInView($view, [], 1, 10);
 
-        self::assertSame($view, $result);
+        self::assertSame(['tags' => []], $result);
     }
 
     public function testReplaceResolvableResourcesInViewFiltersUnresolvedListEntries(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

`ResolvableResourceReplacer` replaces each `ResolvableResource` with the value of its loaded target. When a target cannot be loaded (for example a `link` field pointing at a page that is unpublished, trashed, or absent in the locale), the replacer normally sets the value to `null` in content and drops it from a list in the view.

Two early-returns skipped that step. When `$resolvedResources` is empty, both `replaceRecursively()` and `replaceResolvableResourcesInView()` returned the input untouched:

```php
if (0 === \count($resolvedResources)) {
    return $content;
}
```

An empty map does not only mean "there was nothing to resolve". It also happens when every resolvable on the page failed to load. In that case the `ResolvableResource` object survived into the rendered data, and rendering it in Twig threw:

```
Object of class Sulu\Content\Application\ContentResolver\Value\ResolvableResource could not be converted to string
```

This PR removes both early-returns so an empty map runs through the same walk the other paths already use. A list containing only unresolvable resources now collapses to `[]` instead of keeping the objects.

#### Why?

A page rendered a fatal error when a `link` field pointed at a page that no longer resolves and nothing else on the page resolved either. The behavior was inconsistent with the sibling paths:

- the `$depth > $maxDepth` branch already nulls unresolved resources via `replaceUnresolvedWithNull()`;
- a partial resolution (non-empty map) already nulls and compacts the unresolved entries.

Only the empty-map case leaked the object to the template.

Removing the short-circuit, rather than routing it through `replaceUnresolvedWithNull()`, is deliberate: that helper does not run the list compaction, so a selection of unresolvable resources would become `[null, ...]` instead of `[]` (see `testReplaceResolvableResourcesInViewFiltersUnresolvedListEntries`). The short-circuit was only a walk-skipping optimization, and nulling the survivors requires the walk. The same `$resolvedResources` map is passed down every recursion level, so the change affects only the top-level empty-map case; a non-empty map never reached the short-circuit at any level.

Verified with a reproduction against the current code: a `link` resolvable in an empty map (including the reported shape, a link nested in a block CTA collection) survives as an object before the change and is nulled after it. The two unit tests that asserted the surviving-object behavior are updated to the corrected behavior, and a regression test is added.

#### Example Usage

Not applicable. This is a bug fix with no new public API.

#### To Do

- [ ] Create a documentation PR (not needed: no documented behavior changes)
- [ ] Add breaking changes to UPGRADE.md (not needed: no BC break)
