### PR TITLE
Upgrade Website Bundle Request::get calls to specific Request ParameterBags

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -144,6 +144,7 @@ class AnalyticsController extends AbstractRestController implements SecuredContr
 
     public function getSecurityContext()
     {
+        /** @var Request $request */
         $request = $this->requestStack->getCurrentRequest();
 
         return WebsiteAdmin::getAnalyticsSecurityContext($request->attributes->getString('webspace'));

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -133,7 +133,7 @@ class AnalyticsController extends AbstractRestController implements SecuredContr
      */
     public function cdeleteAction(Request $request, string $webspace)
     {
-        $ids = \array_filter(\explode(',', $request->get('ids', '')));
+        $ids = \array_filter(\explode(',', $request->query->getString('ids', '')));
 
         $this->analyticsManager->removeMultiple($ids);
         $this->entityManager->flush();
@@ -146,7 +146,7 @@ class AnalyticsController extends AbstractRestController implements SecuredContr
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        return WebsiteAdmin::getAnalyticsSecurityContext($request->get('webspace'));
+        return WebsiteAdmin::getAnalyticsSecurityContext($request->attributes->getString('webspace'));
     }
 
     private function buildContent(array $data)

--- a/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Controller/RedirectController.php
@@ -39,7 +39,7 @@ class RedirectController
      */
     public function redirectAction(Request $request)
     {
-        return new RedirectResponse($request->get('url'), 301, ['Cache-Control' => 'private']);
+        return new RedirectResponse($request->attributes->get('url'), 301, ['Cache-Control' => 'private']);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes (see below)
| Deprecations?   | no
| Fixed tickets   | part of #8216

Continues the `Request::get()` migration with the **WebsiteBundle**, following the same pattern as the Category (#8980), Contact (#8981), Media (#8989) and Tag (#8991) bundle PRs.

### Changes

- **`AnalyticsController::cdeleteAction`** — `ids` is a list parameter of a `DELETE` route and is read from the **query bag**. `getString()` also makes the parameter type explicit for the following `\explode()` call.
- **`AnalyticsController::getSecurityContext`** — `webspace` is a **route parameter** and is therefore read from the **attributes bag**. The action itself already receives it as a typed `string $webspace` argument; only the `SecuredControllerInterface` implementation had to fall back to the request.
- **`RedirectController::redirectAction`** — `url` is a **route default** configured in the project routing (`sulu_website.redirect_controller::redirectAction` with a `url` default) and is read from the **attributes bag**.

### BC break

`Request::get()` searches attributes, query *and* body. Reading `url` from the attributes bag only means `RedirectController::redirectAction` no longer honours a `?url=` query parameter that overrides the configured route default — which was never the intended contract of that route and effectively an open redirect. Projects that relied on it need to define the target as a route default instead.

`ids` and `webspace` keep working as before for every caller that uses the routes the way the admin does.

### Out of scope

`Sulu\Component\Rest\ListBuilder\ListRestHelper` still uses `$request->get()` for `ids`, `excludedIds` and `sortBy`. It backs the list endpoints of *every* bundle, so it deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
