### PR TITLE
Prepare ArrayAdapter service definitions for Symfony 8 compatibility

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/ContactBundle/Resources/config/services.php
@@ -107,7 +107,8 @@ return static function(ContainerConfigurator $container) {
         ]);
 
     $services->set('sulu_contact.twig.cache_adapter', ArrayAdapter::class)
-        ->args(['$storeSerialized' => false]);
+        // second argument is $storeSerialized before Symfony 8 and $deepClone since, so it is set positionally
+        ->args([0, false]);
 
     $services->set('sulu_contact.twig', ContactTwigExtension::class)
         ->args([

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/cache.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/cache.php
@@ -18,7 +18,9 @@ use Symfony\Component\DependencyInjection\Reference;
 return static function(ContainerConfigurator $container) {
     $services = $container->services();
 
-    $services->set('sulu_core.cache.memoize.cache_adapter', ArrayAdapter::class);
+    $services->set('sulu_core.cache.memoize.cache_adapter', ArrayAdapter::class)
+        // second argument is $storeSerialized before Symfony 8 and $deepClone since, so it is set positionally
+        ->args([0, false]);
 
     $services->set('sulu_core.cache.memoize', Memoize::class)
         ->args([

--- a/src/Sulu/Bundle/SecurityBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/SecurityBundle/Resources/config/services.php
@@ -279,7 +279,8 @@ return static function(ContainerConfigurator $container) {
         ->tag('sulu.context', ['context' => 'admin']);
 
     $services->set('sulu_security.twig_extension.user.cache_adapter', ArrayAdapter::class)
-        ->args(['$storeSerialized' => false]);
+        // second argument is $storeSerialized before Symfony 8 and $deepClone since, so it is set positionally
+        ->args([0, false]);
 
     $services->set('sulu_security.twig_extension.user', UserTwigExtension::class)
         ->args([


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Pass the second constructor argument of the `ArrayAdapter` service definitions positionally instead of using the named `$storeSerialized` argument.

#### Why?

We want support Symfony 8 in future Sulu versions.

Symfony 8 renamed the second `ArrayAdapter` constructor argument from `$storeSerialized` to `$deepClone`. Setting it positionally keeps the service definitions working on Symfony 6.4, 7.x and 8.
