### PR TITLE
Inject UrlGenerator

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1740,7 +1740,6 @@ Removed unused arguments:
 
 - `Sulu\Component\Webspace\Analyzer\Attributes\WebsiteRequestProcessor::__construct` `$contentMapper` (2nd argument) removed
 - `Sulu\Bundle\SecurityBundle\UserManager\UserManager::__construct` `$groupRepository` (4th argument) removed
-- `Sulu\Bundle\SecurityBundle\Admin\SecurityAdmin::__construct` `$urlGenerator` (3rd argument) removed
 - `Sulu\Bundle\ContactBundle\Controller\ContactController::__construct` `$contactRepository` (7th argument) removed
 - `Sulu\Bundle\ContactBundle\Controller\ContactController::__construct` `$userRepository` (9th argument) removed
 - `Sulu\Bundle\ContactBundle\Controller\ContactController::__construct` `$suluSecuritySystem` (12th argument) removed

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -24,6 +24,7 @@ use Sulu\Component\Security\Authentication\RoleInterface;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SecurityAdmin extends Admin
@@ -60,6 +61,7 @@ class SecurityAdmin extends Admin
         private TranslatorInterface $translator,
         private AdminPool $adminPool,
         private array $resources,
+        private UrlGeneratorInterface $urlGenerator,
         private bool $twoFactorBackupCodesEnabled = false,
     ) {
     }
@@ -198,7 +200,6 @@ class SecurityAdmin extends Admin
     {
         return [
             'endpoints' => [
-                'contexts' => $this->urlGenerator->generate('sulu_security.cget_security-contexts'),
                 'twoFactorSetup' => $this->urlGenerator->generate('sulu_security.post_profile_two-factor_setup'),
                 'twoFactorConfirm' => $this->urlGenerator->generate('sulu_security.post_profile_two-factor_confirm'),
                 'twoFactorBackupCodes' => $this->urlGenerator->generate('sulu_security.post_profile_two-factor_backup-codes'),

--- a/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
+++ b/src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
@@ -58,10 +58,10 @@ class SecurityAdmin extends Admin
     public function __construct(
         private ViewBuilderFactoryInterface $viewBuilderFactory,
         private SecurityCheckerInterface $securityChecker,
+        private UrlGeneratorInterface $urlGenerator,
         private TranslatorInterface $translator,
         private AdminPool $adminPool,
         private array $resources,
-        private UrlGeneratorInterface $urlGenerator,
         private bool $twoFactorBackupCodesEnabled = false,
     ) {
     }

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.php
@@ -96,6 +96,7 @@ return static function(ContainerConfigurator $container) {
             new Reference('translator'),
             new Reference('sulu_admin.admin_pool'),
             '%sulu_admin.resources%',
+            new Reference('router'),
             '%sulu_security.two_factor_backup_codes_enabled%',
         ])
         ->tag('sulu.admin')

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.php
@@ -93,10 +93,10 @@ return static function(ContainerConfigurator $container) {
         ->args([
             new Reference(ViewBuilderFactoryInterface::class),
             new Reference('sulu_security.security_checker'),
+            new Reference('router'),
             new Reference('translator'),
             new Reference('sulu_admin.admin_pool'),
             '%sulu_admin.resources%',
-            new Reference('router'),
             '%sulu_security.two_factor_backup_codes_enabled%',
         ])
         ->tag('sulu.admin')


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes
| Related issues/PRs | 
| License | MIT
| Documentation PR | -

#### What's in this PR?

add back the UrlGenerator to the SecurityAdmin

#### Why?
there is no UrlGenerator in the SecurityAdmin anymore on 3.0, but is still needed for the new TOTP functionality, so we need to add it again

#### Example Usage

