### PR TITLE
Add requirement for symfony doctrine-bridge

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -98,6 +98,7 @@ return $config
             'nyholm/psr7', // required for faster fos http cache clearing
             'symfony/css-selector', // kept for future usage
             'symfony/proxy-manager-bridge', // can only be removed when min symfony version is 6.2
+            'symfony/doctrine-bridge', // install no unsupported Symfony version doctrine bridge
             'symfony/yaml', // we use yaml configurations
         ],
         [ErrorType::UNUSED_DEPENDENCY],

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
         "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
+        "symfony/doctrine-bridge": "^5.4 || ^6.0 || ^7.0",
         "symfony/dom-crawler": "^5.4 || ^6.0 || ^7.0",
         "symfony/error-handler": "^5.4 || ^6.0 || ^7.0",
         "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Add requirement for symfony doctrine-bridge.

#### Why?

Even we use no classes of doctrine bridge ourselves currently even we do not support any Symfony 8 packages weget the Symfony 8 doctrine bridge. This did the last times make some unexpected issues. So we are require the doctrine bridge version to keep it consistent.
