### PR TITLE
Add Symfony 8 compatibility to Commands

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateRoleCommand.php
@@ -108,7 +108,7 @@ class CreateRoleCommand extends Command
     /**
      * @see Command
      */
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         $helper = $this->getHelper('question');
 

--- a/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
+++ b/src/Sulu/Bundle/SecurityBundle/Command/CreateUserCommand.php
@@ -150,7 +150,7 @@ class CreateUserCommand extends Command
         return $this->userRepository->createNew();
     }
 
-    protected function interact(InputInterface $input, OutputInterface $output)
+    protected function interact(InputInterface $input, OutputInterface $output): void
     {
         $roleNames = $this->getRoleNames();
         $helper = $this->getHelper('question');

--- a/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/InitCommandTest.php
+++ b/src/Sulu/Bundle/SecurityBundle/Tests/Functional/Command/InitCommandTest.php
@@ -50,7 +50,7 @@ class InitCommandTest extends SuluTestCase
 
     public function testCreateAnonymousRole(): void
     {
-        $this->runCommand();
+        $this->executeCommand();
 
         $this->assertStringContainsString(
             '[+] Create anonymous role in system "Sulu CMF" as "Anonymous User Sulu CMF".',
@@ -70,7 +70,7 @@ class InitCommandTest extends SuluTestCase
         $this->createAnonymousRole('Sulu CMF');
         $this->getEntityManager()->flush();
 
-        $this->runCommand();
+        $this->executeCommand();
 
         $this->assertStringContainsString(
             '[*] Anonymous role named "Anonymous User Sulu CMF" in system "Sulu CMF" was updated.',
@@ -123,7 +123,7 @@ class InitCommandTest extends SuluTestCase
         return $role;
     }
 
-    private function runCommand(): void
+    private function executeCommand(): void
     {
         $this->tester->execute(
             [],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Add the `void` return type to the `interact` method of the `CreateRoleCommand` and `CreateUserCommand` and rename the private `runCommand` helper of the `InitCommandTest` to `executeCommand`.

#### Why?

We want support Symfony 8 in future Sulu versions.

Symfony 8 declares `Command::interact(): void` and the `KernelTestCase` uses the new `ConsoleCommandAssertionsTrait` which adds a static `runCommand()` method. Both lead to a fatal error when the declarations are not compatible.
