### PR TITLE
Make DATABASE_URL consistent for core tests

### DIFF
--- a/.env
+++ b/.env
@@ -35,7 +35,7 @@ LOCK_DSN=semaphore
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 # DATABASE_URL="postgresql://symfony:ChangeMe@127.0.0.1:5432/app?serverVersion=13&charset=utf8"
-DATABASE_URL="mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.0.27&charset=utf8mb4"
+DATABASE_URL="mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4"
 ###< doctrine/doctrine-bundle ###
 
 ###> sulu/sulu ###

--- a/packages/article/tests/Application/.env
+++ b/packages/article/tests/Application/.env
@@ -1,2 +1,2 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4

--- a/packages/content/tests/Application/.env
+++ b/packages/content/tests/Application/.env
@@ -1,2 +1,2 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4

--- a/packages/custom-url/tests/Application/.env
+++ b/packages/custom-url/tests/Application/.env
@@ -1,2 +1,2 @@
 APP_ENV=test
-DATABASE_URL="mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4"
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4

--- a/packages/page/tests/Application/.env
+++ b/packages/page/tests/Application/.env
@@ -1,2 +1,2 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4

--- a/packages/route/tests/Application/.env
+++ b/packages/route/tests/Application/.env
@@ -1,2 +1,2 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4

--- a/packages/search/tests/Application/.env
+++ b/packages/search/tests/Application/.env
@@ -1,3 +1,3 @@
 APP_ENV=test
 SEAL_DSN=memory://
-DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4

--- a/packages/snippet/tests/Application/.env
+++ b/packages/snippet/tests/Application/.env
@@ -1,2 +1,2 @@
 APP_ENV=test
-DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu_test?serverVersion=5.7&charset=utf8mb4
+DATABASE_URL=mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4

--- a/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
+++ b/src/Sulu/Bundle/TestBundle/Resources/app/config/sulu.yml
@@ -1,6 +1,6 @@
 parameters:
     # Fallback values (used if environmental variables are not set)
-    env(DATABASE_URL): mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.0&charset=utf8mb4
+    env(DATABASE_URL): mysql://root:ChangeMe@127.0.0.1:3306/sulu?serverVersion=8.4.11&charset=utf8mb4
 
 framework:
     secret: secret


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes (only for contributers)
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Make DATABASE_URL consistent so all use `sulu` database when test are run.

#### Why?

Currently the `packages` bundle did configure `sulu_test` which did end with the postfix in `sulu_test_test` and the old core bundles just did use `sulu` which was `sulu_test`. So if tests where run without defining a `DATABASE_URL` it ended up that the database was maybe not created for the old bundles which is annoying for contributers.