### PR TITLE
Remove RequestParametersTrait usages from media controllers for Symfony 8 compatibility

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
@@ -27,7 +27,6 @@ use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\Exception\MissingParameterException;
 use Sulu\Component\Rest\Exception\RestException;
 use Sulu\Component\Rest\ListBuilder\Metadata\FieldDescriptorFactoryInterface;
-use Sulu\Component\Rest\RequestParametersTrait;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Component\Security\Authorization\AccessControl\SecuredObjectControllerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
@@ -46,8 +45,6 @@ class MediaController extends AbstractMediaController implements
     SecuredControllerInterface,
     SecuredObjectControllerInterface
 {
-    use RequestParametersTrait;
-
     /**
      * @param class-string $mediaClass
      */

--- a/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/MediaRedirectController.php
@@ -14,7 +14,6 @@ namespace Sulu\Bundle\MediaBundle\Controller;
 use Sulu\Bundle\MediaBundle\Api\Media;
 use Sulu\Bundle\MediaBundle\Media\Exception\MediaNotFoundException;
 use Sulu\Bundle\MediaBundle\Media\Manager\MediaManagerInterface;
-use Sulu\Component\Rest\RequestParametersTrait;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -24,8 +23,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class MediaRedirectController
 {
-    use RequestParametersTrait;
-
     public function __construct(
         private MediaManagerInterface $mediaManager
     ) {
@@ -40,8 +37,8 @@ class MediaRedirectController
      */
     public function redirectAction(Request $request, $id)
     {
-        $locale = $this->getRequestParameter($request, 'locale', true);
-        $format = $this->getRequestParameter($request, 'format');
+        $locale = $request->query->get('locale') ?? $request->getLocale();
+        $format = $request->query->get('format');
 
         try {
             $media = $this->mediaManager->getById($id, $locale);

--- a/src/Sulu/Component/Rest/RequestParametersTrait.php
+++ b/src/Sulu/Component/Rest/RequestParametersTrait.php
@@ -20,6 +20,9 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @deprecated since Sulu 2.6, use $request->query->get(), $request->request->get(),
  *             $request->attributes->get() or $request->getPayload()->get() instead.
+ *             There will be no support for this trait with Symfony 8, projects,
+ *             libraries, ... upgrading to Symfony 8 must already migrate away from
+ *             this trait.
  */
 trait RequestParametersTrait
 {

--- a/src/Sulu/Component/Rest/Tests/Unit/RequestParametersTraitTest.php
+++ b/src/Sulu/Component/Rest/Tests/Unit/RequestParametersTraitTest.php
@@ -21,6 +21,13 @@ class RequestParametersTraitTest extends TestCase
 {
     use RequestParametersTrait;
 
+    public function setUp(): void
+    {
+        if (!\method_exists(Request::class, 'get')) { // @phpstan-ignore-line function.alreadyNarrowedType
+            $this->markTestSkipped('Symfony version does not support get() method.');
+        }
+    }
+
     public function testGetRequestParameter(): void
     {
         $request = new Request(['test' => 'data']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | parts of #8216
| Related issues/PRs | #9008, #9007, #8216
| License | MIT
| Documentation PR | 

#### What's in this PR?

Continues the Symfony 8 preparation by removing the `RequestParametersTrait` from the media controllers:

 - `MediaController` did not use any method of the trait anymore, so the usage was just removed
 - `MediaRedirectController` reads the parameters from the query bag now instead
 - the `@deprecated` annotation of the `RequestParametersTrait` states that there will be no support
   for it with Symfony 8
 - the `RequestParametersTraitTest` is skipped when `Request::get()` does not exist anymore

#### Why?

Symfony 8 removes `Request::get()`, which is used by the `RequestParametersTrait`. Every usage of the
trait inside the core needs to be migrated to the specific `ParameterBag`s, so the trait can be
removed together with the Symfony 8 support.

#### BC Breaks/Deprecations

The `locale` query parameter of the `sulu_media.redirect` route is not mandatory anymore, the request
locale is used as fallback instead of throwing a `MissingParameterException`.