### PR TITLE
Upgrade Tag Bundle Request::get calls to specific Request ParameterBags

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -28759,12 +28759,6 @@ parameters:
 			path: src/Sulu/Bundle/TagBundle/Controller/Exception/ConstraintViolationException.php
 
 		-
-			message: '#^Cannot access offset ''id'' on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\TagBundle\\Controller\\TagController\:\:deleteAction\(\) has parameter \$id with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -28795,12 +28789,6 @@ parameters:
 			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
 
 		-
-			message: '#^Parameter \#1 \$data of method Sulu\\Bundle\\TagBundle\\Tag\\TagManagerInterface\:\:save\(\) expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
-
-		-
 			message: '#^Parameter \#1 \$id of method Sulu\\Bundle\\TagBundle\\Tag\\TagManagerInterface\:\:delete\(\) expects float\|int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -28814,18 +28802,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$id of method Sulu\\Component\\Rest\\AbstractRestController\:\:responseGetById\(\) expects int\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
-
-		-
-			message: '#^Parameter \#1 \$key of method Symfony\\Component\\HttpFoundation\\Request\:\:get\(\) expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
-
-		-
-			message: '#^Parameter \#2 \$destTagId of method Sulu\\Bundle\\TagBundle\\Tag\\TagManagerInterface\:\:merge\(\) expects float\|int, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -28846,12 +28822,6 @@ parameters:
 			message: '#^Parameter \#2 \$id of method Sulu\\Bundle\\TagBundle\\Tag\\TagManagerInterface\:\:save\(\) expects float\|int\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 2
-			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Sulu/Bundle/TagBundle/Controller/TagController.php
 
 		-

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -24,6 +24,7 @@ use Sulu\Bundle\TagBundle\Tag\TagRepositoryInterface;
 use Sulu\Component\Rest\AbstractRestController;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\Exception\MissingArgumentException;
+use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\ListBuilder\CollectionRepresentation;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
@@ -229,8 +230,8 @@ class TagController extends AbstractRestController implements SecuredControllerI
     public function postMergeAction(Request $request)
     {
         try {
-            $srcTagIds = \explode(',', $request->query->getString('src'));
-            $destTagId = $request->query->getInt('dest');
+            $srcTagIds = \explode(',', $request->query->getString('src') ?: throw new MissingParameterException(self::class, 'src'));
+            $destTagId = $request->query->getInt('dest') ?: throw new MissingParameterException(self::class, 'dest');
 
             $destTag = $this->tagManager->merge($srcTagIds, $destTagId);
 

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -230,7 +230,8 @@ class TagController extends AbstractRestController implements SecuredControllerI
     public function postMergeAction(Request $request)
     {
         try {
-            $srcTagIds = \explode(',', $request->query->getString('src') ?: throw new MissingParameterException(self::class, 'src'));
+            $src = $request->query->getString('src') ?: throw new MissingParameterException(self::class, 'src');
+            $srcTagIds = \explode(',', $src);
             $destTagId = $request->query->getInt('dest') ?: throw new MissingParameterException(self::class, 'dest');
 
             $destTag = $this->tagManager->merge($srcTagIds, $destTagId);

--- a/src/Sulu/Bundle/TagBundle/Controller/TagController.php
+++ b/src/Sulu/Bundle/TagBundle/Controller/TagController.php
@@ -91,20 +91,19 @@ class TagController extends AbstractRestController implements SecuredControllerI
      */
     public function cgetAction(Request $request)
     {
-        if ('true' == $request->get('flat')) {
+        if ('true' == $request->query->get('flat')) {
             $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors('tags');
             $listBuilder = $this->listBuilderFactory->create($this->tagClass);
 
             $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 
-            $names = \array_filter(\explode(',', $request->get('names', '')));
+            $names = \array_filter(\explode(',', $request->query->getString('names')));
             if (\count($names) > 0) {
                 $listBuilder->in($fieldDescriptors['name'], $names);
                 $listBuilder->limit(\count($names));
             }
 
-            $idsParam = $request->get('ids', '');
-            $ids = \array_filter(\explode(',', \is_string($idsParam) ? $idsParam : ''));
+            $ids = \array_filter(\explode(',', $request->query->getString('ids')));
             if (\count($ids) > 0 && isset($fieldDescriptors['id'])) {
                 $listBuilder->in($fieldDescriptors['id'], $ids);
                 $listBuilder->limit(\count($ids));
@@ -138,7 +137,7 @@ class TagController extends AbstractRestController implements SecuredControllerI
      */
     public function postAction(Request $request)
     {
-        $name = $request->get('name');
+        $name = $request->getPayload()->get('name');
 
         try {
             if (null == $name) {
@@ -173,7 +172,7 @@ class TagController extends AbstractRestController implements SecuredControllerI
      */
     public function putAction(Request $request, $id)
     {
-        $name = $request->get('name');
+        $name = $request->getPayload()->get('name');
 
         try {
             if (null == $name) {
@@ -230,9 +229,8 @@ class TagController extends AbstractRestController implements SecuredControllerI
     public function postMergeAction(Request $request)
     {
         try {
-            $srcParam = $request->get('src');
-            $srcTagIds = \explode(',', \is_scalar($srcParam) ? (string) $srcParam : '');
-            $destTagId = $request->get('dest');
+            $srcTagIds = \explode(',', $request->query->getString('src'));
+            $destTagId = $request->query->getInt('dest');
 
             $destTag = $this->tagManager->merge($srcTagIds, $destTagId);
 
@@ -259,8 +257,10 @@ class TagController extends AbstractRestController implements SecuredControllerI
         try {
             $tags = [];
 
+            $payload = $request->getPayload();
+
             $i = 0;
-            while ($item = $request->get($i)) {
+            while ($item = $payload->all((string) $i)) {
                 if (isset($item['id'])) {
                     $tags[] = $this->tagManager->save($item, $item['id']);
                 } else {

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -401,6 +401,28 @@ class TagControllerTest extends SuluTestCase
         $this->assertEquals('Entity with the type "Sulu\Bundle\TagBundle\Entity\Tag" and the id "1233" not found.', $response->message);
     }
 
+    public function testMergeWithoutSource(): void
+    {
+        $this->client->jsonRequest(
+            'POST',
+            '/api/tags/merge?' . \http_build_query(['dest' => 1]),
+            []
+        );
+
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
+    }
+
+    public function testMergeWithoutDestination(): void
+    {
+        $this->client->jsonRequest(
+            'POST',
+            '/api/tags/merge?' . \http_build_query(['src' => 1]),
+            []
+        );
+
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
+    }
+
     public function testPatch(): void
     {
         $this->createTag('tag1');

--- a/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -351,8 +351,8 @@ class TagControllerTest extends SuluTestCase
         $tagIds = [$tag2Id, $tag3Id, $tag4Id];
         $this->client->jsonRequest(
             'POST',
-            '/api/tags/merge',
-            ['src' => \implode(',', $tagIds), 'dest' => $tag1Id]
+            '/api/tags/merge?' . \http_build_query(['src' => \implode(',', $tagIds), 'dest' => $tag1Id]),
+            []
         );
         $this->assertHttpStatusCode(303, $this->client->getResponse());
         $this->assertEquals('/api/tags/' . $tag1->getId(), $this->client->getResponse()->headers->get('location'));
@@ -390,8 +390,8 @@ class TagControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/tags/merge',
-            ['src' => 1233, 'dest' => $tag1->getId()]
+            '/api/tags/merge?' . \http_build_query(['src' => 1233, 'dest' => $tag1->getId()]),
+            []
         );
 
         $this->assertHttpStatusCode(404, $this->client->getResponse());

--- a/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
+++ b/src/Sulu/Bundle/TagBundle/Tests/Unit/Twig/TagTwigExtensionTest.php
@@ -119,7 +119,6 @@ class TagTwigExtensionTest extends TestCase
         $requestReveal = $request->reveal();
         $requestReveal->query = new InputBag([$tagsParameter => $tagsString]);
         $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($tagsParameter, '')->willReturn($tagsString);
         $request->getPathInfo()->willReturn($url);
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
@@ -165,7 +164,6 @@ class TagTwigExtensionTest extends TestCase
         $requestReveal = $request->reveal();
         $requestReveal->query = new InputBag([$tagsParameter => $tagsString]);
         $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($tagsParameter, '')->willReturn($tagsString);
         $request->getPathInfo()->willReturn($url);
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);
@@ -208,7 +206,6 @@ class TagTwigExtensionTest extends TestCase
         $requestReveal = $request->reveal();
         $requestReveal->query = new InputBag([$tagsParameter => $tagsString]);
         $requestStack->getCurrentRequest()->willReturn($requestReveal);
-        $request->get($tagsParameter, '')->willReturn($tagsString);
         $request->getPathInfo()->willReturn($url);
 
         $serializer = $this->prophesize(ArraySerializerInterface::class);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes (see below)
| Deprecations?   | no
| Fixed tickets   | part of #8216

Continues the `Request::get()` migration with the **TagBundle**, following the same pattern as the Category (#8980), Contact (#8981) and Media bundle PRs.

`Sulu\Component\Tag\Request\TagRequestHandler` was already migrated in #8967, so `TagController` was the last remaining consumer in this bundle.

### Changes

- **`cgetAction`** — `flat`, `names` and `ids` are list/filter parameters of a `GET` route and are read from the **query bag**. Using `getString()` makes the manual `\is_string($idsParam)` guard obsolete.
- **`postAction` / `putAction`** — `name` is entity data and is read from the **payload**. `getData()` already read `$request->request->all()` and stays untouched.
- **`postMergeAction`** — `src` and `dest` are read from the **query bag**.
- **`cpatchAction`** — items are read via `$payload->all((string) $i)`, which also fixes the current int-passed-as-string-key call.

`dest` is read with `getInt()` so it matches `TagManagerInterface::merge()`, which lets the corresponding phpstan baseline entry go away as well.

### About the merge endpoint

`POST /api/tags/merge` previously accepted `src`/`dest` in either place because `Request::get()` searches query *and* body. It has **no consumer in the admin** (the TagBundle ships no `Resources/js`, and there is no `tags/merge` reference anywhere in the frontend), so nothing in Sulu regresses.

Query was chosen because it matches how the admin sends action parameters everywhere else — e.g. `ResourceStore.copyFromLocale` calls `ResourceRequester.post(resourceKey, {}, {action: 'copy_locale', src: ..., dest: ...})`, i.e. `src`/`dest` in the query string with an empty body. The two functional tests were sending them in the JSON body, which is why they are adjusted here — the old tests were not authoritative about the intended contract.

Projects calling this endpoint with `src`/`dest` in the request body need to move them into the query string.

### Out of scope

`Sulu\Component\Rest\ListBuilder\ListRestHelper` still uses `$request->get()` for `ids`, `excludedIds` and `sortBy`. It backs the list endpoints of *every* bundle, so it deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)