### PR TITLE
Webspace restrictions do not apply in new ArticleBundle

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Route/ArticleRouteDefaultsProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Route/ArticleRouteDefaultsProvider.php
@@ -92,6 +92,17 @@ class ArticleRouteDefaultsProvider implements RouteDefaultsProviderInterface
             throw new NotFoundHttpException(\sprintf('No article found for id "%s" and locale "%s"', $id, $locale));
         }
 
+        // Article routes are stored without a webspace (see RoutableDataMapper), so a single route matches every
+        // webspace via the "webspaceOrNull" filter. The article is therefore only served through its configured
+        // main or additional webspaces; requesting it through any other webspace results in a 404.
+        $requestWebspace = $this->getRequestWebspaceKey();
+        if (null !== $requestWebspace
+            && $requestWebspace !== $dimensionContent->getMainWebspace()
+            && !\in_array($requestWebspace, $dimensionContent->getAdditionalWebspaces(), true)
+        ) {
+            throw new NotFoundHttpException(\sprintf('No article found for id "%s" and locale "%s" in webspace "%s"', $id, $locale, $requestWebspace));
+        }
+
         $templateKey = $dimensionContent->getTemplateKey();
         if (!$templateKey) {
             throw new NotFoundHttpException(\sprintf('No template found for id "%s" and locale "%s"', $id, $locale));

--- a/packages/article/tests/Functional/Integration/ArticleWebspaceRoutingTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleWebspaceRoutingTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Tests\Functional\Integration;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Sulu\Article\Tests\Traits\CreateArticleTrait;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Route\Domain\Value\RequestAttributeEnum;
+
+#[CoversNothing]
+class ArticleWebspaceRoutingTest extends SuluTestCase
+{
+    use CreateArticleTrait;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $requestContext = self::getContainer()->get('router.request_context');
+        $requestContext->setParameter(RequestAttributeEnum::WEBSPACE->value, 'sulu-io');
+    }
+
+    public function testArticleIsAvailableThroughMainWebspace(): void
+    {
+        self::purgeDatabase();
+
+        self::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Webspace Routing Article',
+                    'url' => '/webspace-routing-article',
+                    'mainWebspace' => 'sulu-io',
+                ],
+            ],
+        ]);
+
+        self::ensureKernelShutdown();
+
+        $websiteClient = $this->createWebsiteClient();
+        $websiteClient->request('GET', 'http://sulu.io/en/webspace-routing-article');
+
+        $this->assertHttpStatusCode(200, $websiteClient->getResponse());
+    }
+
+    public function testArticleIsNotAvailableThroughUnrelatedWebspace(): void
+    {
+        self::purgeDatabase();
+
+        // The article is only exposed through its main webspace "sulu-io". Its route is stored without a
+        // webspace, so it technically matches every webspace slug - the ArticleRouteDefaultsProvider is
+        // responsible for restricting it to the configured webspaces.
+        self::createArticle([
+            'en' => [
+                'live' => [
+                    'template' => 'article',
+                    'title' => 'Webspace Routing Article',
+                    'url' => '/webspace-routing-article',
+                    'mainWebspace' => 'sulu-io',
+                ],
+            ],
+        ]);
+
+        self::ensureKernelShutdown();
+
+        $websiteClient = $this->createWebsiteClient();
+        $websiteClient->request('GET', 'http://blog.io/en/webspace-routing-article');
+
+        $this->assertHttpStatusCode(404, $websiteClient->getResponse());
+    }
+}

--- a/packages/article/tests/Unit/Infrastructure/Sulu/Route/ArticleRouteDefaultsProviderTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Route/ArticleRouteDefaultsProviderTest.php
@@ -38,6 +38,7 @@ use Sulu\Route\Domain\Model\Route;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ArticleRouteDefaultsProviderTest extends TestCase
@@ -150,7 +151,7 @@ class ArticleRouteDefaultsProviderTest extends TestCase
 
         $this->articleRepository->findOneBy(Argument::cetera())->willReturn(null);
 
-        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectException(NotFoundHttpException::class);
 
         $provider->getDefaults(new Route(Article::RESOURCE_KEY, '123-123-123', 'en', '/test-article'));
     }
@@ -267,7 +268,7 @@ class ArticleRouteDefaultsProviderTest extends TestCase
         $this->assertArrayNotHasKey('_seo', $result);
     }
 
-    public function testGetDefaultsDoesNotSetCanonicalUrlForUnrelatedWebspace(): void
+    public function testGetDefaultsThrowsNotFoundForUnrelatedWebspace(): void
     {
         $provider = $this->getArticleRouteDefaultsProviderInstance();
 
@@ -282,15 +283,33 @@ class ArticleRouteDefaultsProviderTest extends TestCase
         $resolvedDimensionContent->setAdditionalWebspaces(['blog']);
 
         $this->prepareArticle($article, $resolvedDimensionContent, $locale);
-        $this->prepareTemplateMetadata('ArticleController::indexAction', 'article.html.twig', 'seconds', '3600');
 
         $this->pushRequestWithWebspace('unrelated');
 
-        $this->routeGenerator->generate(Argument::cetera())->shouldNotBeCalled();
+        $this->expectException(NotFoundHttpException::class);
 
-        $result = $provider->getDefaults(new Route(Article::RESOURCE_KEY, '123-123-123', $locale, $slug));
+        $provider->getDefaults(new Route(Article::RESOURCE_KEY, '123-123-123', $locale, $slug));
+    }
 
-        $this->assertArrayNotHasKey('_seo', $result);
+    public function testGetDefaultsThrowsNotFoundWhenNoMainWebspaceConfigured(): void
+    {
+        $provider = $this->getArticleRouteDefaultsProviderInstance();
+
+        $locale = 'en';
+        $slug = '/test-article';
+
+        $article = new Article('123-123-123');
+        $resolvedDimensionContent = new ArticleDimensionContent($article);
+        $resolvedDimensionContent->setLocale($locale);
+        $resolvedDimensionContent->setTemplateKey('default');
+
+        $this->prepareArticle($article, $resolvedDimensionContent, $locale);
+
+        $this->pushRequestWithWebspace('sulu-io');
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $provider->getDefaults(new Route(Article::RESOURCE_KEY, '123-123-123', $locale, $slug));
     }
 
     private function prepareArticle(Article $article, ArticleDimensionContent $dimensionContent, string $routeLocale): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no yes
| Fixed tickets | fixes #8953
| Related issues/PRs | #8953
| License | MIT

#### What's in this PR?

Sulu does not limit the webspaces that an Article entity is exposed under.

#### Why?

Buggy