### PR TITLE
Use php routing files from third party bundles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "dragonmantank/cron-expression": "^1.1 || ^2.0 || ^3.0",
         "friendsofsymfony/http-cache": "^3.0",
         "friendsofsymfony/http-cache-bundle": "^3.0",
-        "friendsofsymfony/jsrouting-bundle": "^3.0",
+        "friendsofsymfony/jsrouting-bundle": "^3.6",
         "friendsofsymfony/rest-bundle": "^3.2",
         "gedmo/doctrine-extensions": "^3.8",
         "guzzlehttp/promises": "^1.0 || ^2.0 || ^3.0",

--- a/config/routes/fos_js_routing_admin.yaml
+++ b/config/routes/fos_js_routing_admin.yaml
@@ -1,3 +1,3 @@
 fos_js_routing:
     prefix: /admin
-    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing-sf4.xml"
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.php"

--- a/config/routes/framework.yaml
+++ b/config/routes/framework.yaml
@@ -1,4 +1,4 @@
 when@dev:
     _errors:
-        resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+        resource: '@FrameworkBundle/Resources/config/routing/errors.php'
         prefix: /_error

--- a/config/routes/web_profiler.yaml
+++ b/config/routes/web_profiler.yaml
@@ -1,8 +1,8 @@
 when@dev:
     web_profiler_wdt:
-        resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.php'
         prefix: /_wdt
 
     web_profiler_profiler:
-        resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.php'
         prefix: /_profiler

--- a/packages/content/tests/Application/config/routing_admin.yml
+++ b/packages/content/tests/Application/config/routing_admin.yml
@@ -1,7 +1,7 @@
 # FosJsRoutingBundle
 fos_js_routing:
     prefix: /admin
-    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing-sf4.xml"
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.php"
 
 # Sulu
 sulu_tag_api:

--- a/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Application/config/routing.yml
@@ -1,7 +1,7 @@
 # Required vendor routes
 fos_js_routing:
     prefix: /admin
-    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing-sf4.xml"
+    resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.php"
 
 # Sulu Routes
 sulu_tag_api:

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yaml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yaml
@@ -1,3 +1,3 @@
 _errors:
-    resource: "@FrameworkBundle/Resources/config/routing/errors.xml"
+    resource: "@FrameworkBundle/Resources/config/routing/errors.php"
     prefix:   /_error

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yaml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yaml
@@ -1,9 +1,4 @@
-# Use following if Symfony min Version is 7.x
-#_errors:
-#    resource: "@FrameworkBundle/Resources/config/routing/errors.php"
-#    prefix:   /_error
-#
-# until we use:
+# For Symfony 6.4 - 8.x compatibility we use:
 _preview_error:
     path: /_error/{code}.{_format}
     defaults:
@@ -11,3 +6,8 @@ _preview_error:
         _format: html
     requirements:
         code: '\d+'
+
+# If min version is Symfony 7.x, we can use the following instead:
+#_errors:
+#    resource: "@FrameworkBundle/Resources/config/routing/errors.php"
+#    prefix:   /_error

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yaml
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/routing_error.yaml
@@ -1,3 +1,13 @@
-_errors:
-    resource: "@FrameworkBundle/Resources/config/routing/errors.php"
-    prefix:   /_error
+# Use following if Symfony min Version is 7.x
+#_errors:
+#    resource: "@FrameworkBundle/Resources/config/routing/errors.php"
+#    prefix:   /_error
+#
+# until we use:
+_preview_error:
+    path: /_error/{code}.{_format}
+    defaults:
+        _controller: 'error_controller::preview'
+        _format: html
+    requirements:
+        code: '\d+'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | no
| BC breaks? | no 
| Deprecations? | no  <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | #8216  <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Use php routing files from third party bundles.

#### Why?

We want support Symfony 8 in future Sulu versions.