### PR TITLE
Add Symfony 8 compatibility to Security Voters

### DIFF
--- a/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/Security/PreviewVoter.php
+++ b/src/Sulu/Bundle/PreviewBundle/Infrastructure/Symfony/Security/PreviewVoter.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\PreviewBundle\Infrastructure\Symfony\Security;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -57,7 +58,7 @@ class PreviewVoter implements VoterInterface
      *
      * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
      */
-    public function vote(TokenInterface $token, $object, array $attributes): int
+    public function vote(TokenInterface $token, $object, array $attributes, ?Vote $vote = null): int
     {
         return VoterInterface::ACCESS_GRANTED;
     }

--- a/src/Sulu/Bundle/TestBundle/Testing/TestVoter.php
+++ b/src/Sulu/Bundle/TestBundle/Testing/TestVoter.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\TestBundle\Testing;
 
 use Sulu\Component\Security\Authentication\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -56,7 +57,7 @@ class TestVoter implements VoterInterface
      *
      * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
      */
-    public function vote(TokenInterface $token, $object, array $attributes): int
+    public function vote(TokenInterface $token, $object, array $attributes, ?Vote $vote = null): int
     {
         $user = $token->getUser();
 

--- a/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
+++ b/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
@@ -14,6 +14,7 @@ namespace Sulu\Component\Security\Authorization;
 use Sulu\Bundle\SecurityBundle\Entity\User;
 use Sulu\Component\Security\Authorization\AccessControl\AccessControlManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**

--- a/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
+++ b/src/Sulu/Component/Security/Authorization/SecurityContextVoter.php
@@ -43,7 +43,7 @@ class SecurityContextVoter implements VoterInterface
         return SecurityCondition::class === $class || \is_subclass_of($class, SecurityCondition::class);
     }
 
-    public function vote(TokenInterface $token, $object, array $attributes): int
+    public function vote(TokenInterface $token, $object, array $attributes, ?Vote $vote = null): int
     {
         /** @var User $user */
         $user = $token->getUser();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Add the new `$vote` argument to the `vote` method of the `SecurityContextVoter`, `PreviewVoter` and `TestVoter`.

#### Why?

We want support Symfony 8 in future Sulu versions.

Symfony 8 declares `VoterInterface::vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int`, so implementations without the fourth argument lead to a fatal error.
