### PR TITLE
Make the test AppCache kernels compatible to Symfony 8

### DIFF
--- a/packages/content/tests/Application/AppCache.php
+++ b/packages/content/tests/Application/AppCache.php
@@ -111,14 +111,12 @@ class AppCache extends SuluHttpCache implements KernelInterface
 
     public function getShareDir(): ?string
     {
-        // before Symfony 7.4 the method is not part of the KernelInterface but SuluKernel provides it already
         return $this->kernel->getShareDir();
     }
 
     public function getLogDir(): string
     {
-        // the KernelInterface returns a nullable string since Symfony 8 but requires a string before
-        return $this->kernel->getLogDir() ?? '';
+        return $this->kernel->getLogDir();
     }
 
     public function getCharset(): string

--- a/packages/content/tests/Application/AppCache.php
+++ b/packages/content/tests/Application/AppCache.php
@@ -109,9 +109,16 @@ class AppCache extends SuluHttpCache implements KernelInterface
         return $this->kernel->getBuildDir();
     }
 
+    public function getShareDir(): ?string
+    {
+        // before Symfony 7.4 the method is not part of the KernelInterface but SuluKernel provides it already
+        return $this->kernel->getShareDir();
+    }
+
     public function getLogDir(): string
     {
-        return $this->kernel->getLogDir();
+        // the KernelInterface returns a nullable string since Symfony 8 but requires a string before
+        return $this->kernel->getLogDir() ?? '';
     }
 
     public function getCharset(): string

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/AppCache.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/AppCache.php
@@ -99,14 +99,12 @@ class AppCache extends SuluHttpCache implements KernelInterface
 
     public function getShareDir(): ?string
     {
-        // before Symfony 7.4 the method is not part of the KernelInterface but SuluKernel provides it already
         return $this->kernel->getShareDir();
     }
 
     public function getLogDir(): string
     {
-        // the KernelInterface returns a nullable string since Symfony 8 but requires a string before
-        return $this->kernel->getLogDir() ?? '';
+        return $this->kernel->getLogDir();
     }
 
     public function getCharset(): string

--- a/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/AppCache.php
+++ b/src/Sulu/Bundle/AudienceTargetingBundle/Tests/Application/AppCache.php
@@ -27,16 +27,6 @@ class AppCache extends SuluHttpCache implements KernelInterface
         $this->addSubscriber(new AudienceTargetingCacheListener());
     }
 
-    public function serialize()
-    {
-        return $this->kernel->serialize();
-    }
-
-    public function unserialize($serialized): void
-    {
-        $this->kernel->unserialize($serialized);
-    }
-
     public function registerBundles(): iterable
     {
         return $this->kernel->registerBundles();
@@ -62,19 +52,14 @@ class AppCache extends SuluHttpCache implements KernelInterface
         return $this->kernel->getBundles();
     }
 
-    public function getBundle($name, $first = true): BundleInterface
+    public function getBundle(string $name): BundleInterface
     {
-        return $this->kernel->getBundle($name, $first);
+        return $this->kernel->getBundle($name);
     }
 
-    public function locateResource($name, $dir = null, $first = true): string
+    public function locateResource(string $name): string
     {
-        return $this->kernel->locateResource($name, $dir, $first);
-    }
-
-    public function getName()
-    {
-        return $this->kernel->getName();
+        return $this->kernel->locateResource($name);
     }
 
     public function getEnvironment(): string
@@ -112,9 +97,16 @@ class AppCache extends SuluHttpCache implements KernelInterface
         return $this->kernel->getBuildDir();
     }
 
+    public function getShareDir(): ?string
+    {
+        // before Symfony 7.4 the method is not part of the KernelInterface but SuluKernel provides it already
+        return $this->kernel->getShareDir();
+    }
+
     public function getLogDir(): string
     {
-        return $this->kernel->getLogDir();
+        // the KernelInterface returns a nullable string since Symfony 8 but requires a string before
+        return $this->kernel->getLogDir() ?? '';
     }
 
     public function getCharset(): string


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Add the `getShareDir` method to the `AppCache` test kernels, keep `getLogDir` returning a string and remove the no longer existing `serialize`, `unserialize` and `getName` delegations together with the outdated `getBundle` and `locateResource` signatures.

#### Why?

We want support Symfony 8 in future Sulu versions.

Symfony 8 added `getShareDir` to the `KernelInterface` and made `getLogDir` nullable, so the test kernels which implement the interface manually need to be adjusted.
