### PR TITLE
Upgrade Media Bundle Request::get calls to specific Request ParameterBags

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/AbstractMediaController.php
@@ -28,10 +28,8 @@ abstract class AbstractMediaController extends AbstractRestController
     protected function getData(Request $request, $fallback = true)
     {
         $data = $request->request->all();
-        $data['locale'] = $request->get('locale', $fallback ? $this->getLocale($request) : null);
-        $data['collection'] = $request->get('collection');
-        $data['title'] = $request->get('title');
-        $data['formats'] = $request->get('formats', []);
+        $data['locale'] = $request->query->get('locale', $fallback ? $this->getLocale($request) : null);
+        $data['collection'] = $request->query->get('collection') ?: $request->getPayload()->get('collection');
 
         return $data;
     }

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -157,7 +157,7 @@ class CollectionController extends AbstractRestController implements SecuredCont
         $sortOrder = $this->listRestHelper->getSortOrder();
         $includeRoot = $request->query->getBoolean('includeRoot');
 
-        $locale = $request->query->get('locale') ?: throw new MissingParameterException(self::class, 'locale');
+        $locale = $this->getLocale($request) ?: throw new MissingParameterException(self::class, 'locale');
 
         if ('root' === $parentId) {
             $includeRoot = false;
@@ -298,7 +298,7 @@ class CollectionController extends AbstractRestController implements SecuredCont
     protected function moveEntity($id, Request $request)
     {
         $destinationId = (int) $request->query->get('destination');
-        $locale = $request->query->get('locale') ?: throw new MissingParameterException(self::class, 'locale');
+        $locale = $this->getLocale($request) ?: throw new MissingParameterException(self::class, 'locale');
 
         $collection = $this->collectionManager->move($id, $locale, $destinationId);
         $view = $this->view($collection);
@@ -320,7 +320,7 @@ class CollectionController extends AbstractRestController implements SecuredCont
             'style' => $request->request->all('style'),
             'type' => $type,
             'parent' => $request->request->get('parent'),
-            'locale' => $request->request->get('locale'),
+            'locale' => $this->getLocale($request),
             'title' => $request->request->get('title'),
             'description' => $request->request->get('description'),
 

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -340,12 +340,12 @@ class CollectionController extends AbstractRestController implements SecuredCont
     protected function saveEntity($id, Request $request)
     {
         /** @var string|null $parent */
-        $parent = $request->query->get('parent') ?? $request->request->get('parent');
+        $parent = $request->request->get('parent');
         $breadcrumb = $request->query->getBoolean('breadcrumb');
 
         $this->checkSystemCollection($id, $parent);
 
-        if (!$request->request->has('locale')) {
+        if (!$request->query->has('locale')) {
             throw new MissingParameterException(self::class, 'locale');
         }
 
@@ -353,7 +353,7 @@ class CollectionController extends AbstractRestController implements SecuredCont
             $data = [
                 ...$this->getData($request),
                 'id' => $id,
-                'locale' => $request->request->get('locale'),
+                'locale' => $request->query->get('locale'),
             ];
 
             $collection = $this->collectionManager->save($data, $this->getUser()->getId(), $breadcrumb);

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -134,7 +134,7 @@ class MediaStreamController
             }
 
             if ($request->query->has('inline')) {
-                $forceInline = $request->query->getBoolean('inline');
+                $forceInline = (bool) $request->query->get('inline', false);
                 $dispositionType = $forceInline ? ResponseHeaderBag::DISPOSITION_INLINE : ResponseHeaderBag::DISPOSITION_ATTACHMENT;
             } else {
                 $dispositionType = $this->dispositionTypeResolver->getByMimeType($fileVersion->getMimeType());

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaStreamController.php
@@ -107,9 +107,9 @@ class MediaStreamController
                 \ob_end_clean();
             }
 
-            $version = $request->get('v', null);
+            $version = $request->query->get('v', null);
             $version = \is_numeric($version) ? ((int) $version) : null;
-            $noCount = $request->get('no-count', false);
+            $noCount = $request->query->get('no-count', false);
 
             $fileVersion = $this->getFileVersion($id, $version);
 
@@ -134,7 +134,7 @@ class MediaStreamController
             }
 
             if ($request->query->has('inline')) {
-                $forceInline = (bool) $request->get('inline', false);
+                $forceInline = $request->query->getBoolean('inline');
                 $dispositionType = $forceInline ? ResponseHeaderBag::DISPOSITION_INLINE : ResponseHeaderBag::DISPOSITION_ATTACHMENT;
             } else {
                 $dispositionType = $this->dispositionTypeResolver->getByMimeType($fileVersion->getMimeType());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -689,9 +689,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'style' => [
                     'type' => 'circle',
                     'color' => $generateColor,
@@ -786,9 +787,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'style' => [
                     'type' => 'circle',
                     'color' => $generateColor,
@@ -902,9 +904,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'style' => [
                     'type' => 'circle',
                     'color' => $generateColor,
@@ -933,9 +936,10 @@ class CollectionControllerTest extends SuluTestCase
     {
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'title' => 'Test Collection 2',
                 'type' => [
                     'id' => $this->collectionType1->getId(),
@@ -1052,7 +1056,9 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
+            '/api/collections?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
             [
                 'style' => [
                     'type' => 'circle',
@@ -1063,7 +1069,6 @@ class CollectionControllerTest extends SuluTestCase
                 ],
                 'title' => 'Test Collection 2',
                 'description' => 'This Description 2 is only for testing',
-                'locale' => 'en-gb',
             ]
         );
 
@@ -1080,7 +1085,9 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $this->collection1->getId(),
+            '/api/collections/' . $this->collection1->getId() . '?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
             [
                 'style' => [
                     'type' => 'circle',
@@ -1091,7 +1098,6 @@ class CollectionControllerTest extends SuluTestCase
                 ],
                 'title' => 'Test Collection changed',
                 'description' => 'This Description is only for testing changed',
-                'locale' => 'en-gb',
             ]
         );
 
@@ -1192,7 +1198,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $childCollection->getId() . '?breadcrumb=true',
+            '/api/collections/' . $childCollection->getId() . '?' . \http_build_query([
+                'locale' => 'en-gb',
+                'breadcrumb' => 'true',
+            ]),
             [
                 'style' => [
                     'type' => 'circle',
@@ -1203,7 +1212,6 @@ class CollectionControllerTest extends SuluTestCase
                 ],
                 'title' => 'Test Child Collection changed',
                 'description' => 'This Description is only for testing changed',
-                'locale' => 'en-gb',
             ]
         );
 
@@ -1227,7 +1235,9 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $childCollection->getId(),
+            '/api/collections/' . $childCollection->getId() . '?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
             [
                 'style' => [
                     'type' => 'circle',
@@ -1236,7 +1246,6 @@ class CollectionControllerTest extends SuluTestCase
                 'type' => ['id' => $this->collectionType1->getId()],
                 'title' => 'Test Child Collection changed',
                 'description' => 'This Description is only for testing changed',
-                'locale' => 'en-gb',
             ]
         );
 
@@ -1262,9 +1271,10 @@ class CollectionControllerTest extends SuluTestCase
         // Test put with only details
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $this->collection1->getId(),
-            [
+            '/api/collections/' . $this->collection1->getId() . '?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'style' => [
                     'type' => 'quader',
                     'color' => '#00ccff',
@@ -1297,9 +1307,10 @@ class CollectionControllerTest extends SuluTestCase
     {
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/404',
-            [
+            '/api/collections/404?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'style' => [
                     'type' => 'quader',
                     'color' => '#00ccff',
@@ -1895,9 +1906,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'type' => [
                     'id' => $this->collectionType1->getId(),
                 ],
@@ -1918,9 +1930,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $collectionId,
-            [
+            '/api/collections/' . $collectionId . '?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'type' => [
                     'id' => $this->collectionType1->getId(),
                 ],

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -880,10 +880,11 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/media',
+            '/api/media?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
             [
                 'collection' => $this->collection->getId(),
-                'locale' => 'en-gb',
                 'title' => 'New Image Title',
                 'description' => 'New Image Description',
                 'copyright' => 'My copyright',
@@ -942,9 +943,10 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/media',
-            [
+            '/api/media?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'collection' => $this->collection->getId(),
             ],
             [
@@ -972,9 +974,10 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/media',
-            [
+            '/api/media?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'collection' => $this->collection->getId(),
             ],
             [
@@ -1001,9 +1004,10 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/media',
-            [
+            '/api/media?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'collection' => $this->collection->getId(),
             ],
             [
@@ -1032,10 +1036,12 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/media/' . $media->getId() . '?action=new-version',
+            '/api/media/' . $media->getId() . '?' . \http_build_query([
+                'locale' => 'en-gb',
+                'action' => 'new-version',
+            ]),
             [
                 'collection' => $this->collection->getId(),
-                'locale' => 'en-gb',
                 'title' => 'New Image Title',
                 'description' => 'New Image Description',
                 'copyright' => 'My copyright',
@@ -1074,7 +1080,10 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/media/' . $media->getId() . '?locale=en&action=new-version',
+            '/api/media/' . $media->getId() . '?' . \http_build_query([
+                'locale' => 'en',
+                'action' => 'new-version',
+            ]),
             [],
             [
                 'fileVersion' => $photo,
@@ -1086,14 +1095,18 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'DELETE',
-            '/api/media/' . $mediaId . '/versions/1?locale=en'
+            '/api/media/' . $mediaId . '/versions/1?' . \http_build_query([
+                'locale' => 'en',
+            ]),
         );
 
         $this->assertHttpStatusCode(204, $this->client->getResponse());
 
         $this->client->jsonRequest(
             'GET',
-            '/api/media/' . $mediaId . '?locale=en'
+            '/api/media/' . $mediaId . '?' . \http_build_query([
+                'locale' => 'en',
+            ]),
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());
@@ -1108,7 +1121,9 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'DELETE',
-            '/api/media/' . $media->getId() . '/versions/1?locale=en'
+            '/api/media/' . $media->getId() . '/versions/1?' . \http_build_query([
+                'locale' => 'en',
+            ]),
         );
 
         $this->assertHttpStatusCode(400, $this->client->getResponse());
@@ -1120,7 +1135,9 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'DELETE',
-            '/api/media/' . $media->getId() . '/versions/2?locale=en'
+            '/api/media/' . $media->getId() . '/versions/2?' . \http_build_query([
+                'locale' => 'en',
+            ]),
         );
 
         $this->assertHttpStatusCode(404, $this->client->getResponse());
@@ -1136,7 +1153,10 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/media/' . $media->getId() . '?locale=en&action=new-version',
+            '/api/media/' . $media->getId() . '?' . \http_build_query([
+                'locale' => 'en',
+                'action' => 'new-version',
+            ]),
             [],
             [
                 'fileVersion' => $photo,
@@ -1148,7 +1168,9 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'DELETE',
-            '/api/media/' . $media->getId() . '/versions/2?locale=en'
+            '/api/media/' . $media->getId() . '/versions/2?' . \http_build_query([
+                'locale' => 'en',
+            ]),
         );
 
         $this->assertHttpStatusCode(400, $this->client->getResponse());
@@ -1160,7 +1182,9 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/media/' . $media->getId() . '?locale=de',
+            '/api/media/' . $media->getId() . '?' . \http_build_query([
+                'locale' => 'de',
+            ]),
             [
                 'description' => null,
                 'copyright' => null,
@@ -1195,7 +1219,9 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/media/' . $media->getId() . '?locale=en',
+            '/api/media/' . $media->getId() . '?' . \http_build_query([
+                'locale' => 'en',
+            ]),
             [
                 'targetGroups' => [],
             ]
@@ -1216,10 +1242,11 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/media/' . $media->getId(),
+            '/api/media/' . $media->getId() . '?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
             [
                 'collection' => $this->collection->getId(),
-                'locale' => 'en-gb',
                 'title' => 'Update Title',
                 'description' => 'Update Description',
                 'copyright' => 'My copyright',
@@ -1262,7 +1289,9 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'GET',
-            '/api/media/' . $mediaId . '?locale=en'
+            '/api/media/' . $mediaId . '?' . \http_build_query([
+                'locale' => 'en',
+            ]),
         );
 
         $response = \json_decode($this->client->getResponse()->getContent());
@@ -1280,7 +1309,10 @@ class MediaControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/media/' . $media->getId() . '?locale=en&action=new-version',
+            '/api/media/' . $media->getId() . '?' . \http_build_query([
+                'locale' => 'en',
+                'action' => 'new-version',
+            ]),
             [
                 'collection' => $this->collection->getId(),
             ],
@@ -1311,12 +1343,19 @@ class MediaControllerTest extends SuluTestCase
         $mediaId = $media->getId();
         $this->assertFileExists($this->getStoragePath() . '/1/photo.jpeg');
 
-        $this->client->jsonRequest('DELETE', '/api/media/' . $mediaId);
+        $this->client->jsonRequest(
+            'DELETE',
+            '/api/media/' . $mediaId . '?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
+        );
         $this->assertNotNull($this->client->getResponse()->getStatusCode());
 
         $this->client->jsonRequest(
             'GET',
-            '/api/media/' . $mediaId . '?locale=en-gb'
+            '/api/media/' . $mediaId . '?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
         );
 
         $this->assertHttpStatusCode(404, $this->client->getResponse());

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/MediaControllerTest.php
@@ -882,9 +882,9 @@ class MediaControllerTest extends SuluTestCase
             'POST',
             '/api/media?' . \http_build_query([
                 'locale' => 'en-gb',
+                'collection' => $this->collection->getId(),
             ]),
             [
-                'collection' => $this->collection->getId(),
                 'title' => 'New Image Title',
                 'description' => 'New Image Description',
                 'copyright' => 'My copyright',
@@ -945,10 +945,9 @@ class MediaControllerTest extends SuluTestCase
             'POST',
             '/api/media?' . \http_build_query([
                 'locale' => 'en',
-            ]),
-            [
                 'collection' => $this->collection->getId(),
-            ],
+            ]),
+            [],
             [
                 'fileVersion' => $photo,
             ]
@@ -976,10 +975,9 @@ class MediaControllerTest extends SuluTestCase
             'POST',
             '/api/media?' . \http_build_query([
                 'locale' => 'en',
-            ]),
-            [
                 'collection' => $this->collection->getId(),
-            ],
+            ]),
+            [],
             [
                 'fileVersion' => $photo,
             ]
@@ -1006,10 +1004,9 @@ class MediaControllerTest extends SuluTestCase
             'POST',
             '/api/media?' . \http_build_query([
                 'locale' => 'en',
-            ]),
-            [
                 'collection' => $this->collection->getId(),
-            ],
+            ]),
+            [],
             [
                 'fileVersion' => $photo,
             ]
@@ -1039,9 +1036,9 @@ class MediaControllerTest extends SuluTestCase
             '/api/media/' . $media->getId() . '?' . \http_build_query([
                 'locale' => 'en-gb',
                 'action' => 'new-version',
+                'collection' => $this->collection->getId(),
             ]),
             [
-                'collection' => $this->collection->getId(),
                 'title' => 'New Image Title',
                 'description' => 'New Image Description',
                 'copyright' => 'My copyright',
@@ -1312,10 +1309,9 @@ class MediaControllerTest extends SuluTestCase
             '/api/media/' . $media->getId() . '?' . \http_build_query([
                 'locale' => 'en',
                 'action' => 'new-version',
-            ]),
-            [
                 'collection' => $this->collection->getId(),
-            ],
+            ]),
+            [],
             [
                 'fileVersion' => $photo,
             ]


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | yes technically
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | https://github.com/sulu/sulu/issues/8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Upgrade Media Bundle `Request::get` calls to the specific request parameter bags (`query` / payload) in `AbstractMediaController` and `MediaStreamController`. The redundant `title` and `formats` assignments in `AbstractMediaController::getData()` are dropped, as both are already part of `$request->request->all()`.

#### Why?

Required for the Symfony 8 upgrade.
