### PR TITLE
Fix proxy manager circular service reference

### DIFF
--- a/src/Sulu/Bundle/CoreBundle/Resources/config/cache.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/cache.php
@@ -47,10 +47,5 @@ return static function(ContainerConfigurator $container) {
 
     $services->set('sulu_core.proxy_manager.file_locator', FileLocator::class)
         ->private()
-        // Use the "%sulu_core.proxy_cache_dir%" parameter directly instead of reading it back from the
-        // "sulu_core.proxy_manager.configuration" service. Both resolve to the same value, but going through
-        // the service creates a circular reference (configuration -> file_writer_generator_strategy ->
-        // file_locator -> configuration) that the Symfony DI dumper can compile into an infinitely recursing
-        // container factory method.
         ->args(['%sulu_core.proxy_cache_dir%']);
 };

--- a/src/Sulu/Bundle/CoreBundle/Resources/config/cache.php
+++ b/src/Sulu/Bundle/CoreBundle/Resources/config/cache.php
@@ -47,5 +47,10 @@ return static function(ContainerConfigurator $container) {
 
     $services->set('sulu_core.proxy_manager.file_locator', FileLocator::class)
         ->private()
-        ->args([expr('service(\'sulu_core.proxy_manager.configuration\').getProxiesTargetDir()')]);
+        // Use the "%sulu_core.proxy_cache_dir%" parameter directly instead of reading it back from the
+        // "sulu_core.proxy_manager.configuration" service. Both resolve to the same value, but going through
+        // the service creates a circular reference (configuration -> file_writer_generator_strategy ->
+        // file_locator -> configuration) that the Symfony DI dumper can compile into an infinitely recursing
+        // container factory method.
+        ->args(['%sulu_core.proxy_cache_dir%']);
 };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Related Issues | https://github.com/symfony/symfony/issues/65270

#### What's in this PR?

`Configuration::getProxiesTargetDir()` only ever returns the value that
Sulu sets via `setProxiesTargetDir('%sulu_core.proxy_cache_dir%')`, so
the file locator can take that parameter directly. This removes the
cycle entirely.

#### Why?

The "sulu_core.proxy_manager.file_locator" service read its target
directory back from the "sulu_core.proxy_manager.configuration" service
via a `service('...').getProxiesTargetDir()` expression. Since the
configuration service transitively depends on the file locator
(configuration -> file_writer_generator_strategy -> file_locator), this
formed a circular reference.