### PR TITLE
Deprecate AbstractRestController, RestControllerTrait and ApiWrapper

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -4,6 +4,15 @@ For every update follow the [Upgrade Documentation](https://docs.sulu.io/2.x/upg
 
 ## 2.6.26
 
+### Deprecated `AbstractRestController`, `RestControllerTrait` and `ApiWrapper`
+
+The `AbstractRestController` and the `RestControllerTrait` have been deprecated. We recommend building
+your own controllers instead of extending the class or using the trait, and injecting the services you
+require yourself.
+
+The `ApiWrapper` has been deprecated as well, as wrapping entities into API objects is no longer
+required. Use your own DTOs instead, or configure the serializer of your choice.
+
 ### Two factor authentication via authenticator apps (TOTP)
 
 The `totp` two factor method is now available in the admin profile when the `scheb/2fa-totp`

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -11,7 +11,7 @@ your own controllers instead of extending the class or using the trait, and inje
 require yourself.
 
 The `ApiWrapper` has been deprecated as well, as wrapping entities into API objects is no longer
-required. Use your own DTOs instead, or configure the serializer of your choice.
+recommended. Use your own DTOs instead, or configure the serializer of your choice.
 
 ### Two factor authentication via authenticator apps (TOTP)
 

--- a/src/Sulu/Component/Rest/AbstractRestController.php
+++ b/src/Sulu/Component/Rest/AbstractRestController.php
@@ -17,6 +17,9 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 /**
  * Abstract Controller for extracting some required rest functionality.
+ *
+ * @deprecated since Sulu 2.6, we recommend building your own controllers instead of extending this
+ *             class and injecting the required services yourself.
  */
 abstract class AbstractRestController
 {

--- a/src/Sulu/Component/Rest/ApiWrapper.php
+++ b/src/Sulu/Component/Rest/ApiWrapper.php
@@ -15,6 +15,9 @@ use JMS\Serializer\Annotation\Exclude;
 
 /**
  * The abstract base class for an API object, which wraps another entity.
+ *
+ * @deprecated since Sulu 2.6, the usage of ApiWrapper or ApiObject is no longer required.
+ *             Use your own DTOs instead or configure the serializer of your choice.
  */
 class ApiWrapper
 {

--- a/src/Sulu/Component/Rest/ApiWrapper.php
+++ b/src/Sulu/Component/Rest/ApiWrapper.php
@@ -16,7 +16,7 @@ use JMS\Serializer\Annotation\Exclude;
 /**
  * The abstract base class for an API object, which wraps another entity.
  *
- * @deprecated since Sulu 2.6, the usage of ApiWrapper or ApiObject is no longer required.
+ * @deprecated since Sulu 2.6, the usage of ApiWrapper is no longer required.
  *             Use your own DTOs instead or configure the serializer of your choice.
  */
 class ApiWrapper

--- a/src/Sulu/Component/Rest/ContextAwareNormalizerInterface.php
+++ b/src/Sulu/Component/Rest/ContextAwareNormalizerInterface.php
@@ -15,11 +15,20 @@ use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface as S
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 if (\class_exists(SymfonyContextAwareNormalizerInterface::class)) {
-    // BC Layer for Symfony <= 6.4: https://github.com/symfony/symfony/blob/7.1/UPGRADE-7.0.md#serializer
+    /**
+     * @internal This is just a BC layer for Symfony <= 6.4, please use the Symfony interface instead.
+     *
+     * @see https://github.com/symfony/symfony/blob/7.1/UPGRADE-7.0.md#serializer
+     */
     interface ContextAwareNormalizerInterface extends SymfonyContextAwareNormalizerInterface
     {
     }
 } else {
+    /**
+     * @internal This is just a BC layer for Symfony <= 6.4, please use the Symfony interface instead.
+     *
+     * @see https://github.com/symfony/symfony/blob/7.1/UPGRADE-7.0.md#serializer
+     */
     interface ContextAwareNormalizerInterface extends NormalizerInterface
     {
     }

--- a/src/Sulu/Component/Rest/RequestParametersTrait.php
+++ b/src/Sulu/Component/Rest/RequestParametersTrait.php
@@ -16,7 +16,10 @@ use Sulu\Component\Rest\Exception\ParameterDataTypeException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * handles request parameters.
+ * Handles request parameters.
+ *
+ * @deprecated since Sulu 2.6, use $request->query->get(), $request->request->get(),
+ *             $request->attributes->get() or $request->getPayload()->get() instead.
  */
 trait RequestParametersTrait
 {

--- a/src/Sulu/Component/Rest/RestControllerTrait.php
+++ b/src/Sulu/Component/Rest/RestControllerTrait.php
@@ -17,6 +17,10 @@ use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\Exception\RestException;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprecated since Sulu 2.6, we recommend building your own controllers instead of using this trait
+ *             and injecting the required services yourself.
+ */
 trait RestControllerTrait
 {
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | -
| Related issues/PRs | #8973, #8793
| License | MIT
| Documentation PR | -

#### What's in this PR?

Deprecates the legacy REST helper classes of the `Sulu\Component\Rest` namespace:

 - `AbstractRestController`
 - `RestControllerTrait`
 - `ApiWrapper`

It also completes the already announced `RequestParametersTrait` deprecation with a proper
`@deprecated` annotation on the trait itself, and marks the `ContextAwareNormalizerInterface`
BC layer as `@internal`.

The deprecations are documented in `UPGRADE-2.x.md`.

#### Why?

These classes are leftovers from the time Sulu shipped its own REST abstraction on top of
FOSRestBundle. Nowadays a plain Symfony controller with the services you actually need injected is
simpler, easier to type and does not tie your controllers to Sulu internals. The same applies to
`ApiWrapper`: wrapping entities into API objects is no longer needed, own DTOs or a configured
serializer are the better choice.

#### Example Usage

```php
// instead of extending AbstractRestController / using RestControllerTrait
class MyController
{
    public function __construct(
        private MyRepository $repository,
    ) {
    }

    public function getAction(Request $request): JsonResponse
    {
        // instead of $this->getRequestParameter($request, 'locale')
        $locale = $request->query->getString('locale');

        return new JsonResponse($this->repository->findBy(['locale' => $locale]));
    }
}
```

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
