### PR TITLE
Add missing archive action to getActionIcon

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Resources/js/utils/Permission/getActionIcon.js
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/js/utils/Permission/getActionIcon.js
@@ -14,6 +14,8 @@ export default function getActionIcon(action: string) {
             return 'su-lock';
         case 'live':
             return 'su-publish';
+        case 'archive':
+            return 'su-archive';
         default:
             throw new Error('No icon defined for "' + action + '"');
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adding an icon for permission action type `archive`.

#### Why?

The related [`PermissionTypes::ARCHIVE`](https://github.com/sulu/sulu/blob/0f0d065927ab291dce0d5cccc414521749fb04e8/src/Sulu/Component/Security/Authorization/PermissionTypes.php#L27) was added 5 years ago but never at the related [getActionIcon.js](https://github.com/sulu/sulu/blob/0f0d065927ab291dce0d5cccc414521749fb04e8/src/Sulu/Bundle/SecurityBundle/Resources/js/utils/Permission/getActionIcon.js)

<img width="478" height="163" alt="image" src="https://github.com/user-attachments/assets/762e0ae7-bd18-4afc-b7cd-6804cebbf6bb" />


#### Example Usage

At an admin class extending `Sulu\Bundle\AdminBundle\Admin\Admin`:

```php
public function getSecurityContexts(): array
{
	return [
		Admin::SULU_ADMIN_SECURITY_SYSTEM => [
			'Testgroup' => [
				'test_permission' => [
					PermissionTypes::VIEW,
					PermissionTypes::ADD,
					PermissionTypes::ARCHIVE,
				],
			],
		],
	];
}
```

And then try to open the permission view of a role e.g. `/admin/#/roles/1/details`