### PR TITLE
Create search index on build

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17209,6 +17209,12 @@ parameters:
 			path: src/Sulu/Bundle/CoreBundle/Build/DatabaseBuilder.php
 
 		-
+			message: '#^Cannot call method getOption\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/Sulu/Bundle/CoreBundle/Build/SearchBuilder.php
+
+		-
 			message: '#^Cannot access offset ''command'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 1

--- a/src/Sulu/Bundle/CoreBundle/Build/SearchBuilder.php
+++ b/src/Sulu/Bundle/CoreBundle/Build/SearchBuilder.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\CoreBundle\Build;
+
+/**
+ * Builder for initializing the search indexes.
+ */
+class SearchBuilder extends SuluBuilder
+{
+    public function getName()
+    {
+        return 'search';
+    }
+
+    public function getDependencies()
+    {
+        return [];
+    }
+
+    public function build()
+    {
+        if ($this->input->getOption('destroy')) {
+            $this->execCommand('Dropping the search indexes', 'cmsig:seal:index-drop', ['--force' => true]);
+        }
+
+        $this->execCommand('Creating the search indexes', 'cmsig:seal:index-create');
+    }
+}

--- a/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
+++ b/src/Sulu/Bundle/CoreBundle/DependencyInjection/SuluCoreExtension.php
@@ -188,6 +188,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                             'fixtures' => [],
                             'system_collections' => [],
                             'security' => [],
+                            'search' => [],
                         ],
                     ],
                     'dev' => [
@@ -197,6 +198,7 @@ class SuluCoreExtension extends Extension implements PrependExtensionInterface
                             'user' => [],
                             'system_collections' => [],
                             'security' => [],
+                            'search' => [],
                         ],
                     ],
                 ],

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/build.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/build.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sulu\Bundle\CoreBundle\Build\DatabaseBuilder;
 use Sulu\Bundle\CoreBundle\Build\FixturesBuilder;
+use Sulu\Bundle\CoreBundle\Build\SearchBuilder;
 
 return static function(ContainerConfigurator $container) {
     $services = $container->services();
@@ -23,5 +24,8 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_core.build.builder.fixtures', FixturesBuilder::class)
         // additional dependencies, other bundles can append their builders via a compiler pass
         ->args([[]])
+        ->tag('massive_build.builder');
+
+    $services->set('sulu_core.build.builder.search', SearchBuilder::class)
         ->tag('massive_build.builder');
 };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adds `SearchBuilder` which creates the SEAL index (dropped first if `--destroy` is passed)

#### Why?

currently missing

#### Example Usage

`bin/adminconsole sulu:build dev -n --destroy`