### PR TITLE
Upgrade PageController Request::get call to specific Request ParameterBag

### DIFF
--- a/packages/page/src/UserInterface/Controller/Admin/PageController.php
+++ b/packages/page/src/UserInterface/Controller/Admin/PageController.php
@@ -634,7 +634,7 @@ final class PageController implements SecuredControllerInterface, SecuredObjectC
     {
         // For detail actions, use id parameter
         // For list action, no specific object (will check webspace-level permissions)
-        $id = $request->get('id');
+        $id = $request->attributes->get('id');
 
         return \is_string($id) ? $id : '';
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Upgrade the `Request::get` call in the `PageController` to the specific `attributes` Request ParameterBag.

#### Why?

We want support Symfony 8 in future Sulu versions.

The `Request::get` method is deprecated since Symfony 7.4 and was removed in Symfony 8.
