### PR TITLE
Deprecate persistence component repositories and traits

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -4,6 +4,17 @@ For every update follow the [Upgrade Documentation](https://docs.sulu.io/2.x/upg
 
 ## 2.6.26
 
+### Deprecated persistence component repositories and traits
+
+The `RelationTrait` and the `OrderByTrait` have been deprecated. We recommend building your own
+relation and order-by handling logic instead of using these traits.
+
+The `EntityRepository` and the `RepositoryInterface` have been deprecated as well. We recommend
+building your own repositories instead of extending the class or implementing the interface.
+
+The doctrine event subscribers `MetadataSubscriber`, `TimestampableSubscriber` and
+`UserBlameSubscriber` have been marked as `@internal`, so no bc promise is given for them anymore.
+
 ### Deprecated `AbstractRestController`, `RestControllerTrait` and `ApiWrapper`
 
 The `AbstractRestController` and the `RestControllerTrait` have been deprecated. We recommend building

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/MetadataSubscriber.php
@@ -18,6 +18,8 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Persistence\Mapping\ReflectionService;
 
 /**
+ * @internal no bc-promise given, we recommend building your own metadata subscriber instead of using this class.
+ *
  * Doctrine subscriber used to manipulate metadata.
  */
 class MetadataSubscriber

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -16,6 +16,8 @@ use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Sulu\Component\Persistence\Model\TimestampableInterface;
 
 /**
+ * @internal no bc-promise given, we recommend building your own metadata subscriber if you need to extend something.
+ *
  * Manage the timestamp fields on models implementing the
  * TimestampableInterface.
  */

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/TimestampableSubscriber.php
@@ -16,7 +16,7 @@ use Doctrine\Persistence\Event\LoadClassMetadataEventArgs;
 use Sulu\Component\Persistence\Model\TimestampableInterface;
 
 /**
- * @internal no bc-promise given, we recommend building your own metadata subscriber if you need to extend something.
+ * @internal no bc-promise given, we recommend building your own timestampable subscriber if you need to extend something.
  *
  * Manage the timestamp fields on models implementing the
  * TimestampableInterface.

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
- * @internal no bc-promise given, we recommend building your own metadata subscriber if you need to extend something.
+ * @internal no bc-promise given, we recommend building your own user blame subscriber if you need to extend something.
  *
  * Ensure that blame can be assigned to users when they break things.
  *

--- a/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
+++ b/src/Sulu/Component/Persistence/EventSubscriber/ORM/UserBlameSubscriber.php
@@ -21,6 +21,8 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
+ * @internal no bc-promise given, we recommend building your own metadata subscriber if you need to extend something.
+ *
  * Ensure that blame can be assigned to users when they break things.
  *
  * Persists the user that created and the last user that changed ORM classes

--- a/src/Sulu/Component/Persistence/RelationTrait.php
+++ b/src/Sulu/Component/Persistence/RelationTrait.php
@@ -12,7 +12,7 @@
 namespace Sulu\Component\Persistence;
 
 /**
- * Offers methods for easier handling of relations.
+ * @deprecated since Sulu 2.6, we recommend building your own relation handling logic instead of using this trait.
  */
 trait RelationTrait
 {

--- a/src/Sulu/Component/Persistence/Repository/ORM/EntityRepository.php
+++ b/src/Sulu/Component/Persistence/Repository/ORM/EntityRepository.php
@@ -15,6 +15,8 @@ use Doctrine\ORM\EntityRepository as BaseEntityRepository;
 use Sulu\Component\Persistence\Repository\RepositoryInterface;
 
 /**
+ * @deprecated since Sulu 2.6, we recommend building your own repository instead of using this class.
+ *
  * Doctrine ORM entity repository.
  *
  * @template T of object

--- a/src/Sulu/Component/Persistence/Repository/ORM/OrderByTrait.php
+++ b/src/Sulu/Component/Persistence/Repository/ORM/OrderByTrait.php
@@ -14,6 +14,8 @@ namespace Sulu\Component\Persistence\Repository\ORM;
 use Doctrine\ORM\QueryBuilder;
 
 /**
+ * @deprecated since Sulu 2.6, we recommend building your own order-by handling logic instead of using this trait.
+ *
  * Trait for handling order-by functionality of repositories.
  */
 trait OrderByTrait

--- a/src/Sulu/Component/Persistence/Repository/RepositoryInterface.php
+++ b/src/Sulu/Component/Persistence/Repository/RepositoryInterface.php
@@ -14,6 +14,8 @@ namespace Sulu\Component\Persistence\Repository;
 use Doctrine\Persistence\ObjectRepository;
 
 /**
+ * @deprecated since Sulu 2.6, we recommend building your own repository interface instead of using this.
+ *
  * Repository interface.
  *
  * @template T of object


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | 
| Related issues/PRs | #8996
| License | MIT
| Documentation PR | 

#### What's in this PR?

Deprecates the remaining public API of the persistence component:

 - `RelationTrait` and `OrderByTrait` are deprecated
 - `EntityRepository` and `RepositoryInterface` are deprecated
 - `MetadataSubscriber`, `TimestampableSubscriber` and `UserBlameSubscriber` are marked as `@internal`

The deprecations are documented in `UPGRADE-2.x.md`.

#### Why?

Follow up to #8996. These helpers hide little logic behind an inflexible API, and every project is
better served by its own repositories and relation handling built directly on doctrine. Marking the
doctrine event subscribers as `@internal` allows us to adjust them to upcoming doctrine versions
without a bc break.

#### BC Breaks/Deprecations

No bc breaks, only docblock annotations were added.