### PR TITLE
Fix link property clearing

### DIFF
--- a/packages/content/src/Application/PropertyResolver/Resolver/LinkPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/LinkPropertyResolver.php
@@ -28,12 +28,7 @@ class LinkPropertyResolver implements PropertyResolverInterface
             || !(\is_string($data['href']) || \is_integer($data['href']))
             || !\is_string($data['provider'])
         ) {
-            if (\is_array($data) && \array_key_exists('href', $data) && null === $data['href']) {
-                // an emptied link field is saved as an array with all values set to null
-                return ContentView::create(null, [...$params]);
-            }
-
-            return ContentView::create($data, [...$params]);
+            return ContentView::create(null, [...$params]);
         }
 
         /** @var string $resourceLoaderKey */

--- a/packages/content/src/Application/PropertyResolver/Resolver/LinkPropertyResolver.php
+++ b/packages/content/src/Application/PropertyResolver/Resolver/LinkPropertyResolver.php
@@ -28,6 +28,11 @@ class LinkPropertyResolver implements PropertyResolverInterface
             || !(\is_string($data['href']) || \is_integer($data['href']))
             || !\is_string($data['provider'])
         ) {
+            if (\is_array($data) && \array_key_exists('href', $data) && null === $data['href']) {
+                // an emptied link field is saved as an array with all values set to null
+                return ContentView::create(null, [...$params]);
+            }
+
             return ContentView::create($data, [...$params]);
         }
 

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/LinkPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/LinkPropertyResolverTest.php
@@ -84,7 +84,7 @@ class LinkPropertyResolverTest extends TestCase
     {
         $contentView = $this->resolver->resolve($data, 'en');
 
-        $this->assertSame($data, $contentView->getContent());
+        $this->assertNull($contentView->getContent());
         $this->assertSame([], $contentView->getView());
     }
 

--- a/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/LinkPropertyResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/PropertyResolver/Resolver/LinkPropertyResolverTest.php
@@ -36,6 +36,23 @@ class LinkPropertyResolverTest extends TestCase
         $this->assertSame([], $contentView->getView());
     }
 
+    public function testResolveEmptiedLink(): void
+    {
+        $contentView = $this->resolver->resolve([
+            'provider' => null,
+            'target' => null,
+            'anchor' => null,
+            'query' => null,
+            'href' => null,
+            'title' => null,
+            'rel' => null,
+            'locale' => 'en',
+        ], 'en');
+
+        $this->assertNull($contentView->getContent());
+        $this->assertSame([], $contentView->getView());
+    }
+
     public function testResolveNullParams(): void
     {
         $contentView = $this->resolver->resolve(null, 'en', ['custom' => 'params']);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8943
| Related issues/PRs | #9019 
| License | MIT
| Documentation PR | -

#### What's in this PR?
correctly clear the link property and fix return value of `LinkPropertyResolver` when property has been cleared and is still an array.

#### Why?

#8943 
currently, clearing a link property breaks things as the values are still saved as an array.

#### Example Usage
