### PR TITLE
Upgrade Webspace Analyzer Attributes Request::get calls to specific Request ParameterBags

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36601,34 +36601,10 @@ parameters:
 			path: src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
 
 		-
-			message: '#^Parameter \#1 \$key of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findWebspaceByKey\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
-
-		-
-			message: '#^Parameter \#1 \$locale of static method Sulu\\Component\\Localization\\Localization\:\:createFromString\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
-
-		-
 			message: '#^Property Sulu\\Component\\Webspace\\Analyzer\\Attributes\\AdminRequestProcessor\:\:\$environment is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
-
-		-
-			message: '#^Parameter \#1 \$portalKey of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findPortalInformationsByPortalKeyAndLocale\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
-
-		-
-			message: '#^Parameter \#2 \$locale of method Sulu\\Component\\Webspace\\Manager\\WebspaceManagerInterface\:\:findPortalInformationsByPortalKeyAndLocale\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
 
 		-
 			message: '#^If condition is always true\.$#'

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
@@ -31,8 +31,8 @@ class AdminRequestProcessor implements RequestProcessorInterface
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
         $attributes = [];
-        $attributes['webspaceKey'] = $request->get('webspace') ?: $request->get('webspaceKey');
-        $attributes['locale'] = $request->get('locale', $request->get('language'));
+        $attributes['webspaceKey'] = $this->getWebspaceKey($request);
+        $attributes['locale'] = $this->getLocale($request);
 
         $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, $attributes['webspaceKey']); // TODO move in own request listener
 
@@ -58,5 +58,29 @@ class AdminRequestProcessor implements RequestProcessorInterface
     public function validate(RequestAttributes $attributes)
     {
         return true;
+    }
+
+    /**
+     * The webspace is either part of the route (e.g. "/admin/api/webspaces/{webspace}/analytics") or is sent
+     * as query parameter by the administration interface (e.g. "/admin/api/pages?webspace=example").
+     */
+    private function getWebspaceKey(Request $request): ?string
+    {
+        return $request->attributes->getString('webspace')
+            ?: $request->query->getString('webspace')
+            ?: $request->attributes->getString('webspaceKey')
+            ?: $request->query->getString('webspaceKey')
+            ?: null;
+    }
+
+    /**
+     * The locale is sent as query parameter by the administration interface, the "language" parameter is only
+     * kept as fallback for consumers which still use the parameter name of the sulu 1.x administration interface.
+     */
+    private function getLocale(Request $request): ?string
+    {
+        return $request->query->getString('locale')
+            ?: $request->query->getString('language')
+            ?: null;
     }
 }

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/AdminRequestProcessor.php
@@ -63,6 +63,10 @@ class AdminRequestProcessor implements RequestProcessorInterface
     /**
      * The webspace is either part of the route (e.g. "/admin/api/webspaces/{webspace}/analytics") or is sent
      * as query parameter by the administration interface (e.g. "/admin/api/pages?webspace=example").
+     *
+     * Some routes and requests of the administration interface use "webspaceKey" as parameter name instead
+     * (e.g. "/admin/api/webspaces/{webspaceKey}" or "/admin/preview/render?webspaceKey=example"), therefore both
+     * parameter names are read from the route and from the query.
      */
     private function getWebspaceKey(Request $request): ?string
     {

--- a/src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
+++ b/src/Sulu/Component/Webspace/Analyzer/Attributes/ParameterRequestProcessor.php
@@ -29,13 +29,18 @@ class ParameterRequestProcessor implements RequestProcessorInterface
 
     public function process(Request $request, RequestAttributes $requestAttributes)
     {
-        if (!$request->get('_locale') || !$request->get('_portal')) {
+        // the "_locale" and "_portal" parameters are set as defaults of a route and are therefore
+        // available in the attributes of the request
+        $locale = $request->attributes->getString('_locale');
+        $portalKey = $request->attributes->getString('_portal');
+
+        if (!$locale || !$portalKey) {
             return new RequestAttributes();
         }
 
         $portalInformations = $this->webspaceManager->findPortalInformationsByPortalKeyAndLocale(
-            $request->get('_portal'),
-            $request->get('_locale'),
+            $portalKey,
+            $locale,
             $this->environment
         );
 

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/AdminRequestProcessorTest.php
@@ -73,6 +73,41 @@ class AdminRequestProcessorTest extends TestCase
         $this->assertEquals($localization, $result->getAttribute('localization'));
     }
 
+    public function testProcessWithWebspaceRouteAttribute(): void
+    {
+        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $provider = new AdminRequestProcessor($webspaceManager->reveal(), 'prod');
+
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getLocalization('de')->willReturn(Localization::createFromString('de'));
+        $webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace->reveal());
+
+        $request = Request::create('/admin/api/webspaces/sulu_io/analytics?locale=de', 'GET', [], [], [], ['HTTP_HOST' => 'sulu.io']);
+        $request->attributes->set('webspace', 'sulu_io');
+
+        $result = $provider->process($request, new RequestAttributes());
+
+        $this->assertSame('sulu_io', $result->getAttribute('webspaceKey'));
+        $this->assertSame('de', $result->getAttribute('locale'));
+    }
+
+    public function testProcessWithWebspaceKeyQueryParameter(): void
+    {
+        $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $provider = new AdminRequestProcessor($webspaceManager->reveal(), 'prod');
+
+        $webspace = $this->prophesize(Webspace::class);
+        $webspace->getLocalization('de')->willReturn(Localization::createFromString('de'));
+        $webspaceManager->findWebspaceByKey('sulu_io')->willReturn($webspace->reveal());
+
+        $request = Request::create('/admin/preview/render?webspaceKey=sulu_io&locale=de', 'GET', [], [], [], ['HTTP_HOST' => 'sulu.io']);
+
+        $result = $provider->process($request, new RequestAttributes());
+
+        $this->assertSame('sulu_io', $result->getAttribute('webspaceKey'));
+        $this->assertSame('de', $result->getAttribute('locale'));
+    }
+
     public function testValidate(): void
     {
         $webspaceManager = $this->prophesize(WebspaceManagerInterface::class);

--- a/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/ParameterRequestProcessorTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Unit/Analyzer/Attributes/ParameterRequestProcessorTest.php
@@ -46,7 +46,7 @@ class ParameterRequestProcessorTest extends TestCase
 
     public function testProcess(): void
     {
-        $request = new Request(['_portal' => 'sulu_io', '_locale' => 'de']);
+        $request = new Request([], [], ['_portal' => 'sulu_io', '_locale' => 'de']);
 
         $portalInformation = new PortalInformation(1);
 
@@ -60,7 +60,7 @@ class ParameterRequestProcessorTest extends TestCase
 
     public function testProcessWithoutLocale(): void
     {
-        $request = new Request(['_portal' => 'sulu_io']);
+        $request = new Request([], [], ['_portal' => 'sulu_io']);
 
         $this->assertEquals(
             new RequestAttributes(),
@@ -70,7 +70,7 @@ class ParameterRequestProcessorTest extends TestCase
 
     public function testProcessWithoutPortal(): void
     {
-        $request = new Request(['_locale' => 'sulu_io']);
+        $request = new Request([], [], ['_locale' => 'sulu_io']);
 
         $this->assertEquals(
             new RequestAttributes(),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes (see below)
| Deprecations?   | no
| Fixed tickets   | part of #8216

Continues the `Request::get()` migration with the request processors in `Sulu\Component\Webspace\Analyzer\Attributes`, following the same pattern as the Category (#8980), Contact (#8981), Media (#8989) and Tag (#8991) bundle PRs.

The bag was chosen based on the callers that actually exist in the PHP and JavaScript code, not based on how the existing unit tests happened to build their `Request` objects.

### `AdminRequestProcessor`

- **`webspace` / `webspaceKey`** — read from the **attributes bag first, then the query bag**, because both are real:
  - route parameter: `/admin/api/webspaces/{webspace}/analytics` (`WebsiteBundle`), `/admin/api/webspaces/{webspace}/custom-urls` (`CustomUrlBundle`), `/admin/api/webspaces/{webspaceKey}` (`PageBundle`)
  - query parameter: every admin request built by `ResourceRequester`/`symfonyRouting.generate()`, e.g. `SmartContentStore` (`webspace`), `PreviewStore` and `UpdateFormStoreToolbarAction` (`webspaceKey`)

  This keeps the previous precedence of `Request::get()` (attributes before query) and the precedence of `webspace` over `webspaceKey`.
- **`locale` / `language`** — read from the **query bag**. All admin requests send the locale in the query string; no Sulu route declares a `{locale}` path parameter. `language` is the parameter name of the Sulu 1.x administration interface and is kept as a fallback, the same way `PageController::getLocale()` and `SnippetController` still accept it — the latter already reads it from `$request->query`.

The lookups moved into two private methods so that both the intent and the `?string` return type are explicit — the latter matters because `getString()` returns `''` instead of `null`, while the code below relies on `null` to skip the localization lookup.

### `ParameterRequestProcessor`

- **`_portal` / `_locale`** — read from the **attributes bag**. Both are route defaults: `_locale` is a Symfony routing parameter that always ends up in the attributes, and `_portal` is its Sulu counterpart which projects declare next to it in the route defaults. Nothing in Sulu or in the admin sends either of them as a query parameter.

The unit test built the request with query parameters, which is why it is adjusted here — it was not authoritative about the intended contract.

### BC break

`Request::get()` searches attributes, query *and* body. The body is no longer considered for any of these parameters, so an API consumer that sent `webspace`, `webspaceKey`, `locale` or `language` in the request body instead of the query string needs to move them into the query string. The administration interface never did this.

For `_portal` and `_locale` a route default keeps working as before; a query parameter `?_portal=…&_locale=…` is not evaluated anymore.

### Other

Four now-obsolete `mixed given` entries could be removed from the phpstan baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
