### PR TITLE
Fix search indexing merging adjacent words when stripping HTML tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "composer-runtime-api": "^2.0",
-        "cmsig/seal": "^0.12.4",
+        "cmsig/seal": "^0.12.16",
         "cmsig/seal-symfony-bundle": "^0.12",
         "contao/imagine-svg": "^1.0",
         "doctrine/collections": "^1.6 || ^2.0",

--- a/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
+++ b/packages/article/src/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Article\Infrastructure\Sulu\Search\Visitor;
 
+use CmsIg\Seal\Converter\HtmlToTextConverter;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
@@ -187,7 +188,7 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
 
             $value = $this->getValueByPath($templateData, $fieldPath);
             if (null !== $value) {
-                $extracted = $this->extractTextFromValue($value);
+                $extracted = $this->extractTextFromValue($value, $fieldInfo['type']);
                 $content = \array_merge($content, $extracted);
             }
         }
@@ -212,7 +213,7 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
 
             $value = $this->getValueByPath($templateData, $fieldPath);
             if (\is_string($value) && '' !== \trim($value)) {
-                return $this->stripHtml($value);
+                return $this->normalizeText($value, $fieldInfo['type']);
             }
         }
 
@@ -309,10 +310,10 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
     /**
      * @return array<int, string>
      */
-    private function extractTextFromValue(mixed $value): array
+    private function extractTextFromValue(mixed $value, string $type): array
     {
         if (\is_string($value)) {
-            $text = $this->stripHtml($value);
+            $text = $this->normalizeText($value, $type);
 
             return !empty(\trim($text)) ? [$text] : [];
         }
@@ -321,9 +322,9 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
             $content = [];
             foreach ($value as $item) {
                 if (\is_array($item)) {
-                    $content = \array_merge($content, $this->extractTextFromValue($item));
+                    $content = \array_merge($content, $this->extractTextFromValue($item, $type));
                 } elseif (\is_string($item)) {
-                    $text = $this->stripHtml($item);
+                    $text = $this->normalizeText($item, $type);
                     if (!empty(\trim($text))) {
                         $content[] = $text;
                     }
@@ -336,8 +337,19 @@ class WebsiteArticleReindexContentEnhancer implements WebsiteArticleReindexProvi
         return [];
     }
 
-    private function stripHtml(string $html): string
+    /**
+     * Extracts the searchable plain text from a field value. Only rich-text
+     * (text_editor) fields contain HTML, so those are converted with SEAL's
+     * HtmlToTextConverter — which drops tags, decodes entities and keeps words
+     * separated across block boundaries. Plain-text fields (text_line,
+     * text_area) are left untouched apart from trimming.
+     */
+    private function normalizeText(string $value, string $type): string
     {
-        return \trim(\strip_tags($html));
+        if ('text_editor' === $type) {
+            return HtmlToTextConverter::convert($value);
+        }
+
+        return \trim($value);
     }
 }

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsiteArticleReindexContentEnhancerTest.php
@@ -173,6 +173,46 @@ class WebsiteArticleReindexContentEnhancerTest extends TestCase
         $this->assertSame(['Hello world'], $returnedData['content']);
     }
 
+    public function testVisitConvertsHtmlOnlyForTextEditorFields(): void
+    {
+        // text_line/text_area are plain text and must be kept as-is; only the
+        // text_editor field runs through SEAL's HTML-to-text conversion, which
+        // keeps words separated across block boundaries (<br>, </p><p>) instead
+        // of merging them into a single, unsearchable token.
+        $lineField = new FieldMetadata('line');
+        $lineField->setType('text_line');
+        $lineField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $editorField = new FieldMetadata('editor');
+        $editorField->setType('text_editor');
+        $editorField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($lineField);
+        $formMetadata->addItem($editorField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('article', 'en', [])
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'line' => 'a < b <notatag>',
+                'editor' => '<p>first<br>second</p><p>third</p>',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['a < b <notatag>', "first\nsecond\nthird"], $returnedData['content']);
+    }
+
     public function testVisitFiltersNonTextFieldTypes(): void
     {
         $titleField = new FieldMetadata('title');

--- a/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
+++ b/packages/page/src/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Infrastructure\Sulu\Search\Visitor;
 
+use CmsIg\Seal\Converter\HtmlToTextConverter;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FieldMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormMetadata;
@@ -187,7 +188,7 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
 
             $value = $this->getValueByPath($templateData, $fieldPath);
             if (null !== $value) {
-                $extracted = $this->extractTextFromValue($value);
+                $extracted = $this->extractTextFromValue($value, $fieldInfo['type']);
                 $content = \array_merge($content, $extracted);
             }
         }
@@ -212,7 +213,7 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
 
             $value = $this->getValueByPath($templateData, $fieldPath);
             if (\is_string($value) && '' !== \trim($value)) {
-                return $this->stripHtml($value);
+                return $this->normalizeText($value, $fieldInfo['type']);
             }
         }
 
@@ -309,10 +310,10 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
     /**
      * @return array<int, string>
      */
-    private function extractTextFromValue(mixed $value): array
+    private function extractTextFromValue(mixed $value, string $type): array
     {
         if (\is_string($value)) {
-            $text = $this->stripHtml($value);
+            $text = $this->normalizeText($value, $type);
 
             return !empty(\trim($text)) ? [$text] : [];
         }
@@ -321,9 +322,9 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
             $content = [];
             foreach ($value as $item) {
                 if (\is_array($item)) {
-                    $content = \array_merge($content, $this->extractTextFromValue($item));
+                    $content = \array_merge($content, $this->extractTextFromValue($item, $type));
                 } elseif (\is_string($item)) {
-                    $text = $this->stripHtml($item);
+                    $text = $this->normalizeText($item, $type);
                     if (!empty(\trim($text))) {
                         $content[] = $text;
                     }
@@ -336,8 +337,19 @@ class WebsitePageReindexContentEnhancer implements WebsitePageReindexProviderEnh
         return [];
     }
 
-    private function stripHtml(string $html): string
+    /**
+     * Extracts the searchable plain text from a field value. Only rich-text
+     * (text_editor) fields contain HTML, so those are converted with SEAL's
+     * HtmlToTextConverter — which drops tags, decodes entities and keeps words
+     * separated across block boundaries. Plain-text fields (text_line,
+     * text_area) are left untouched apart from trimming.
+     */
+    private function normalizeText(string $value, string $type): string
     {
-        return \trim(\strip_tags($html));
+        if ('text_editor' === $type) {
+            return HtmlToTextConverter::convert($value);
+        }
+
+        return \trim($value);
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Search/Visitor/WebsitePageReindexContentEnhancerTest.php
@@ -173,6 +173,46 @@ class WebsitePageReindexContentEnhancerTest extends TestCase
         $this->assertSame(['Hello world'], $returnedData['content']);
     }
 
+    public function testVisitConvertsHtmlOnlyForTextEditorFields(): void
+    {
+        // text_line/text_area are plain text and must be kept as-is; only the
+        // text_editor field runs through SEAL's HTML-to-text conversion, which
+        // keeps words separated across block boundaries (<br>, </p><p>) instead
+        // of merging them into a single, unsearchable token.
+        $lineField = new FieldMetadata('line');
+        $lineField->setType('text_line');
+        $lineField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $editorField = new FieldMetadata('editor');
+        $editorField->setType('text_editor');
+        $editorField->addTag($this->createTag(TagMetadata::SEARCH_FIELD_TAG));
+
+        $formMetadata = new FormMetadata();
+        $formMetadata->setKey('default');
+        $formMetadata->addItem($lineField);
+        $formMetadata->addItem($editorField);
+
+        $typedFormMetadata = new TypedFormMetadata();
+        $typedFormMetadata->addForm('default', $formMetadata);
+
+        $this->formMetadataProvider->getMetadata('page', 'en', [])
+            ->willReturn($typedFormMetadata)
+            ->shouldBeCalledOnce();
+
+        $result = [
+            'templateKey' => 'default',
+            'locale' => 'en',
+            'templateData' => [
+                'line' => 'a < b <notatag>',
+                'editor' => '<p>first<br>second</p><p>third</p>',
+            ],
+        ];
+
+        $returnedData = $this->enhancer->enhanceDocument($result, ['content' => []]);
+
+        $this->assertSame(['a < b <notatag>', "first\nsecond\nthird"], $returnedData['content']);
+    }
+
     public function testVisitFiltersNonTextFieldTypes(): void
     {
         $titleField = new FieldMetadata('title');


### PR DESCRIPTION
WebsitePageReindexContentEnhancer and WebsiteArticleReindexContentEnhancer stripped HTML with strip_tags() alone, which removes tags without leaving a separator. Words separated only by tags `(e.g. "a<br>b" or "</p><p>") `were concatenated into a single token, so only the first word stayed findable (as a prefix) while the rest became unsearchable.

Convert rich-text (text_editor) values with cmsig/seal's HtmlToTextConverter, which drops tags, decodes entities and keeps words separated across block boundaries. Only text_editor fields hold HTML, so plain-text fields (text_line, text_area) are used as-is. Requires cmsig/seal ^0.12.16 for the converter. Adds a regression test to both packages.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/8955