### PR TITLE
Add Cache Clear Permission

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -23,6 +23,24 @@ Run the new migration to apply the schema change:
 ```bash
 bin/console doctrine:migrations:migrate
 ```
+## 3.1
+
+### Cache clearing now requires a dedicated permission
+
+Clearing the webspace cache (from the page list or snippet areas toolbar) used to be gated by the `LIVE` permission on
+the webspace security context (`sulu.webspaces.<webspace>`). It is now gated by the `DELETE` permission on a new,
+dedicated security context: `sulu.webspaces.<webspace>.cache`.
+
+A migration (`Sulu\Bundle\WebsiteBundle\Migrations\Version20260805120000`) grants the new `DELETE` permission on
+`sulu.webspaces.<webspace>.cache` to every role that already had `LIVE` permission on `sulu.webspaces.<webspace>`, so
+existing roles keep the ability to clear the cache after running:
+
+```bash
+bin/console doctrine:migrations:migrate
+```
+
+Review your roles afterwards and adjust the new `sulu.webspaces.<webspace>.cache` permission if a role should no
+longer be allowed to clear the cache, or should gain it despite not having had `LIVE` permission before.
 
 ## 3.0.8
 

--- a/packages/page/assets/js/views/PageList/PageList.js
+++ b/packages/page/assets/js/views/PageList/PageList.js
@@ -256,7 +256,7 @@ const PageListWithToolbar = withToolbar(PageList, function() {
                 value: !this.excludeGhostsAndShadows.get(),
             },
             this.cacheClearToolbarAction.getToolbarItemConfig(),
-        ],
+        ].filter(Boolean),
         locale: {
             value: this.locale.get(),
             onChange: action((locale) => {

--- a/packages/page/assets/js/views/PageList/PageList.js
+++ b/packages/page/assets/js/views/PageList/PageList.js
@@ -4,9 +4,9 @@ import {observer} from 'mobx-react';
 import React from 'react';
 import {Loader, Icon} from 'sulu-admin-bundle/components';
 import {formMetadataStore, List, ListStore, withToolbar} from 'sulu-admin-bundle/containers';
+import {AbstractViewToolbarAction, viewToolbarActionRegistry} from 'sulu-admin-bundle/views';
 import userStore from 'sulu-admin-bundle/stores/userStore/userStore';
 import {translate} from 'sulu-admin-bundle/utils';
-import {CacheClearToolbarAction} from 'sulu-website-bundle/containers';
 import {Route} from 'sulu-admin-bundle/services';
 import pageListStyles from './pageList.scss';
 import type {Localization} from 'sulu-admin-bundle/stores';
@@ -33,7 +33,7 @@ class PageList extends React.Component<Props> {
     page: IObservableValue<number> = observable.box();
     locale: IObservableValue<string> = observable.box();
     excludeGhostsAndShadows: IObservableValue<boolean> = observable.box(false);
-    cacheClearToolbarAction: CacheClearToolbarAction;
+    toolbarActions: Array<AbstractViewToolbarAction> = [];
     listStore: ListStore;
     excludeGhostsAndShadowsDisposer: () => void;
     webspaceKeyDisposer: () => void;
@@ -125,7 +125,13 @@ class PageList extends React.Component<Props> {
 
         observableOptions.locale = this.locale;
 
-        this.cacheClearToolbarAction = new CacheClearToolbarAction(webspace);
+        const {toolbarActions = []} = router.route.options;
+        toolbarActions.forEach((toolbarAction) => {
+            this.toolbarActions.push(new (viewToolbarActionRegistry.get(toolbarAction.type))(
+                router,
+                toolbarAction.options
+            ));
+        });
 
         this.listStore = new ListStore(
             PAGES_RESOURCE_KEY,
@@ -157,6 +163,7 @@ class PageList extends React.Component<Props> {
         this.webspaceKeyDisposer();
         this.listStore.destroy();
         this.excludeGhostsAndShadowsDisposer();
+        this.toolbarActions.forEach((toolbarAction) => toolbarAction.destroy());
     }
 
     handleEditClick = (id: string | number) => {
@@ -231,7 +238,7 @@ class PageList extends React.Component<Props> {
                         toolbarClassName={pageListStyles.listToolbar}
                     />
                 }
-                {this.cacheClearToolbarAction.getNode()}
+                {this.toolbarActions.map((toolbarAction) => toolbarAction.getNode())}
             </div>
         );
     }
@@ -255,8 +262,10 @@ const PageListWithToolbar = withToolbar(PageList, function() {
                 type: 'toggler',
                 value: !this.excludeGhostsAndShadows.get(),
             },
-            this.cacheClearToolbarAction.getToolbarItemConfig(),
-        ].filter(Boolean),
+            ...this.toolbarActions
+                .map((toolbarAction) => toolbarAction.getToolbarItemConfig())
+                .filter((item) => item != null),
+        ],
         locale: {
             value: this.locale.get(),
             onChange: action((locale) => {

--- a/packages/page/assets/js/views/PageList/tests/PageList.test.js
+++ b/packages/page/assets/js/views/PageList/tests/PageList.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {extendObservable as mockExtendObservable, observable} from 'mobx';
 import {mount} from 'enzyme';
-import {Router} from 'sulu-admin-bundle/services';
+import {Route, Router} from 'sulu-admin-bundle/services';
 import {findWithHighOrderFunction, defaultWebspace} from 'sulu-admin-bundle/utils/TestHelper';
 
 jest.mock('sulu-admin-bundle/containers', () => ({
@@ -95,7 +95,7 @@ jest.mock('sulu-admin-bundle/containers/List/stores/ListStore', () => jest.fn(fu
 }));
 jest.mock('sulu-admin-bundle/containers/ListOverlay', () => jest.fn().mockReturnValue(null));
 
-jest.mock('sulu-website-bundle/containers/CacheClearToolbarAction', () => jest.fn(function() {
+jest.mock('sulu-website-bundle/views/toolbarActions/CacheClearToolbarAction', () => jest.fn(function() {
     this.getNode = jest.fn();
     this.getToolbarItemConfig = jest.fn();
 }));
@@ -120,9 +120,12 @@ test('Render PageList', () => {
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {},
-    };
+    });
 
     const webspaceOverview = mount(
         <PageList
@@ -168,9 +171,12 @@ test('Should show loader if available page types have not been loaded yet', () =
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {},
-    };
+    });
 
     const webspaceOverview = mount(
         <PageList
@@ -208,9 +214,12 @@ test('Should show the locales from the webspace configuration for the toolbar', 
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {},
-    };
+    });
 
     const webspaceOverview = mount(
         <PageList
@@ -255,9 +264,12 @@ test('Should change excludeGhostsAndShadows when value of toggler is changed', (
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {},
-    };
+    });
 
     const webspaceOverview = mount(
         <PageList
@@ -313,9 +325,12 @@ test('Should set webspace if copied page is in different webspace than the sourc
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {},
-    };
+    });
 
     const webspaceOverview = mount(
         <PageList
@@ -339,7 +354,7 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
     const viewToolbarActionRegistry = require('sulu-admin-bundle/views').viewToolbarActionRegistry;
     const PageList = require('../PageList').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, PageList);
-    const CacheClearToolbarAction = require('sulu-website-bundle/containers').CacheClearToolbarAction;
+    const CacheClearToolbarAction = require('sulu-website-bundle/views').CacheClearToolbarAction;
     viewToolbarActionRegistry.get.mockReturnValue(CacheClearToolbarAction);
 
     const webspaceKey = observable.box('sulu');
@@ -355,7 +370,10 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {
             toolbarActions: [
                 {
@@ -364,7 +382,7 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
                 },
             ],
         },
-    };
+    });
 
     const pageList = mount(
         <PageList
@@ -423,9 +441,12 @@ test('Destroy ListStore to avoid many requests and reset active to be set on web
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {},
-    };
+    });
 
     const webspaceOverview = mount(
         <PageList
@@ -456,9 +477,12 @@ test('Should bind router', () => {
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {},
-    };
+    });
 
     const webspaceOverview = mount(
         <PageList
@@ -492,9 +516,12 @@ test('Should call disposers on unmount', () => {
     router.attributes = {
         webspace: 'sulu',
     };
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_page.page_list',
+        path: '/pages/:locale',
+        type: 'sulu_page.page_list',
         options: {},
-    };
+    });
 
     const webspaceOverview = mount(
         <PageList

--- a/packages/page/assets/js/views/PageList/tests/PageList.test.js
+++ b/packages/page/assets/js/views/PageList/tests/PageList.test.js
@@ -60,6 +60,12 @@ jest.mock('sulu-admin-bundle/containers', () => ({
     withToolbar: jest.fn((Component) => Component),
 }));
 
+jest.mock('sulu-admin-bundle/views', () => ({
+    viewToolbarActionRegistry: {
+        get: jest.fn(),
+    },
+}));
+
 jest.mock('sulu-admin-bundle/containers/List/registries/listAdapterRegistry', () => ({
     get: jest.fn().mockReturnValue(require('sulu-admin-bundle/containers/List/adapters/ColumnListAdapter').default),
     has: jest.fn().mockReturnValue(true),
@@ -114,6 +120,9 @@ test('Render PageList', () => {
     router.attributes = {
         webspace: 'sulu',
     };
+    router.route = {
+        options: {},
+    };
 
     const webspaceOverview = mount(
         <PageList
@@ -159,6 +168,9 @@ test('Should show loader if available page types have not been loaded yet', () =
     router.attributes = {
         webspace: 'sulu',
     };
+    router.route = {
+        options: {},
+    };
 
     const webspaceOverview = mount(
         <PageList
@@ -195,6 +207,9 @@ test('Should show the locales from the webspace configuration for the toolbar', 
     const router = new Router({});
     router.attributes = {
         webspace: 'sulu',
+    };
+    router.route = {
+        options: {},
     };
 
     const webspaceOverview = mount(
@@ -239,6 +254,9 @@ test('Should change excludeGhostsAndShadows when value of toggler is changed', (
     const router = new Router({});
     router.attributes = {
         webspace: 'sulu',
+    };
+    router.route = {
+        options: {},
     };
 
     const webspaceOverview = mount(
@@ -295,6 +313,9 @@ test('Should set webspace if copied page is in different webspace than the sourc
     router.attributes = {
         webspace: 'sulu',
     };
+    router.route = {
+        options: {},
+    };
 
     const webspaceOverview = mount(
         <PageList
@@ -315,9 +336,11 @@ test('Should set webspace if copied page is in different webspace than the sourc
 
 test('Should use CacheClearToolbarAction for cache clearing', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const viewToolbarActionRegistry = require('sulu-admin-bundle/views').viewToolbarActionRegistry;
     const PageList = require('../PageList').default;
     const toolbarFunction = findWithHighOrderFunction(withToolbar, PageList);
     const CacheClearToolbarAction = require('sulu-website-bundle/containers').CacheClearToolbarAction;
+    viewToolbarActionRegistry.get.mockReturnValue(CacheClearToolbarAction);
 
     const webspaceKey = observable.box('sulu');
 
@@ -332,6 +355,16 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
     router.attributes = {
         webspace: 'sulu',
     };
+    router.route = {
+        options: {
+            toolbarActions: [
+                {
+                    type: 'sulu_website.cache_clear',
+                    options: {},
+                },
+            ],
+        },
+    };
 
     const pageList = mount(
         <PageList
@@ -345,7 +378,8 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
 
     const cacheClearToolbarAction: CacheClearToolbarAction = (CacheClearToolbarAction: any).mock.instances[0];
 
-    expect(CacheClearToolbarAction).toHaveBeenCalledWith('sulu');
+    expect(viewToolbarActionRegistry.get).toHaveBeenCalledWith('sulu_website.cache_clear');
+    expect(CacheClearToolbarAction).toHaveBeenCalledWith(router, {});
     expect(cacheClearToolbarAction.getNode).toHaveBeenCalledWith();
 
     expect(cacheClearToolbarAction.getToolbarItemConfig).not.toHaveBeenCalled();
@@ -389,6 +423,9 @@ test('Destroy ListStore to avoid many requests and reset active to be set on web
     router.attributes = {
         webspace: 'sulu',
     };
+    router.route = {
+        options: {},
+    };
 
     const webspaceOverview = mount(
         <PageList
@@ -418,6 +455,9 @@ test('Should bind router', () => {
     const router = new Router({});
     router.attributes = {
         webspace: 'sulu',
+    };
+    router.route = {
+        options: {},
     };
 
     const webspaceOverview = mount(
@@ -451,6 +491,9 @@ test('Should call disposers on unmount', () => {
     const router = new Router({});
     router.attributes = {
         webspace: 'sulu',
+    };
+    router.route = {
+        options: {},
     };
 
     const webspaceOverview = mount(

--- a/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
+++ b/packages/page/src/Infrastructure/Sulu/Admin/PageAdmin.php
@@ -200,6 +200,9 @@ class PageAdmin extends Admin
                     ->setOption('tabTitle', 'sulu_page.pages')
                     ->setOption('tabOrder', 0)
                     ->setOption('tabPriority', 1024)
+                    ->setOption('toolbarActions', [
+                        new ToolbarAction('sulu_website.cache_clear'),
+                    ])
                     ->addRerenderAttribute('webspace')
                     ->setParent(static::WEBSPACE_TABS_VIEW)
             );

--- a/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
@@ -4,8 +4,8 @@ import {action, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import {Button, Dialog, Loader, Table} from 'sulu-admin-bundle/components';
 import {SingleListOverlay, withToolbar} from 'sulu-admin-bundle/containers';
+import {AbstractViewToolbarAction, viewToolbarActionRegistry} from 'sulu-admin-bundle/views';
 import {translate} from 'sulu-admin-bundle/utils';
-import {CacheClearToolbarAction} from 'sulu-website-bundle/containers';
 import Hint from 'sulu-admin-bundle/components/Hint';
 import SnippetAreaStore from './stores/SnippetAreaStore';
 import snippetAreasStyles from './snippetAreas.scss';
@@ -16,7 +16,7 @@ class SnippetAreas extends React.Component<ViewProps> {
     @observable openedAreaKey: ?string = undefined;
     snippetAreaStore: SnippetAreaStore;
     @observable deleteAreaKey: ?string = undefined;
-    cacheClearToolbarAction: CacheClearToolbarAction;
+    toolbarActions: Array<AbstractViewToolbarAction> = [];
 
     constructor(props: ViewProps) {
         super(props);
@@ -33,7 +33,18 @@ class SnippetAreas extends React.Component<ViewProps> {
         }
 
         this.snippetAreaStore = new SnippetAreaStore(webspace);
-        this.cacheClearToolbarAction = new CacheClearToolbarAction(webspace);
+
+        const {toolbarActions = []} = router.route.options;
+        toolbarActions.forEach((toolbarAction) => {
+            this.toolbarActions.push(new (viewToolbarActionRegistry.get(toolbarAction.type))(
+                router,
+                toolbarAction.options
+            ));
+        });
+    }
+
+    componentWillUnmount() {
+        this.toolbarActions.forEach((toolbarAction) => toolbarAction.destroy());
     }
 
     @action handleSnippetClick = (snippetUuid: string) => {
@@ -173,7 +184,7 @@ class SnippetAreas extends React.Component<ViewProps> {
                 >
                     {translate('sulu_admin.delete_warning_text')}
                 </Dialog>
-                {this.cacheClearToolbarAction.getNode()}
+                {this.toolbarActions.map((toolbarAction) => toolbarAction.getNode())}
             </Fragment>
         );
     }
@@ -181,8 +192,8 @@ class SnippetAreas extends React.Component<ViewProps> {
 
 export default withToolbar(SnippetAreas, function() {
     return {
-        items: [
-            this.cacheClearToolbarAction.getToolbarItemConfig(),
-        ].filter(Boolean),
+        items: this.toolbarActions
+            .map((toolbarAction) => toolbarAction.getToolbarItemConfig())
+            .filter((item) => item != null),
     };
 });

--- a/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
@@ -183,6 +183,6 @@ export default withToolbar(SnippetAreas, function() {
     return {
         items: [
             this.cacheClearToolbarAction.getToolbarItemConfig(),
-        ],
+        ].filter(Boolean),
     };
 });

--- a/packages/snippet/assets/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -18,7 +18,7 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
 }));
 jest.mock('../stores/SnippetAreaStore', () => jest.fn());
 
-jest.mock('sulu-website-bundle/containers/CacheClearToolbarAction', () => jest.fn(function() {
+jest.mock('sulu-website-bundle/views/toolbarActions/CacheClearToolbarAction', () => jest.fn(function() {
     this.getNode = jest.fn();
     this.getToolbarItemConfig = jest.fn();
 }));
@@ -272,11 +272,14 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
     const SnippetAreas = require('../SnippetAreas').default;
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
     const toolbarFunction = findWithHighOrderFunction(withToolbar, SnippetAreas);
-    const CacheClearToolbarAction = require('sulu-website-bundle/containers').CacheClearToolbarAction;
+    const CacheClearToolbarAction = require('sulu-website-bundle/views').CacheClearToolbarAction;
     viewToolbarActionRegistry.get.mockReturnValue(CacheClearToolbarAction);
 
     const router = new Router();
-    router.route = {
+    router.route = new Route({
+        name: 'sulu_snippet.snippet_areas',
+        path: '/snippet-areas',
+        type: 'sulu_snippet.snippet_areas',
         options: {
             toolbarActions: [
                 {
@@ -285,7 +288,7 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
                 },
             ],
         },
-    };
+    });
 
     // $FlowFixMe
     SnippetAreaStore.mockImplementation(function() {

--- a/packages/snippet/assets/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -8,6 +8,11 @@ jest.mock('sulu-admin-bundle/containers', () => ({
     SingleListOverlay: jest.fn(() => null),
     withToolbar: jest.fn((Component) => Component),
 }));
+jest.mock('sulu-admin-bundle/views', () => ({
+    viewToolbarActionRegistry: {
+        get: jest.fn(),
+    },
+}));
 jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) =>key),
 }));
@@ -21,6 +26,9 @@ jest.mock('sulu-admin-bundle/services/Router/Router', () => jest.fn(function() {
     this.navigate = jest.fn();
     this.attributes = {
         webspace: 'sulu',
+    };
+    this.route = {
+        options: {},
     };
 }));
 
@@ -260,12 +268,24 @@ test('Navigate when selected default snippet is clicked', () => {
 
 test('Should use CacheClearToolbarAction for cache clearing', () => {
     const withToolbar = require('sulu-admin-bundle/containers').withToolbar;
+    const viewToolbarActionRegistry = require('sulu-admin-bundle/views').viewToolbarActionRegistry;
     const SnippetAreas = require('../SnippetAreas').default;
     const SnippetAreaStore = require('../stores/SnippetAreaStore');
     const toolbarFunction = findWithHighOrderFunction(withToolbar, SnippetAreas);
     const CacheClearToolbarAction = require('sulu-website-bundle/containers').CacheClearToolbarAction;
+    viewToolbarActionRegistry.get.mockReturnValue(CacheClearToolbarAction);
 
     const router = new Router();
+    router.route = {
+        options: {
+            toolbarActions: [
+                {
+                    type: 'sulu_website.cache_clear',
+                    options: {},
+                },
+            ],
+        },
+    };
 
     // $FlowFixMe
     SnippetAreaStore.mockImplementation(function() {
@@ -285,6 +305,8 @@ test('Should use CacheClearToolbarAction for cache clearing', () => {
 
     const cacheClearToolbarAction: CacheClearToolbarAction = (CacheClearToolbarAction: any).mock.instances[0];
 
+    expect(viewToolbarActionRegistry.get).toHaveBeenCalledWith('sulu_website.cache_clear');
+    expect(CacheClearToolbarAction).toHaveBeenCalledWith(router, {});
     expect(cacheClearToolbarAction.getNode).toHaveBeenCalledWith();
 
     expect(cacheClearToolbarAction.getToolbarItemConfig).not.toHaveBeenCalled();

--- a/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAreaAdmin.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAreaAdmin.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Snippet\Infrastructure\Sulu\Admin;
 
 use Sulu\Bundle\AdminBundle\Admin\Admin;
+use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -53,6 +54,9 @@ class SnippetAreaAdmin extends Admin
                 ->setOption('snippetEditView', SnippetAdmin::EDIT_TABS_VIEW)
                 ->setOption('tabTitle', 'sulu_snippet.webspace_default_snippets')
                 ->setOption('tabOrder', 3072)
+                ->setOption('toolbarActions', [
+                    new ToolbarAction('sulu_website.cache_clear'),
+                ])
                 ->setParent(PageAdmin::WEBSPACE_TABS_VIEW)
                 ->addRerenderAttribute('webspace'),
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/index.js
@@ -12,11 +12,14 @@ import List, {
 import AuthorizationConsent from './AuthorizationConsent';
 import Tabs from './Tabs';
 import ResourceTabs from './ResourceTabs';
+import AbstractViewToolbarAction from './toolbarActions/AbstractViewToolbarAction';
+import viewToolbarActionRegistry from './registries/viewToolbarActionRegistry';
 
 export {
     AbstractListItemAction,
     AbstractListToolbarAction,
     AbstractFormToolbarAction,
+    AbstractViewToolbarAction,
     List,
     listItemActionRegistry,
     listToolbarActionRegistry,
@@ -25,4 +28,5 @@ export {
     AuthorizationConsent,
     ResourceTabs,
     Tabs,
+    viewToolbarActionRegistry,
 };

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/registries/viewToolbarActionRegistry.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/registries/viewToolbarActionRegistry.js
@@ -1,0 +1,35 @@
+// @flow
+import AbstractViewToolbarAction from '../toolbarActions/AbstractViewToolbarAction';
+
+class ViewToolbarActionRegistry {
+    toolbarActions: {[name: string]: Class<AbstractViewToolbarAction>} = {};
+
+    constructor() {
+        this.clear();
+    }
+
+    clear() {
+        this.toolbarActions = {};
+    }
+
+    add(name: string, item: Class<AbstractViewToolbarAction>) {
+        if (name in this.toolbarActions) {
+            throw new Error('The key "' + name + '" has already been used for another ToolbarAction!');
+        }
+
+        this.toolbarActions[name] = item;
+    }
+
+    get(name: string) {
+        if (!(name in this.toolbarActions)) {
+            throw new Error(
+                'There is no toolbar item with key "' + name + '" registered!' +
+                '\n\nRegistered keys: ' + Object.keys(this.toolbarActions).sort().join(', ')
+            );
+        }
+
+        return this.toolbarActions[name];
+    }
+}
+
+export default new ViewToolbarActionRegistry();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/tests/registries/viewToolbarActionRegistry.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/tests/registries/viewToolbarActionRegistry.test.js
@@ -1,0 +1,32 @@
+// @flow
+import viewToolbarActionRegistry from '../../registries/viewToolbarActionRegistry';
+import AbstractViewToolbarAction from '../../toolbarActions/AbstractViewToolbarAction';
+
+beforeEach(() => {
+    viewToolbarActionRegistry.clear();
+});
+
+test('Clear all toolbar actions', () => {
+    viewToolbarActionRegistry.add('test1', AbstractViewToolbarAction);
+    expect(Object.keys(viewToolbarActionRegistry.toolbarActions)).toHaveLength(1);
+
+    viewToolbarActionRegistry.clear();
+    expect(Object.keys(viewToolbarActionRegistry.toolbarActions)).toHaveLength(0);
+});
+
+test('Add toolbar action', () => {
+    viewToolbarActionRegistry.add('test1', AbstractViewToolbarAction);
+    viewToolbarActionRegistry.add('test2', AbstractViewToolbarAction);
+
+    expect(viewToolbarActionRegistry.get('test1')).toBe(AbstractViewToolbarAction);
+    expect(viewToolbarActionRegistry.get('test2')).toBe(AbstractViewToolbarAction);
+});
+
+test('Add toolbar action with existing key should throw', () => {
+    viewToolbarActionRegistry.add('test1', AbstractViewToolbarAction);
+    expect(() => viewToolbarActionRegistry.add('test1', AbstractViewToolbarAction)).toThrow(/test1/);
+});
+
+test('Get toolbar action of not existing key', () => {
+    expect(() => viewToolbarActionRegistry.get('XXX')).toThrow();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/toolbarActions/AbstractViewToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/toolbarActions/AbstractViewToolbarAction.js
@@ -1,0 +1,26 @@
+// @flow
+import Router from '../../services/Router';
+import type {ToolbarItemConfig} from '../../containers/Toolbar/types';
+import type {Node} from 'react';
+
+export default class AbstractViewToolbarAction {
+    router: Router;
+    options: {[key: string]: mixed};
+
+    constructor(router: Router, options: {[key: string]: mixed} = {}) {
+        this.router = router;
+        this.options = options;
+    }
+
+    getNode(): Node {
+        return null;
+    }
+
+    getToolbarItemConfig(): ?ToolbarItemConfig<*> {
+        throw new Error('The getToolbarItemConfig method must be implemented by the sub class!');
+    }
+
+    destroy() {
+
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Admin/WebsiteAdmin.php
@@ -70,6 +70,11 @@ class WebsiteAdmin extends Admin
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
             $securityContextKey = self::getAnalyticsSecurityContext($webspace->getKey());
             $webspaceContexts[$securityContextKey] = $this->getSecurityContextPermissions();
+
+            $cacheSecurityContextKey = self::getCacheSecurityContext($webspace->getKey());
+            $webspaceContexts[$cacheSecurityContextKey] = [
+                PermissionTypes::DELETE,
+            ];
         }
 
         return [
@@ -85,6 +90,9 @@ class WebsiteAdmin extends Admin
             self::SULU_ADMIN_SECURITY_SYSTEM => [
                 'Webspaces' => [
                     self::getAnalyticsSecurityContext('#webspace#') => $this->getSecurityContextPermissions(),
+                    self::getCacheSecurityContext('#webspace#') => [
+                        PermissionTypes::DELETE,
+                    ],
                 ],
             ],
         ];
@@ -107,10 +115,20 @@ class WebsiteAdmin extends Admin
 
     public function getConfig(): ?array
     {
+        $webspaceCachePermissions = [];
+        /* @var Webspace $webspace */
+        foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
+            $webspaceCachePermissions[$webspace->getKey()] = $this->securityChecker->hasPermission(
+                self::getCacheSecurityContext($webspace->getKey()),
+                PermissionTypes::DELETE
+            );
+        }
+
         return [
             'endpoints' => [
                 'clearCache' => $this->urlGenerator->generate('sulu_website.cache.remove'),
             ],
+            'webspaceCachePermissions' => $webspaceCachePermissions,
         ];
     }
 
@@ -136,5 +154,13 @@ class WebsiteAdmin extends Admin
     public static function getAnalyticsSecurityContext(string $webspaceKey): string
     {
         return \sprintf('%s%s.%s', PageAdmin::SECURITY_CONTEXT_PREFIX, $webspaceKey, 'analytics');
+    }
+
+    /**
+     * Returns security context for cache clearing in given webspace.
+     */
+    public static function getCacheSecurityContext(string $webspaceKey): string
+    {
+        return \sprintf('%s%s.%s', PageAdmin::SECURITY_CONTEXT_PREFIX, $webspaceKey, 'cache');
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/CacheController.php
@@ -11,11 +11,11 @@
 
 namespace Sulu\Bundle\WebsiteBundle\Controller;
 
+use Sulu\Bundle\WebsiteBundle\Admin\WebsiteAdmin;
 use Sulu\Bundle\WebsiteBundle\Cache\CacheClearerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
-use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -39,10 +39,10 @@ class CacheController
     public function clearAction(Request $request)
     {
         $webspaceKey = $request->query->get('webspaceKey');
-        if ($webspaceKey && !$this->checkLivePermissionForWebspace($webspaceKey)) {
+        if ($webspaceKey && !$this->checkCachePermissionForWebspace($webspaceKey)) {
             return new JsonResponse(null, 403);
         }
-        if (!$webspaceKey && !$this->checkLivePermissionForAllWebspaces()) {
+        if (!$webspaceKey && !$this->checkCachePermissionForAllWebspaces()) {
             return new JsonResponse(null, 403);
         }
 
@@ -58,15 +58,14 @@ class CacheController
 
     /**
      * Check the permissions for all webspaces.
-     * Returns true if the user has live permission in all webspaces.
+     * Returns true if the user has cache permission in all webspaces.
      *
      * @return bool
      */
-    private function checkLivePermissionForAllWebspaces()
+    private function checkCachePermissionForAllWebspaces()
     {
         foreach ($this->webspaceManager->getWebspaceCollection() as $webspace) {
-            $context = PageAdmin::getPageSecurityContext($webspace->getKey());
-            if (!$this->securityChecker->hasPermission($context, PermissionTypes::LIVE)) {
+            if (!$this->checkCachePermissionForWebspace($webspace->getKey())) {
                 return false;
             }
         }
@@ -74,11 +73,11 @@ class CacheController
         return true;
     }
 
-    private function checkLivePermissionForWebspace(string $webspaceKey): bool
+    private function checkCachePermissionForWebspace(string $webspaceKey): bool
     {
         return $this->securityChecker->hasPermission(
-            PageAdmin::getPageSecurityContext($webspaceKey),
-            PermissionTypes::LIVE
+            WebsiteAdmin::getCacheSecurityContext($webspaceKey),
+            PermissionTypes::DELETE
         );
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/DependencyInjection/SuluWebsiteExtension.php
@@ -50,6 +50,17 @@ class SuluWebsiteExtension extends Extension implements PrependExtensionInterfac
             );
         }
 
+        if ($container->hasExtension('doctrine_migrations')) {
+            $container->prependExtensionConfig(
+                'doctrine_migrations',
+                [
+                    'migrations_paths' => [
+                        'Sulu\\Bundle\\WebsiteBundle\\Migrations' => __DIR__ . '/../Migrations',
+                    ],
+                ]
+            );
+        }
+
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
                 'sulu_admin',

--- a/src/Sulu/Bundle/WebsiteBundle/Migrations/Version20260805120000.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Migrations/Version20260805120000.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Cache clearing used to be gated by the LIVE permission on the webspace security context
+ * (`sulu.webspaces.<webspace>`). It is now gated by the DELETE permission on a dedicated
+ * cache security context (`sulu.webspaces.<webspace>.cache`). Grants the new permission to
+ * every role that already had LIVE access, so upgrading does not silently revoke the ability
+ * to clear the cache.
+ */
+final class Version20260805120000 extends AbstractMigration
+{
+    private const LIVE_PERMISSION = 2;
+
+    private const DELETE_PERMISSION = 8;
+
+    public function getDescription(): string
+    {
+        return 'Grant the new webspace cache permission to roles that already had LIVE permission on the webspace';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (!$schema->hasTable('se_permissions')) {
+            return;
+        }
+
+        $rows = $this->connection->createQueryBuilder()
+            ->select('context', 'permissions', 'idRoles')
+            ->from('se_permissions')
+            ->where('context LIKE :prefix')
+            ->andWhere('context NOT LIKE :nested')
+            ->setParameter('prefix', 'sulu.webspaces.%')
+            ->setParameter('nested', 'sulu.webspaces.%.%')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        foreach ($rows as $row) {
+            if (0 === ((int) $row['permissions'] & self::LIVE_PERMISSION)) {
+                continue;
+            }
+
+            $this->grantCachePermission($row['context'] . '.cache', (int) $row['idRoles']);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Not reversible: the DELETE bit added to `<webspace>.cache` contexts cannot be
+        // distinguished from grants an administrator may have added manually since the
+        // upgrade, so removing it here could revoke access that was deliberately granted.
+    }
+
+    private function grantCachePermission(string $context, int $roleId): void
+    {
+        $existing = $this->connection->createQueryBuilder()
+            ->select('id', 'permissions')
+            ->from('se_permissions')
+            ->where('context = :context')
+            ->andWhere('idRoles = :roleId')
+            ->setParameter('context', $context)
+            ->setParameter('roleId', $roleId)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (false === $existing) {
+            $this->connection->createQueryBuilder()
+                ->insert('se_permissions')
+                ->values([
+                    'context' => ':context',
+                    'permissions' => ':permissions',
+                    'idRoles' => ':roleId',
+                ])
+                ->setParameter('context', $context)
+                ->setParameter('permissions', self::DELETE_PERMISSION)
+                ->setParameter('roleId', $roleId)
+                ->executeStatement();
+
+            return;
+        }
+
+        $permissions = (int) $existing['permissions'] | self::DELETE_PERMISSION;
+        if ($permissions === (int) $existing['permissions']) {
+            return;
+        }
+
+        $this->connection->createQueryBuilder()
+            ->update('se_permissions')
+            ->set('permissions', ':permissions')
+            ->where('id = :id')
+            ->setParameter('permissions', $permissions)
+            ->setParameter('id', $existing['id'])
+            ->executeStatement();
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Migrations/Version20260805120000.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Migrations/Version20260805120000.php
@@ -51,11 +51,22 @@ final class Version20260805120000 extends AbstractMigration
             ->fetchAllAssociative();
 
         foreach ($rows as $row) {
-            if (0 === ((int) $row['permissions'] & self::LIVE_PERMISSION)) {
+            $context = $row['context'];
+            $permissions = $row['permissions'];
+            $roleId = $row['idRoles'];
+
+            if (!\is_string($context)
+                || !(\is_int($permissions) || \is_string($permissions))
+                || !(\is_int($roleId) || \is_string($roleId))
+            ) {
                 continue;
             }
 
-            $this->grantCachePermission($row['context'] . '.cache', (int) $row['idRoles']);
+            if (0 === ((int) $permissions & self::LIVE_PERMISSION)) {
+                continue;
+            }
+
+            $this->grantCachePermission($context . '.cache', (int) $roleId);
         }
     }
 
@@ -94,8 +105,17 @@ final class Version20260805120000 extends AbstractMigration
             return;
         }
 
-        $permissions = (int) $existing['permissions'] | self::DELETE_PERMISSION;
-        if ($permissions === (int) $existing['permissions']) {
+        $existingPermissions = $existing['permissions'];
+        $existingId = $existing['id'];
+
+        if (!(\is_int($existingPermissions) || \is_string($existingPermissions))
+            || !(\is_int($existingId) || \is_string($existingId))
+        ) {
+            return;
+        }
+
+        $permissions = (int) $existingPermissions | self::DELETE_PERMISSION;
+        if ($permissions === (int) $existingPermissions) {
             return;
         }
 
@@ -104,7 +124,7 @@ final class Version20260805120000 extends AbstractMigration
             ->set('permissions', ':permissions')
             ->where('id = :id')
             ->setParameter('permissions', $permissions)
-            ->setParameter('id', $existing['id'])
+            ->setParameter('id', (int) $existingId)
             ->executeStatement();
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/CacheClearToolbarAction.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/CacheClearToolbarAction.js
@@ -4,8 +4,10 @@ import {action, observable} from 'mobx';
 import {Dialog} from 'sulu-admin-bundle/components';
 import {Requester} from 'sulu-admin-bundle/services';
 import {buildQueryString, translate} from 'sulu-admin-bundle/utils';
+import {AbstractViewToolbarAction} from 'sulu-admin-bundle/views';
+import type Router from 'sulu-admin-bundle/services/Router';
 
-export default class CacheClearToolbarAction {
+export default class CacheClearToolbarAction extends AbstractViewToolbarAction {
     static clearCacheEndpoint: string;
     static webspaceCachePermissions: {[webspaceKey: string]: boolean};
 
@@ -13,8 +15,10 @@ export default class CacheClearToolbarAction {
     @observable cacheClearing = false;
     @observable showDialog = false;
 
-    constructor(webspaceKey: ?string) {
-        this.webspaceKey = webspaceKey;
+    constructor(router: Router, options: {[key: string]: mixed} = {}) {
+        super(router, options);
+
+        this.webspaceKey = router.attributes.webspace;
     }
 
     hasPermission() {

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/CacheClearToolbarAction.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/CacheClearToolbarAction.js
@@ -7,6 +7,7 @@ import {buildQueryString, translate} from 'sulu-admin-bundle/utils';
 
 export default class CacheClearToolbarAction {
     static clearCacheEndpoint: string;
+    static webspaceCachePermissions: {[webspaceKey: string]: boolean};
 
     webspaceKey: ?string;
     @observable cacheClearing = false;
@@ -14,6 +15,16 @@ export default class CacheClearToolbarAction {
 
     constructor(webspaceKey: ?string) {
         this.webspaceKey = webspaceKey;
+    }
+
+    hasPermission() {
+        if (!this.webspaceKey) {
+            return true;
+        }
+
+        const {webspaceCachePermissions} = CacheClearToolbarAction;
+
+        return !!webspaceCachePermissions && !!webspaceCachePermissions[this.webspaceKey];
     }
 
     getNode() {
@@ -36,6 +47,10 @@ export default class CacheClearToolbarAction {
     }
 
     getToolbarItemConfig() {
+        if (!this.hasPermission()) {
+            return undefined;
+        }
+
         return {
             icon: 'su-paint',
             label: translate('sulu_website.cache_clear'),

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/index.js
@@ -1,4 +1,0 @@
-// @flow
-import CacheClearToolbarAction from './CacheClearToolbarAction';
-
-export default CacheClearToolbarAction;

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/tests/CacheClearToolbarAction.test.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/tests/CacheClearToolbarAction.test.js
@@ -11,8 +11,12 @@ jest.mock('sulu-admin-bundle/utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
 
+jest.mock('sulu-admin-bundle/views', () => ({
+    AbstractViewToolbarAction: require('sulu-admin-bundle/views/toolbarActions/AbstractViewToolbarAction').default,
+}));
+
 test('Return item config with correct icon, type and label and return closed dialog', () => {
-    const cacheClearToolbarAction = new CacheClearToolbarAction();
+    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {}});
 
     expect(cacheClearToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
         icon: 'su-paint',
@@ -32,7 +36,7 @@ test('Return item config with correct icon, type and label and return closed dia
 
 test('Open dialog on toolbar item click', () => {
     CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': true};
-    const cacheClearToolbarAction = new CacheClearToolbarAction('sulu-io');
+    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {webspace: 'sulu-io'}});
 
     const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
     toolbarItemConfig.onClick();
@@ -44,7 +48,7 @@ test('Open dialog on toolbar item click', () => {
 });
 
 test('Close dialog on cancel click', () => {
-    const cacheClearToolbarAction = new CacheClearToolbarAction();
+    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {}});
 
     const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
     toolbarItemConfig.onClick();
@@ -62,7 +66,7 @@ test('Close dialog on cancel click', () => {
 });
 
 test('Call delete when dialog is confirmed', () => {
-    const cacheClearToolbarAction = new CacheClearToolbarAction();
+    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {}});
     CacheClearToolbarAction.clearCacheEndpoint = '/cache';
 
     const deletePromise = Promise.resolve();
@@ -94,14 +98,14 @@ test('Call delete when dialog is confirmed', () => {
 
 test('Return no item config when user has no cache permission for webspace', () => {
     CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': false};
-    const cacheClearToolbarAction = new CacheClearToolbarAction('sulu-io');
+    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {webspace: 'sulu-io'}});
 
     expect(cacheClearToolbarAction.getToolbarItemConfig()).toEqual(undefined);
 });
 
 test('Call delete when dialog is confirmed with query parameter', () => {
     CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': true};
-    const cacheClearToolbarAction = new CacheClearToolbarAction('sulu-io');
+    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {webspace: 'sulu-io'}});
     CacheClearToolbarAction.clearCacheEndpoint = '/cache';
 
     const deletePromise = Promise.resolve();

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/tests/CacheClearToolbarAction.test.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/tests/CacheClearToolbarAction.test.js
@@ -31,6 +31,7 @@ test('Return item config with correct icon, type and label and return closed dia
 });
 
 test('Open dialog on toolbar item click', () => {
+    CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': true};
     const cacheClearToolbarAction = new CacheClearToolbarAction('sulu-io');
 
     const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
@@ -91,7 +92,15 @@ test('Call delete when dialog is confirmed', () => {
     });
 });
 
+test('Return no item config when user has no cache permission for webspace', () => {
+    CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': false};
+    const cacheClearToolbarAction = new CacheClearToolbarAction('sulu-io');
+
+    expect(cacheClearToolbarAction.getToolbarItemConfig()).toEqual(undefined);
+});
+
 test('Call delete when dialog is confirmed with query parameter', () => {
+    CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': true};
     const cacheClearToolbarAction = new CacheClearToolbarAction('sulu-io');
     CacheClearToolbarAction.clearCacheEndpoint = '/cache';
 

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/index.js
@@ -1,4 +1,1 @@
 // @flow
-import CacheClearToolbarAction from './CacheClearToolbarAction';
-
-export {CacheClearToolbarAction};

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/index.js
@@ -6,6 +6,7 @@ import AnalyticsDomainSelect from './containers/Form/fields/AnalyticsDomainSelec
 
 initializer.addUpdateConfigHook('sulu_website', (config: Object) => {
     CacheClearToolbarAction.clearCacheEndpoint = config.endpoints.clearCache;
+    CacheClearToolbarAction.webspaceCachePermissions = config.webspaceCachePermissions;
 });
 
 fieldRegistry.add('analytics_domain_select', AnalyticsDomainSelect);

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/index.js
@@ -2,7 +2,7 @@
 import {initializer} from 'sulu-admin-bundle/services';
 import {fieldRegistry} from 'sulu-admin-bundle/containers';
 import {viewToolbarActionRegistry} from 'sulu-admin-bundle/views';
-import CacheClearToolbarAction from './containers/CacheClearToolbarAction';
+import CacheClearToolbarAction from './views/toolbarActions/CacheClearToolbarAction';
 import AnalyticsDomainSelect from './containers/Form/fields/AnalyticsDomainSelect';
 
 initializer.addUpdateConfigHook('sulu_website', (config: Object) => {

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/index.js
@@ -1,6 +1,7 @@
 // @flow
 import {initializer} from 'sulu-admin-bundle/services';
 import {fieldRegistry} from 'sulu-admin-bundle/containers';
+import {viewToolbarActionRegistry} from 'sulu-admin-bundle/views';
 import CacheClearToolbarAction from './containers/CacheClearToolbarAction';
 import AnalyticsDomainSelect from './containers/Form/fields/AnalyticsDomainSelect';
 
@@ -8,5 +9,7 @@ initializer.addUpdateConfigHook('sulu_website', (config: Object) => {
     CacheClearToolbarAction.clearCacheEndpoint = config.endpoints.clearCache;
     CacheClearToolbarAction.webspaceCachePermissions = config.webspaceCachePermissions;
 });
+
+viewToolbarActionRegistry.add('sulu_website.cache_clear', CacheClearToolbarAction);
 
 fieldRegistry.add('analytics_domain_select', AnalyticsDomainSelect);

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/views/index.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/views/index.js
@@ -1,0 +1,4 @@
+// @flow
+import CacheClearToolbarAction from './toolbarActions/CacheClearToolbarAction';
+
+export {CacheClearToolbarAction};

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/views/toolbarActions/CacheClearToolbarAction.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/views/toolbarActions/CacheClearToolbarAction.js
@@ -18,7 +18,8 @@ export default class CacheClearToolbarAction extends AbstractViewToolbarAction {
     constructor(router: Router, options: {[key: string]: mixed} = {}) {
         super(router, options);
 
-        this.webspaceKey = router.attributes.webspace;
+        const {webspace} = router.attributes;
+        this.webspaceKey = typeof webspace === 'string' ? webspace : undefined;
     }
 
     hasPermission() {

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/js/views/toolbarActions/tests/CacheClearToolbarAction.test.js
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/js/views/toolbarActions/tests/CacheClearToolbarAction.test.js
@@ -1,10 +1,14 @@
 // @flow
 import {shallow} from 'enzyme';
-import {Requester} from 'sulu-admin-bundle/services';
+import {Requester, Router} from 'sulu-admin-bundle/services';
 import CacheClearToolbarAction from '../CacheClearToolbarAction';
 
 jest.mock('sulu-admin-bundle/services/Requester', () => ({
     delete: jest.fn(),
+}));
+
+jest.mock('sulu-admin-bundle/services/Router/Router', () => jest.fn(function(attributes) {
+    this.attributes = attributes || {};
 }));
 
 jest.mock('sulu-admin-bundle/utils/Translator', () => ({
@@ -16,7 +20,7 @@ jest.mock('sulu-admin-bundle/views', () => ({
 }));
 
 test('Return item config with correct icon, type and label and return closed dialog', () => {
-    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {}});
+    const cacheClearToolbarAction = new CacheClearToolbarAction(new Router({}));
 
     expect(cacheClearToolbarAction.getToolbarItemConfig()).toEqual(expect.objectContaining({
         icon: 'su-paint',
@@ -36,9 +40,12 @@ test('Return item config with correct icon, type and label and return closed dia
 
 test('Open dialog on toolbar item click', () => {
     CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': true};
-    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {webspace: 'sulu-io'}});
+    const cacheClearToolbarAction = new CacheClearToolbarAction(new Router({webspace: 'sulu-io'}));
 
     const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
     toolbarItemConfig.onClick();
 
     const element = shallow(cacheClearToolbarAction.getNode());
@@ -48,9 +55,12 @@ test('Open dialog on toolbar item click', () => {
 });
 
 test('Close dialog on cancel click', () => {
-    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {}});
+    const cacheClearToolbarAction = new CacheClearToolbarAction(new Router({}));
 
     const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
     toolbarItemConfig.onClick();
 
     let element = shallow(cacheClearToolbarAction.getNode());
@@ -66,13 +76,16 @@ test('Close dialog on cancel click', () => {
 });
 
 test('Call delete when dialog is confirmed', () => {
-    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {}});
+    const cacheClearToolbarAction = new CacheClearToolbarAction(new Router({}));
     CacheClearToolbarAction.clearCacheEndpoint = '/cache';
 
     const deletePromise = Promise.resolve();
     Requester.delete.mockReturnValue(deletePromise);
 
     const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
     toolbarItemConfig.onClick();
 
     let element = shallow(cacheClearToolbarAction.getNode());
@@ -98,20 +111,23 @@ test('Call delete when dialog is confirmed', () => {
 
 test('Return no item config when user has no cache permission for webspace', () => {
     CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': false};
-    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {webspace: 'sulu-io'}});
+    const cacheClearToolbarAction = new CacheClearToolbarAction(new Router({webspace: 'sulu-io'}));
 
     expect(cacheClearToolbarAction.getToolbarItemConfig()).toEqual(undefined);
 });
 
 test('Call delete when dialog is confirmed with query parameter', () => {
     CacheClearToolbarAction.webspaceCachePermissions = {'sulu-io': true};
-    const cacheClearToolbarAction = new CacheClearToolbarAction({attributes: {webspace: 'sulu-io'}});
+    const cacheClearToolbarAction = new CacheClearToolbarAction(new Router({webspace: 'sulu-io'}));
     CacheClearToolbarAction.clearCacheEndpoint = '/cache';
 
     const deletePromise = Promise.resolve();
     Requester.delete.mockReturnValue(deletePromise);
 
     const toolbarItemConfig = cacheClearToolbarAction.getToolbarItemConfig();
+    if (!toolbarItemConfig) {
+        throw new Error('The toolbarItemConfig should be a value!');
+    }
     toolbarItemConfig.onClick();
 
     let element = shallow(cacheClearToolbarAction.getNode());

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/CacheControllerTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Controller/CacheControllerTest.php
@@ -18,7 +18,7 @@ use Sulu\Bundle\SecurityBundle\Entity\Role;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Bundle\SecurityBundle\Entity\UserRole;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
-use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
+use Sulu\Bundle\WebsiteBundle\Admin\WebsiteAdmin;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class CacheControllerTest extends SuluTestCase
@@ -61,7 +61,7 @@ class CacheControllerTest extends SuluTestCase
         $entityManager->persist($role);
 
         $suluWebspacePermission = new Permission();
-        $suluWebspacePermission->setContext(PageAdmin::getPageSecurityContext('sulu_io'));
+        $suluWebspacePermission->setContext(WebsiteAdmin::getCacheSecurityContext('sulu_io'));
         $suluWebspacePermission->setPermissions(127);
         $suluWebspacePermission->setRole($role);
         $role->addPermission($suluWebspacePermission);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adds a new webspace permission that determines whether a role can clear the webspace cache or not.

#### Why?
3.1 feature

#### Example Usage

Enable / Disable the permission in the Admin UI
<img width="1178" height="277" alt="image" src="https://github.com/user-attachments/assets/2ce4deac-d26b-442b-a4e7-52709c4c12a1" />
