### PR TITLE
Upgrade CategoryRequestHandler Request::get call to specific Request ParameterBag

### DIFF
--- a/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
+++ b/src/Sulu/Component/Category/Request/CategoryRequestHandler.php
@@ -26,7 +26,7 @@ class CategoryRequestHandler implements CategoryRequestHandlerInterface
     public function getCategories($categoriesParameter = 'categories')
     {
         if (null !== $this->requestStack->getCurrentRequest()) {
-            $categories = $this->requestStack->getCurrentRequest()->get($categoriesParameter, '');
+            $categories = $this->requestStack->getCurrentRequest()->query->get($categoriesParameter, '');
         } else {
             $categories = '';
         }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Upgrade the `Request::get` call in the `CategoryRequestHandler` to the specific `query` Request ParameterBag, which is already used by the other methods of the same class.

#### Why?

We want support Symfony 8 in future Sulu versions.

The `Request::get` method is deprecated since Symfony 7.4 and was removed in Symfony 8.
