### PR TITLE
Add conflict to doctrine/orm 3.6.8 and 3.7.x-dev version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,6 +161,7 @@
     },
     "conflict": {
         "doctrine/doctrine-bundle": "2.13.1 || 2.13.x-dev || 2.14.x-dev",
+        "doctrine/orm": "3.6.8 || 3.7.x-dev",
         "jms/serializer-bundle": "4.1.0",
         "oro/doctrine-extensions": "2.0.3 || 2.0.4",
         "php-http/discovery": "< 1.8.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? |  yes
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/doctrine/orm/issues/12547, https://github.com/symfony/symfony/pull/64389, https://github.com/symfony/symfony/pull/65169, https://github.com/doctrine/orm/issues/12549
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add conflict to current 3.6.8 and 3.7.0-dev version.

#### Why?

Most of the CI jobs are currently failing because of last doctrine release.
