### PR TITLE
Fix redirect .html and .htm page URLs to their canonical URL

### DIFF
--- a/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
+++ b/packages/route/src/Application/Routing/Matcher/RouteCollectionForRequestRouteLoader.php
@@ -17,6 +17,7 @@ use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
 use Sulu\Component\Webspace\PortalInformation;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route as SymfonyRoute;
@@ -90,6 +91,27 @@ final readonly class RouteCollectionForRequestRouteLoader implements RouteCollec
 
         if (null === $route) {
             return new RouteCollection();
+        }
+
+        $pathInfo = \rawurldecode($request->getPathInfo());
+        $requestFormat = $request->getRequestFormat(null);
+
+        if (\in_array($requestFormat, ['htm', 'html'], true)
+            && \str_ends_with($pathInfo, '.' . $requestFormat)
+        ) {
+            // redirect "<url>.html" and "<url>.htm" to the canonical "<url>" to avoid duplicated content
+            $routeCollection = new RouteCollection();
+            $routeCollection->add('sulu_route.html_redirect_route_id_' . $route->getId(), new SymfonyRoute(
+                $pathInfo,
+                [
+                    '_controller' => RedirectController::class,
+                    'path' => \substr($pathInfo, 0, -(\strlen($requestFormat) + 1)),
+                    'permanent' => true,
+                ],
+                host: $request->getHost(),
+            ));
+
+            return $routeCollection;
         }
 
         $routeDefaultsProvider = $this->routeDefaultsProviderLocator->get($route->getResourceKey());

--- a/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
+++ b/packages/route/tests/Unit/Application/Routing/Matcher/RouteCollectionForRequestRouteLoaderTest.php
@@ -23,6 +23,7 @@ use Sulu\Route\Application\Routing\Matcher\RouteDefaultsProviderInterface;
 use Sulu\Route\Domain\Model\Route;
 use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
 use Sulu\Route\Domain\Value\RequestAttributeEnum;
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RequestContext;
@@ -122,6 +123,51 @@ class RouteCollectionForRequestRouteLoaderTest extends TestCase
             ],
             $route->getDefaults(),
         );
+    }
+
+    public function testGetRouteCollectionForRequestRedirectsHtmlFormatToCanonicalUrl(): void
+    {
+        $request = Request::create('/test.html');
+        $request->setRequestFormat('html');
+        $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, 'the_site');
+        $request->attributes->set(RequestAttributeEnum::SLUG->value, '/test');
+
+        $routeModel = new Route('resource_key_example', '1', 'en', '/test', 'the_site');
+        static::setPrivateProperty($routeModel, 'id', 1);
+
+        $this->routeRepository->findFirstBy(Argument::cetera())->willReturn($routeModel);
+        $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
+
+        $this->assertCount(1, $routeCollection);
+        $route = $routeCollection->get('sulu_route.html_redirect_route_id_1');
+
+        $this->assertNotNull($route);
+        $this->assertSame('/test.html', $route->getPath());
+        $this->assertSame(
+            [
+                '_controller' => RedirectController::class,
+                'path' => '/test',
+                'permanent' => true,
+            ],
+            $route->getDefaults(),
+        );
+    }
+
+    public function testGetRouteCollectionForRequestDoesNotRedirectOtherFormats(): void
+    {
+        $request = Request::create('/test.rss');
+        $request->setRequestFormat('rss');
+        $request->attributes->set(RequestAttributeEnum::WEBSPACE->value, 'the_site');
+        $request->attributes->set(RequestAttributeEnum::SLUG->value, '/test');
+
+        $routeModel = new Route('resource_key_example', '1', 'en', '/test', 'the_site');
+        static::setPrivateProperty($routeModel, 'id', 1);
+
+        $this->routeRepository->findFirstBy(Argument::cetera())->willReturn($routeModel);
+        $routeCollection = $this->routeCollectionForRequestRouteLoader->getRouteCollectionForRequest($request);
+
+        $this->assertCount(1, $routeCollection);
+        $this->assertNotNull($routeCollection->get('sulu_route.route_id_1'));
     }
 
     #[DataProvider('provideEncodedSlugMatches')]


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8992
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

`RouteCollectionForRequestRouteLoader` now answers `<url>.html` and `<url>.htm` requests with a permanent redirect to the canonical `<url>` when the target route exists, restoring the 2.6 behavior of `ContentRouteProvider`. The redirect reuses the same idiom as `RouteHistoryDefaultsProvider` (Symfony's `RedirectController` with `path` + `permanent`, which preserves the query string).

On the open design question from #8992 (each loader vs RouteBundle): I went with the RouteBundle, since that mirrors 2.6 (the `ContentRouteProvider` was the central matching point back then) and covers every resource type routed through the loader, not only pages. Happy to move it if you prefer the per-loader approach.

Only `htm`/`html` formats are redirected, like in 2.6, so custom formats (e.g. `.rss`, `.json` routes) keep being served; the loader also checks that the path info actually ends with the format suffix before rewriting it.

#### Why?

`/asdf.html` currently renders the page instead of redirecting to `/asdf`: the request analyzer strips the format before the slug lookup, so the route matches, but the redirect that 2.6 generated in that situation was lost in the 3.0 routing, which can end in duplicated content.

Covered by two unit tests: the `.html` request produces the 301 redirect route to the canonical URL, and a non-html format keeps the normal rendering route.
