### PR TITLE
Add ViewUrlGenerator to generate Admin URLs from PHP

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGenerator.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGenerator.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\View;
+
+use Sulu\Bundle\AdminBundle\Exception\ViewParameterNotFoundException;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ViewUrlGenerator implements ViewUrlGeneratorInterface
+{
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+        private ViewRegistry $viewRegistry,
+        private ?RequestStack $requestStack = null,
+    ) {
+    }
+
+    public function generate(
+        string $viewName,
+        array $viewParameters = [],
+        int $referenceType = self::ABSOLUTE_PATH,
+    ): string {
+        $view = $this->viewRegistry->findViewByName($viewName);
+        $viewParameters = $this->resolveDefaultParameters($view->getPath(), $viewParameters);
+
+        $path = \preg_replace_callback(
+            '/:([a-zA-Z0-9_]+)/',
+            function(array $matches) use ($viewName, $viewParameters) {
+                $parameter = $matches[1];
+
+                if (!\array_key_exists($parameter, $viewParameters)) {
+                    throw new ViewParameterNotFoundException($parameter, $viewName);
+                }
+
+                return \rawurlencode((string) $viewParameters[$parameter]);
+            },
+            $view->getPath()
+        );
+
+        $adminUrl = $this->urlGenerator->generate('sulu_admin', [], $referenceType);
+
+        return \rtrim($adminUrl, '/') . '/#' . $path;
+    }
+
+    /**
+     * @param array<string, int|string> $viewParameters
+     *
+     * @return array<string, int|string>
+     */
+    private function resolveDefaultParameters(string $path, array $viewParameters): array
+    {
+        $request = $this->requestStack?->getCurrentRequest();
+
+        if (!$request) {
+            return $viewParameters;
+        }
+
+        $webspace = $request->attributes->get('webspace');
+
+        if (!\array_key_exists('webspace', $viewParameters)
+            && \str_contains($path, ':webspace')
+            && \is_string($webspace)
+            && '' !== $webspace
+        ) {
+            $viewParameters['webspace'] = $webspace;
+        }
+
+        if (!\array_key_exists('locale', $viewParameters) && \str_contains($path, ':locale')) {
+            $locale = $request->query->get('locale');
+            $viewParameters['locale'] = \is_string($locale) && '' !== $locale ? $locale : $request->getLocale();
+        }
+
+        return $viewParameters;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGenerator.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGenerator.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\AdminBundle\Admin\View;
 
 use Sulu\Bundle\AdminBundle\Exception\ViewParameterNotFoundException;
+use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -20,17 +21,17 @@ class ViewUrlGenerator implements ViewUrlGeneratorInterface
     public function __construct(
         private UrlGeneratorInterface $urlGenerator,
         private ViewRegistry $viewRegistry,
-        private ?RequestStack $requestStack = null,
+        private RequestStack $requestStack,
     ) {
     }
 
     public function generate(
         string $viewName,
         array $viewParameters = [],
-        int $referenceType = self::ABSOLUTE_PATH,
+        int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
     ): string {
         $view = $this->viewRegistry->findViewByName($viewName);
-        $viewParameters = $this->resolveDefaultParameters($view->getPath(), $viewParameters);
+        $viewParameters = \array_merge($this->getDefaultParameters($view->getPath()), $viewParameters);
 
         $path = \preg_replace_callback(
             '/:([a-zA-Z0-9_]+)/',
@@ -52,33 +53,29 @@ class ViewUrlGenerator implements ViewUrlGeneratorInterface
     }
 
     /**
-     * @param array<string, int|string> $viewParameters
-     *
-     * @return array<string, int|string>
+     * @return array<string, string>
      */
-    private function resolveDefaultParameters(string $path, array $viewParameters): array
+    private function getDefaultParameters(string $path): array
     {
-        $request = $this->requestStack?->getCurrentRequest();
+        $request = $this->requestStack->getCurrentRequest();
 
         if (!$request) {
-            return $viewParameters;
+            return [];
         }
 
-        $webspace = $request->attributes->get('webspace');
+        $defaultParameters = [];
 
-        if (!\array_key_exists('webspace', $viewParameters)
-            && \str_contains($path, ':webspace')
-            && \is_string($webspace)
-            && '' !== $webspace
-        ) {
-            $viewParameters['webspace'] = $webspace;
+        $webspace = $request->attributes->get(RequestAttributeEnum::WEBSPACE->value);
+
+        if (\str_contains($path, ':webspace') && \is_string($webspace) && '' !== $webspace) {
+            $defaultParameters['webspace'] = $webspace;
         }
 
-        if (!\array_key_exists('locale', $viewParameters) && \str_contains($path, ':locale')) {
+        if (\str_contains($path, ':locale')) {
             $locale = $request->query->get('locale');
-            $viewParameters['locale'] = \is_string($locale) && '' !== $locale ? $locale : $request->getLocale();
+            $defaultParameters['locale'] = \is_string($locale) && '' !== $locale ? $locale : $request->getLocale();
         }
 
-        return $viewParameters;
+        return $defaultParameters;
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGeneratorInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGeneratorInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\View;
+
+use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
+use Sulu\Bundle\AdminBundle\Exception\ViewParameterNotFoundException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface as SymfonyUrlGeneratorInterface;
+
+/**
+ * Generates urls to the Sulu Admin frontend application which point to a given View.
+ */
+interface ViewUrlGeneratorInterface
+{
+    public const ABSOLUTE_URL = SymfonyUrlGeneratorInterface::ABSOLUTE_URL;
+
+    public const ABSOLUTE_PATH = SymfonyUrlGeneratorInterface::ABSOLUTE_PATH;
+
+    public const RELATIVE_PATH = SymfonyUrlGeneratorInterface::RELATIVE_PATH;
+
+    public const NETWORK_PATH = SymfonyUrlGeneratorInterface::NETWORK_PATH;
+
+    /**
+     * @param array<string, int|string> $viewParameters
+     *
+     * @throws ViewNotFoundException
+     * @throws ViewParameterNotFoundException
+     */
+    public function generate(
+        string $viewName,
+        array $viewParameters = [],
+        int $referenceType = self::ABSOLUTE_PATH,
+    ): string;
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGeneratorInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGeneratorInterface.php
@@ -13,23 +13,16 @@ namespace Sulu\Bundle\AdminBundle\Admin\View;
 
 use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
 use Sulu\Bundle\AdminBundle\Exception\ViewParameterNotFoundException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface as SymfonyUrlGeneratorInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Generates urls to the Sulu Admin frontend application which point to a given View.
  */
 interface ViewUrlGeneratorInterface
 {
-    public const ABSOLUTE_URL = SymfonyUrlGeneratorInterface::ABSOLUTE_URL;
-
-    public const ABSOLUTE_PATH = SymfonyUrlGeneratorInterface::ABSOLUTE_PATH;
-
-    public const RELATIVE_PATH = SymfonyUrlGeneratorInterface::RELATIVE_PATH;
-
-    public const NETWORK_PATH = SymfonyUrlGeneratorInterface::NETWORK_PATH;
-
     /**
      * @param array<string, int|string> $viewParameters
+     * @param UrlGeneratorInterface::ABSOLUTE_URL|UrlGeneratorInterface::ABSOLUTE_PATH|UrlGeneratorInterface::RELATIVE_PATH|UrlGeneratorInterface::NETWORK_PATH $referenceType
      *
      * @throws ViewNotFoundException
      * @throws ViewParameterNotFoundException
@@ -37,6 +30,6 @@ interface ViewUrlGeneratorInterface
     public function generate(
         string $viewName,
         array $viewParameters = [],
-        int $referenceType = self::ABSOLUTE_PATH,
+        int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
     ): string;
 }

--- a/src/Sulu/Bundle/AdminBundle/Exception/ViewParameterNotFoundException.php
+++ b/src/Sulu/Bundle/AdminBundle/Exception/ViewParameterNotFoundException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Exception;
+
+/**
+ * An instance of this exception signals that a view could not be generated because
+ * a parameter required by its path was not given.
+ */
+class ViewParameterNotFoundException extends \Exception
+{
+    public function __construct(private string $parameter, private string $view)
+    {
+        parent::__construct(
+            \sprintf(
+                'The parameter "%s" is required to generate the url for the view "%s" but was not given.',
+                $parameter,
+                $view
+            )
+        );
+    }
+
+    public function getParameter(): string
+    {
+        return $this->parameter;
+    }
+
+    public function getView(): string
+    {
+        return $this->view;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
@@ -16,8 +16,11 @@ use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGenerator;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGeneratorInterface;
 use Sulu\Bundle\AdminBundle\Application\BlockIdGenerator\BlockIdGenerator;
 use Sulu\Bundle\AdminBundle\Application\BlockIdGenerator\BlockIdGeneratorInterface;
+use Sulu\Bundle\AdminBundle\Command\DownloadBuildCommand;
 use Sulu\Bundle\AdminBundle\Command\DownloadLanguageCommand;
 use Sulu\Bundle\AdminBundle\Command\InfoCommand;
 use Sulu\Bundle\AdminBundle\Command\UpdateBuildCommand;
@@ -299,6 +302,16 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_admin.view_registry', ViewRegistry::class)
         ->args([new Reference('sulu_admin.admin_pool')])
         ->tag('sulu.context', ['context' => 'admin']);
+
+    $services->set('sulu_admin.view_url_generator', ViewUrlGenerator::class)
+        ->args([
+            new Reference('router'),
+            new Reference('sulu_admin.view_registry'),
+            new Reference('request_stack'),
+        ])
+        ->tag('sulu.context', ['context' => 'admin']);
+
+    $services->alias(ViewUrlGeneratorInterface::class, 'sulu_admin.view_url_generator');
 
     $services->set('sulu_admin.navigation_registry', NavigationRegistry::class)
         ->args([

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
@@ -20,7 +20,6 @@ use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGenerator;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGeneratorInterface;
 use Sulu\Bundle\AdminBundle\Application\BlockIdGenerator\BlockIdGenerator;
 use Sulu\Bundle\AdminBundle\Application\BlockIdGenerator\BlockIdGeneratorInterface;
-use Sulu\Bundle\AdminBundle\Command\DownloadBuildCommand;
 use Sulu\Bundle\AdminBundle\Command\DownloadLanguageCommand;
 use Sulu\Bundle\AdminBundle\Command\InfoCommand;
 use Sulu\Bundle\AdminBundle\Command\UpdateBuildCommand;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewUrlGeneratorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewUrlGeneratorTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\View;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Admin\View\View;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGenerator;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGeneratorInterface;
+use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
+use Sulu\Bundle\AdminBundle\Exception\ViewParameterNotFoundException;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ViewUrlGeneratorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<UrlGeneratorInterface>
+     */
+    private ObjectProphecy $urlGenerator;
+
+    /**
+     * @var ObjectProphecy<ViewRegistry>
+     */
+    private ObjectProphecy $viewRegistry;
+
+    /**
+     * @var ObjectProphecy<RequestStack>
+     */
+    private ObjectProphecy $requestStack;
+
+    public function setUp(): void
+    {
+        $this->urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $this->viewRegistry = $this->prophesize(ViewRegistry::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+    }
+
+    private function createViewUrlGenerator(bool $withRequestStack = true): ViewUrlGenerator
+    {
+        return new ViewUrlGenerator(
+            $this->urlGenerator->reveal(),
+            $this->viewRegistry->reveal(),
+            $withRequestStack ? $this->requestStack->reveal() : null
+        );
+    }
+
+    public function testGenerate(): void
+    {
+        $view = new View('sulu_contact.contact_edit_form.details', '/contacts/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_contact.contact_edit_form.details')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+
+        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/admin/');
+
+        $viewUrlGenerator = $this->createViewUrlGenerator();
+
+        $this->assertSame(
+            '/admin/#/contacts/1/details',
+            $viewUrlGenerator->generate('sulu_contact.contact_edit_form.details', ['id' => 1])
+        );
+    }
+
+    public function testGenerateWithoutPlaceholders(): void
+    {
+        $view = new View('sulu_contact.contacts', '/contacts', 'list');
+        $this->viewRegistry->findViewByName('sulu_contact.contacts')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+
+        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/admin/');
+
+        $viewUrlGenerator = $this->createViewUrlGenerator();
+
+        $this->assertSame('/admin/#/contacts', $viewUrlGenerator->generate('sulu_contact.contacts'));
+    }
+
+    public function testGenerateUrlEncodesParameters(): void
+    {
+        $view = new View('sulu_contact.contact_edit_form.details', '/contacts/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_contact.contact_edit_form.details')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+
+        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/admin/');
+
+        $viewUrlGenerator = $this->createViewUrlGenerator();
+
+        $this->assertSame(
+            '/admin/#/contacts/john%2Fdoe/details',
+            $viewUrlGenerator->generate('sulu_contact.contact_edit_form.details', ['id' => 'john/doe'])
+        );
+    }
+
+    public function testGenerateWithAbsoluteUrl(): void
+    {
+        $view = new View('sulu_contact.contact_edit_form.details', '/contacts/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_contact.contact_edit_form.details')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+
+        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.org/admin/');
+
+        $viewUrlGenerator = $this->createViewUrlGenerator();
+
+        $this->assertSame(
+            'https://example.org/admin/#/contacts/1/details',
+            $viewUrlGenerator->generate(
+                'sulu_contact.contact_edit_form.details',
+                ['id' => 1],
+                ViewUrlGeneratorInterface::ABSOLUTE_URL
+            )
+        );
+    }
+
+    public function testGenerateThrowsExceptionForMissingParameter(): void
+    {
+        $this->expectException(ViewParameterNotFoundException::class);
+
+        $view = new View('sulu_contact.contact_edit_form.details', '/contacts/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_contact.contact_edit_form.details')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+
+        $viewUrlGenerator = $this->createViewUrlGenerator();
+        $viewUrlGenerator->generate('sulu_contact.contact_edit_form.details');
+    }
+
+    public function testGeneratePropagatesViewNotFoundException(): void
+    {
+        $this->expectException(ViewNotFoundException::class);
+
+        $this->viewRegistry->findViewByName('sulu_contact.not_existing')
+            ->willThrow(new ViewNotFoundException('sulu_contact.not_existing'));
+
+        $viewUrlGenerator = $this->createViewUrlGenerator(false);
+        $viewUrlGenerator->generate('sulu_contact.not_existing');
+    }
+
+    public function testGenerateFillsWebspaceAndLocaleFromRequest(): void
+    {
+        $view = new View('sulu_page.page_edit_form', '/webspaces/:webspace/pages/:locale/:id', 'page');
+        $this->viewRegistry->findViewByName('sulu_page.page_edit_form')->willReturn($view);
+
+        $request = Request::create('/', 'GET', ['locale' => 'de']);
+        $request->attributes = new ParameterBag(['webspace' => 'sulu']);
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
+        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/admin/');
+
+        $viewUrlGenerator = $this->createViewUrlGenerator();
+
+        $this->assertSame(
+            '/admin/#/webspaces/sulu/pages/de/3',
+            $viewUrlGenerator->generate('sulu_page.page_edit_form', ['id' => 3])
+        );
+    }
+
+    public function testGenerateFallsBackToRequestLocaleWhenQueryLocaleMissing(): void
+    {
+        $view = new View('sulu_page.pages', '/pages/:locale', 'list');
+        $this->viewRegistry->findViewByName('sulu_page.pages')->willReturn($view);
+
+        $request = new Request();
+        $request->setLocale('en');
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
+        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/admin/');
+
+        $viewUrlGenerator = $this->createViewUrlGenerator();
+
+        $this->assertSame('/admin/#/pages/en', $viewUrlGenerator->generate('sulu_page.pages'));
+    }
+
+    public function testGenerateExplicitParameterOverridesRequestDefault(): void
+    {
+        $view = new View('sulu_page.pages', '/pages/:locale', 'list');
+        $this->viewRegistry->findViewByName('sulu_page.pages')->willReturn($view);
+
+        $request = Request::create('/', 'GET', ['locale' => 'de']);
+        $this->requestStack->getCurrentRequest()->willReturn($request);
+
+        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willReturn('/admin/');
+
+        $viewUrlGenerator = $this->createViewUrlGenerator();
+
+        $this->assertSame(
+            '/admin/#/pages/en',
+            $viewUrlGenerator->generate('sulu_page.pages', ['locale' => 'en'])
+        );
+    }
+
+    public function testGenerateWithoutRequestStackThrowsForRequiredParameter(): void
+    {
+        $this->expectException(ViewParameterNotFoundException::class);
+
+        $view = new View('sulu_page.pages', '/pages/:locale', 'list');
+        $this->viewRegistry->findViewByName('sulu_page.pages')->willReturn($view);
+
+        $viewUrlGenerator = $this->createViewUrlGenerator(false);
+        $viewUrlGenerator->generate('sulu_page.pages');
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewUrlGeneratorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ViewUrlGeneratorTest.php
@@ -17,9 +17,9 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\AdminBundle\Admin\View\View;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGenerator;
-use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGeneratorInterface;
 use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
 use Sulu\Bundle\AdminBundle\Exception\ViewParameterNotFoundException;
+use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -51,12 +51,12 @@ class ViewUrlGeneratorTest extends TestCase
         $this->requestStack = $this->prophesize(RequestStack::class);
     }
 
-    private function createViewUrlGenerator(bool $withRequestStack = true): ViewUrlGenerator
+    private function createViewUrlGenerator(): ViewUrlGenerator
     {
         return new ViewUrlGenerator(
             $this->urlGenerator->reveal(),
             $this->viewRegistry->reveal(),
-            $withRequestStack ? $this->requestStack->reveal() : null
+            $this->requestStack->reveal()
         );
     }
 
@@ -66,7 +66,7 @@ class ViewUrlGeneratorTest extends TestCase
         $this->viewRegistry->findViewByName('sulu_contact.contact_edit_form.details')->willReturn($view);
         $this->requestStack->getCurrentRequest()->willReturn(null);
 
-        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn('/admin/');
 
         $viewUrlGenerator = $this->createViewUrlGenerator();
@@ -83,7 +83,7 @@ class ViewUrlGeneratorTest extends TestCase
         $this->viewRegistry->findViewByName('sulu_contact.contacts')->willReturn($view);
         $this->requestStack->getCurrentRequest()->willReturn(null);
 
-        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn('/admin/');
 
         $viewUrlGenerator = $this->createViewUrlGenerator();
@@ -97,7 +97,7 @@ class ViewUrlGeneratorTest extends TestCase
         $this->viewRegistry->findViewByName('sulu_contact.contact_edit_form.details')->willReturn($view);
         $this->requestStack->getCurrentRequest()->willReturn(null);
 
-        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn('/admin/');
 
         $viewUrlGenerator = $this->createViewUrlGenerator();
@@ -114,7 +114,7 @@ class ViewUrlGeneratorTest extends TestCase
         $this->viewRegistry->findViewByName('sulu_contact.contact_edit_form.details')->willReturn($view);
         $this->requestStack->getCurrentRequest()->willReturn(null);
 
-        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_URL)
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)
             ->willReturn('https://example.org/admin/');
 
         $viewUrlGenerator = $this->createViewUrlGenerator();
@@ -124,7 +124,7 @@ class ViewUrlGeneratorTest extends TestCase
             $viewUrlGenerator->generate(
                 'sulu_contact.contact_edit_form.details',
                 ['id' => 1],
-                ViewUrlGeneratorInterface::ABSOLUTE_URL
+                UrlGeneratorInterface::ABSOLUTE_URL
             )
         );
     }
@@ -148,7 +148,7 @@ class ViewUrlGeneratorTest extends TestCase
         $this->viewRegistry->findViewByName('sulu_contact.not_existing')
             ->willThrow(new ViewNotFoundException('sulu_contact.not_existing'));
 
-        $viewUrlGenerator = $this->createViewUrlGenerator(false);
+        $viewUrlGenerator = $this->createViewUrlGenerator();
         $viewUrlGenerator->generate('sulu_contact.not_existing');
     }
 
@@ -158,10 +158,10 @@ class ViewUrlGeneratorTest extends TestCase
         $this->viewRegistry->findViewByName('sulu_page.page_edit_form')->willReturn($view);
 
         $request = Request::create('/', 'GET', ['locale' => 'de']);
-        $request->attributes = new ParameterBag(['webspace' => 'sulu']);
+        $request->attributes = new ParameterBag([RequestAttributeEnum::WEBSPACE->value => 'sulu']);
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn('/admin/');
 
         $viewUrlGenerator = $this->createViewUrlGenerator();
@@ -181,7 +181,7 @@ class ViewUrlGeneratorTest extends TestCase
         $request->setLocale('en');
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn('/admin/');
 
         $viewUrlGenerator = $this->createViewUrlGenerator();
@@ -197,7 +197,7 @@ class ViewUrlGeneratorTest extends TestCase
         $request = Request::create('/', 'GET', ['locale' => 'de']);
         $this->requestStack->getCurrentRequest()->willReturn($request);
 
-        $this->urlGenerator->generate('sulu_admin', [], ViewUrlGeneratorInterface::ABSOLUTE_PATH)
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_PATH)
             ->willReturn('/admin/');
 
         $viewUrlGenerator = $this->createViewUrlGenerator();
@@ -208,14 +208,15 @@ class ViewUrlGeneratorTest extends TestCase
         );
     }
 
-    public function testGenerateWithoutRequestStackThrowsForRequiredParameter(): void
+    public function testGenerateThrowsForRequiredParameterWithoutCurrentRequest(): void
     {
         $this->expectException(ViewParameterNotFoundException::class);
 
         $view = new View('sulu_page.pages', '/pages/:locale', 'list');
         $this->viewRegistry->findViewByName('sulu_page.pages')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
 
-        $viewUrlGenerator = $this->createViewUrlGenerator(false);
+        $viewUrlGenerator = $this->createViewUrlGenerator();
         $viewUrlGenerator->generate('sulu_page.pages');
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #9012
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#929

#### What's in this PR?

Adds `ViewUrlGenerator` / `ViewUrlGeneratorInterface` to `Sulu\Bundle\AdminBundle\Admin\View`. It resolves a registered view's path via `ViewRegistry` and the `sulu_admin` route, fills in the view's `:param` placeholders, and returns a deep link into the Admin SPA. `webspace`/`locale` view parameters fall back to the current request when not given explicitly and the view's path references them. A missing required view parameter throws `ViewParameterNotFoundException`. Registered as `sulu_admin.view_url_generator`, aliased to `ViewUrlGeneratorInterface`.

Deferred per the working item's open question: a second `ViewResourceUrlGenerator` (resourceKey + resourceView → URL) — needs alignment before building.

#### Why?

Enables generating deep links into the Admin frontend from PHP. Intended first consumer: an upcoming Notify feature building a link from a `DomainEvent`'s resource id/key.

#### Example Usage

```php
$viewUrlGenerator->generate('sulu_contact.contact_edit_form.details', ['id' => 1]);
// /admin/#/contacts/1/details
```

#### To Do

- [x] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md <!-- n/a, no BC breaks -->

#### Checks run locally

- `phpunit` (AdminBundle unit suite, 313 tests) — green
- `phpstan analyse` on changed files — no errors
- `php-cs-fixer fix --dry-run` on changed files — clean
- `bin/adminconsole cache:warmup --env=dev` — DI compiles
