### PR TITLE
Upgrade Category Bundle Request::get calls to specific Request ParameterBags and remove unused 'meta'  in CategoryController

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6919,12 +6919,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Controller\\CategoryController\:\:getRequestParameter\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\CategoryBundle\\Controller\\CategoryController\:\:initializeListBuilder\(\) has parameter \$locale with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -7069,24 +7063,6 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
 
 		-
-			message: '#^Parameter \#1 \$key of method Sulu\\Bundle\\CategoryBundle\\Category\\CategoryManagerInterface\:\:findByKey\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
-
-		-
-			message: '#^Parameter \#1 \$parentKey of method Sulu\\Bundle\\CategoryBundle\\Category\\CategoryManagerInterface\:\:findChildrenByParentKey\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
-
-		-
-			message: '#^Parameter \#2 \$array of function array_key_exists expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
-
-		-
 			message: '#^Parameter \#2 \$categories of class Sulu\\Bundle\\CategoryBundle\\Api\\RootCategory constructor expects array, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7099,25 +7075,13 @@ parameters:
 			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
 
 		-
-			message: '#^Parameter \#2 \$locale of method Sulu\\Bundle\\CategoryBundle\\Category\\CategoryManagerInterface\:\:getApiObject\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#2 \$locale of method Sulu\\Bundle\\CategoryBundle\\Category\\CategoryManagerInterface\:\:getApiObject\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
 
 		-
 			message: '#^Parameter \#2 \$parent of method Sulu\\Bundle\\CategoryBundle\\Category\\CategoryManagerInterface\:\:move\(\) expects int\|null, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -31425,19 +31389,13 @@ parameters:
 		-
 			message: '#^Cannot access property \$query on Symfony\\Component\\HttpFoundation\\Request\|null\.$#'
 			identifier: property.nonObject
-			count: 5
-			path: src/Sulu/Component/Category/Request/CategoryRequestHandler.php
-
-		-
-			message: '#^Cannot call method get\(\) on Symfony\\Component\\HttpFoundation\\Request\|null\.$#'
-			identifier: method.nonObject
-			count: 3
+			count: 2
 			path: src/Sulu/Component/Category/Request/CategoryRequestHandler.php
 
 		-
 			message: '#^Cannot call method getPathInfo\(\) on Symfony\\Component\\HttpFoundation\\Request\|null\.$#'
 			identifier: method.nonObject
-			count: 5
+			count: 2
 			path: src/Sulu/Component/Category/Request/CategoryRequestHandler.php
 
 		-
@@ -31491,7 +31449,7 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 4
+			count: 1
 			path: src/Sulu/Component/Category/Request/CategoryRequestHandler.php
 
 		-

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -26,7 +26,6 @@ use Sulu\Component\Rest\ListBuilder\FieldDescriptorInterface;
 use Sulu\Component\Rest\ListBuilder\ListBuilderInterface;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
 use Sulu\Component\Rest\ListBuilder\PaginatedRepresentation;
-use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Rest\RestHelperInterface;
 use Sulu\Component\Security\SecuredControllerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,8 +37,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class CategoryController extends AbstractRestController implements SecuredControllerInterface
 {
-    use RequestParametersTrait;
-
     /**
      * @param class-string $categoryClass
      */
@@ -58,7 +55,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
 
     public function getAction($id, Request $request)
     {
-        $locale = $this->getRequestParameter($request, 'locale', true);
+        $locale = $this->getLocale($request) ?: throw new MissingParameterException(self::class, 'locale');
         $findCallback = function($id) use ($locale) {
             $entity = $this->categoryManager->findById($id);
 
@@ -72,7 +69,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
 
     public function cgetAction(Request $request)
     {
-        $locale = $this->getRequestParameter($request, 'locale', true);
+        $locale = $this->getLocale($request) ?: throw new MissingParameterException(self::class, 'locale');
         $rootKey = $request->query->get('rootKey');
         $parentId = $request->query->get('parentId');
         $includeRoot = $request->query->getBoolean('includeRoot');
@@ -127,7 +124,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
 
     private function move($id, Request $request)
     {
-        $destination = $this->getRequestParameter($request, 'destination', true);
+        $destination = $request->query->get('destination' ?: throw new MissingParameterException(self::class, 'destination'));
         if ('root' === $destination) {
             $destination = null;
         }
@@ -171,7 +168,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
     protected function saveCategory(Request $request, $id = null, $patch = false)
     {
         $payload = $request->getPayload();
-        $mediasData = $payload->get('medias');
+        $mediasData = $payload->all('medias');
         $medias = null;
         if ($mediasData && \array_key_exists('ids', $mediasData)) {
             $medias = $mediasData['ids'];
@@ -184,7 +181,6 @@ class CategoryController extends AbstractRestController implements SecuredContro
             'description' => (empty($payload->get('description'))) ? null : $payload->get('description'),
             'medias' => $medias,
             'key' => (empty($payload->get('key'))) ? null : $payload->get('key'),
-            'meta' => $payload->get('meta'),
             'parent' => $payload->get('parentId'),
         ];
         $entity = $this->categoryManager->save($data, null, $locale, $patch);

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -73,18 +73,18 @@ class CategoryController extends AbstractRestController implements SecuredContro
     public function cgetAction(Request $request)
     {
         $locale = $this->getRequestParameter($request, 'locale', true);
-        $rootKey = $request->get('rootKey');
-        $parentId = $request->get('parentId');
-        $includeRoot = $this->getBooleanRequestParameter($request, 'includeRoot', false, false);
+        $rootKey = $request->query->get('rootKey');
+        $parentId = $request->query->get('parentId');
+        $includeRoot = $request->query->getBoolean('includeRoot');
 
         if ('root' === $parentId) {
             $includeRoot = false;
             $parentId = null;
         }
 
-        if ('true' == $request->get('flat')) {
+        if ('true' == $request->query->get('flat')) {
             $rootId = ($rootKey) ? $this->categoryManager->findByKey($rootKey)->getId() : null;
-            $expandedIds = \array_filter(\explode(',', $request->get('expandedIds', $request->get('selectedIds', $request->query->get('ids', '')))));
+            $expandedIds = \array_filter(\explode(',', $request->query->getString('expandedIds', $request->query->getString('selectedIds', $request->query->get('ids', '')))));
             $defaultSort = !$request->query->has('sortBy');
             $list = $this->getListRepresentation(
                 $request,
@@ -135,7 +135,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
         $category = $this->categoryManager->move($id, $destination);
 
         return $this->handleView($this->view(
-            $this->categoryManager->getApiObject($category, $request->get('locale')))
+            $this->categoryManager->getApiObject($category, $this->getLocale($request)))
         );
     }
 
@@ -170,21 +170,22 @@ class CategoryController extends AbstractRestController implements SecuredContro
      */
     protected function saveCategory(Request $request, $id = null, $patch = false)
     {
-        $mediasData = $request->get('medias');
+        $payload = $request->getPayload();
+        $mediasData = $payload->get('medias');
         $medias = null;
         if ($mediasData && \array_key_exists('ids', $mediasData)) {
             $medias = $mediasData['ids'];
         }
 
-        $locale = $this->getRequestParameter($request, 'locale', true);
+        $locale = $this->getLocale($request) ?: throw new MissingParameterException(self::class, 'locale');
         $data = [
             'id' => $id,
-            'name' => (empty($request->get('name'))) ? null : $request->get('name'),
-            'description' => (empty($request->get('description'))) ? null : $request->get('description'),
+            'name' => (empty($payload->get('name'))) ? null : $payload->get('name'),
+            'description' => (empty($payload->get('description'))) ? null : $payload->get('description'),
             'medias' => $medias,
-            'key' => (empty($request->get('key'))) ? null : $request->get('key'),
-            'meta' => $request->get('meta'),
-            'parent' => $request->get('parentId'),
+            'key' => (empty($payload->get('key'))) ? null : $payload->get('key'),
+            'meta' => $payload->get('meta'),
+            'parent' => $payload->get('parentId'),
         ];
         $entity = $this->categoryManager->save($data, null, $locale, $patch);
         $category = $this->categoryManager->getApiObject($entity, $locale);
@@ -232,7 +233,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
             );
         }
 
-        $search = $request->get('search');
+        $search = $request->query->get('search');
 
         if (!$search) {
             // expand collected parents if search is not set

--- a/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
+++ b/src/Sulu/Bundle/CategoryBundle/Controller/CategoryController.php
@@ -81,7 +81,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
 
         if ('true' == $request->query->get('flat')) {
             $rootId = ($rootKey) ? $this->categoryManager->findByKey($rootKey)->getId() : null;
-            $expandedIds = \array_filter(\explode(',', $request->query->getString('expandedIds', $request->query->getString('selectedIds', $request->query->get('ids', '')))));
+            $expandedIds = \array_filter(\explode(',', $request->query->getString('expandedIds', $request->query->getString('selectedIds', $request->query->getString('ids', '')))));
             $defaultSort = !$request->query->has('sortBy');
             $list = $this->getListRepresentation(
                 $request,
@@ -93,7 +93,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
                 $defaultSort
             );
         } elseif ($request->query->has('ids')) {
-            $ids = \array_filter(\explode(',', $request->query->get('ids')));
+            $ids = \array_filter(\explode(',', $request->query->getString('ids')));
             $entities = $this->categoryManager->findByIds($ids);
             $categories = $this->categoryManager->getApiObjects($entities, $locale);
             $list = new CollectionRepresentation($categories, CategoryInterface::RESOURCE_KEY);
@@ -124,7 +124,7 @@ class CategoryController extends AbstractRestController implements SecuredContro
 
     private function move($id, Request $request)
     {
-        $destination = $request->query->get('destination' ?: throw new MissingParameterException(self::class, 'destination'));
+        $destination = $request->query->get('destination') ?: throw new MissingParameterException(self::class, 'destination');
         if ('root' === $destination) {
             $destination = null;
         }

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
@@ -178,17 +178,14 @@ class CategoryTwigExtensionTest extends TestCase
         $category = ['id' => 3, 'name' => 'test'];
 
         $manager = $this->prophesize(CategoryManagerInterface::class);
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $string]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($string);
-        $request->getPathInfo()->willReturn($url);
+        $requestStack = new RequestStack();
+        $request = Request::create($url);
+        $requestStack->push($request);
+        $request->query->set($parameter, $string);
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
-        $requestHandler = new CategoryRequestHandler($requestStack->reveal());
+        $requestHandler = new CategoryRequestHandler($requestStack);
 
         $extension = new CategoryTwigExtension(
             $manager->reveal(),
@@ -224,17 +221,14 @@ class CategoryTwigExtensionTest extends TestCase
         $category = ['id' => 3, 'name' => 'test'];
 
         $manager = $this->prophesize(CategoryManagerInterface::class);
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $string]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($string);
-        $request->getPathInfo()->willReturn($url);
+        $requestStack = new RequestStack();
+        $request = Request::create($url);
+        $requestStack->push($request);
+        $request->query->set($parameter, $string);
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
-        $requestHandler = new CategoryRequestHandler($requestStack->reveal());
+        $requestHandler = new CategoryRequestHandler($requestStack);
 
         $extension = new CategoryTwigExtension(
             $manager->reveal(),
@@ -264,17 +258,14 @@ class CategoryTwigExtensionTest extends TestCase
     public function testClearUrl(string $parameter, string $url, string $string): void
     {
         $manager = $this->prophesize(CategoryManagerInterface::class);
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $string]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($string);
-        $request->getPathInfo()->willReturn($url);
+        $requestStack = new RequestStack();
+        $request = Request::create($url);
+        $requestStack->push($request);
+        $request->query->set($parameter, $string);
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
-        $requestHandler = new CategoryRequestHandler($requestStack->reveal());
+        $requestHandler = new CategoryRequestHandler($requestStack);
 
         $tagExtension = new CategoryTwigExtension(
             $manager->reveal(),

--- a/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
+++ b/src/Sulu/Bundle/CategoryBundle/Tests/Unit/Twig/CategoryTwigExtensionTest.php
@@ -26,7 +26,6 @@ use Sulu\Component\Category\Request\CategoryRequestHandler;
 use Sulu\Component\Category\Request\CategoryRequestHandlerInterface;
 use Sulu\Component\Serializer\ArraySerializerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 

--- a/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
+++ b/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
@@ -12,6 +12,7 @@
 namespace Sulu\Component\Category\Request;
 
 use Symfony\Component\HttpFoundation\RequestStack;
+use Webmozart\Assert\Assert;
 
 /**
  * Handles categories in current request.
@@ -41,6 +42,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
     public function appendCategoryToUrl($category, $categoriesParameter = 'categories')
     {
         $request = $this->requestStack->getCurrentRequest();
+        Assert::notNull($request, 'The CategoryRequestHandler needs a request');
 
         if (!(\is_array($category) && \array_key_exists('id', $category))) {
             return;
@@ -66,6 +68,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
     public function removeCategoryFromUrl($category, $categoriesParameter = 'categories')
     {
         $request = $this->requestStack->getCurrentRequest();
+        Assert::notNull($request, 'The CategoryRequestHandler needs a request');
 
         if (!(\is_array($category) && \array_key_exists('id', $category))) {
             return;
@@ -93,6 +96,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
     public function toggleCategoryInUrl($category, $categoriesParameter = 'categories')
     {
         $request = $this->requestStack->getCurrentRequest();
+        Assert::notNull($request, 'The CategoryRequestHandler needs a request');
 
         if (!(\is_array($category) && \array_key_exists('id', $category))) {
             return;

--- a/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
+++ b/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
@@ -49,7 +49,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
         $id = $category['id'];
 
         // extend comma separated list
-        $categories = $request->get($categoriesParameter, '');
+        $categories = $request->query->get($categoriesParameter, '');
         /** @var array<string> $categoriesArray */
         $categoriesArray = \array_filter(\array_merge(\explode(',', $categories), [$id]));
         $categories = \implode(',', \array_unique($categoriesArray));
@@ -74,7 +74,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
         $id = $category['id'];
 
         // extend comma separated list
-        $categories = $request->get($categoriesParameter, '');
+        $categories = $request->query->get($categoriesParameter, '');
         /** @var array<string> $categoriesArray */
         $categoriesArray = \array_filter(\explode(',', $categories), function($categoryId) use ($id) {
             return $categoryId && $categoryId != $id;
@@ -101,7 +101,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
         $id = $category['id'];
 
         // extend comma separated list
-        $categories = $request->get($categoriesParameter, '');
+        $categories = $request->query->get($categoriesParameter, '');
         $categoriesArray = \explode(',', $categories);
 
         if (\in_array($id, $categoriesArray)) {

--- a/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
+++ b/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
@@ -42,15 +42,12 @@ class CategoryRequestHandlerTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('getProvider')]
     public function testGet($parameter, $queryString, $expected): void
     {
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
+        $requestStack = new RequestStack();
+        $request = Request::create('/');
+        $requestStack->push($request);
+        $request->query->set($parameter, $queryString);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $queryString]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($queryString);
-
-        $handler = new CategoryRequestHandler($requestStack->reveal());
+        $handler = new CategoryRequestHandler($requestStack);
         $result = $handler->getCategories($parameter);
 
         $this->assertEquals($expected, $result);
@@ -81,16 +78,12 @@ class CategoryRequestHandlerTest extends TestCase
     {
         $category = ['id' => 3, 'name' => 'test'];
 
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
+        $requestStack = new RequestStack();
+        $request = Request::create($url);
+        $requestStack->push($request);
+        $request->query->set($parameter, $queryString);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $queryString]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($queryString);
-        $request->getPathInfo()->willReturn($url);
-
-        $handler = new CategoryRequestHandler($requestStack->reveal());
+        $handler = new CategoryRequestHandler($requestStack);
         $result = $handler->appendCategoryToUrl($category, $parameter);
 
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
@@ -121,16 +114,12 @@ class CategoryRequestHandlerTest extends TestCase
     {
         $category = ['id' => 3, 'name' => 'test'];
 
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
+        $requestStack = new RequestStack();
+        $request = Request::create($url);
+        $requestStack->push($request);
+        $request->query->set($parameter, $queryString);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $queryString]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($queryString);
-        $request->getPathInfo()->willReturn($url);
-
-        $handler = new CategoryRequestHandler($requestStack->reveal());
+        $handler = new CategoryRequestHandler($requestStack);
         $result = $handler->removeCategoryFromUrl($category, $parameter);
 
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
@@ -161,16 +150,12 @@ class CategoryRequestHandlerTest extends TestCase
     {
         $category = ['id' => 3, 'name' => 'test'];
 
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
+        $requestStack = new RequestStack();
+        $request = Request::create($url);
+        $requestStack->push($request);
+        $request->query->set($parameter, $queryString);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $queryString]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($queryString);
-        $request->getPathInfo()->willReturn($url);
-
-        $handler = new CategoryRequestHandler($requestStack->reveal());
+        $handler = new CategoryRequestHandler($requestStack);
         $result = $handler->toggleCategoryInUrl($category, $parameter);
 
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
@@ -201,16 +186,12 @@ class CategoryRequestHandlerTest extends TestCase
     {
         $category = ['id' => 3, 'name' => 'test'];
 
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
+        $requestStack = new RequestStack();
+        $request = Request::create($url);
+        $requestStack->push($request);
+        $request->query->set($parameter, $queryString);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $queryString]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($queryString);
-        $request->getPathInfo()->willReturn($url);
-
-        $handler = new CategoryRequestHandler($requestStack->reveal());
+        $handler = new CategoryRequestHandler($requestStack);
         $result = $handler->setCategoryToUrl($category, $parameter);
 
         $this->assertEquals($url . '?' . $parameter . '=' . \urlencode($expected), $result);
@@ -237,16 +218,12 @@ class CategoryRequestHandlerTest extends TestCase
     #[\PHPUnit\Framework\Attributes\DataProvider('removeProvider')]
     public function testRemoveFromUrl($parameter, $url, $queryString): void
     {
-        $requestStack = $this->prophesize(RequestStack::class);
-        $request = $this->prophesize(Request::class);
+        $requestStack = new RequestStack();
+        $request = Request::create($url);
+        $requestStack->push($request);
+        $request->query->set($parameter, $queryString);
 
-        $requestReveal = $request->reveal();
-        $requestReveal->query = new InputBag([$parameter => $queryString]);
-        $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($parameter, '')->willReturn($queryString);
-        $request->getPathInfo()->willReturn($url);
-
-        $handler = new CategoryRequestHandler($requestStack->reveal());
+        $handler = new CategoryRequestHandler($requestStack);
         $result = $handler->removeCategoriesFromUrl($parameter);
 
         $this->assertEquals($url, $result);

--- a/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
+++ b/src/Sulu/Component/Category/Tests/Unit/Request/CategoryRequestHandlerTest.php
@@ -14,7 +14,6 @@ namespace Sulu\Component\Category\Tests\Unit\Request;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Category\Request\CategoryRequestHandler;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no 
| BC breaks? | yes technically
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/issues/8216
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Upgrade Category Bundle Request::get calls to specific Request ParameterBags - #8980

#### Why?

Required for the Symfony 8 upgrade.