### PR TITLE
Fix link property clearing

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/Link.js
@@ -8,7 +8,7 @@ import type {FieldTypeProps} from '../types';
 import type {LinkValue} from '../../Link/types';
 import type {IObservableArray} from 'mobx/lib/mobx';
 
-export default class Link extends React.Component<FieldTypeProps<LinkValue>> {
+export default class Link extends React.Component<FieldTypeProps<?LinkValue>> {
     render() {
         const {
             disabled,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/Link.js
@@ -22,7 +22,7 @@ type Props = {
     enableTitle?: ?boolean,
     excludedTypes: string[],
     locale: IObservableValue<string>,
-    onChange: (value: LinkValue) => void,
+    onChange: (value: ?LinkValue) => void,
     onFinish: () => void,
     types?: string[],
     value: ?LinkValue,
@@ -116,7 +116,12 @@ class Link extends Component<Props> {
     };
 
     @action handleRemoveClick = () => {
-        this.changeValue(undefined, undefined, undefined, undefined, undefined, undefined, undefined);
+        const {onChange, onFinish} = this.props;
+
+        // clear the whole value instead of an object with only undefined properties, otherwise old
+        // sub-property values (e.g. target, anchor) are not properly cleared when the field is saved
+        onChange(undefined);
+        onFinish();
     };
 
     @action handleTitleClick = () => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js
@@ -292,18 +292,8 @@ test('Invalidate values on RemoveButton click', () => {
             const removeButton = link.find('.removeButton');
             removeButton.simulate('click');
 
-            expect(changeSpy).toHaveBeenCalledWith(
-                {
-                    title: undefined,
-                    href: undefined,
-                    provider: undefined,
-                    locale: 'en',
-                    query: undefined,
-                    anchor: undefined,
-                    target: undefined,
-                    rel: undefined,
-                }
-            );
+            expect(changeSpy).toHaveBeenCalledWith(undefined);
+            expect(finishSpy).toHaveBeenCalledWith();
         });
 });
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8943
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?
Clearing a link field saved an object with all properties set to `undefined` instead of clearing the value itself, so old sub-property values (e.g. `target`, `anchor`) survived the save. Clear the whole value on remove instead.

#### Why?
See #8943. On 3.0 this additionally broke `LinkPropertyResolver` (fixed separately there, in #9015); on 2.6 the stored malformed value was tolerated by the legacy `Link` content type, but the field should still save a clean value.