### PR TITLE
Run fixtures builder after homepage builder

### DIFF
--- a/packages/page/src/Infrastructure/Sulu/Build/HomepageBuilder.php
+++ b/packages/page/src/Infrastructure/Sulu/Build/HomepageBuilder.php
@@ -15,9 +15,11 @@ use Sulu\Bundle\CoreBundle\Build\SuluBuilder;
 
 class HomepageBuilder extends SuluBuilder
 {
+    public const NAME = 'homepage';
+
     public function getName(): string
     {
-        return 'homepage';
+        return self::NAME;
     }
 
     public function getDependencies(): array

--- a/packages/page/src/Infrastructure/Symfony/DependencyInjection/Compiler/FixturesBuilderDependencyPass.php
+++ b/packages/page/src/Infrastructure/Symfony/DependencyInjection/Compiler/FixturesBuilderDependencyPass.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Symfony\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Page fixtures need the homepage of a webspace to exist, as it is the parent of all other pages. Therefore the
+ * "fixtures" builder has to run after the "homepage" builder. Both builders only depend on the "database" builder,
+ * which makes their order depend on the order the bundles are registered in.
+ *
+ * @internal
+ */
+final class FixturesBuilderDependencyPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('sulu_core.build.builder.fixtures')
+            || !$container->hasDefinition('sulu_page.homepage_builder')
+        ) {
+            return;
+        }
+
+        $definition = $container->getDefinition('sulu_core.build.builder.fixtures');
+
+        /** @var string[] $additionalDependencies */
+        $additionalDependencies = $definition->getArguments()[0] ?? [];
+        $additionalDependencies[] = 'homepage';
+
+        $definition->setArgument(0, \array_values(\array_unique($additionalDependencies)));
+    }
+}

--- a/packages/page/src/Infrastructure/Symfony/DependencyInjection/Compiler/FixturesBuilderDependencyPass.php
+++ b/packages/page/src/Infrastructure/Symfony/DependencyInjection/Compiler/FixturesBuilderDependencyPass.php
@@ -13,13 +13,18 @@ declare(strict_types=1);
 
 namespace Sulu\Page\Infrastructure\Symfony\DependencyInjection\Compiler;
 
+use Sulu\Page\Infrastructure\Sulu\Build\HomepageBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Webmozart\Assert\Assert;
 
 /**
  * Page fixtures need the homepage of a webspace to exist, as it is the parent of all other pages. Therefore the
  * "fixtures" builder has to run after the "homepage" builder. Both builders only depend on the "database" builder,
  * which makes their order depend on the order the bundles are registered in.
+ *
+ * Runs as an optimization pass (after Symfony has resolved named arguments) so that argument 0 of the fixtures
+ * builder definition is always addressed positionally, regardless of how it was originally configured.
  *
  * @internal
  */
@@ -35,9 +40,12 @@ final class FixturesBuilderDependencyPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('sulu_core.build.builder.fixtures');
 
-        /** @var string[] $additionalDependencies */
         $additionalDependencies = $definition->getArguments()[0] ?? [];
-        $additionalDependencies[] = 'homepage';
+
+        Assert::isArray($additionalDependencies, 'Expected argument 0 of service "sulu_core.build.builder.fixtures" to be an array.');
+        Assert::allString($additionalDependencies, 'Expected argument 0 of service "sulu_core.build.builder.fixtures" to contain only strings.');
+
+        $additionalDependencies[] = HomepageBuilder::NAME;
 
         $definition->setArgument(0, \array_values(\array_unique($additionalDependencies)));
     }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -93,6 +93,7 @@ use Sulu\Page\Infrastructure\Symfony\Twig\Extension\PageTwigExtension;
 use Sulu\Page\UserInterface\Command\InitializeHomepageCommand;
 use Sulu\Page\UserInterface\Controller\Admin\PageController;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -888,6 +889,8 @@ final class SuluPageBundle extends AbstractBundle
             PageDimensionContentInterface::class => 'sulu.model.page_content.class',
         ], $container);
         $container->addCompilerPass(new OverrideTreeListenerPass());
-        $container->addCompilerPass(new FixturesBuilderDependencyPass());
+        // run after Symfony's ResolveNamedArgumentsPass (also an optimization pass) so argument 0 of the
+        // fixtures builder definition is always resolved to a plain positional array before we touch it
+        $container->addCompilerPass(new FixturesBuilderDependencyPass(), PassConfig::TYPE_OPTIMIZE, -10);
     }
 }

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -85,6 +85,7 @@ use Sulu\Page\Infrastructure\Sulu\Security\PageSecurityListener;
 use Sulu\Page\Infrastructure\Sulu\Sitemap\PagesSitemapProvider;
 use Sulu\Page\Infrastructure\Sulu\Trash\PageTrashItemHandler;
 use Sulu\Page\Infrastructure\Sulu\Webspace\PageSegmentListener;
+use Sulu\Page\Infrastructure\Symfony\DependencyInjection\Compiler\FixturesBuilderDependencyPass;
 use Sulu\Page\Infrastructure\Symfony\DependencyInjection\Compiler\OverrideTreeListenerPass;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\ContentPathTwigExtension;
 use Sulu\Page\Infrastructure\Symfony\Twig\Extension\NavigationTwigExtension;
@@ -887,5 +888,6 @@ final class SuluPageBundle extends AbstractBundle
             PageDimensionContentInterface::class => 'sulu.model.page_content.class',
         ], $container);
         $container->addCompilerPass(new OverrideTreeListenerPass());
+        $container->addCompilerPass(new FixturesBuilderDependencyPass());
     }
 }

--- a/packages/page/tests/Unit/Infrastructure/Symfony/DependencyInjection/Compiler/FixturesBuilderDependencyPassTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Symfony/DependencyInjection/Compiler/FixturesBuilderDependencyPassTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Symfony\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sulu\Bundle\CoreBundle\Build\FixturesBuilder;
+use Sulu\Page\Infrastructure\Sulu\Build\HomepageBuilder;
+use Sulu\Page\Infrastructure\Symfony\DependencyInjection\Compiler\FixturesBuilderDependencyPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class FixturesBuilderDependencyPassTest extends AbstractCompilerPassTestCase
+{
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new FixturesBuilderDependencyPass());
+    }
+
+    public function testAddsHomepageAsAdditionalDependency(): void
+    {
+        $this->registerFixturesBuilder();
+        $this->registerHomepageBuilder();
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sulu_core.build.builder.fixtures',
+            0,
+            ['homepage'],
+        );
+    }
+
+    public function testKeepsExistingAdditionalDependencies(): void
+    {
+        $this->registerFixturesBuilder(['other']);
+        $this->registerHomepageBuilder();
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sulu_core.build.builder.fixtures',
+            0,
+            ['other', 'homepage'],
+        );
+    }
+
+    public function testDoesNotAddHomepageTwice(): void
+    {
+        $this->registerFixturesBuilder(['homepage']);
+        $this->registerHomepageBuilder();
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sulu_core.build.builder.fixtures',
+            0,
+            ['homepage'],
+        );
+    }
+
+    public function testDoesNothingWithoutHomepageBuilder(): void
+    {
+        $this->registerFixturesBuilder();
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sulu_core.build.builder.fixtures',
+            0,
+            [],
+        );
+    }
+
+    public function testDoesNothingWithoutFixturesBuilder(): void
+    {
+        $this->registerHomepageBuilder();
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sulu_core.build.builder.fixtures');
+    }
+
+    /**
+     * @param string[] $additionalDependencies
+     */
+    private function registerFixturesBuilder(array $additionalDependencies = []): void
+    {
+        $this->setDefinition(
+            'sulu_core.build.builder.fixtures',
+            new Definition(FixturesBuilder::class, [$additionalDependencies]),
+        );
+    }
+
+    private function registerHomepageBuilder(): void
+    {
+        $this->setDefinition('sulu_page.homepage_builder', new Definition(HomepageBuilder::class));
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
@@ -17,14 +17,19 @@ namespace Sulu\Bundle\CoreBundle\Build;
 class FixturesBuilder extends SuluBuilder
 {
     /**
+     * @var string[]
+     */
+    private array $additionalDependencies = [];
+
+    /**
      * Fixtures often require data which is created by builders of optional bundles. As the core bundle can not
      * depend on those builders, they can register themselves as additional dependency instead.
      *
      * @param string[] $additionalDependencies
      */
-    public function __construct(
-        private array $additionalDependencies = [],
-    ) {
+    public function __construct(array $additionalDependencies = [])
+    {
+        $this->additionalDependencies = $additionalDependencies;
     }
 
     public function getName()

--- a/src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/FixturesBuilder.php
@@ -16,6 +16,17 @@ namespace Sulu\Bundle\CoreBundle\Build;
  */
 class FixturesBuilder extends SuluBuilder
 {
+    /**
+     * Fixtures often require data which is created by builders of optional bundles. As the core bundle can not
+     * depend on those builders, they can register themselves as additional dependency instead.
+     *
+     * @param string[] $additionalDependencies
+     */
+    public function __construct(
+        private array $additionalDependencies = [],
+    ) {
+    }
+
     public function getName()
     {
         return 'fixtures';
@@ -23,7 +34,7 @@ class FixturesBuilder extends SuluBuilder
 
     public function getDependencies()
     {
-        return ['database'];
+        return \array_values(\array_unique(\array_merge(['database'], $this->additionalDependencies)));
     }
 
     public function build()

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/build.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/build.php
@@ -21,5 +21,7 @@ return static function(ContainerConfigurator $container) {
         ->tag('massive_build.builder');
 
     $services->set('sulu_core.build.builder.fixtures', FixturesBuilder::class)
+        // additional dependencies, other bundles can append their builders via a compiler pass
+        ->args([[]])
         ->tag('massive_build.builder');
 };

--- a/src/Sulu/Bundle/CoreBundle/Tests/Unit/Build/FixturesBuilderTest.php
+++ b/src/Sulu/Bundle/CoreBundle/Tests/Unit/Build/FixturesBuilderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Tests\Unit\Build;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\CoreBundle\Build\FixturesBuilder;
+
+class FixturesBuilderTest extends TestCase
+{
+    public function testGetDependencies(): void
+    {
+        $builder = new FixturesBuilder();
+
+        $this->assertSame(['database'], $builder->getDependencies());
+    }
+
+    public function testGetDependenciesWithAdditionalDependencies(): void
+    {
+        $builder = new FixturesBuilder(['homepage']);
+
+        $this->assertSame(['database', 'homepage'], $builder->getDependencies());
+    }
+
+    public function testGetDependenciesRemovesDuplicates(): void
+    {
+        $builder = new FixturesBuilder(['database', 'homepage', 'homepage']);
+
+        $this->assertSame(['database', 'homepage'], $builder->getDependencies());
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Makes the `fixtures` builder of the `SuluCoreBundle` run **after** the `homepage` builder of the page package.

* `FixturesBuilder` accepts an optional list of additional dependencies via its constructor (defaults to `[]`, so nothing changes for existing setups).
* `SuluPageBundle` appends `homepage` to that list through the new `FixturesBuilderDependencyPass`, which is a no-op when either builder is missing.

#### Why?

`Sulu\Bundle\CoreBundle\Build\FixturesBuilder` and `Sulu\Page\Infrastructure\Sulu\Build\HomepageBuilder` both declare exactly one dependency: `database`. They are siblings with no ordering constraint between them, so `Massive\Bundle\BuildBundle\Build\BuildRegistry::resolveDependencies()` breaks the tie by the order in which the builders were tagged — which follows bundle registration order. Today `SuluCoreBundle` is registered before `SuluPageBundle`, so `fixtures` happens to run first.

In Sulu 3.0 the homepage is an ORM record that only `sulu:page:initialize` creates, and every page fixture needs it — either as the parent of the pages it creates (`CreatePageMessageHandler::HOMEPAGE_PARENT_ID`) or to modify the root page itself. So loading page fixtures before the `homepage` builder fails:

```
Target: fixtures

    doctrine:fixtures:load ({"--no-interaction":true,"--append":true})

       > loading App\DataFixtures\Document\DocumentFixture

    In PageSeeder.php line 56:

      Homepage not found. Run sulu:page:initialize first.
```

The `SuluCoreBundle` cannot simply declare `homepage` as a dependency: the builder is registered by `SuluPageBundle` only (`sulu_page.homepage_builder`), which is optional, and `BuildRegistry` throws `Builder "fixtures" has dependency on unknown builder "homepage"` when it is absent. The builder API has no "run before" declaration either, so the page package has no way to express the ordering on its own — hence the small extension point in the core builder.

#### Example Usage

Other bundles that create data required by fixtures can use the same extension point:

```php
public function process(ContainerBuilder $container): void
{
    if (!$container->hasDefinition('sulu_core.build.builder.fixtures')) {
        return;
    }

    $definition = $container->getDefinition('sulu_core.build.builder.fixtures');
    $definition->setArgument(0, [...$definition->getArguments()[0] ?? [], 'my_builder']);
}
```

Build order before:

```
Target: database
Target: fixtures    <- fails, no homepage yet
Target: homepage
```

after:

```
Target: database
Target: homepage
Target: fixtures
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
