### PR TITLE
Add Symfony 8 compatibility to AuthenticationFailureListener

### DIFF
--- a/src/Sulu/Bundle/SecurityBundle/EventListener/AuthenticationFailureListener.php
+++ b/src/Sulu/Bundle/SecurityBundle/EventListener/AuthenticationFailureListener.php
@@ -34,7 +34,7 @@ class AuthenticationFailureListener implements EventSubscriberInterface
     /**
      * @return array<string, string>
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             LoginFailureEvent::class => 'onLoginFailure',


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Add the `array` return type to the `getSubscribedEvents` method of the `AuthenticationFailureListener`.

#### Why?

We want support Symfony 8 in future Sulu versions.

Symfony 8 declares `EventSubscriberInterface::getSubscribedEvents(): array` which leads to a fatal error when the implementation does not declare the return type.
