### PR TITLE
Upgrade Security Bundle Request::get calls to specific Request ParameterBags

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -2,23 +2,6 @@
 
 ## 3.0.8
 
-### Security bundle endpoints read their parameters from a specific request bag
-
-The security controllers no longer use `Request::get()`, which accepted a parameter in the query string and in the
-request body alike. Every parameter is now read from the bag the admin frontend actually sends it in:
-
-| Endpoint | Parameter | Read from |
-| --- | --- | --- |
-| `DELETE /admin/api/profile/settings` | `key` | query |
-| `PATCH /admin/api/profile/settings` | all settings | body |
-| `PUT /admin/api/profile` | `firstName`, `lastName`, `username`, `email`, `locale`, `password`, `twoFactor` | body |
-| `PUT /admin/api/roles/{roleId}/settings/{key}` | `value` | body |
-| `GET /admin/api/users` | `flat`, `contactId` | query |
-| `POST /security/reset/email` | `user` | body |
-| `POST /security/reset` | `token`, `password` | body |
-
-Custom clients that passed one of these parameters in the other bag need to be adjusted.
-
 ### Route value is required when saving routable content
 
 `Sulu\Content\Domain\Model\RoutableInterface` gained the static method `isRouteMandatory()`. Classes using the `RoutableTrait` inherit the default `true`, other implementations need to add the method. When it returns `true`, saving a routable entity with an empty route value for its route field is rejected. Return `false` for resources that are allowed to live without a URL.

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -2,6 +2,23 @@
 
 ## 3.0.8
 
+### Security bundle endpoints read their parameters from a specific request bag
+
+The security controllers no longer use `Request::get()`, which accepted a parameter in the query string and in the
+request body alike. Every parameter is now read from the bag the admin frontend actually sends it in:
+
+| Endpoint | Parameter | Read from |
+| --- | --- | --- |
+| `DELETE /admin/api/profile/settings` | `key` | query |
+| `PATCH /admin/api/profile/settings` | all settings | body |
+| `PUT /admin/api/profile` | `firstName`, `lastName`, `username`, `email`, `locale`, `password`, `twoFactor` | body |
+| `PUT /admin/api/roles/{roleId}/settings/{key}` | `value` | body |
+| `GET /admin/api/users` | `flat`, `contactId` | query |
+| `POST /security/reset/email` | `user` | body |
+| `POST /security/reset` | `token`, `password` | body |
+
+Custom clients that passed one of these parameters in the other bag need to be adjusted.
+
 ### Route value is required when saving routable content
 
 `Sulu\Content\Domain\Model\RoutableInterface` gained the static method `isRouteMandatory()`. Classes using the `RoutableTrait` inherit the default `true`, other implementations need to add the method. When it returns `true`, saving a routable entity with an empty route value for its route field is rejected. Return `false` for resources that are allowed to live without a URL.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25969,12 +25969,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Command/InitCommand.php
 
 		-
-			message: '#^Binary operation "\." between ''The resourceKey "'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 2
-			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
-
-		-
 			message: '#^Cannot access offset ''security_class'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2
@@ -26023,33 +26017,9 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
 
 		-
-			message: '#^Parameter \#2 \$identifier of method Sulu\\Component\\Security\\Authorization\\AccessControl\\AccessControlManagerInterface\:\:getPermissions\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
-
-		-
-			message: '#^Parameter \#2 \$identifier of method Sulu\\Component\\Security\\Authorization\\AccessControl\\AccessControlManagerInterface\:\:setPermissions\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
-
-		-
-			message: '#^Parameter \#2 \$replace of function str_replace expects array\<string\>\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
-
-		-
 			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
-
-		-
-			message: '#^Possibly invalid array key type mixed\.$#'
-			identifier: offsetAccess.invalidOffset
-			count: 5
 			path: src/Sulu/Bundle/SecurityBundle/Controller/PermissionController.php
 
 		-
@@ -26185,12 +26155,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
 
 		-
-			message: '#^Parameter \#1 \$identifier of method Sulu\\Bundle\\SecurityBundle\\Controller\\ResettingController\:\:findUser\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
-
-		-
 			message: '#^Parameter \#1 \$limit of class Sulu\\Bundle\\SecurityBundle\\Security\\Exception\\TokenEmailsLimitReachedException constructor expects int, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -26209,19 +26173,7 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
 
 		-
-			message: '#^Parameter \#1 \$token of method Sulu\\Bundle\\SecurityBundle\\Controller\\ResettingController\:\:generateTokenHash\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
-
-		-
 			message: '#^Parameter \#1 \$user of method Symfony\\Component\\PasswordHasher\\Hasher\\PasswordHasherFactoryInterface\:\:getPasswordHasher\(\) expects string\|Symfony\\Component\\PasswordHasher\\Hasher\\PasswordHasherAwareInterface\|Symfony\\Component\\Security\\Core\\User\\PasswordAuthenticatedUserInterface, Symfony\\Component\\Security\\Core\\User\\UserInterface given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
-
-		-
-			message: '#^Parameter \#2 \$password of method Sulu\\Bundle\\SecurityBundle\\Controller\\ResettingController\:\:changePassword\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
@@ -78,14 +78,16 @@ class ProfileController
         $this->checkArguments($request);
         /** @var User $user */
         $user = $this->tokenStorage->getToken()->getUser();
-        $this->userManager->save($this->getData($request), $request->get('locale'), $user->getId(), true);
+        $payload = $request->getPayload();
 
-        $user->setFirstName((string) $request->request->get('firstName'));
-        $user->setLastName((string) $request->request->get('lastName'));
+        $this->userManager->save($this->getData($request), $payload->getString('locale'), $user->getId(), true);
+
+        $user->setFirstName($payload->getString('firstName'));
+        $user->setLastName($payload->getString('lastName'));
 
         if ($user instanceof TwoFactorInterface) {
             /** @var array{method?: string|null} $twoFactorData */
-            $twoFactorData = $request->request->all('twoFactor');
+            $twoFactorData = $payload->all('twoFactor');
             $twoFactorMethod = $twoFactorData['method'] ?? null;
 
             if ($twoFactorMethod) {
@@ -134,7 +136,7 @@ class ProfileController
      */
     public function patchSettingsAction(Request $request)
     {
-        $settings = $request->request->all();
+        $settings = $request->getPayload()->all();
 
         try {
             /** @var User $user */
@@ -174,7 +176,7 @@ class ProfileController
      */
     public function deleteSettingsAction(Request $request)
     {
-        $key = $request->get('key');
+        $key = $request->query->getString('key');
 
         try {
             if (!$key) {
@@ -209,19 +211,21 @@ class ProfileController
      */
     private function checkArguments(Request $request)
     {
-        if (null === $request->get('firstName')) {
+        $payload = $request->getPayload();
+
+        if (null === $payload->get('firstName')) {
             throw new MissingArgumentException($this->contactClass, 'firstName');
         }
-        if (null === $request->get('lastName')) {
+        if (null === $payload->get('lastName')) {
             throw new MissingArgumentException($this->contactClass, 'lastName');
         }
-        if (null === $request->get('username')) {
+        if (null === $payload->get('username')) {
             throw new MissingArgumentException($this->userClass, 'username');
         }
-        if (null === $request->get('email')) {
+        if (null === $payload->get('email')) {
             throw new MissingArgumentException($this->userClass, 'email');
         }
-        if (null === $request->get('locale')) {
+        if (null === $payload->get('locale')) {
             throw new MissingArgumentException($this->userClass, 'locale');
         }
     }
@@ -233,7 +237,7 @@ class ProfileController
     {
         $data = [];
 
-        foreach ($request->request->all() as $key => $value) {
+        foreach ($request->getPayload()->all() as $key => $value) {
             if (\in_array($key, ['firstName', 'lastName', 'username', 'email', 'password', 'locale'], true)) {
                 $data[$key] = $value;
             }

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ProfileController.php
@@ -176,7 +176,7 @@ class ProfileController
      */
     public function deleteSettingsAction(Request $request)
     {
-        $key = $request->query->getString('key');
+        $key = $request->getPayload()->getString('key');
 
         try {
             if (!$key) {

--- a/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/ResettingController.php
@@ -112,7 +112,7 @@ class ResettingController
     public function sendEmailAction(Request $request)
     {
         try {
-            $user = $this->findUser($request->get('user'));
+            $user = $this->findUser($request->getPayload()->getString('user'));
             $maxNumberEmails = $this->tokenSendLimit;
 
             if (new \DateTime() >= $user->getPasswordResetTokenExpiresAt()) {
@@ -145,15 +145,16 @@ class ResettingController
     public function resetAction(Request $request)
     {
         try {
-            $token = $request->get('token');
+            $payload = $request->getPayload();
+            $token = $payload->getString('token');
 
-            if (null == $token) {
+            if ('' === $token) {
                 throw new NoTokenFoundException();
             }
 
             /** @var User $user */
             $user = $this->findUserByValidToken($this->generateTokenHash($token));
-            $this->changePassword($user, $request->get('password', ''));
+            $this->changePassword($user, $payload->getString('password'));
             $this->deleteToken($user);
             $this->loginUser($user, $request);
             $response = new JsonResponse(['user' => $user->getUsername()]);

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleSettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleSettingController.php
@@ -63,8 +63,11 @@ class RoleSettingController extends AbstractRestController implements SecuredCon
             $setting = $this->roleSettingRepository->createNew();
         }
 
+        // the value can be of any type (scalar or array), so neither `InputBag::get` nor `InputBag::all` can be used here
+        $payload = $request->getPayload()->all();
+
         $setting->setKey($key);
-        $setting->setValue($request->get('value', []));
+        $setting->setValue($payload['value'] ?? []);
         $setting->setRole($this->entityManager->getReference(Role::class, $roleId));
 
         $this->entityManager->persist($setting);

--- a/src/Sulu/Bundle/SecurityBundle/Controller/RoleSettingController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/RoleSettingController.php
@@ -64,10 +64,10 @@ class RoleSettingController extends AbstractRestController implements SecuredCon
         }
 
         // the value can be of any type (scalar or array), so neither `InputBag::get` nor `InputBag::all` can be used here
-        $payload = $request->getPayload()->all();
+        $payloadData = $request->getPayload()->all();
 
         $setting->setKey($key);
-        $setting->setValue($payload['value'] ?? []);
+        $setting->setValue($payloadData['value'] ?? []);
         $setting->setRole($this->entityManager->getReference(Role::class, $roleId));
 
         $this->entityManager->persist($setting);

--- a/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
+++ b/src/Sulu/Bundle/SecurityBundle/Controller/UserController.php
@@ -280,7 +280,7 @@ class UserController extends AbstractRestController implements SecuredController
     public function cgetAction(Request $request)
     {
         $view = null;
-        if ('true' == $request->get('flat')) {
+        if ('true' == $request->query->get('flat')) {
             $listBuilder = $this->doctrineListBuilderFactory->create($this->userClass);
 
             $this->restHelper->initializeListBuilder($listBuilder, $this->getFieldDescriptors());
@@ -294,7 +294,7 @@ class UserController extends AbstractRestController implements SecuredController
             );
             $view = $this->view($list, 200);
         } else {
-            $contactId = $request->get('contactId');
+            $contactId = $request->query->get('contactId');
 
             if (null != $contactId) {
                 $user = $this->entityManager->getRepository($this->userClass)->findUserByContact($contactId);

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ProfileControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ProfileControllerTest.php
@@ -408,7 +408,8 @@ class ProfileControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'DELETE',
-            '/api/profile/settings?' . \http_build_query(['key' => 'setting-key'])
+            '/api/profile/settings',
+            ['key' => 'setting-key']
         );
 
         $userSetting = $this->client->getContainer()->get('sulu_security.user_setting_repository')->findOneBy(

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ProfileControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ProfileControllerTest.php
@@ -408,8 +408,7 @@ class ProfileControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'DELETE',
-            '/api/profile/settings',
-            ['key' => 'setting-key']
+            '/api/profile/settings?' . \http_build_query(['key' => 'setting-key'])
         );
 
         $userSetting = $this->client->getContainer()->get('sulu_security.user_setting_repository')->findOneBy(
@@ -420,5 +419,12 @@ class ProfileControllerTest extends SuluTestCase
         );
 
         $this->assertNull($userSetting);
+    }
+
+    public function testDeleteSettingsWithoutKey(): void
+    {
+        $this->client->jsonRequest('DELETE', '/api/profile/settings');
+
+        $this->assertHttpStatusCode(400, $this->client->getResponse());
     }
 }

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Controller/ResettingControllerTest.php
@@ -387,10 +387,10 @@ class ResettingControllerTest extends SuluTestCase
     {
         $passwordBefore = $this->users[2]->getPassword();
 
-        $this->client->jsonRequest('GET', '/security/reset?' . \http_build_query([
+        $this->client->jsonRequest('POST', '/security/reset', [
             'token' => 'thistokendoesnotexist',
             'password' => 'thispasswordshouldnotbeapplied',
-        ]));
+        ]);
         $response = \json_decode($this->client->getResponse()->getContent());
         /** @var User $user */
         $user = $this->em->find(User::class, $this->users[2]->getId());


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Fixed tickets   | part of #8216

Continues the `Request::get()` migration with the **SecurityBundle**, following the same pattern as the Category (#8980), Contact (#8981), Media (#8989), Tag (#8991) and Website (#8993) bundle PRs. `PermissionController` was already migrated in #8986, `RoleController` and `ProfileTwoFactorController` never used `Request::get()`, so `ProfileController`, `ResettingController`, `RoleSettingController` and `UserController` were the last remaining consumers in this bundle.

As in the previous PRs the **real caller is the source of truth**, not the existing functional tests.

### Changes

| Endpoint | Parameter | Bag | Why |
| --- | --- | --- | --- |
| `DELETE /admin/api/profile/settings` | `key` | payload | see below |
| `PATCH /admin/api/profile/settings` | settings map | payload | `userStore.js` → `Requester.patch(endpoints.profileSettings, persistentSettings)` |
| `PUT /admin/api/profile` | `firstName`, `lastName`, `username`, `email`, `locale`, `password`, `twoFactor` | payload | `ProfileFormOverlay` → `ResourceStore.save()` → `ResourceRequester.put(resourceKey, this.data, {id: '-'})`, i.e. the data is the JSON body |
| `PUT /admin/api/roles/{roleId}/settings/{key}` | `value` | payload | see below |
| `GET /admin/api/users` | `flat`, `contactId` | query | `flat` is added by `ResourceRequester.getList()`, `contactId` comes from `SecurityAdmin::setIdQueryParameter('contactId')` and is put into the URL by `ResourceStore` — this also matches `postAction`/`checkArguments`, which already read it from the query bag |
| `POST /security/reset/email` | `user` | payload | `userStore.forgotPassword()` → `Requester.post(endpoints.forgotPasswordReset, data)` |
| `POST /security/reset` | `token`, `password` | payload | `userStore.resetPassword()` → `Requester.post(endpoints.resetPassword, data)` |

`ProfileController` mixed `$request->get()` and `$request->request` before; it now consistently uses `$request->getPayload()`, which also works when the FOSRestBundle body listener is not in play.

### About `DELETE /admin/api/profile/settings`

This endpoint has no consumer in the current admin — only the `PATCH` variant is used, via `userStore.updatePersistentSettings()`. The last real caller was the Sulu 1.x `app.sandbox.sulu.deleteUserSetting()` (added together with the endpoint in 003cc7c), which did:

```js
app.sandbox.util.ajax({type: 'DELETE', url: '/admin/security/profile/settings', data: {key: key}});
```

jQuery only appends `data` to the URL for `GET`/`HEAD`, so `key` was sent in the **request body**. The payload bag it is.

### About `PUT /admin/api/roles/{roleId}/settings/{key}`

`value` can be a scalar *or* an array (both are covered by the existing `testPut`/`testPutArray`), so neither `InputBag::get()` (rejects arrays) nor `InputBag::all()` (rejects scalars) works. It is read as `$request->getPayload()->all()['value'] ?? []` with a comment explaining why.

This endpoint has no consumer in the admin either, but `roleId` and `key` are route placeholders, so the payload is the only place `value` can conventionally come from — which is also what the existing tests already do.

### `POST /security/reset`

`token` is now read with `getString()`, so a missing token yields `''` instead of `null`; the `NoTokenFoundException` check was adjusted accordingly and the behaviour is unchanged.

`testResetActionWithInvalidToken` was sending the parameters as a `GET` query string, while the real caller only ever `POST`s a JSON body — `Login.handleResetPasswordFormSubmit()` → `userStore.resetPassword({...data, token})` → `Requester.post(Config.endpoints.resetPassword, data)`, and `Requester.post` sets `body: JSON.stringify(...)`. The test is aligned with that.

### Out of scope

`Sulu\Component\Rest\ListBuilder\ListRestHelper`, `Sulu\Component\Rest\RequestParametersTrait` and `Sulu\Component\Category\Request\CategoryRequestHandler` still use `$request->get()`. They back the list endpoints of *every* bundle and deserve their own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
