### PR TITLE
Fix list search for columns without a text type

### DIFF
--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
@@ -50,6 +51,16 @@ class DoctrineListBuilder extends AbstractListBuilder
 {
     use SecuredEntityRepositoryTrait;
     use EncodeAliasTrait;
+
+    /**
+     * Doctrine types which are mapped to a text column on every supported database platform.
+     */
+    private const TEXT_FIELD_TYPES = [
+        Types::ASCII_STRING,
+        Types::SIMPLE_ARRAY,
+        Types::STRING,
+        Types::TEXT,
+    ];
 
     /**
      * @var DoctrineFieldDescriptorInterface[]
@@ -722,7 +733,7 @@ class DoctrineListBuilder extends AbstractListBuilder
         if (null !== $this->search) {
             $searchParts = [];
             foreach ($this->searchFields as $searchField) {
-                $searchParts[] = $searchField->getSearch();
+                $searchParts[] = $this->getSearchStatement($searchField);
             }
 
             $this->queryBuilder->andWhere('(' . \implode(' OR ', $searchParts) . ')');
@@ -730,6 +741,40 @@ class DoctrineListBuilder extends AbstractListBuilder
         }
 
         return $this->queryBuilder;
+    }
+
+    /**
+     * Returns the search statement of the given field descriptor. Fields which are not mapped to a
+     * text column are casted, because strict database platforms like PostgreSQL do not allow LOWER()
+     * to be used on other column types. Text columns are left untouched, so that indexes defined on
+     * them are not affected.
+     */
+    private function getSearchStatement(DoctrineFieldDescriptorInterface $searchField): string
+    {
+        if (!$searchField instanceof DoctrineFieldDescriptor
+            || $searchField instanceof DoctrineCountFieldDescriptor
+            || $this->isTextField($searchField->getEntityName(), $searchField->getFieldName())
+        ) {
+            return $searchField->getSearch();
+        }
+
+        return \sprintf('LOWER(CAST(%s AS TEXT)) LIKE LOWER(:search)', $searchField->getSelect());
+    }
+
+    private function isTextField(string $entityName, string $fieldName): bool
+    {
+        // entity names are also used as aliases and therefore do not have to reference a real entity
+        if (!\class_exists($entityName)) {
+            return true;
+        }
+
+        $classMetadata = $this->em->getClassMetadata($entityName);
+
+        if (!$classMetadata->hasField($fieldName)) {
+            return true;
+        }
+
+        return \in_array($classMetadata->getTypeOfField($fieldName), self::TEXT_FIELD_TYPES, true);
     }
 
     /**

--- a/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
+++ b/src/Sulu/Component/Rest/ListBuilder/Doctrine/DoctrineListBuilder.php
@@ -11,7 +11,6 @@
 
 namespace Sulu\Component\Rest\ListBuilder\Doctrine;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Bundle\SecurityBundle\AccessControl\AccessControlQueryEnhancerInterface;
@@ -51,16 +50,6 @@ class DoctrineListBuilder extends AbstractListBuilder
 {
     use SecuredEntityRepositoryTrait;
     use EncodeAliasTrait;
-
-    /**
-     * Doctrine types which are mapped to a text column on every supported database platform.
-     */
-    private const TEXT_FIELD_TYPES = [
-        Types::ASCII_STRING,
-        Types::SIMPLE_ARRAY,
-        Types::STRING,
-        Types::TEXT,
-    ];
 
     /**
      * @var DoctrineFieldDescriptorInterface[]
@@ -744,37 +733,19 @@ class DoctrineListBuilder extends AbstractListBuilder
     }
 
     /**
-     * Returns the search statement of the given field descriptor. Fields which are not mapped to a
-     * text column are casted, because strict database platforms like PostgreSQL do not allow LOWER()
-     * to be used on other column types. Text columns are left untouched, so that indexes defined on
-     * them are not affected.
+     * Returns the search statement of the given field descriptor. The column is casted, because strict
+     * database platforms like PostgreSQL do not allow LOWER() to be used on a column which is not of a
+     * text type. Descriptors which build their own statement keep it, because it can not be casted.
      */
     private function getSearchStatement(DoctrineFieldDescriptorInterface $searchField): string
     {
         if (!$searchField instanceof DoctrineFieldDescriptor
             || $searchField instanceof DoctrineCountFieldDescriptor
-            || $this->isTextField($searchField->getEntityName(), $searchField->getFieldName())
         ) {
             return $searchField->getSearch();
         }
 
-        return \sprintf('LOWER(CAST(%s AS TEXT)) LIKE LOWER(:search)', $searchField->getSelect());
-    }
-
-    private function isTextField(string $entityName, string $fieldName): bool
-    {
-        // entity names are also used as aliases and therefore do not have to reference a real entity
-        if (!\class_exists($entityName)) {
-            return true;
-        }
-
-        $classMetadata = $this->em->getClassMetadata($entityName);
-
-        if (!$classMetadata->hasField($fieldName)) {
-            return true;
-        }
-
-        return \in_array($classMetadata->getTypeOfField($fieldName), self::TEXT_FIELD_TYPES, true);
+        return \sprintf('LOWER(CAST(%s AS STRING)) LIKE LOWER(:search)', $searchField->getSelect());
     }
 
     /**

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -29,8 +29,10 @@ use Sulu\Bundle\SecurityBundle\System\SystemStoreInterface;
 use Sulu\Bundle\TestBundle\Testing\ReadObjectAttributeTrait;
 use Sulu\Component\Rest\Exception\InvalidSearchException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineCaseFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineConcatenationFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineCountFieldDescriptor;
+use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptor;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineFieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\Doctrine\FieldDescriptor\DoctrineJoinDescriptor;
@@ -632,6 +634,79 @@ class DoctrineListBuilderTest extends TestCase
             '(LOWER(' . self::$translationEntityNameAlias . '.desc) LIKE LOWER(:search) OR LOWER(' . self::$entityNameAlias . '.name) LIKE LOWER(:search))'
         )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('search', '%val%e%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->doctrineListBuilder->execute();
+    }
+
+    /**
+     * @return \Generator<string, array{DoctrineFieldDescriptorInterface, string, string}>
+     */
+    public static function provideSearchField(): \Generator
+    {
+        yield 'text field is not casted' => [
+            new DoctrineFieldDescriptor('name', 'name', Role::class),
+            'string',
+            'LOWER(Sulu_Bundle_SecurityBundle_Entity_Role.name) LIKE LOWER(:search)',
+        ];
+
+        yield 'non text field is casted' => [
+            new DoctrineFieldDescriptor('id', 'id', Role::class),
+            'integer',
+            'LOWER(CAST(Sulu_Bundle_SecurityBundle_Entity_Role.id AS TEXT)) LIKE LOWER(:search)',
+        ];
+
+        yield 'count field is not casted' => [
+            new DoctrineCountFieldDescriptor('id', 'id', Role::class),
+            'integer',
+            'LOWER(COUNT(Sulu_Bundle_SecurityBundle_Entity_Role.id)) LIKE LOWER(:search)',
+        ];
+
+        yield 'concatenation field is not casted' => [
+            new DoctrineConcatenationFieldDescriptor(
+                [
+                    new DoctrineFieldDescriptor('id', 'id', Role::class),
+                    new DoctrineFieldDescriptor('name', 'name', Role::class),
+                ],
+                'name'
+            ),
+            'integer',
+            'LOWER(CONCAT(Sulu_Bundle_SecurityBundle_Entity_Role.id, CONCAT(\' \', Sulu_Bundle_SecurityBundle_Entity_Role.name))) LIKE LOWER(:search)',
+        ];
+
+        yield 'case field is not casted' => [
+            new DoctrineCaseFieldDescriptor(
+                'name',
+                new DoctrineDescriptor(Role::class, 'id'),
+                new DoctrineDescriptor(Role::class, 'name')
+            ),
+            'integer',
+            'LOWER(Sulu_Bundle_SecurityBundle_Entity_Role.id) LIKE LOWER(:search)'
+                . ' OR (Sulu_Bundle_SecurityBundle_Entity_Role.id IS NULL'
+                . ' AND LOWER(Sulu_Bundle_SecurityBundle_Entity_Role.name) LIKE LOWER(:search))',
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSearchField')]
+    public function testSearchWithFieldType(
+        DoctrineFieldDescriptorInterface $searchField,
+        string $fieldType,
+        string $expectedStatement
+    ): void {
+        $this->classMetadata->hasField(Argument::any())->willReturn(true);
+        $this->classMetadata->getTypeOfField(Argument::any())->willReturn($fieldType);
+
+        $this->doctrineListBuilder->addSearchField($searchField);
+        $this->doctrineListBuilder->search('value');
+
+        $this->queryBuilder->addOrderBy(self::$entityNameAlias . '.id', 'ASC')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->distinct(false)->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->where(self::$entityNameAlias . '.id IN (:ids)')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('ids', ['1', '2', '3'])->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+
+        $this->queryBuilder->andWhere('(' . $expectedStatement . ')')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
+        $this->queryBuilder->setParameter('search', '%value%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->doctrineListBuilder->execute();
     }

--- a/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/ListBuilder/Doctrine/DoctrineListBuilderTest.php
@@ -605,7 +605,8 @@ class DoctrineListBuilderTest extends TestCase
         $this->queryBuilder->addSelect(self::$entityNameAlias . '.id AS id')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
         $this->queryBuilder->andWhere(
-            '(LOWER(' . self::$translationEntityNameAlias . '.desc) LIKE LOWER(:search) OR LOWER(' . self::$entityNameAlias . '.name) LIKE LOWER(:search))'
+            '(LOWER(CAST(' . self::$translationEntityNameAlias . '.desc AS STRING)) LIKE LOWER(:search)'
+            . ' OR LOWER(CAST(' . self::$entityNameAlias . '.name AS STRING)) LIKE LOWER(:search))'
         )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('search', '%value%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
@@ -631,7 +632,8 @@ class DoctrineListBuilderTest extends TestCase
         $this->doctrineListBuilder->search('val*e');
 
         $this->queryBuilder->andWhere(
-            '(LOWER(' . self::$translationEntityNameAlias . '.desc) LIKE LOWER(:search) OR LOWER(' . self::$entityNameAlias . '.name) LIKE LOWER(:search))'
+            '(LOWER(CAST(' . self::$translationEntityNameAlias . '.desc AS STRING)) LIKE LOWER(:search)'
+            . ' OR LOWER(CAST(' . self::$entityNameAlias . '.name AS STRING)) LIKE LOWER(:search))'
         )->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
         $this->queryBuilder->setParameter('search', '%val%e%')->willReturn($this->queryBuilder->reveal())->shouldBeCalled();
 
@@ -639,25 +641,17 @@ class DoctrineListBuilderTest extends TestCase
     }
 
     /**
-     * @return \Generator<string, array{DoctrineFieldDescriptorInterface, string, string}>
+     * @return \Generator<string, array{DoctrineFieldDescriptorInterface, string}>
      */
     public static function provideSearchField(): \Generator
     {
-        yield 'text field is not casted' => [
+        yield 'field is casted' => [
             new DoctrineFieldDescriptor('name', 'name', Role::class),
-            'string',
-            'LOWER(Sulu_Bundle_SecurityBundle_Entity_Role.name) LIKE LOWER(:search)',
-        ];
-
-        yield 'non text field is casted' => [
-            new DoctrineFieldDescriptor('id', 'id', Role::class),
-            'integer',
-            'LOWER(CAST(Sulu_Bundle_SecurityBundle_Entity_Role.id AS TEXT)) LIKE LOWER(:search)',
+            'LOWER(CAST(Sulu_Bundle_SecurityBundle_Entity_Role.name AS STRING)) LIKE LOWER(:search)',
         ];
 
         yield 'count field is not casted' => [
             new DoctrineCountFieldDescriptor('id', 'id', Role::class),
-            'integer',
             'LOWER(COUNT(Sulu_Bundle_SecurityBundle_Entity_Role.id)) LIKE LOWER(:search)',
         ];
 
@@ -669,7 +663,6 @@ class DoctrineListBuilderTest extends TestCase
                 ],
                 'name'
             ),
-            'integer',
             'LOWER(CONCAT(Sulu_Bundle_SecurityBundle_Entity_Role.id, CONCAT(\' \', Sulu_Bundle_SecurityBundle_Entity_Role.name))) LIKE LOWER(:search)',
         ];
 
@@ -679,7 +672,6 @@ class DoctrineListBuilderTest extends TestCase
                 new DoctrineDescriptor(Role::class, 'id'),
                 new DoctrineDescriptor(Role::class, 'name')
             ),
-            'integer',
             'LOWER(Sulu_Bundle_SecurityBundle_Entity_Role.id) LIKE LOWER(:search)'
                 . ' OR (Sulu_Bundle_SecurityBundle_Entity_Role.id IS NULL'
                 . ' AND LOWER(Sulu_Bundle_SecurityBundle_Entity_Role.name) LIKE LOWER(:search))',
@@ -687,14 +679,10 @@ class DoctrineListBuilderTest extends TestCase
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('provideSearchField')]
-    public function testSearchWithFieldType(
+    public function testSearchWithFieldDescriptor(
         DoctrineFieldDescriptorInterface $searchField,
-        string $fieldType,
         string $expectedStatement
     ): void {
-        $this->classMetadata->hasField(Argument::any())->willReturn(true);
-        $this->classMetadata->getTypeOfField(Argument::any())->willReturn($fieldType);
-
         $this->doctrineListBuilder->addSearchField($searchField);
         $this->doctrineListBuilder->search('value');
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

The list builder now wraps the search field in a `CAST(... AS STRING)` before it applies `LOWER()`. The cast is translated to the correct type by the already registered CAST function of the Doctrine extensions, which resolves it to `char` on MySQL and to `varchar` on PostgreSQL. Only field descriptors which map to a single column are casted, so composed descriptors like the concatenation descriptor or the case descriptor keep their previous statement, and the count descriptor is left untouched as well.

#### Why?

PostgreSQL does not allow `LOWER()` on a column which is not of a text type. Searching a list over an integer column or over a uuid column therefore failed with a database error. MySQL and MariaDB coerce such values silently, which is the reason this stayed unnoticed until now.

The cast is applied unconditionally instead of only on non-text columns. Resolving the Doctrine type first would mean maintaining a list of text types in Sulu, which goes stale as soon as Doctrine or the Symfony Doctrine Bridge adds one. There is also nothing to gain from skipping it: the search parameter is built as `%value%`, so the `LIKE` carries a leading wildcard and cannot use a b-tree index either way.
