### PR TITLE
Add Collapsible and CollapsibleCollection components

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/BlockCollection.js
@@ -15,8 +15,10 @@ import type {RenderBlockContentCallback, BlockMode, Message} from './types';
 type Props<T: string, U: {_id?: string, type: T, ...}> = {|
     addButtonText?: ?string,
     collapsable: boolean,
+    collapseAllText?: ?string,
     defaultType: T,
     disabled: boolean,
+    expandAllText?: ?string,
     generateBlockIds?: (count: number) => Promise<Array<string>>,
     icons?: Array<Array<string>>,
     maxOccurs?: ?number,
@@ -787,6 +789,7 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
     };
 
     renderBlockToolbarButton = () => {
+        const {collapseAllText, expandAllText} = this.props;
         const allCollapsed = this.expandedBlocks.every((v) => !v);
         return (
             <div className={blockCollectionStyles.blockCollectionActionButtonContainer}>
@@ -816,8 +819,8 @@ class BlockCollection<T: string, U: {_id?: string, type: T, ...}> extends React.
                     />
                     <span className={blockCollectionStyles.blockCollectionActionButtonText}>
                         {allCollapsed
-                            ? translate('sulu_admin.expand_all_blocks')
-                            : translate('sulu_admin.collapse_all_blocks')
+                            ? (expandAllText ? expandAllText : translate('sulu_admin.expand_all_blocks'))
+                            : (collapseAllText ? collapseAllText : translate('sulu_admin.collapse_all_blocks'))
                         }
                     </span>
                 </button>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/README.md
@@ -72,3 +72,20 @@ const renderBlockContent = (value) => (<p>{value.content || <i>There is no conte
 
 <BlockCollection collapsable={false} onChange={setValue} value={value} renderBlockContent={renderBlockContent} />
 ```
+
+The labels of the control collapsing and expanding all blocks at once can be replaced with
+`collapseAllText` and `expandAllText`.
+
+```javascript
+const [value, setValue] = React.useState([{content: 'That is some content'}, {content: 'That is some more content'}]);
+
+const renderBlockContent = (value) => (<p>{value.content || <i>There is no content</i>}</p>);
+
+<BlockCollection
+    collapseAllText="Collapse all sections"
+    expandAllText="Expand all sections"
+    onChange={setValue}
+    renderBlockContent={renderBlockContent}
+    value={value}
+/>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/BlockCollection.test.js
@@ -387,6 +387,20 @@ test('Should allow to expand all blocks', async() => {
     expect(isBlockExpanded(1)).toEqual(true);
 });
 
+test('Should render the given texts instead of the default translations', async() => {
+    const {user} = renderBlockCollection({
+        collapseAllText: 'Collapse all sections',
+        expandAllText: 'Expand all sections',
+        value: [{content: 'Test 1', type: 'editor'}, {content: 'Test 2', type: 'editor'}],
+    });
+
+    expect(getButtonByName('Expand all sections')).toBeInTheDocument();
+
+    await user.click(getButtonByName('Expand all sections'));
+
+    expect(getButtonByName('Collapse all sections')).toBeInTheDocument();
+});
+
 test('Should allow to reorder blocks by using drag and drop', async() => {
     const changeSpy = jest.fn();
     const sortEndSpy = jest.fn();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/BlockCollection/tests/__snapshots__/BlockCollection.test.js.snap
@@ -13,7 +13,7 @@ exports[`Should render a fully filled block list 1`] = `
         type="button"
       >
         <span
-          aria-label="su-check"
+          aria-hidden="true"
           class="su-check blockCollectionActionButtonIcon"
         />
         <span
@@ -27,7 +27,7 @@ exports[`Should render a fully filled block list 1`] = `
         type="button"
       >
         <span
-          aria-label="su-expand-vertical"
+          aria-hidden="true"
           class="su-expand-vertical blockCollectionActionButtonIcon"
         />
         <span
@@ -164,7 +164,7 @@ exports[`Should render a non-movable block list 1`] = `
         type="button"
       >
         <span
-          aria-label="su-check"
+          aria-hidden="true"
           class="su-check blockCollectionActionButtonIcon"
         />
         <span
@@ -178,7 +178,7 @@ exports[`Should render a non-movable block list 1`] = `
         type="button"
       >
         <span
-          aria-label="su-collapse-vertical"
+          aria-hidden="true"
           class="su-collapse-vertical blockCollectionActionButtonIcon"
         />
         <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/Action.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/Action.js
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react';
+import Icon from '../Icon';
+import collapsibleStyles from './collapsible.scss';
+import type {ActionConfig} from './types';
+
+type Props = {|
+    action: ActionConfig,
+|};
+
+export default class Action extends React.PureComponent<Props> {
+    handleClick = (event: SyntheticEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+
+        this.props.action.onClick();
+    };
+
+    render() {
+        const {action} = this.props;
+
+        return (
+            <button
+                aria-label={action.label}
+                className={collapsibleStyles.action}
+                onClick={this.handleClick}
+                type="button"
+            >
+                <Icon name={action.icon} />
+            </button>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/Collapsible.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/Collapsible.js
@@ -11,7 +11,6 @@ type Props = {|
     actions: Array<ActionConfig>,
     children: Node,
     expanded: boolean,
-    extra?: Node,
     handle?: Node,
     onCollapse?: () => void,
     onExpand?: () => void,
@@ -58,7 +57,7 @@ export default class Collapsible extends React.Component<Props> {
     };
 
     render() {
-        const {actions, children, extra, handle, subtitle, title} = this.props;
+        const {actions, children, handle, subtitle, title} = this.props;
         const expanded = this.expanded;
 
         const collapsibleClass = classNames(
@@ -80,11 +79,8 @@ export default class Collapsible extends React.Component<Props> {
                             <span className={collapsibleStyles.subtitle}>{subtitle}</span>
                         }
                         <div className={collapsibleStyles.spacer} />
-                        {extra &&
-                            <div className={collapsibleStyles.extra}>{extra}</div>
-                        }
-                        {actions.map((action) => (
-                            <Action action={action} key={action.icon + action.label} />
+                        {actions.map((action, index) => (
+                            <Action action={action} key={index} />
                         ))}
                         {this.collapsible &&
                             <button

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/Collapsible.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/Collapsible.js
@@ -1,0 +1,107 @@
+// @flow
+import React from 'react';
+import classNames from 'classnames';
+import Icon from '../Icon';
+import collapsibleStyles from './collapsible.scss';
+import Action from './Action';
+import type {ActionConfig} from './types';
+import type {Node} from 'react';
+
+type Props = {|
+    actions: Array<ActionConfig>,
+    children: Node,
+    expanded: boolean,
+    extra?: Node,
+    handle?: Node,
+    onCollapse?: () => void,
+    onExpand?: () => void,
+    subtitle?: string,
+    title: string,
+|};
+
+export default class Collapsible extends React.Component<Props> {
+    static defaultProps = {
+        actions: [],
+        expanded: false,
+    };
+
+    get collapsible(): boolean {
+        const {onCollapse, onExpand} = this.props;
+
+        return !!onCollapse && !!onExpand;
+    }
+
+    get expanded(): boolean {
+        return this.props.expanded || !this.collapsible;
+    }
+
+    handleClick = () => {
+        const {onExpand} = this.props;
+
+        if (!this.expanded && onExpand) {
+            onExpand();
+        }
+    };
+
+    handleToggleClick = (event: SyntheticEvent<HTMLButtonElement>) => {
+        event.stopPropagation();
+
+        const {onCollapse, onExpand} = this.props;
+
+        if (this.expanded) {
+            if (onCollapse) {
+                onCollapse();
+            }
+        } else if (onExpand) {
+            onExpand();
+        }
+    };
+
+    render() {
+        const {actions, children, extra, handle, subtitle, title} = this.props;
+        const expanded = this.expanded;
+
+        const collapsibleClass = classNames(
+            collapsibleStyles.collapsible,
+            {
+                [collapsibleStyles.expanded]: expanded,
+            }
+        );
+
+        return (
+            <section className={collapsibleClass} onClick={this.handleClick} role="switch">
+                {handle &&
+                    <div className={collapsibleStyles.handle}>{handle}</div>
+                }
+                <div className={collapsibleStyles.content}>
+                    <header className={collapsibleStyles.header}>
+                        <span className={collapsibleStyles.title}>{title}</span>
+                        {subtitle &&
+                            <span className={collapsibleStyles.subtitle}>{subtitle}</span>
+                        }
+                        <div className={collapsibleStyles.spacer} />
+                        {extra &&
+                            <div className={collapsibleStyles.extra}>{extra}</div>
+                        }
+                        {actions.map((action) => (
+                            <Action action={action} key={action.icon + action.label} />
+                        ))}
+                        {this.collapsible &&
+                            <button
+                                aria-expanded={expanded}
+                                className={collapsibleStyles.toggle}
+                                onClick={this.handleToggleClick}
+                                type="button"
+                            >
+                                <Icon name={expanded ? 'su-collapse-vertical' : 'su-expand-vertical'} />
+                            </button>
+                        }
+                    </header>
+                    {expanded &&
+                        <article className={collapsibleStyles.children}>{children}</article>
+                    }
+                </div>
+            </section>
+        );
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/README.md
@@ -1,0 +1,77 @@
+A collapsible groups content in a card with a header. The header shows a `title`, an optional grey
+`subtitle`, an optional `extra` node and any number of `actions`, each rendered as an icon
+button. The component is controlled: pass `expanded` together with the `onExpand` and `onCollapse`
+callbacks.
+
+```javascript
+const [expanded, setExpanded] = React.useState(true);
+
+const onCollapse = () => setExpanded(false);
+const onExpand = () => setExpanded(true);
+
+<Collapsible
+    expanded={expanded}
+    onCollapse={onCollapse}
+    onExpand={onExpand}
+    subtitle="3 attributes"
+    title="General"
+>
+    That is the content of the collapsible!
+</Collapsible>
+```
+
+Actions are shown as icon buttons in the header. Their `label` becomes the button's accessible name,
+and clicking one never expands or collapses the card.
+
+```javascript
+const [expanded, setExpanded] = React.useState(true);
+
+const onCollapse = () => setExpanded(false);
+const onExpand = () => setExpanded(true);
+const actions = [
+    {icon: 'su-trash-alt', label: 'Delete', onClick: () => alert('Delete was invoked!')},
+];
+
+<Collapsible
+    actions={actions}
+    expanded={expanded}
+    onCollapse={onCollapse}
+    onExpand={onExpand}
+    title="General"
+>
+    That is the content of the collapsible!
+</Collapsible>
+```
+
+The `extra` prop takes arbitrary JSX and is rendered in the header before the actions, which
+makes it a good place for a progress indicator. The `handle` prop works the same way as on the
+`Block` component and renders a separate column on the left, e.g. for a drag handle.
+
+```javascript
+const Icon = require('../Icon').default;
+
+const [expanded, setExpanded] = React.useState(false);
+
+const onCollapse = () => setExpanded(false);
+const onExpand = () => setExpanded(true);
+
+<Collapsible
+    expanded={expanded}
+    extra={<span>4/7</span>}
+    handle={<Icon name="su-more" />}
+    onCollapse={onCollapse}
+    onExpand={onExpand}
+    title="Electrical specifications"
+>
+    That is the content of the collapsible!
+</Collapsible>
+```
+
+If the `onCollapse` and `onExpand` props are not set, the collapsible cannot be collapsed and no
+toggle is rendered:
+
+```javascript
+<Collapsible title="General">
+    That is the content of the collapsible!
+</Collapsible>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/README.md
@@ -1,6 +1,5 @@
 A collapsible groups content in a card with a header. The header shows a `title`, an optional grey
-`subtitle`, an optional `extra` node and any number of `actions`, each rendered as an icon
-button. The component is controlled: pass `expanded` together with the `onExpand` and `onCollapse`
+`subtitle` and any number of `actions`, each rendered as an icon button. The component is controlled: pass `expanded` together with the `onExpand` and `onCollapse`
 callbacks.
 
 ```javascript
@@ -19,6 +18,10 @@ const onExpand = () => setExpanded(true);
     That is the content of the collapsible!
 </Collapsible>
 ```
+
+A collapsed collapsible does not render its children, unlike the `Block` component, which keeps them
+mounted and greys them out. Focus and scroll position inside a collapsible are therefore lost when it
+is collapsed.
 
 Actions are shown as icon buttons in the header. Their `label` becomes the button's accessible name,
 and clicking one never expands or collapses the card.
@@ -43,9 +46,8 @@ const actions = [
 </Collapsible>
 ```
 
-The `extra` prop takes arbitrary JSX and is rendered in the header before the actions, which
-makes it a good place for a progress indicator. The `handle` prop works the same way as on the
-`Block` component and renders a separate column on the left, e.g. for a drag handle.
+The `handle` prop works the same way as on the `Block` component and renders a separate column on
+the left, e.g. for a drag handle.
 
 ```javascript
 const Icon = require('../Icon').default;
@@ -57,7 +59,6 @@ const onExpand = () => setExpanded(true);
 
 <Collapsible
     expanded={expanded}
-    extra={<span>4/7</span>}
     handle={<Icon name="su-more" />}
     onCollapse={onCollapse}
     onExpand={onExpand}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/collapsible.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/collapsible.scss
@@ -59,11 +59,6 @@ $collapsibleIconColor: $gray;
     flex-grow: 1;
 }
 
-.extra {
-    display: flex;
-    align-items: center;
-}
-
 .action,
 .toggle {
     cursor: pointer;
@@ -77,4 +72,5 @@ $collapsibleIconColor: $gray;
 
 .children {
     border-top: 1px solid $collapsibleBorderColor;
+    padding: 20px;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/collapsible.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/collapsible.scss
@@ -1,0 +1,80 @@
+@import '../../containers/Application/colors.scss';
+
+$collapsibleBackgroundColor: $white;
+$collapsibleBorderColor: $silver;
+$collapsibleHandleColor: $black;
+$collapsibleHandleBackgroundColor: $silver;
+$collapsibleSubtitleColor: $gray;
+$collapsibleIconColor: $gray;
+
+.collapsible {
+    display: flex;
+    background-color: $collapsibleBackgroundColor;
+    border: 1px solid $collapsibleBorderColor;
+    border-radius: 3px;
+
+    &:not(.expanded) {
+        cursor: pointer;
+    }
+}
+
+.handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-grow: 0;
+    flex-shrink: 0;
+    color: $collapsibleHandleColor;
+    background-color: $collapsibleHandleBackgroundColor;
+    overflow: hidden;
+    width: fit-content;
+}
+
+.content {
+    flex-grow: 1;
+    font-size: 12px;
+    line-height: 18px;
+    width: 0;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    height: 56px;
+    padding: 0 20px;
+}
+
+.title {
+    font-size: 14px;
+    font-weight: bold;
+}
+
+.subtitle {
+    color: $collapsibleSubtitleColor;
+    font-size: 12px;
+    margin-left: 10px;
+}
+
+.spacer {
+    flex-grow: 1;
+}
+
+.extra {
+    display: flex;
+    align-items: center;
+}
+
+.action,
+.toggle {
+    cursor: pointer;
+    border: none;
+    background: none;
+    color: $collapsibleIconColor;
+    font-size: 14px;
+    margin-left: 20px;
+    padding: 0;
+}
+
+.children {
+    border-top: 1px solid $collapsibleBorderColor;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/index.js
@@ -1,0 +1,5 @@
+// @flow
+import Collapsible from './Collapsible';
+
+export default Collapsible;
+export type {ActionConfig} from './types';

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/tests/Collapsible.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/tests/Collapsible.test.js
@@ -1,0 +1,172 @@
+// @flow
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Collapsible from '../Collapsible';
+
+test('Render an expanded collapsible with title, subtitle, extra node and handle', () => {
+    const {container} = render(
+        <Collapsible
+            actions={[{icon: 'su-trash-alt', label: 'Delete', onClick: jest.fn()}]}
+            expanded={true}
+            extra={<span>4/7</span>}
+            handle={<span>Handle</span>}
+            onCollapse={jest.fn()}
+            onExpand={jest.fn()}
+            subtitle="3 attributes"
+            title="General"
+        >
+            Some collapsible content
+        </Collapsible>
+    );
+
+    expect(container).toMatchSnapshot();
+});
+
+test('Render title and subtitle', () => {
+    render(
+        <Collapsible subtitle="3 attributes" title="General">
+            Some collapsible content
+        </Collapsible>
+    );
+
+    expect(screen.getByText('General')).toBeInTheDocument();
+    expect(screen.getByText('3 attributes')).toBeInTheDocument();
+});
+
+test('Render the children and the collapse icon when expanded', () => {
+    render(
+        <Collapsible expanded={true} onCollapse={jest.fn()} onExpand={jest.fn()} title="General">
+            Some collapsible content
+        </Collapsible>
+    );
+
+    expect(screen.getByText('Some collapsible content')).toBeInTheDocument();
+    expect(screen.getByLabelText('su-collapse-vertical')).toBeInTheDocument();
+});
+
+test('Do not render the children and show the expand icon when collapsed', () => {
+    render(
+        <Collapsible expanded={false} onCollapse={jest.fn()} onExpand={jest.fn()} title="General">
+            Some collapsible content
+        </Collapsible>
+    );
+
+    expect(screen.queryByText('Some collapsible content')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('su-expand-vertical')).toBeInTheDocument();
+});
+
+test('Render the children and no toggle when no expand and collapse callbacks are given', () => {
+    render(
+        <Collapsible expanded={false} title="General">
+            Some collapsible content
+        </Collapsible>
+    );
+
+    expect(screen.getByText('Some collapsible content')).toBeInTheDocument();
+    expect(screen.queryByLabelText('su-collapse-vertical')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('su-expand-vertical')).not.toBeInTheDocument();
+});
+
+test('Clicking the toggle of an expanded collapsible should call the onCollapse callback', async() => {
+    const collapseSpy = jest.fn();
+    const expandSpy = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+        <Collapsible expanded={true} onCollapse={collapseSpy} onExpand={expandSpy} title="General">
+            Some collapsible content
+        </Collapsible>
+    );
+
+    await user.click(screen.getByLabelText('su-collapse-vertical'));
+
+    expect(collapseSpy).toHaveBeenCalledWith();
+    expect(expandSpy).not.toHaveBeenCalled();
+});
+
+test('Clicking the toggle of a collapsed collapsible should call the onExpand callback once', async() => {
+    const collapseSpy = jest.fn();
+    const expandSpy = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+        <Collapsible expanded={false} onCollapse={collapseSpy} onExpand={expandSpy} title="General">
+            Some collapsible content
+        </Collapsible>
+    );
+
+    await user.click(screen.getByLabelText('su-expand-vertical'));
+
+    expect(expandSpy).toHaveBeenCalledTimes(1);
+    expect(collapseSpy).not.toHaveBeenCalled();
+});
+
+test('Clicking a collapsed collapsible should call the onExpand callback', async() => {
+    const expandSpy = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+        <Collapsible expanded={false} onCollapse={jest.fn()} onExpand={expandSpy} title="General">
+            Some collapsible content
+        </Collapsible>
+    );
+
+    await user.click(screen.getByText('General'));
+
+    expect(expandSpy).toHaveBeenCalledWith();
+});
+
+test('Clicking an expanded collapsible should not call the onExpand callback', async() => {
+    const expandSpy = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+        <Collapsible expanded={true} onCollapse={jest.fn()} onExpand={expandSpy} title="General">
+            Some collapsible content
+        </Collapsible>
+    );
+
+    await user.click(screen.getByText('General'));
+
+    expect(expandSpy).not.toHaveBeenCalled();
+});
+
+test('Clicking an action should call its callback without expanding the collapsible', async() => {
+    const deleteSpy = jest.fn();
+    const expandSpy = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+        <Collapsible
+            actions={[{icon: 'su-trash-alt', label: 'Delete', onClick: deleteSpy}]}
+            expanded={false}
+            onCollapse={jest.fn()}
+            onExpand={expandSpy}
+            title="General"
+        >
+            Some collapsible content
+        </Collapsible>
+    );
+
+    await user.click(screen.getByLabelText('Delete'));
+
+    expect(deleteSpy).toHaveBeenCalledWith();
+    expect(expandSpy).not.toHaveBeenCalled();
+});
+
+test('Render the extra node and the handle in their slots', () => {
+    render(
+        <Collapsible
+            expanded={true}
+            extra={<span>4/7</span>}
+            handle={<span>Handle</span>}
+            title="General"
+        >
+            Some collapsible content
+        </Collapsible>
+    );
+
+    expect(screen.getByText('4/7')).toBeInTheDocument();
+    expect(screen.getByText('Handle')).toBeInTheDocument();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/tests/Collapsible.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/tests/Collapsible.test.js
@@ -4,12 +4,11 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Collapsible from '../Collapsible';
 
-test('Render an expanded collapsible with title, subtitle, extra node and handle', () => {
+test('Render an expanded collapsible with title, subtitle and handle', () => {
     const {container} = render(
         <Collapsible
             actions={[{icon: 'su-trash-alt', label: 'Delete', onClick: jest.fn()}]}
             expanded={true}
-            extra={<span>4/7</span>}
             handle={<span>Handle</span>}
             onCollapse={jest.fn()}
             onExpand={jest.fn()}
@@ -155,18 +154,12 @@ test('Clicking an action should call its callback without expanding the collapsi
     expect(expandSpy).not.toHaveBeenCalled();
 });
 
-test('Render the extra node and the handle in their slots', () => {
+test('Render the handle in its slot', () => {
     render(
-        <Collapsible
-            expanded={true}
-            extra={<span>4/7</span>}
-            handle={<span>Handle</span>}
-            title="General"
-        >
+        <Collapsible expanded={true} handle={<span>Handle</span>} title="General">
             Some collapsible content
         </Collapsible>
     );
 
-    expect(screen.getByText('4/7')).toBeInTheDocument();
     expect(screen.getByText('Handle')).toBeInTheDocument();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/tests/__snapshots__/Collapsible.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/tests/__snapshots__/Collapsible.test.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Render an expanded collapsible with title, subtitle, extra node and handle 1`] = `
+<div>
+  <section
+    class="collapsible expanded"
+    role="switch"
+  >
+    <div
+      class="handle"
+    >
+      <span>
+        Handle
+      </span>
+    </div>
+    <div
+      class="content"
+    >
+      <header
+        class="header"
+      >
+        <span
+          class="title"
+        >
+          General
+        </span>
+        <span
+          class="subtitle"
+        >
+          3 attributes
+        </span>
+        <div
+          class="spacer"
+        />
+        <div
+          class="extra"
+        >
+          <span>
+            4/7
+          </span>
+        </div>
+        <button
+          aria-label="Delete"
+          class="action"
+          type="button"
+        >
+          <span
+            aria-label="su-trash-alt"
+            class="su-trash-alt"
+          />
+        </button>
+        <button
+          aria-expanded="true"
+          class="toggle"
+          type="button"
+        >
+          <span
+            aria-label="su-collapse-vertical"
+            class="su-collapse-vertical"
+          />
+        </button>
+      </header>
+      <article
+        class="children"
+      >
+        Some collapsible content
+      </article>
+    </div>
+  </section>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/tests/__snapshots__/Collapsible.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/tests/__snapshots__/Collapsible.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Render an expanded collapsible with title, subtitle, extra node and handle 1`] = `
+exports[`Render an expanded collapsible with title, subtitle and handle 1`] = `
 <div>
   <section
     class="collapsible expanded"
@@ -32,13 +32,6 @@ exports[`Render an expanded collapsible with title, subtitle, extra node and han
         <div
           class="spacer"
         />
-        <div
-          class="extra"
-        >
-          <span>
-            4/7
-          </span>
-        </div>
         <button
           aria-label="Delete"
           class="action"

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Collapsible/types.js
@@ -1,0 +1,6 @@
+// @flow
+export type ActionConfig = {|
+    icon: string,
+    label: string,
+    onClick: () => void,
+|};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/CollapsibleCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/CollapsibleCollection.js
@@ -1,0 +1,136 @@
+// @flow
+import React from 'react';
+import {action, observable} from 'mobx';
+import {observer} from 'mobx-react';
+import {translate} from '../../utils';
+import Button from '../Button';
+import Collapsible from '../Collapsible';
+import Icon from '../Icon';
+import collapsibleCollectionStyles from './collapsibleCollection.scss';
+import type {ChildrenArray, Element} from 'react';
+
+type Props = {|
+    addButtonText?: ?string,
+    children?: ChildrenArray<Element<typeof Collapsible> | false>,
+    collapseAllText?: ?string,
+    expandAllText?: ?string,
+    onAddClick?: () => void,
+|};
+
+@observer
+class CollapsibleCollection extends React.Component<Props> {
+    // Keys of removed children linger here; every reader only tests membership against current children.
+    @observable collapsedKeys: Array<string | number> = [];
+
+    getChildKey(child: Element<typeof Collapsible>, index: number): string | number {
+        return child.key !== null && child.key !== undefined ? child.key : index;
+    }
+
+    get childKeys(): Array<string | number> {
+        const {children} = this.props;
+
+        // $FlowFixMe
+        return React.Children.map(children, (child, index) => {
+            if (!child) {
+                return null;
+            }
+
+            return this.getChildKey(child, index);
+        }) || [];
+    }
+
+    get allCollapsed(): boolean {
+        const childKeys = this.childKeys;
+
+        return childKeys.length > 0 && childKeys.every((key) => this.collapsedKeys.includes(key));
+    }
+
+    @action handleCollapse = (key: string | number) => {
+        if (!this.collapsedKeys.includes(key)) {
+            this.collapsedKeys.push(key);
+        }
+    };
+
+    @action handleExpand = (key: string | number) => {
+        this.collapsedKeys = this.collapsedKeys.filter((collapsedKey) => collapsedKey !== key);
+    };
+
+    @action handleCollapseAllClick = () => {
+        this.collapsedKeys = this.childKeys;
+    };
+
+    @action handleExpandAllClick = () => {
+        this.collapsedKeys = [];
+    };
+
+    handleAddClick = () => {
+        const {onAddClick} = this.props;
+
+        if (onAddClick) {
+            onAddClick();
+        }
+    };
+
+    renderToggle = () => {
+        const {collapseAllText, expandAllText} = this.props;
+        const allCollapsed = this.allCollapsed;
+
+        return (
+            <div className={collapsibleCollectionStyles.toolbar}>
+                <button
+                    className={collapsibleCollectionStyles.toolbarButton}
+                    onClick={allCollapsed ? this.handleExpandAllClick : this.handleCollapseAllClick}
+                    type="button"
+                >
+                    <Icon
+                        aria-hidden={true}
+                        className={collapsibleCollectionStyles.toolbarButtonIcon}
+                        name={allCollapsed ? 'su-expand-vertical' : 'su-collapse-vertical'}
+                    />
+                    <span className={collapsibleCollectionStyles.toolbarButtonText}>
+                        {allCollapsed
+                            ? (expandAllText ? expandAllText : translate('sulu_admin.expand_all'))
+                            : (collapseAllText ? collapseAllText : translate('sulu_admin.collapse_all'))
+                        }
+                    </span>
+                </button>
+            </div>
+        );
+    };
+
+    render() {
+        const {addButtonText, children, onAddClick} = this.props;
+
+        return (
+            <section className={collapsibleCollectionStyles.collapsibleCollection}>
+                {this.childKeys.length > 0 && this.renderToggle()}
+                <div className={collapsibleCollectionStyles.items}>
+                    {/* $FlowFixMe */}
+                    {React.Children.map(children, (child, index) => {
+                        if (!child) {
+                            return null;
+                        }
+
+                        const key = this.getChildKey(child, index);
+
+                        // $FlowFixMe
+                        return React.cloneElement(child, {
+                            expanded: !this.collapsedKeys.includes(key),
+                            onCollapse: () => this.handleCollapse(key),
+                            onExpand: () => this.handleExpand(key),
+                        });
+                    })}
+                </div>
+                {onAddClick &&
+                    <div className={collapsibleCollectionStyles.addButtonContainer}>
+                        <Button icon="su-plus" onClick={this.handleAddClick} skin="secondary">
+                            {addButtonText ? addButtonText : translate('sulu_admin.add')}
+                        </Button>
+                    </div>
+                }
+            </section>
+        );
+    }
+}
+
+export default CollapsibleCollection;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/CollapsibleCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/CollapsibleCollection.js
@@ -1,93 +1,119 @@
 // @flow
 import React from 'react';
-import {action, observable} from 'mobx';
+import {action, observable, reaction} from 'mobx';
 import {observer} from 'mobx-react';
-import {translate} from '../../utils';
+import {arrayMove, translate} from '../../utils';
 import Button from '../Button';
-import Collapsible from '../Collapsible';
 import Icon from '../Icon';
+import SortableCollapsibleList from './SortableCollapsibleList';
 import collapsibleCollectionStyles from './collapsibleCollection.scss';
-import type {ChildrenArray, Element} from 'react';
+import type {
+    CollapsibleActionConfig,
+    CollapsibleConfig,
+    CollapsibleMode,
+    RenderCollapsibleContentCallback,
+} from './types';
 
-type Props = {|
+type Props<T: CollapsibleConfig> = {|
+    actions: Array<CollapsibleActionConfig>,
     addButtonText?: ?string,
-    children?: ChildrenArray<Element<typeof Collapsible> | false>,
     collapseAllText?: ?string,
     expandAllText?: ?string,
+    movable: boolean,
     onAddClick?: () => void,
+    onChange: (value: Array<T>) => void,
+    onSortEnd?: (oldIndex: number, newIndex: number) => void,
+    renderCollapsibleContent: RenderCollapsibleContentCallback<T>,
+    value: Array<T>,
 |};
 
 @observer
-class CollapsibleCollection extends React.Component<Props> {
-    // Keys of removed children linger here; every reader only tests membership against current children.
-    @observable collapsedKeys: Array<string | number> = [];
+class CollapsibleCollection<T: CollapsibleConfig> extends React.Component<Props<T>> {
+    static defaultProps = {
+        actions: [],
+        movable: true,
+        value: [],
+    };
 
-    getChildKey(child: Element<typeof Collapsible>, index: number): string | number {
-        return child.key !== null && child.key !== undefined ? child.key : index;
+    @observable expandedCollapsibles: Array<boolean> = [];
+    @observable mode: CollapsibleMode = 'sortable';
+
+    fillArraysDisposer: ?() => *;
+
+    constructor(props: Props<T>) {
+        super(props);
+
+        this.fillArraysDisposer = reaction(() => this.props.value.length, this.fillArrays, {fireImmediately: true});
+
+        if (props.movable === false) {
+            this.mode = 'static';
+        }
     }
 
-    get childKeys(): Array<string | number> {
-        const {children} = this.props;
-
-        // $FlowFixMe
-        return React.Children.map(children, (child, index) => {
-            if (!child) {
-                return null;
-            }
-
-            return this.getChildKey(child, index);
-        }) || [];
+    componentWillUnmount() {
+        this.fillArraysDisposer?.();
     }
 
-    get allCollapsed(): boolean {
-        const childKeys = this.childKeys;
+    @action fillArrays = () => {
+        const {value} = this.props;
+        const {expandedCollapsibles} = this;
 
-        return childKeys.length > 0 && childKeys.every((key) => this.collapsedKeys.includes(key));
-    }
+        if (expandedCollapsibles.length > value.length) {
+            expandedCollapsibles.splice(value.length);
+        }
 
-    @action handleCollapse = (key: string | number) => {
-        if (!this.collapsedKeys.includes(key)) {
-            this.collapsedKeys.push(key);
+        // A collapsible is expanded when it enters the collection.
+        expandedCollapsibles.push(...new Array(value.length - expandedCollapsibles.length).fill(true));
+    };
+
+    @action handleCollapse = (index: number) => {
+        this.expandedCollapsibles[index] = false;
+    };
+
+    @action handleExpand = (index: number) => {
+        this.expandedCollapsibles[index] = true;
+    };
+
+    @action handleClickCollapseAll = () => {
+        this.expandedCollapsibles.forEach((expanded, index) => {
+            this.expandedCollapsibles[index] = false;
+        });
+    };
+
+    @action handleClickExpandAll = () => {
+        this.expandedCollapsibles.forEach((expanded, index) => {
+            this.expandedCollapsibles[index] = true;
+        });
+    };
+
+    @action handleSortEnd = ({newIndex, oldIndex}: {newIndex: number, oldIndex: number}) => {
+        const {onChange, onSortEnd, value} = this.props;
+
+        this.expandedCollapsibles = arrayMove(this.expandedCollapsibles, oldIndex, newIndex);
+        onChange(arrayMove(value, oldIndex, newIndex));
+
+        if (onSortEnd) {
+            onSortEnd(oldIndex, newIndex);
         }
     };
 
-    @action handleExpand = (key: string | number) => {
-        this.collapsedKeys = this.collapsedKeys.filter((collapsedKey) => collapsedKey !== key);
-    };
-
-    @action handleCollapseAllClick = () => {
-        this.collapsedKeys = this.childKeys;
-    };
-
-    @action handleExpandAllClick = () => {
-        this.collapsedKeys = [];
-    };
-
-    handleAddClick = () => {
-        const {onAddClick} = this.props;
-
-        if (onAddClick) {
-            onAddClick();
-        }
-    };
-
-    renderToggle = () => {
+    renderToggleButton = () => {
         const {collapseAllText, expandAllText} = this.props;
-        const allCollapsed = this.allCollapsed;
+        const allCollapsed = this.expandedCollapsibles.every((expanded) => !expanded);
 
         return (
-            <div className={collapsibleCollectionStyles.toolbar}>
+            <div className={collapsibleCollectionStyles.collapsibleCollectionActionButtonContainer}>
                 <button
-                    className={collapsibleCollectionStyles.toolbarButton}
-                    onClick={allCollapsed ? this.handleExpandAllClick : this.handleCollapseAllClick}
+                    className={collapsibleCollectionStyles.collapsibleCollectionActionButton}
+                    onClick={allCollapsed ? this.handleClickExpandAll : this.handleClickCollapseAll}
                     type="button"
                 >
                     <Icon
                         aria-hidden={true}
-                        className={collapsibleCollectionStyles.toolbarButtonIcon}
+                        className={collapsibleCollectionStyles.collapsibleCollectionActionButtonIcon}
                         name={allCollapsed ? 'su-expand-vertical' : 'su-collapse-vertical'}
                     />
-                    <span className={collapsibleCollectionStyles.toolbarButtonText}>
+                    <span className={collapsibleCollectionStyles.collapsibleCollectionActionButtonText}>
                         {allCollapsed
                             ? (expandAllText ? expandAllText : translate('sulu_admin.expand_all'))
                             : (collapseAllText ? collapseAllText : translate('sulu_admin.collapse_all'))
@@ -99,31 +125,29 @@ class CollapsibleCollection extends React.Component<Props> {
     };
 
     render() {
-        const {addButtonText, children, onAddClick} = this.props;
+        const {actions, addButtonText, onAddClick, renderCollapsibleContent, value} = this.props;
 
         return (
             <section className={collapsibleCollectionStyles.collapsibleCollection}>
-                {this.childKeys.length > 0 && this.renderToggle()}
-                <div className={collapsibleCollectionStyles.items}>
-                    {/* $FlowFixMe */}
-                    {React.Children.map(children, (child, index) => {
-                        if (!child) {
-                            return null;
-                        }
+                {value.length > 1 && this.renderToggleButton()}
 
-                        const key = this.getChildKey(child, index);
+                <div className={collapsibleCollectionStyles.spacer} />
 
-                        // $FlowFixMe
-                        return React.cloneElement(child, {
-                            expanded: !this.collapsedKeys.includes(key),
-                            onCollapse: () => this.handleCollapse(key),
-                            onExpand: () => this.handleExpand(key),
-                        });
-                    })}
-                </div>
+                <SortableCollapsibleList
+                    actions={actions}
+                    expandedCollapsibles={this.expandedCollapsibles}
+                    lockAxis="y"
+                    mode={this.mode}
+                    onCollapse={this.handleCollapse}
+                    onExpand={this.handleExpand}
+                    onSortEnd={this.handleSortEnd}
+                    renderCollapsibleContent={renderCollapsibleContent}
+                    useDragHandle={true}
+                    value={value}
+                />
                 {onAddClick &&
                     <div className={collapsibleCollectionStyles.addButtonContainer}>
-                        <Button icon="su-plus" onClick={this.handleAddClick} skin="secondary">
+                        <Button icon="su-plus" onClick={onAddClick} skin="secondary">
                             {addButtonText ? addButtonText : translate('sulu_admin.add')}
                         </Button>
                     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/README.md
@@ -1,44 +1,77 @@
-The collapsible collection renders a set of `Collapsible` components, owns their expanded state and
-adds a control to collapse or expand all of them at once. Every child starts expanded.
+The collapsible collection renders a `Collapsible` for every entry of its `value` array and owns
+their expanded state. Every entry needs a `title` and may bring a `subtitle`, the content of a
+collapsible comes from the `renderCollapsibleContent` callback. As soon as there is more than one
+entry, a control to collapse or expand all of them at once is shown. Every collapsible starts
+expanded.
 
-Each child should be given a stable `key`: the collection tracks a child's collapsed state by its
-React key, so that state stays attached to the right card when children are added, removed or
-reordered. A child without a key falls back to its position, which misattributes collapsed state
-once children are removed from the middle of the list or reordered.
+The collapsibles are sorted by dragging their handle, which reorders `value` and reports the new
+order through `onChange`.
 
 ```javascript
-const Collapsible = require('../Collapsible').default;
+const [value, setValue] = React.useState([
+    {subtitle: '3 attributes', title: 'General'},
+    {subtitle: '2 attributes', title: 'Marketing'},
+]);
 
-<CollapsibleCollection>
-    <Collapsible key="general" subtitle="3 attributes" title="General">
-        That is the content of the first collapsible!
-    </Collapsible>
-    <Collapsible key="marketing" subtitle="2 attributes" title="Marketing">
-        That is the content of the second collapsible!
-    </Collapsible>
-</CollapsibleCollection>
+const renderCollapsibleContent = (collapsible) => (
+    <div>That is the content of the {collapsible.title} collapsible!</div>
+);
+
+<CollapsibleCollection
+    onChange={setValue}
+    renderCollapsibleContent={renderCollapsibleContent}
+    value={value}
+/>
+```
+
+Set `movable` to `false` to render the collapsibles without a drag handle. The `actions` are shown
+as icon buttons in the header of every collapsible, and their `onClick` is called with the index of
+the collapsible it was invoked on.
+
+```javascript
+const [value, setValue] = React.useState([
+    {subtitle: '3 attributes', title: 'General'},
+    {subtitle: '2 attributes', title: 'Marketing'},
+]);
+
+const actions = [
+    {icon: 'su-trash-alt', label: 'Delete', onClick: (index) => alert('Delete was invoked on ' + index)},
+];
+
+const renderCollapsibleContent = (collapsible) => (
+    <div>That is the content of the {collapsible.title} collapsible!</div>
+);
+
+<CollapsibleCollection
+    actions={actions}
+    movable={false}
+    onChange={setValue}
+    renderCollapsibleContent={renderCollapsibleContent}
+    value={value}
+/>
 ```
 
 Passing an `onAddClick` callback renders an add button below the collapsibles. The labels of the add
-button and of the collapse and expand controls can be replaced with `addButtonText`,
-`collapseAllText` and `expandAllText`.
+button and of the control collapsing and expanding all collapsibles at once can be replaced with
+`addButtonText`, `collapseAllText` and `expandAllText`.
 
 ```javascript
-const Collapsible = require('../Collapsible').default;
+const [value, setValue] = React.useState([
+    {subtitle: '3 attributes', title: 'General'},
+    {subtitle: '2 attributes', title: 'Marketing'},
+]);
 
-const onAddClick = () => alert('Add callback was invoked!');
+const renderCollapsibleContent = (collapsible) => (
+    <div>That is the content of the {collapsible.title} collapsible!</div>
+);
 
 <CollapsibleCollection
     addButtonText="Add attributes"
     collapseAllText="Collapse all groups"
     expandAllText="Expand all groups"
-    onAddClick={onAddClick}
->
-    <Collapsible key="general" subtitle="3 attributes" title="General">
-        That is the content of the first collapsible!
-    </Collapsible>
-    <Collapsible key="marketing" subtitle="2 attributes" title="Marketing">
-        That is the content of the second collapsible!
-    </Collapsible>
-</CollapsibleCollection>
+    onAddClick={() => alert('Add callback was invoked!')}
+    onChange={setValue}
+    renderCollapsibleContent={renderCollapsibleContent}
+    value={value}
+/>
 ```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/README.md
@@ -1,0 +1,44 @@
+The collapsible collection renders a set of `Collapsible` components, owns their expanded state and
+adds a control to collapse or expand all of them at once. Every child starts expanded.
+
+Each child should be given a stable `key`: the collection tracks a child's collapsed state by its
+React key, so that state stays attached to the right card when children are added, removed or
+reordered. A child without a key falls back to its position, which misattributes collapsed state
+once children are removed from the middle of the list or reordered.
+
+```javascript
+const Collapsible = require('../Collapsible').default;
+
+<CollapsibleCollection>
+    <Collapsible key="general" subtitle="3 attributes" title="General">
+        That is the content of the first collapsible!
+    </Collapsible>
+    <Collapsible key="marketing" subtitle="2 attributes" title="Marketing">
+        That is the content of the second collapsible!
+    </Collapsible>
+</CollapsibleCollection>
+```
+
+Passing an `onAddClick` callback renders an add button below the collapsibles. The labels of the add
+button and of the collapse and expand controls can be replaced with `addButtonText`,
+`collapseAllText` and `expandAllText`.
+
+```javascript
+const Collapsible = require('../Collapsible').default;
+
+const onAddClick = () => alert('Add callback was invoked!');
+
+<CollapsibleCollection
+    addButtonText="Add attributes"
+    collapseAllText="Collapse all groups"
+    expandAllText="Expand all groups"
+    onAddClick={onAddClick}
+>
+    <Collapsible key="general" subtitle="3 attributes" title="General">
+        That is the content of the first collapsible!
+    </Collapsible>
+    <Collapsible key="marketing" subtitle="2 attributes" title="Marketing">
+        That is the content of the second collapsible!
+    </Collapsible>
+</CollapsibleCollection>
+```

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/SortableCollapsible.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/SortableCollapsible.js
@@ -1,0 +1,91 @@
+// @flow
+import React from 'react';
+import {SortableElement} from 'react-sortable-hoc';
+import {computed} from 'mobx';
+import {observer} from 'mobx-react';
+import Collapsible from '../Collapsible';
+import SortableHandle from './SortableHandle';
+import type {ActionConfig} from '../Collapsible/types';
+import type {ComponentType} from 'react';
+import type {
+    CollapsibleActionConfig,
+    CollapsibleConfig,
+    CollapsibleMode,
+    RenderCollapsibleContentCallback,
+} from './types';
+
+type Props<T: CollapsibleConfig> = {
+    actions: Array<CollapsibleActionConfig>,
+    expanded: boolean,
+    mode: CollapsibleMode,
+    onCollapse?: (index: number) => void,
+    onExpand?: (index: number) => void,
+    renderCollapsibleContent: RenderCollapsibleContentCallback<T>,
+    sortIndex: number,
+    value: T,
+};
+
+@observer
+class SortableCollapsible<T: CollapsibleConfig> extends React.Component<Props<T>> {
+    static defaultProps = {
+        actions: [],
+        expanded: false,
+        mode: 'sortable',
+    };
+
+    @computed get actions(): Array<ActionConfig> {
+        const {actions, sortIndex} = this.props;
+
+        return actions.map((action) => ({
+            ...action,
+            onClick: () => action.onClick(sortIndex),
+        }));
+    }
+
+    handleCollapse = () => {
+        const {onCollapse, sortIndex} = this.props;
+
+        if (onCollapse) {
+            onCollapse(sortIndex);
+        }
+    };
+
+    handleExpand = () => {
+        const {onExpand, sortIndex} = this.props;
+
+        if (onExpand) {
+            onExpand(sortIndex);
+        }
+    };
+
+    renderHandle = () => {
+        const {mode} = this.props;
+
+        if (mode === 'sortable') {
+            return <SortableHandle />;
+        }
+
+        return null;
+    };
+
+    render() {
+        const {expanded, onCollapse, onExpand, renderCollapsibleContent, sortIndex, value} = this.props;
+
+        return (
+            <Collapsible
+                actions={this.actions}
+                expanded={expanded}
+                handle={this.renderHandle()}
+                onCollapse={onCollapse ? this.handleCollapse : undefined}
+                onExpand={onExpand ? this.handleExpand : undefined}
+                subtitle={value.subtitle}
+                title={value.title}
+            >
+                {renderCollapsibleContent(value, sortIndex, expanded)}
+            </Collapsible>
+        );
+    }
+}
+
+const SortableElementCollapsible: ComponentType<Props<*>> = SortableElement(SortableCollapsible);
+export default SortableElementCollapsible;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/SortableCollapsibleList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/SortableCollapsibleList.js
@@ -1,0 +1,79 @@
+// @flow
+import React from 'react';
+import {observer} from 'mobx-react';
+import {SortableContainer} from 'react-sortable-hoc';
+import SortableCollapsible from './SortableCollapsible';
+import sortableCollapsibleListStyles from './sortableCollapsibleList.scss';
+import type {
+    CollapsibleActionConfig,
+    CollapsibleConfig,
+    CollapsibleMode,
+    RenderCollapsibleContentCallback,
+} from './types';
+
+type Props<T: CollapsibleConfig> = {|
+    actions: Array<CollapsibleActionConfig>,
+    expandedCollapsibles: Array<boolean>,
+    mode: CollapsibleMode,
+    onCollapse?: (index: number) => void,
+    onExpand?: (index: number) => void,
+    renderCollapsibleContent: RenderCollapsibleContentCallback<T>,
+    value: Array<T>,
+|};
+
+@observer
+class SortableCollapsibleList<T: CollapsibleConfig> extends React.Component<Props<T>> {
+    static defaultProps = {
+        actions: [],
+        mode: 'sortable',
+    };
+
+    handleCollapse = (index: number) => {
+        const {onCollapse} = this.props;
+
+        if (onCollapse) {
+            onCollapse(index);
+        }
+    };
+
+    handleExpand = (index: number) => {
+        const {onExpand} = this.props;
+
+        if (onExpand) {
+            onExpand(index);
+        }
+    };
+
+    render() {
+        const {
+            actions,
+            expandedCollapsibles,
+            mode,
+            onCollapse,
+            onExpand,
+            renderCollapsibleContent,
+            value,
+        } = this.props;
+
+        return (
+            <div className={sortableCollapsibleListStyles.sortableCollapsibleList}>
+                {value.map((collapsible, index) => (
+                    <SortableCollapsible
+                        actions={actions}
+                        expanded={expandedCollapsibles[index]}
+                        index={index}
+                        key={index}
+                        mode={mode}
+                        onCollapse={onCollapse ? this.handleCollapse : undefined}
+                        onExpand={onExpand ? this.handleExpand : undefined}
+                        renderCollapsibleContent={renderCollapsibleContent}
+                        sortIndex={index}
+                        value={collapsible}
+                    />
+                ))}
+            </div>
+        );
+    }
+}
+
+export default SortableContainer(SortableCollapsibleList);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/SortableHandle.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/SortableHandle.js
@@ -1,0 +1,7 @@
+// @flow
+import React from 'react';
+import {SortableHandle} from 'react-sortable-hoc';
+import Icon from '../Icon';
+import sortableHandleStyles from './sortableHandle.scss';
+
+export default SortableHandle(() => <Icon className={sortableHandleStyles.sortableHandle} name="su-more" />);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/collapsibleCollection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/collapsibleCollection.scss
@@ -1,15 +1,18 @@
 .collapsibleCollection {
-    display: block;
+    position: relative;
 }
 
-.toolbar {
+.spacer {
+    height: 10px;
+}
+
+.collapsibleCollectionActionButtonContainer {
     display: flex;
     justify-content: flex-end;
     gap: 20px;
-    margin-bottom: 10px;
 }
 
-.toolbarButton {
+.collapsibleCollectionActionButton {
     align-items: center;
     background: none;
     border: none;
@@ -17,18 +20,14 @@
     display: flex;
 }
 
-.toolbarButtonIcon {
+.collapsibleCollectionActionButtonIcon {
     display: inline-block;
     font-size: 14px;
     margin-right: 7px;
 }
 
-.toolbarButtonText {
+.collapsibleCollectionActionButtonText {
     text-decoration: underline;
-}
-
-.items > * + * {
-    margin-top: 10px;
 }
 
 .addButtonContainer {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/collapsibleCollection.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/collapsibleCollection.scss
@@ -1,0 +1,37 @@
+.collapsibleCollection {
+    display: block;
+}
+
+.toolbar {
+    display: flex;
+    justify-content: flex-end;
+    gap: 20px;
+    margin-bottom: 10px;
+}
+
+.toolbarButton {
+    align-items: center;
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+}
+
+.toolbarButtonIcon {
+    display: inline-block;
+    font-size: 14px;
+    margin-right: 7px;
+}
+
+.toolbarButtonText {
+    text-decoration: underline;
+}
+
+.items > * + * {
+    margin-top: 10px;
+}
+
+.addButtonContainer {
+    text-align: center;
+    margin-top: 20px;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/index.js
@@ -1,0 +1,4 @@
+// @flow
+import CollapsibleCollection from './CollapsibleCollection';
+
+export default CollapsibleCollection;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/sortableCollapsibleList.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/sortableCollapsibleList.scss
@@ -1,0 +1,7 @@
+.sortableCollapsibleList {
+    text-align: left;
+
+    & > * + * {
+        margin-top: 10px;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/sortableHandle.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/sortableHandle.scss
@@ -1,0 +1,8 @@
+.sortableHandle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    width: 20px;
+    cursor: move;
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/CollapsibleCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/CollapsibleCollection.test.js
@@ -1,0 +1,223 @@
+// @flow
+import React from 'react';
+import {render, screen, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Collapsible from '../../Collapsible';
+import CollapsibleCollection from '../CollapsibleCollection';
+
+jest.mock('../../../utils/Translator', () => ({
+    translate: (key) => key,
+}));
+
+function getCollapsible(title: string) {
+    // $FlowFixMe
+    return screen.getByText(title).closest('section');
+}
+
+function renderTwoCollapsibles(props: Object = {}) {
+    return render(
+        <CollapsibleCollection {...props}>
+            <Collapsible title="General">
+                <div>General content</div>
+            </Collapsible>
+            <Collapsible title="Marketing">
+                <div>Marketing content</div>
+            </Collapsible>
+        </CollapsibleCollection>
+    );
+}
+
+test('Render two expanded collapsibles', () => {
+    const {container} = renderTwoCollapsibles();
+
+    expect(container).toMatchSnapshot();
+});
+
+test('Render all children expanded by default', () => {
+    renderTwoCollapsibles();
+
+    expect(screen.getByText('General content')).toBeInTheDocument();
+    expect(screen.getByText('Marketing content')).toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
+});
+
+test('Clicking collapse all should collapse every child and flip the toggle', async() => {
+    const user = userEvent.setup();
+    renderTwoCollapsibles();
+
+    await user.click(screen.getByText('sulu_admin.collapse_all'));
+
+    expect(screen.queryByText('General content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.expand_all')).toBeInTheDocument();
+});
+
+test('Clicking expand all should expand every child again', async() => {
+    const user = userEvent.setup();
+    renderTwoCollapsibles();
+
+    await user.click(screen.getByText('sulu_admin.collapse_all'));
+    await user.click(screen.getByText('sulu_admin.expand_all'));
+
+    expect(screen.getByText('General content')).toBeInTheDocument();
+    expect(screen.getByText('Marketing content')).toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
+});
+
+test('Collapsing a single child should leave the other children untouched', async() => {
+    const user = userEvent.setup();
+    renderTwoCollapsibles();
+
+    await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
+
+    expect(screen.queryByText('General content')).not.toBeInTheDocument();
+    expect(screen.getByText('Marketing content')).toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
+});
+
+test('Expanding a single child again should render its content', async() => {
+    const user = userEvent.setup();
+    renderTwoCollapsibles();
+
+    await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
+    await user.click(within(getCollapsible('General')).getByLabelText('su-expand-vertical'));
+
+    expect(screen.getByText('General content')).toBeInTheDocument();
+});
+
+test('Show the expand all toggle when every child was collapsed individually', async() => {
+    const user = userEvent.setup();
+    renderTwoCollapsibles();
+
+    await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
+    await user.click(within(getCollapsible('Marketing')).getByLabelText('su-collapse-vertical'));
+
+    expect(screen.getByText('sulu_admin.expand_all')).toBeInTheDocument();
+});
+
+test('Do not render an add button when no onAddClick callback is given', () => {
+    renderTwoCollapsibles();
+
+    expect(screen.queryByText('sulu_admin.add')).not.toBeInTheDocument();
+});
+
+test('Clicking the add button should call the onAddClick callback', async() => {
+    const addSpy = jest.fn();
+    const user = userEvent.setup();
+    renderTwoCollapsibles({onAddClick: addSpy});
+
+    await user.click(screen.getByText('sulu_admin.add'));
+
+    expect(addSpy).toHaveBeenCalledWith();
+});
+
+test('Render the given texts instead of the default translations', async() => {
+    const user = userEvent.setup();
+    renderTwoCollapsibles({
+        addButtonText: 'Add attributes',
+        collapseAllText: 'Collapse all groups',
+        expandAllText: 'Expand all groups',
+        onAddClick: jest.fn(),
+    });
+
+    expect(screen.getByText('Add attributes')).toBeInTheDocument();
+    expect(screen.getByText('Collapse all groups')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Collapse all groups'));
+
+    expect(screen.getByText('Expand all groups')).toBeInTheDocument();
+});
+
+test('Do not render the collapse all toggle without children', () => {
+    render(<CollapsibleCollection />);
+
+    expect(screen.queryByText('sulu_admin.collapse_all')).not.toBeInTheDocument();
+    expect(screen.queryByText('sulu_admin.expand_all')).not.toBeInTheDocument();
+});
+
+test('Removing a middle child should keep the collapsed state attached to the right card', async() => {
+    const user = userEvent.setup();
+    const {rerender} = render(
+        <CollapsibleCollection>
+            <Collapsible key="general" title="General">
+                <div>General content</div>
+            </Collapsible>
+            <Collapsible key="marketing" title="Marketing">
+                <div>Marketing content</div>
+            </Collapsible>
+            <Collapsible key="shipping" title="Shipping">
+                <div>Shipping content</div>
+            </Collapsible>
+        </CollapsibleCollection>
+    );
+
+    await user.click(within(getCollapsible('Shipping')).getByLabelText('su-collapse-vertical'));
+
+    expect(screen.queryByText('Shipping content')).not.toBeInTheDocument();
+
+    rerender(
+        <CollapsibleCollection>
+            <Collapsible key="general" title="General">
+                <div>General content</div>
+            </Collapsible>
+            <Collapsible key="shipping" title="Shipping">
+                <div>Shipping content</div>
+            </Collapsible>
+        </CollapsibleCollection>
+    );
+
+    expect(screen.getByText('General content')).toBeInTheDocument();
+    expect(screen.queryByText('Shipping content')).not.toBeInTheDocument();
+});
+
+test('A falsy child alongside a real one should render without throwing', () => {
+    render(
+        <CollapsibleCollection>
+            <Collapsible key="general" title="General">
+                <div>General content</div>
+            </Collapsible>
+            {false && (
+                <Collapsible key="marketing" title="Marketing">
+                    <div>Marketing content</div>
+                </Collapsible>
+            )}
+        </CollapsibleCollection>
+    );
+
+    expect(screen.getByText('General content')).toBeInTheDocument();
+    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+});
+
+test('An appended child should start expanded while collapsed siblings stay collapsed', async() => {
+    const user = userEvent.setup();
+    const {rerender} = render(
+        <CollapsibleCollection>
+            <Collapsible key="general" title="General">
+                <div>General content</div>
+            </Collapsible>
+            <Collapsible key="marketing" title="Marketing">
+                <div>Marketing content</div>
+            </Collapsible>
+        </CollapsibleCollection>
+    );
+
+    await user.click(screen.getByText('sulu_admin.collapse_all'));
+
+    rerender(
+        <CollapsibleCollection>
+            <Collapsible key="general" title="General">
+                <div>General content</div>
+            </Collapsible>
+            <Collapsible key="marketing" title="Marketing">
+                <div>Marketing content</div>
+            </Collapsible>
+            <Collapsible key="shipping" title="Shipping">
+                <div>Shipping content</div>
+            </Collapsible>
+        </CollapsibleCollection>
+    );
+
+    expect(screen.getByText('Shipping content')).toBeInTheDocument();
+    expect(screen.queryByText('General content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/CollapsibleCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/CollapsibleCollection.test.js
@@ -1,49 +1,83 @@
 // @flow
 import React from 'react';
-import {render, screen, within} from '@testing-library/react';
+import {act, render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Collapsible from '../../Collapsible';
 import CollapsibleCollection from '../CollapsibleCollection';
 
 jest.mock('../../../utils/Translator', () => ({
     translate: (key) => key,
 }));
 
+const TWO_COLLAPSIBLES = [
+    {subtitle: '3 attributes', title: 'General'},
+    {subtitle: '2 attributes', title: 'Marketing'},
+];
+
+function renderCollapsibleContent(collapsible) {
+    return <div>{collapsible.title} content</div>;
+}
+
+function renderCollapsibleCollection(props: Object = {}) {
+    const ref: any = React.createRef();
+    let currentProps = {
+        onChange: jest.fn(),
+        renderCollapsibleContent,
+        value: TWO_COLLAPSIBLES,
+        ...props,
+    };
+
+    const {container, rerender} = render(<CollapsibleCollection {...currentProps} ref={ref} />);
+
+    return {
+        container,
+        ref,
+        rerenderCollapsibleCollection: (nextProps: Object) => {
+            currentProps = {...currentProps, ...nextProps};
+
+            rerender(<CollapsibleCollection {...currentProps} ref={ref} />);
+        },
+        user: userEvent.setup(),
+    };
+}
+
 function getCollapsible(title: string) {
     // $FlowFixMe
     return screen.getByText(title).closest('section');
 }
 
-function renderTwoCollapsibles(props: Object = {}) {
-    return render(
-        <CollapsibleCollection {...props}>
-            <Collapsible title="General">
-                <div>General content</div>
-            </Collapsible>
-            <Collapsible title="Marketing">
-                <div>Marketing content</div>
-            </Collapsible>
-        </CollapsibleCollection>
-    );
-}
-
 test('Render two expanded collapsibles', () => {
-    const {container} = renderTwoCollapsibles();
+    const {container} = renderCollapsibleCollection();
 
     expect(container).toMatchSnapshot();
 });
 
-test('Render all children expanded by default', () => {
-    renderTwoCollapsibles();
+test('Render all collapsibles expanded by default', () => {
+    renderCollapsibleCollection();
 
     expect(screen.getByText('General content')).toBeInTheDocument();
     expect(screen.getByText('Marketing content')).toBeInTheDocument();
     expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
 });
 
-test('Clicking collapse all should collapse every child and flip the toggle', async() => {
-    const user = userEvent.setup();
-    renderTwoCollapsibles();
+test('Render the title and the subtitle of every collapsible', () => {
+    renderCollapsibleCollection();
+
+    expect(screen.getByText('General')).toBeInTheDocument();
+    expect(screen.getByText('3 attributes')).toBeInTheDocument();
+    expect(screen.getByText('Marketing')).toBeInTheDocument();
+    expect(screen.getByText('2 attributes')).toBeInTheDocument();
+});
+
+test('Call the renderCollapsibleContent callback with the value, the index and the expanded state', () => {
+    const renderSpy = jest.fn((collapsible) => <div>{collapsible.title} content</div>);
+    renderCollapsibleCollection({renderCollapsibleContent: renderSpy});
+
+    expect(renderSpy).toHaveBeenCalledWith(TWO_COLLAPSIBLES[0], 0, true);
+    expect(renderSpy).toHaveBeenCalledWith(TWO_COLLAPSIBLES[1], 1, true);
+});
+
+test('Clicking collapse all should collapse every collapsible and flip the toggle', async() => {
+    const {user} = renderCollapsibleCollection();
 
     await user.click(screen.getByText('sulu_admin.collapse_all'));
 
@@ -52,9 +86,8 @@ test('Clicking collapse all should collapse every child and flip the toggle', as
     expect(screen.getByText('sulu_admin.expand_all')).toBeInTheDocument();
 });
 
-test('Clicking expand all should expand every child again', async() => {
-    const user = userEvent.setup();
-    renderTwoCollapsibles();
+test('Clicking expand all should expand every collapsible again', async() => {
+    const {user} = renderCollapsibleCollection();
 
     await user.click(screen.getByText('sulu_admin.collapse_all'));
     await user.click(screen.getByText('sulu_admin.expand_all'));
@@ -64,9 +97,8 @@ test('Clicking expand all should expand every child again', async() => {
     expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
 });
 
-test('Collapsing a single child should leave the other children untouched', async() => {
-    const user = userEvent.setup();
-    renderTwoCollapsibles();
+test('Collapsing a single collapsible should leave the other ones untouched', async() => {
+    const {user} = renderCollapsibleCollection();
 
     await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
 
@@ -75,9 +107,8 @@ test('Collapsing a single child should leave the other children untouched', asyn
     expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
 });
 
-test('Expanding a single child again should render its content', async() => {
-    const user = userEvent.setup();
-    renderTwoCollapsibles();
+test('Expanding a single collapsible again should render its content', async() => {
+    const {user} = renderCollapsibleCollection();
 
     await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
     await user.click(within(getCollapsible('General')).getByLabelText('su-expand-vertical'));
@@ -85,9 +116,8 @@ test('Expanding a single child again should render its content', async() => {
     expect(screen.getByText('General content')).toBeInTheDocument();
 });
 
-test('Show the expand all toggle when every child was collapsed individually', async() => {
-    const user = userEvent.setup();
-    renderTwoCollapsibles();
+test('Show the expand all toggle when every collapsible was collapsed individually', async() => {
+    const {user} = renderCollapsibleCollection();
 
     await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
     await user.click(within(getCollapsible('Marketing')).getByLabelText('su-collapse-vertical'));
@@ -95,25 +125,72 @@ test('Show the expand all toggle when every child was collapsed individually', a
     expect(screen.getByText('sulu_admin.expand_all')).toBeInTheDocument();
 });
 
-test('Do not render an add button when no onAddClick callback is given', () => {
-    renderTwoCollapsibles();
+test('Do not render the collapse all toggle for a single collapsible', () => {
+    renderCollapsibleCollection({value: [{title: 'General'}]});
 
-    expect(screen.queryByText('sulu_admin.add')).not.toBeInTheDocument();
+    expect(screen.queryByText('sulu_admin.collapse_all')).not.toBeInTheDocument();
+    expect(screen.queryByText('sulu_admin.expand_all')).not.toBeInTheDocument();
 });
 
-test('Clicking the add button should call the onAddClick callback', async() => {
-    const addSpy = jest.fn();
-    const user = userEvent.setup();
-    renderTwoCollapsibles({onAddClick: addSpy});
+test('Do not render the collapse all toggle without a value', () => {
+    renderCollapsibleCollection({value: []});
 
-    await user.click(screen.getByText('sulu_admin.add'));
+    expect(screen.queryByText('sulu_admin.collapse_all')).not.toBeInTheDocument();
+    expect(screen.queryByText('sulu_admin.expand_all')).not.toBeInTheDocument();
+});
 
-    expect(addSpy).toHaveBeenCalledWith();
+test('Render the actions and call their callback with the index of the collapsible', async() => {
+    const deleteSpy = jest.fn();
+    const {user} = renderCollapsibleCollection({
+        actions: [{icon: 'su-trash-alt', label: 'Delete', onClick: deleteSpy}],
+    });
+
+    await user.click(within(getCollapsible('Marketing')).getByLabelText('Delete'));
+
+    expect(deleteSpy).toHaveBeenCalledWith(1);
+    expect(screen.getByText('Marketing content')).toBeInTheDocument();
+});
+
+test('Render a drag handle for every collapsible', () => {
+    renderCollapsibleCollection();
+
+    expect(screen.queryAllByLabelText('su-more')).toHaveLength(2);
+});
+
+test('Do not render a drag handle when the collection is not movable', () => {
+    renderCollapsibleCollection({movable: false});
+
+    expect(screen.queryAllByLabelText('su-more')).toHaveLength(0);
+});
+
+test('Sorting a collapsible should reorder the value and move its expanded state along', async() => {
+    const changeSpy = jest.fn();
+    const sortEndSpy = jest.fn();
+    const value = [{title: 'General'}, {title: 'Marketing'}, {title: 'Shipping'}];
+    const {ref, rerenderCollapsibleCollection, user} = renderCollapsibleCollection({
+        onChange: changeSpy,
+        onSortEnd: sortEndSpy,
+        value,
+    });
+
+    await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
+
+    act(() => {
+        ref.current.handleSortEnd({newIndex: 2, oldIndex: 0});
+    });
+
+    expect(changeSpy).toHaveBeenCalledWith([{title: 'Marketing'}, {title: 'Shipping'}, {title: 'General'}]);
+    expect(sortEndSpy).toHaveBeenCalledWith(0, 2);
+
+    rerenderCollapsibleCollection({value: [{title: 'Marketing'}, {title: 'Shipping'}, {title: 'General'}]});
+
+    expect(screen.queryByText('General content')).not.toBeInTheDocument();
+    expect(screen.getByText('Marketing content')).toBeInTheDocument();
+    expect(screen.getByText('Shipping content')).toBeInTheDocument();
 });
 
 test('Render the given texts instead of the default translations', async() => {
-    const user = userEvent.setup();
-    renderTwoCollapsibles({
+    const {user} = renderCollapsibleCollection({
         addButtonText: 'Add attributes',
         collapseAllText: 'Collapse all groups',
         expandAllText: 'Expand all groups',
@@ -128,96 +205,47 @@ test('Render the given texts instead of the default translations', async() => {
     expect(screen.getByText('Expand all groups')).toBeInTheDocument();
 });
 
-test('Do not render the collapse all toggle without children', () => {
-    render(<CollapsibleCollection />);
+test('Do not render an add button when no onAddClick callback is given', () => {
+    renderCollapsibleCollection();
 
-    expect(screen.queryByText('sulu_admin.collapse_all')).not.toBeInTheDocument();
-    expect(screen.queryByText('sulu_admin.expand_all')).not.toBeInTheDocument();
+    expect(screen.queryByText('sulu_admin.add')).not.toBeInTheDocument();
 });
 
-test('Removing a middle child should keep the collapsed state attached to the right card', async() => {
-    const user = userEvent.setup();
-    const {rerender} = render(
-        <CollapsibleCollection>
-            <Collapsible key="general" title="General">
-                <div>General content</div>
-            </Collapsible>
-            <Collapsible key="marketing" title="Marketing">
-                <div>Marketing content</div>
-            </Collapsible>
-            <Collapsible key="shipping" title="Shipping">
-                <div>Shipping content</div>
-            </Collapsible>
-        </CollapsibleCollection>
-    );
+test('Clicking the add button should call the onAddClick callback', async() => {
+    const addSpy = jest.fn();
+    const {user} = renderCollapsibleCollection({onAddClick: addSpy});
 
-    await user.click(within(getCollapsible('Shipping')).getByLabelText('su-collapse-vertical'));
+    await user.click(screen.getByText('sulu_admin.add'));
 
-    expect(screen.queryByText('Shipping content')).not.toBeInTheDocument();
-
-    rerender(
-        <CollapsibleCollection>
-            <Collapsible key="general" title="General">
-                <div>General content</div>
-            </Collapsible>
-            <Collapsible key="shipping" title="Shipping">
-                <div>Shipping content</div>
-            </Collapsible>
-        </CollapsibleCollection>
-    );
-
-    expect(screen.getByText('General content')).toBeInTheDocument();
-    expect(screen.queryByText('Shipping content')).not.toBeInTheDocument();
+    expect(addSpy).toHaveBeenCalled();
 });
 
-test('A falsy child alongside a real one should render without throwing', () => {
-    render(
-        <CollapsibleCollection>
-            <Collapsible key="general" title="General">
-                <div>General content</div>
-            </Collapsible>
-            {false && (
-                <Collapsible key="marketing" title="Marketing">
-                    <div>Marketing content</div>
-                </Collapsible>
-            )}
-        </CollapsibleCollection>
-    );
+test('Render the given add button text instead of the default translation', () => {
+    renderCollapsibleCollection({addButtonText: 'Add attributes', onAddClick: jest.fn()});
 
-    expect(screen.getByText('General content')).toBeInTheDocument();
-    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+    expect(screen.getByText('Add attributes')).toBeInTheDocument();
 });
 
-test('An appended child should start expanded while collapsed siblings stay collapsed', async() => {
-    const user = userEvent.setup();
-    const {rerender} = render(
-        <CollapsibleCollection>
-            <Collapsible key="general" title="General">
-                <div>General content</div>
-            </Collapsible>
-            <Collapsible key="marketing" title="Marketing">
-                <div>Marketing content</div>
-            </Collapsible>
-        </CollapsibleCollection>
-    );
+test('An appended collapsible should start expanded while collapsed siblings stay collapsed', async() => {
+    const {rerenderCollapsibleCollection, user} = renderCollapsibleCollection();
 
     await user.click(screen.getByText('sulu_admin.collapse_all'));
 
-    rerender(
-        <CollapsibleCollection>
-            <Collapsible key="general" title="General">
-                <div>General content</div>
-            </Collapsible>
-            <Collapsible key="marketing" title="Marketing">
-                <div>Marketing content</div>
-            </Collapsible>
-            <Collapsible key="shipping" title="Shipping">
-                <div>Shipping content</div>
-            </Collapsible>
-        </CollapsibleCollection>
-    );
+    rerenderCollapsibleCollection({value: [...TWO_COLLAPSIBLES, {title: 'Shipping'}]});
 
     expect(screen.getByText('Shipping content')).toBeInTheDocument();
     expect(screen.queryByText('General content')).not.toBeInTheDocument();
     expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+});
+
+test('A removed collapsible should not leave its expanded state behind', async() => {
+    const value = [{title: 'General'}, {title: 'Marketing'}, {title: 'Shipping'}];
+    const {rerenderCollapsibleCollection, user} = renderCollapsibleCollection({value});
+
+    await user.click(within(getCollapsible('Shipping')).getByLabelText('su-collapse-vertical'));
+
+    rerenderCollapsibleCollection({value: [{title: 'General'}, {title: 'Marketing'}]});
+    rerenderCollapsibleCollection({value});
+
+    expect(screen.getByText('Shipping content')).toBeInTheDocument();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/__snapshots__/CollapsibleCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/__snapshots__/CollapsibleCollection.test.js.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Render two expanded collapsibles 1`] = `
+<div>
+  <section
+    class="collapsibleCollection"
+  >
+    <div
+      class="toolbar"
+    >
+      <button
+        class="toolbarButton"
+        type="button"
+      >
+        <span
+          aria-label="su-collapse-vertical"
+          class="su-collapse-vertical toolbarButtonIcon"
+        />
+        <span
+          class="toolbarButtonText"
+        >
+          sulu_admin.collapse_all
+        </span>
+      </button>
+    </div>
+    <div
+      class="items"
+    >
+      <section
+        class="collapsible expanded"
+        role="switch"
+      >
+        <div
+          class="content"
+        >
+          <header
+            class="header"
+          >
+            <span
+              class="title"
+            >
+              General
+            </span>
+            <div
+              class="spacer"
+            />
+            <button
+              aria-expanded="true"
+              class="toggle"
+              type="button"
+            >
+              <span
+                aria-label="su-collapse-vertical"
+                class="su-collapse-vertical"
+              />
+            </button>
+          </header>
+          <article
+            class="children"
+          >
+            <div>
+              General content
+            </div>
+          </article>
+        </div>
+      </section>
+      <section
+        class="collapsible expanded"
+        role="switch"
+      >
+        <div
+          class="content"
+        >
+          <header
+            class="header"
+          >
+            <span
+              class="title"
+            >
+              Marketing
+            </span>
+            <div
+              class="spacer"
+            />
+            <button
+              aria-expanded="true"
+              class="toggle"
+              type="button"
+            >
+              <span
+                aria-label="su-collapse-vertical"
+                class="su-collapse-vertical"
+              />
+            </button>
+          </header>
+          <article
+            class="children"
+          >
+            <div>
+              Marketing content
+            </div>
+          </article>
+        </div>
+      </section>
+    </div>
+  </section>
+</div>
+`;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/__snapshots__/CollapsibleCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/__snapshots__/CollapsibleCollection.test.js.snap
@@ -6,30 +6,41 @@ exports[`Render two expanded collapsibles 1`] = `
     class="collapsibleCollection"
   >
     <div
-      class="toolbar"
+      class="collapsibleCollectionActionButtonContainer"
     >
       <button
-        class="toolbarButton"
+        class="collapsibleCollectionActionButton"
         type="button"
       >
         <span
-          aria-label="su-collapse-vertical"
-          class="su-collapse-vertical toolbarButtonIcon"
+          aria-hidden="true"
+          class="su-collapse-vertical collapsibleCollectionActionButtonIcon"
         />
         <span
-          class="toolbarButtonText"
+          class="collapsibleCollectionActionButtonText"
         >
           sulu_admin.collapse_all
         </span>
       </button>
     </div>
     <div
-      class="items"
+      class="spacer"
+    />
+    <div
+      class="sortableCollapsibleList"
     >
       <section
         class="collapsible expanded"
         role="switch"
       >
+        <div
+          class="handle"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more sortableHandle"
+          />
+        </div>
         <div
           class="content"
         >
@@ -41,43 +52,10 @@ exports[`Render two expanded collapsibles 1`] = `
             >
               General
             </span>
-            <div
-              class="spacer"
-            />
-            <button
-              aria-expanded="true"
-              class="toggle"
-              type="button"
-            >
-              <span
-                aria-label="su-collapse-vertical"
-                class="su-collapse-vertical"
-              />
-            </button>
-          </header>
-          <article
-            class="children"
-          >
-            <div>
-              General content
-            </div>
-          </article>
-        </div>
-      </section>
-      <section
-        class="collapsible expanded"
-        role="switch"
-      >
-        <div
-          class="content"
-        >
-          <header
-            class="header"
-          >
             <span
-              class="title"
+              class="subtitle"
             >
-              Marketing
+              3 attributes
             </span>
             <div
               class="spacer"
@@ -97,7 +75,60 @@ exports[`Render two expanded collapsibles 1`] = `
             class="children"
           >
             <div>
-              Marketing content
+              General
+               content
+            </div>
+          </article>
+        </div>
+      </section>
+      <section
+        class="collapsible expanded"
+        role="switch"
+      >
+        <div
+          class="handle"
+        >
+          <span
+            aria-label="su-more"
+            class="su-more sortableHandle"
+          />
+        </div>
+        <div
+          class="content"
+        >
+          <header
+            class="header"
+          >
+            <span
+              class="title"
+            >
+              Marketing
+            </span>
+            <span
+              class="subtitle"
+            >
+              2 attributes
+            </span>
+            <div
+              class="spacer"
+            />
+            <button
+              aria-expanded="true"
+              class="toggle"
+              type="button"
+            >
+              <span
+                aria-label="su-collapse-vertical"
+                class="su-collapse-vertical"
+              />
+            </button>
+          </header>
+          <article
+            class="children"
+          >
+            <div>
+              Marketing
+               content
             </div>
           </article>
         </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/types.js
@@ -1,0 +1,19 @@
+// @flow
+import type {Node} from 'react';
+
+export type CollapsibleConfig = {
+    subtitle?: string,
+    title: string,
+    ...
+};
+
+export type CollapsibleActionConfig = {|
+    icon: string,
+    label: string,
+    onClick: (index: number) => void,
+|};
+
+export type CollapsibleMode = 'static' | 'sortable';
+
+export type RenderCollapsibleContentCallback<T: CollapsibleConfig>
+    = (value: T, index: number, expanded: boolean) => Node;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/Icon.js
@@ -9,6 +9,7 @@ import iconStyles from './icon.scss';
 import type {ElementRef} from 'react';
 
 type Props = {
+    'aria-hidden'?: boolean,
     className?: string,
     iconRef?: (ref: ?ElementRef<'span'>) => void,
     name: string,
@@ -47,6 +48,7 @@ export default class Icon extends React.PureComponent<Props> {
 
     render() {
         const {className, name, onClick, iconRef, style} = this.props;
+        const ariaHidden = this.props['aria-hidden'];
         let fontClass = '';
 
         if (!name || name.length <= 0) {
@@ -91,7 +93,14 @@ export default class Icon extends React.PureComponent<Props> {
             : {};
 
         return (
-            <span aria-label={name} className={iconClass} ref={iconRef} style={style} {...onClickProperties} />
+            <span
+                aria-hidden={ariaHidden ? true : undefined}
+                aria-label={ariaHidden ? undefined : name}
+                className={iconClass}
+                ref={iconRef}
+                style={style}
+                {...onClickProperties}
+            />
         );
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Icon/tests/Icon.test.js
@@ -14,6 +14,14 @@ test('Icon should render', () => {
     expect(container).toMatchSnapshot();
 });
 
+test('Icon should be hidden from the accessibility tree instead of exposing its name', () => {
+    render(<Icon aria-hidden={true} name="su-save" />);
+
+    expect(screen.queryByLabelText('su-save')).not.toBeInTheDocument();
+    // $FlowFixMe
+    expect(document.querySelector('.su-save')).toHaveAttribute('aria-hidden', 'true');
+});
+
 test('Icon should not render with invalid icon', () => {
     const {container} = render(<Icon name="xxx" />);
     expect(container).toMatchSnapshot();

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/index.js
@@ -7,6 +7,8 @@ import ButtonGroup from './ButtonGroup';
 import Checkbox, {CheckboxGroup} from './Checkbox';
 import CircleSelection from './CircleSelection';
 import CircularProgressbar from './CircularProgressbar';
+import Collapsible from './Collapsible';
+import CollapsibleCollection from './CollapsibleCollection';
 import CroppedText from './CroppedText';
 import DatePicker from './DatePicker';
 import Dialog from './Dialog';
@@ -54,6 +56,8 @@ export {
     CheckboxGroup,
     CircleSelection,
     CircularProgressbar,
+    Collapsible,
+    CollapsibleCollection,
     CroppedText,
     DatePicker,
     Dialog,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/__snapshots__/FieldBlocks.test.js.snap
@@ -12,7 +12,7 @@ exports[`Render block with schema 1`] = `
       type="button"
     >
       <span
-        aria-label="su-check"
+        aria-hidden="true"
         class="su-check blockCollectionActionButtonIcon"
       />
       <span
@@ -26,7 +26,7 @@ exports[`Render block with schema 1`] = `
       type="button"
     >
       <span
-        aria-label="su-collapse-vertical"
+        aria-hidden="true"
         class="su-collapse-vertical blockCollectionActionButtonIcon"
       />
       <span
@@ -308,7 +308,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
       type="button"
     >
       <span
-        aria-label="su-check"
+        aria-hidden="true"
         class="su-check blockCollectionActionButtonIcon"
       />
       <span
@@ -322,7 +322,7 @@ exports[`Render block with schema and error on fields already being modified 1`]
       type="button"
     >
       <span
-        aria-label="su-collapse-vertical"
+        aria-hidden="true"
         class="su-collapse-vertical blockCollectionActionButtonIcon"
       />
       <span
@@ -645,7 +645,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
       type="button"
     >
       <span
-        aria-label="su-check"
+        aria-hidden="true"
         class="su-check blockCollectionActionButtonIcon"
       />
       <span
@@ -659,7 +659,7 @@ exports[`Render block with schema and error on fields already being modified 2`]
       type="button"
     >
       <span
-        aria-label="su-collapse-vertical"
+        aria-hidden="true"
         class="su-collapse-vertical blockCollectionActionButtonIcon"
       />
       <span
@@ -985,7 +985,7 @@ exports[`Render collapsed blocks with block previews 1`] = `
       type="button"
     >
       <span
-        aria-label="su-check"
+        aria-hidden="true"
         class="su-check blockCollectionActionButtonIcon"
       />
       <span
@@ -999,7 +999,7 @@ exports[`Render collapsed blocks with block previews 1`] = `
       type="button"
     >
       <span
-        aria-label="su-expand-vertical"
+        aria-hidden="true"
         class="su-expand-vertical blockCollectionActionButtonIcon"
       />
       <span
@@ -1157,7 +1157,7 @@ exports[`Render collapsed blocks with block previews 2`] = `
       type="button"
     >
       <span
-        aria-label="su-check"
+        aria-hidden="true"
         class="su-check blockCollectionActionButtonIcon"
       />
       <span
@@ -1171,7 +1171,7 @@ exports[`Render collapsed blocks with block previews 2`] = `
       type="button"
     >
       <span
-        aria-label="su-expand-vertical"
+        aria-hidden="true"
         class="su-expand-vertical blockCollectionActionButtonIcon"
       />
       <span
@@ -1325,7 +1325,7 @@ exports[`Render collapsed blocks with block previews and sections 1`] = `
       type="button"
     >
       <span
-        aria-label="su-check"
+        aria-hidden="true"
         class="su-check blockCollectionActionButtonIcon"
       />
       <span
@@ -1339,7 +1339,7 @@ exports[`Render collapsed blocks with block previews and sections 1`] = `
       type="button"
     >
       <span
-        aria-label="su-expand-vertical"
+        aria-hidden="true"
         class="su-expand-vertical blockCollectionActionButtonIcon"
       />
       <span
@@ -1487,7 +1487,7 @@ exports[`Render collapsed blocks with block previews without tags 1`] = `
       type="button"
     >
       <span
-        aria-label="su-check"
+        aria-hidden="true"
         class="su-check blockCollectionActionButtonIcon"
       />
       <span
@@ -1501,7 +1501,7 @@ exports[`Render collapsed blocks with block previews without tags 1`] = `
       type="button"
     >
       <span
-        aria-label="su-expand-vertical"
+        aria-hidden="true"
         class="su-expand-vertical blockCollectionActionButtonIcon"
       />
       <span
@@ -1655,7 +1655,7 @@ exports[`Render collapsed blocks with block previews without tags and with secti
       type="button"
     >
       <span
-        aria-label="su-check"
+        aria-hidden="true"
         class="su-check blockCollectionActionButtonIcon"
       />
       <span
@@ -1669,7 +1669,7 @@ exports[`Render collapsed blocks with block previews without tags and with secti
       type="button"
     >
       <span
-        aria-label="su-expand-vertical"
+        aria-hidden="true"
         class="su-expand-vertical blockCollectionActionButtonIcon"
       />
       <span

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -248,6 +248,8 @@
     "sulu_admin.select_multiple_blocks": "Mehrere Blöcke auswählen",
     "sulu_admin.collapse_all_blocks": "Alle Blöcke ausblenden",
     "sulu_admin.expand_all_blocks": "Alle Blöcke erweitern",
+    "sulu_admin.collapse_all": "Alle ausblenden",
+    "sulu_admin.expand_all": "Alle erweitern",
     "sulu_admin.%count%_blocks_copied": "{count} {count, plural, =1 {Block} other {Blöcke}} zur Zwischenablage kopiert.",
     "sulu_admin.%count%_blocks_duplicated": "{count} {count, plural, =1 {Block} other {Blöcke}} dupliziert.",
     "sulu_admin.%count%_blocks_removed": "{count} {count, plural, =1 {Block} other {Blöcke}} gelöscht.",

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -248,6 +248,8 @@
     "sulu_admin.select_multiple_blocks": "Select multiple blocks",
     "sulu_admin.collapse_all_blocks": "Collapse all blocks",
     "sulu_admin.expand_all_blocks": "Expand all blocks",
+    "sulu_admin.collapse_all": "Collapse all",
+    "sulu_admin.expand_all": "Expand all",
     "sulu_admin.%count%_blocks_copied": "{count} {count, plural, =1 {block} other {blocks}} copied to clipboard.",
     "sulu_admin.%count%_blocks_duplicated": "{count} {count, plural, =1 {block} other {blocks}} duplicated.",
     "sulu_admin.%count%_blocks_removed": "{count} {count, plural, =1 {block} other {blocks}} removed.",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Two new components:

* **`Collapsible`** renders a card with a header showing a `title`, an optional grey `subtitle` and any number of `actions`, each rendered as an icon button. It is controlled through `expanded` together with `onExpand` and `onCollapse`. Without those callbacks it renders permanently expanded and without a toggle. A `handle` can be passed for dragging, the same way as on `Block`. 
* **`CollapsibleCollection`** renders a `Collapsible` for every entry of its `value` array and owns their expanded state. The content of a collapsible comes from the `renderCollapsibleContent` callback. The collection adds a control to collapse or expand all of them at once, an optional add button, and sorting by dragging the handle, which reorders `value` and reports the new order through `onChange`. Set `movable` to `false` to render without the handle.

Two smaller changes on existing components:

* `Icon` accepts `aria-hidden`. A hidden icon no longer contributes its name to the accessible name of its parent, so buttons like "Collapse all" are not announced as "su-collapse-vertical Collapse all" anymore.
* `BlockCollection` got `collapseAllText` and `expandAllText`, for consistency with `CollapsibleCollection`.

#### Why?

Grouping form content under collapsible headers currently means reaching for `Block` and `BlockCollection`, which bring along types, settings, selection, sorting and the clipboard. These two components do the grouping and nothing else.

#### Example Usage

```javascript
const [value, setValue] = React.useState([
    {subtitle: '3 attributes', title: 'General'},
    {subtitle: '2 attributes', title: 'Marketing'},
]);

const renderCollapsibleContent = (collapsible) => (
    <div>That is the content of the {collapsible.title} collapsible!</div>
);

<CollapsibleCollection
    onAddClick={handleAddClick}
    onChange={setValue}
    renderCollapsibleContent={renderCollapsibleContent}
    value={value}
/>
```
  
  
<img width="956" height="122" alt="image" src="https://github.com/user-attachments/assets/deedd01d-2703-4188-88ff-ddb166cc8264" />
<img width="934" height="108" alt="image" src="https://github.com/user-attachments/assets/7949c7a7-952d-418c-ba6a-7a8d0b12b73d" />
<img width="929" height="88" alt="image" src="https://github.com/user-attachments/assets/733110f1-84b9-4465-be2d-ed6b08929b8a" />
<img width="938" height="108" alt="image" src="https://github.com/user-attachments/assets/3e64d966-7119-411f-9446-ad771106bd19" />
