### PR TITLE
Remove not longer required doctrine/orm conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,7 +161,7 @@
     },
     "conflict": {
         "doctrine/doctrine-bundle": "2.13.1 || 2.13.x-dev || 2.14.x-dev",
-        "doctrine/orm": "3.6.8 || 3.7.x-dev",
+        "doctrine/orm": "3.7.x-dev",
         "jms/serializer-bundle": "4.1.0",
         "oro/doctrine-extensions": "2.0.3 || 2.0.4",
         "php-http/discovery": "< 1.8.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no 
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | https://github.com/sulu/sulu/pull/8974
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Remove not longer required doctrine/orm conflict.

#### Why?

The issue was Symfony related and new Symfony Version 7.4.16 fixed the issue.

The conflict to 3.7.x is not yet fixed see: https://github.com/doctrine/orm/issues/12549