### PR TITLE
Upgrade ListRestHelper Request::get calls to specific Request ParameterBags

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4141,12 +4141,6 @@ parameters:
 			path: src/Sulu/Bundle/AudienceTargetingBundle/Controller/TargetGroupController.php
 
 		-
-			message: '#^Strict comparison using \=\=\= between null and string will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/Sulu/Bundle/AudienceTargetingBundle/Controller/TargetGroupController.php
-
-		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1
@@ -12673,12 +12667,6 @@ parameters:
 			path: src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
 
 		-
-			message: '#^Argument of an invalid type string\|null supplied for foreach, only iterables are supported\.$#'
-			identifier: foreach.nonIterable
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
-
-		-
 			message: '#^Binary operation "\+\=" between \(float\|int\) and mixed results in an error\.$#'
 			identifier: assignOp.invalid
 			count: 2
@@ -12873,12 +12861,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\ContactBundle\\Controller\\AccountController\:\:initFieldDescriptors\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
-
-		-
-			message: '#^Method Symfony\\Component\\HttpFoundation\\ParameterBag\:\:all\(\) invoked with 2 parameters, 0\-1 required\.$#'
-			identifier: arguments.count
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
 
@@ -13160,12 +13142,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#2 \$socialMediaProfiles of method Sulu\\Bundle\\ContactBundle\\Contact\\AbstractContactManager\<Sulu\\Bundle\\ContactBundle\\Entity\\AccountInterface,Sulu\\Bundle\\ContactBundle\\Api\\Account,Sulu\\Bundle\\ContactBundle\\Entity\\AccountAddress\>\:\:processSocialMediaProfiles\(\) expects array, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/AccountController.php
@@ -13503,12 +13479,6 @@ parameters:
 		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
-
-		-
-			message: '#^Parameter \#1 \$key of method Symfony\\Component\\HttpFoundation\\InputBag\<bool\|float\|int\|string\|null\>\:\:get\(\) expects string, int\<0, max\> given\.$#'
-			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/ContactBundle/Controller/ContactTitleController.php
 
@@ -25735,18 +25705,6 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/Admin/Helper/SystemLanguageSelect.php
 
 		-
-			message: '#^Access to an undefined property Sulu\\Bundle\\SecurityBundle\\Admin\\SecurityAdmin\:\:\$urlGenerator\.$#'
-			identifier: property.notFound
-			count: 5
-			path: src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
-
-		-
-			message: '#^Cannot call method generate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: src/Sulu/Bundle/SecurityBundle/Admin/SecurityAdmin.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\SecurityBundle\\Admin\\SecurityAdmin\:\:__construct\(\) has parameter \$resources with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -29833,12 +29791,6 @@ parameters:
 			path: src/Sulu/Bundle/WebsiteBundle/Command/DumpSitemapCommand.php
 
 		-
-			message: '#^Cannot call method get\(\) on Symfony\\Component\\HttpFoundation\\Request\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\WebsiteBundle\\Controller\\AnalyticsController\:\:buildContent\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -29852,18 +29804,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$ids of method Sulu\\Bundle\\WebsiteBundle\\Analytics\\AnalyticsManagerInterface\:\:removeMultiple\(\) expects array\<int\>, array\<int\<0, max\>, string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
-
-		-
-			message: '#^Parameter \#1 \$webspaceKey of static method Sulu\\Bundle\\WebsiteBundle\\Admin\\WebsiteAdmin\:\:getAnalyticsSecurityContext\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/WebsiteBundle/Controller/AnalyticsController.php
@@ -32497,18 +32437,6 @@ parameters:
 			path: src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
 
 		-
-			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
-			identifier: equal.alwaysTrue
-			count: 1
-			path: src/Sulu/Component/Persistence/RelationTrait.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
-			identifier: notIdentical.alwaysFalse
-			count: 1
-			path: src/Sulu/Component/Persistence/RelationTrait.php
-
-		-
 			message: '#^Parameter \#1 \$objects of class Sulu\\Component\\Persistence\\EventSubscriber\\ORM\\MetadataSubscriber constructor expects array\<string, array\<string, array\{model\?\: class\-string\<object\>, repository\?\: class\-string\<Doctrine\\ORM\\EntityRepository\<object\>\>\}\>\>, array\{sulu\: array\{contact\: array\{model\: ''stdClass'', repository\: ''Sulu\\\\Bundle\\\\ContactBundle\\\\Entity\\\\ContactRepository''\}, member\: array\{model\: ''Closure''\}, user\: array\{model\: class\-string\<stdClass\>\}\}\} given\.$#'
 			identifier: argument.type
 			count: 1
@@ -33655,8 +33583,20 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListBuilderInterface.php
 
 		-
-			message: '#^Binary operation "\-" between mixed and 1 results in an error\.$#'
+			message: '#^Binary operation "\*" between int\<min, \-1\>\|int\<1, max\> and mixed results in an error\.$#'
 			identifier: binaryOp.invalid
+			count: 1
+			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+
+		-
+			message: '#^Binary operation "\-" between 1\|string and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+
+		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
@@ -33673,13 +33613,7 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getFilter\(\) should return array but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getLimit\(\) should return int\|null but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getLimit\(\) should return int\|null but returns int\<1, max\>\|string\|null\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -33691,7 +33625,7 @@ parameters:
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
 		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getPage\(\) should return int but returns mixed\.$#'
+			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getPage\(\) should return int but returns int\|string\.$#'
 			identifier: return.type
 			count: 1
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -33700,24 +33634,6 @@ parameters:
 			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getSearchFields\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getSearchPattern\(\) should return string\|null but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
-
-		-
-			message: '#^Method Sulu\\Component\\Rest\\ListBuilder\\ListRestHelper\:\:getSortOrder\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
-
-		-
-			message: '#^Parameter \#2 \$string of function explode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 4
 			path: src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -28219,6 +28219,12 @@ parameters:
 			path: src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
 
 		-
+			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 1
+			path: src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+
+		-
 			message: '#^Method Sulu\\Bundle\\SecurityBundle\\UserManager\\UserManager\:\:addUserRole\(\) has parameter \$userRoleData with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -28564,6 +28570,12 @@ parameters:
 			message: '#^Result of && is always false\.$#'
 			identifier: booleanAnd.alwaysFalse
 			count: 3
+			path: src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
 			path: src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php
 
 		-
@@ -34399,12 +34411,6 @@ parameters:
 			path: src/Sulu/Component/Rest/RestHelper.php
 
 		-
-			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
-			identifier: equal.alwaysTrue
-			count: 1
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
 			message: '#^Method Sulu\\Component\\Rest\\RestHelper\:\:compareData\(\) has parameter \$entities with no value type specified in iterable type Traversable\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -34528,12 +34534,6 @@ parameters:
 			message: '#^Possibly invalid array key type mixed\.$#'
 			identifier: offsetAccess.invalidOffset
 			count: 2
-			path: src/Sulu/Component/Rest/RestHelper.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
-			identifier: notIdentical.alwaysFalse
-			count: 1
 			path: src/Sulu/Component/Rest/RestHelper.php
 
 		-

--- a/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
+++ b/src/Sulu/Component/Rest/ListBuilder/ListRestHelper.php
@@ -54,21 +54,21 @@ class ListRestHelper implements ListRestHelperInterface
 
     public function getIds()
     {
-        $idsString = $this->getRequest()->get('ids');
+        $idsString = $this->getRequest()->query->get('ids');
 
         return (null !== $idsString) ? \array_filter(\explode(',', $idsString)) : null;
     }
 
     public function getExcludedIds()
     {
-        $excludedIdsString = $this->getRequest()->get('excludedIds');
+        $excludedIdsString = $this->getRequest()->query->get('excludedIds');
 
         return (null !== $excludedIdsString) ? \array_filter(\explode(',', $excludedIdsString)) : [];
     }
 
     public function getSortColumn()
     {
-        $sortColumn = $this->getRequest()->get('sortBy', null);
+        $sortColumn = $this->getRequest()->query->get('sortBy', null);
         if (null === $sortColumn || !\is_string($sortColumn)) {
             return null;
         }
@@ -88,7 +88,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getSortOrder()
     {
-        return $this->getRequest()->get('sortOrder', 'asc');
+        return $this->getRequest()->query->get('sortOrder', 'asc');
     }
 
     /**
@@ -109,7 +109,7 @@ class ListRestHelper implements ListRestHelperInterface
             $default = \count($ids);
         }
 
-        return $this->getRequest()->get('limit', $default);
+        return $this->getRequest()->query->get('limit', $default);
     }
 
     /**
@@ -120,7 +120,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getOffset()
     {
-        $page = $this->getRequest()->get('page', 1);
+        $page = $this->getRequest()->query->get('page', 1);
         $limit = $this->getLimit();
 
         return (null != $limit) ? $limit * ($page - 1) : null;
@@ -131,7 +131,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getPage()
     {
-        return $this->getRequest()->get('page', 1);
+        return $this->getRequest()->query->get('page', 1);
     }
 
     /**
@@ -142,7 +142,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getFields()
     {
-        $fields = $this->getRequest()->get('fields');
+        $fields = $this->getRequest()->query->get('fields');
 
         return (null != $fields) ? \explode(',', $fields) : null;
     }
@@ -152,7 +152,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getSearchPattern()
     {
-        return $this->getRequest()->get('search');
+        return $this->getRequest()->query->get('search');
     }
 
     /**
@@ -162,7 +162,7 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getSearchFields()
     {
-        $searchFields = $this->getRequest()->get('searchFields');
+        $searchFields = $this->getRequest()->query->get('searchFields');
 
         return (null != $searchFields) ? \explode(',', $searchFields) : [];
     }
@@ -172,6 +172,6 @@ class ListRestHelper implements ListRestHelperInterface
      */
     public function getFilter()
     {
-        return $this->getRequest()->get('filter', []);
+        return $this->getRequest()->query->all('filter');
     }
 }

--- a/src/Sulu/Component/Rest/Tests/Unit/RequestParametersTraitTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RequestParametersTraitTest.php
@@ -12,7 +12,6 @@
 namespace Sulu\Component\Rest\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\ParameterDataTypeException;
 use Sulu\Component\Rest\RequestParametersTrait;
@@ -20,7 +19,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RequestParametersTraitTest extends TestCase
 {
-    use ProphecyTrait;
     use RequestParametersTrait;
 
     public function testGetRequestParameter(): void
@@ -73,18 +71,17 @@ class RequestParametersTraitTest extends TestCase
     {
         $this->expectException(MissingParameterException::class);
 
-        $request = $this->prophesize(Request::class);
+        $request = new Request();
 
-        $this->getBooleanRequestParameter($request->reveal(), 'test', true);
+        $this->getBooleanRequestParameter($request, 'test', true);
     }
 
     public function testGetBooleanRequestWrongParameter(): void
     {
         $this->expectException(ParameterDataTypeException::class);
 
-        $request = $this->prophesize(Request::class);
-        $request->get('test', null)->willReturn('asdf');
+        $request = new Request(['test' => 'asdf']);
 
-        $this->getBooleanRequestParameter($request->reveal(), 'test', true);
+        $this->getBooleanRequestParameter($request, 'test', true);
     }
 }

--- a/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
+++ b/src/Sulu/Component/Webspace/Tests/Functional/Analyzer/RequestAnalyzerTest.php
@@ -26,8 +26,6 @@ use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Portal;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Component\Webspace\Webspace;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -244,10 +242,7 @@ class RequestAnalyzerTest extends TestCase
         $this->webspaceManager->findPortalInformationsByUrl(Argument::any(), Argument::any())->willReturn([]);
         $this->webspaceManager->getPortalInformations(Argument::any())->willReturn([]);
 
-        $request = $this->getMockBuilder(Request::class)->getMock();
-        $request->request = new InputBag(['post' => 1]);
-        $request->query = new InputBag(['get' => 1]);
-        $request->attributes = new ParameterBag();
+        $request = new Request(['get' => 1], ['post' => 1]);
 
         $this->requestAnalyzer->analyze($request);
         $this->requestAnalyzer->validate($request);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #8216
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Upgrade the `Request::get` calls in the `ListRestHelper` to the specific `query` Request ParameterBag. The `filter` parameter uses `query->all` because it holds an array.

Additionally the `RequestParametersTraitTest` and the `RequestAnalyzerTest` no longer mock the `Request` class but use real `Request` instances instead.

#### Why?

We want support Symfony 8 in future Sulu versions.

The `Request::get` method is deprecated since Symfony 7.4 and was removed in Symfony 8. Symfony 8.1 also converted the `attributes`, `query` and `request` properties of the `Request` to property hooks, so setting them on a mocked request no longer works as expected.
