### PR TITLE
Fix ResourceLocator marking the form dirty on blur without a change

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/ResourceLocator.js
@@ -102,7 +102,10 @@ class ResourceLocator extends React.Component<Props> {
 
         if (value) {
             const newValue = value.replace(/([-])$/g, '');
-            onChange(newValue);
+
+            if (newValue !== value) {
+                onChange(newValue);
+            }
         }
 
         if (onBlur) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/ResourceLocator/tests/ResourceLocator.test.js
@@ -303,3 +303,21 @@ test('ResourceLocator should call the onBlur callback when the Input finishes ed
     fireEvent.blur(getInput());
     expect(finishSpy).toHaveBeenCalledWith();
 });
+
+test('ResourceLocator should remove a trailing dash and call onChange on blur', () => {
+    const onChange = jest.fn();
+    const locale = observable.box('en');
+    render(<ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value="/some/url-" />);
+
+    fireEvent.blur(getInput());
+    expect(onChange).toHaveBeenCalledWith('/some/url');
+});
+
+test('ResourceLocator should not call onChange on blur when the value does not change', () => {
+    const onChange = jest.fn();
+    const locale = observable.box('en');
+    render(<ResourceLocator locale={locale} mode="leaf" onBlur={jest.fn()} onChange={onChange} value="/some/url" />);
+
+    fireEvent.blur(getInput());
+    expect(onChange).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
The blur handler stripped a trailing dash and called onChange whenever a value was present. When the value did not end in a dash, onChange ran with the unchanged value, marking the form store dirty and enabling the save button even though nothing was edited — focusing and leaving the field sufficed.

Only call onChange when the trailing-dash cleanup actually changed the value. Adds regression tests for the trailing-dash and no-change cases.

| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no