### PR TITLE
Register text_editor property metadata mapper

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2209,6 +2209,12 @@ parameters:
 			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/SingleSelectionPropertyMetadataMapper.php
 
 		-
+			message: '#^Parameter \#1 \$name of class Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\PropertyMetadata constructor expects string, float\|int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextEditorPropertyMetadataMapper.php
+
+		-
 			message: '#^Method Sulu\\Bundle\\AdminBundle\\Metadata\\SchemaMetadata\\StringMetadata\:\:toJsonSchema\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextEditorPropertyMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextEditorPropertyMetadataMapper.php
@@ -19,9 +19,8 @@ class TextEditorPropertyMetadataMapper implements PropertyMetadataMapperInterfac
     {
         $mandatory = $propertyMetadata->isRequired();
 
-        // text_editor values contain HTML markup, so character based min/max length
-        // constraints are not supported (see docs/reference/content-types/text_editor.html) -
-        // only the mandatory (i.e. not empty) constraint is mapped here.
+        // text_editor values contain HTML markup, so configurable min/max-length constraints are not supported
+        // (see docs/reference/content-types/text_editor.html). Only the mandatory (non-empty) constraint is mapped here.
         $textEditorMetadata = new StringMetadata(
             $mandatory ? 1 : null,
             null,
@@ -37,8 +36,8 @@ class TextEditorPropertyMetadataMapper implements PropertyMetadataMapperInterfac
         }
 
         return new PropertyMetadata(
-            $propertyMetadata->getName(),
-            $propertyMetadata->isRequired(),
+            (string) $propertyMetadata->getName(),
+            $mandatory,
             $textEditorMetadata
         );
     }

--- a/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextEditorPropertyMetadataMapper.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/SchemaMetadata/TextEditorPropertyMetadataMapper.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata;
+
+use Sulu\Component\Content\Metadata\PropertyMetadata as ContentPropertyMetadata;
+
+class TextEditorPropertyMetadataMapper implements PropertyMetadataMapperInterface
+{
+    public function mapPropertyMetadata(ContentPropertyMetadata $propertyMetadata): PropertyMetadata
+    {
+        $mandatory = $propertyMetadata->isRequired();
+
+        // text_editor values contain HTML markup, so character based min/max length
+        // constraints are not supported (see docs/reference/content-types/text_editor.html) -
+        // only the mandatory (i.e. not empty) constraint is mapped here.
+        $textEditorMetadata = new StringMetadata(
+            $mandatory ? 1 : null,
+            null,
+            null
+        );
+
+        if (!$mandatory) {
+            $textEditorMetadata = new AnyOfsMetadata([
+                new NullMetadata(),
+                new EmptyStringMetadata(),
+                $textEditorMetadata,
+            ]);
+        }
+
+        return new PropertyMetadata(
+            $propertyMetadata->getName(),
+            $propertyMetadata->isRequired(),
+            $textEditorMetadata
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
@@ -48,6 +48,7 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperRegist
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMinMaxValueResolver;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SelectionPropertyMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\SingleSelectionPropertyMetadataMapper;
+use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\TextEditorPropertyMetadataMapper;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\TextPropertyMetadataMapper;
 use Sulu\Bundle\AdminBundle\Serializer\Handler\SchemaHandler;
 use Sulu\Bundle\AdminBundle\Serializer\Subscriber\DropdownToolbarActionSubscriber;
@@ -169,7 +170,9 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_admin.property_metadata_mapper.text', TextPropertyMetadataMapper::class)
         ->args([new Reference('sulu_admin.property_metadata_min_max_value_resolver')])
         ->tag('sulu_admin.property_metadata_mapper', ['type' => 'text_line'])
-        ->tag('sulu_admin.property_metadata_mapper', ['type' => 'text_area'])
+        ->tag('sulu_admin.property_metadata_mapper', ['type' => 'text_area']);
+
+    $services->set('sulu_admin.property_metadata_mapper.text_editor', TextEditorPropertyMetadataMapper::class)
         ->tag('sulu_admin.property_metadata_mapper', ['type' => 'text_editor']);
 
     $services->set('sulu_admin.property_metadata_mapper.selection', SelectionPropertyMetadataMapper::class)

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
@@ -169,7 +169,8 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_admin.property_metadata_mapper.text', TextPropertyMetadataMapper::class)
         ->args([new Reference('sulu_admin.property_metadata_min_max_value_resolver')])
         ->tag('sulu_admin.property_metadata_mapper', ['type' => 'text_line'])
-        ->tag('sulu_admin.property_metadata_mapper', ['type' => 'text_area']);
+        ->tag('sulu_admin.property_metadata_mapper', ['type' => 'text_area'])
+        ->tag('sulu_admin.property_metadata_mapper', ['type' => 'text_editor']);
 
     $services->set('sulu_admin.property_metadata_mapper.selection', SelectionPropertyMetadataMapper::class)
         ->args([new Reference('sulu_admin.property_metadata_min_max_value_resolver')]);

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/default.json
@@ -432,7 +432,7 @@
                                         ]
                                     },
                                     "then": {
-                                        "$ref": "#\/definitions\/text_block"
+                                        "$ref": "#/definitions/text_block"
                                     }
                                 },
                                 {
@@ -448,7 +448,7 @@
                                         ]
                                     },
                                     "then": {
-                                        "$ref": "#\/definitions\/text_block2"
+                                        "$ref": "#/definitions/text_block2"
                                     }
                                 },
                                 {
@@ -464,14 +464,23 @@
                                         ]
                                     },
                                     "then": {
-                                        "type": [
-                                            "number",
-                                            "string",
-                                            "boolean",
-                                            "object",
-                                            "array",
-                                            "null"
-                                        ]
+                                        "type": "object",
+                                        "properties": {
+                                            "text_editor": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string",
+                                                        "maxLength": 0
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
+                                        }
                                     }
                                 },
                                 {
@@ -520,7 +529,7 @@
                                                                 ]
                                                             },
                                                             "then": {
-                                                                "$ref": "#\/definitions\/text_block2"
+                                                                "$ref": "#/definitions/text_block2"
                                                             }
                                                         },
                                                         {
@@ -536,7 +545,7 @@
                                                                 ]
                                                             },
                                                             "then": {
-                                                                "$ref": "#\/definitions\/text_block3"
+                                                                "$ref": "#/definitions/text_block3"
                                                             }
                                                         }
                                                     ]
@@ -579,6 +588,20 @@
                         "type": "string",
                         "minLength": 1
                     },
+                    "description": {
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    },
                     "blocks": {
                         "type": "array",
                         "items": {
@@ -596,7 +619,7 @@
                                         ]
                                     },
                                     "then": {
-                                        "$ref": "#\/definitions\/text_block2"
+                                        "$ref": "#/definitions/text_block2"
                                     }
                                 },
                                 {
@@ -612,14 +635,23 @@
                                         ]
                                     },
                                     "then": {
-                                        "type": [
-                                            "number",
-                                            "string",
-                                            "boolean",
-                                            "object",
-                                            "array",
-                                            "null"
-                                        ]
+                                        "type": "object",
+                                        "properties": {
+                                            "text_editor": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "null"
+                                                    },
+                                                    {
+                                                        "type": "string",
+                                                        "maxLength": 0
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ]
+                                            }
+                                        }
                                     }
                                 }
                             ]
@@ -636,6 +668,20 @@
                     "title": {
                         "type": "string",
                         "minLength": 1
+                    },
+                    "description": {
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     }
                 },
                 "required": [
@@ -648,6 +694,20 @@
                     "title": {
                         "type": "string",
                         "minLength": 1
+                    },
+                    "description": {
+                        "anyOf": [
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "string",
+                                "maxLength": 0
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
                     }
                 },
                 "required": [

--- a/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Functional/Controller/fixtures/overview.json
@@ -307,14 +307,23 @@
                                 ]
                             },
                             "then": {
-                                "type": [
-                                    "number",
-                                    "string",
-                                    "boolean",
-                                    "object",
-                                    "array",
-                                    "null"
-                                ]
+                                "type": "object",
+                                "properties": {
+                                    "text_editor": {
+                                        "anyOf": [
+                                            {
+                                                "type": "null"
+                                            },
+                                            {
+                                                "type": "string",
+                                                "maxLength": 0
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    }
+                                }
                             }
                         }
                     ]
@@ -337,14 +346,23 @@
                                 ]
                             },
                             "then": {
-                                "type": [
-                                    "number",
-                                    "string",
-                                    "boolean",
-                                    "object",
-                                    "array",
-                                    "null"
-                                ]
+                                "type": "object",
+                                "properties": {
+                                    "text_editor": {
+                                        "anyOf": [
+                                            {
+                                                "type": "null"
+                                            },
+                                            {
+                                                "type": "string",
+                                                "maxLength": 0
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    }
+                                }
                             }
                         }
                     ]


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8916
| Related issues/PRs | #8916
| License | MIT
| Documentation PR | none

#### What's in this PR?

Tags `text_editor` with `TextPropertyMetadataMapper` in `services.php`, matching `text_line`/`text_area`.

#### Why?

`text_editor` had no property metadata mapper registered. Without one, `FormMetadataMapper` falls back to a bare `PropertyMetadata` with no JSON schema constraint, so a mandatory `text_editor` field gets no `minLength`, and the admin form silently accepts an empty value instead of showing a validation error.

#### Example Usage

Mark a `text_editor` property `mandatory="true"` in a template, leave it empty in the admin form, try to save — now blocked with a validation error, same as `text_line`/`text_area`.