### PR TITLE
Give uploaded media files the default permissions of a new file

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -53,6 +53,10 @@ class LocalStorage implements StorageInterface
             throw new FilenameAlreadyExistsException($filePath);
         }
         $this->filesystem->copy($tempPath, $filePath);
+        // the temporary file of an upload is only readable by its owner (0600) and
+        // symfony/filesystem >= 7.4 preserves that mode when copying: give the copy
+        // the default mode of a newly created file instead (0666 minus the umask)
+        $this->filesystem->chmod($filePath, 0666, \umask());
 
         return $storageOptions;
     }

--- a/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Storage/LocalStorage.php
@@ -54,8 +54,9 @@ class LocalStorage implements StorageInterface
         }
         $this->filesystem->copy($tempPath, $filePath);
         // the temporary file of an upload is only readable by its owner (0600) and
-        // symfony/filesystem >= 7.4 preserves that mode when copying: give the copy
-        // the default mode of a newly created file instead (0666 minus the umask)
+        // symfony/filesystem preserves that mode when copying since 6.4.39: give
+        // the copy the default mode of a newly created file instead (0666 minus
+        // the umask), which also keeps stored media non-executable
         $this->filesystem->chmod($filePath, 0666, \umask());
 
         return $storageOptions;

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/LocalStorageTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Storage/LocalStorageTest.php
@@ -45,6 +45,29 @@ class LocalStorageTest extends TestCase
         \rmdir(\dirname($pathName));
     }
 
+    public function testSaveGivesTheFileTheDefaultPermissionsOfANewFile(): void
+    {
+        if ('/' !== \DIRECTORY_SEPARATOR) {
+            self::markTestSkipped('File permissions are not supported on Windows.');
+        }
+
+        $tempPath = \tempnam(\sys_get_temp_dir(), 'sulu_media_test');
+        self::assertNotFalse($tempPath);
+        \file_put_contents($tempPath, 'test');
+        // an uploaded file is only readable by its owner
+        \chmod($tempPath, 0600);
+
+        $storageOptions = $this->localStorage->save($tempPath, 'permissions-test.jpg', ['segment' => '02']);
+        $pathName = $this->localStorage->getPath($storageOptions);
+
+        try {
+            self::assertSame(0666 & ~\umask(), \fileperms($pathName) & 0777);
+        } finally {
+            \unlink($pathName);
+            \unlink($tempPath);
+        }
+    }
+
     public function testLoadThrowsExceptionOnNonExistingFile(): void
     {
         self::expectException(IOException::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8965
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

`LocalStorage::save()` now gives the copied media file the default mode of a newly created file (`0666` minus the process umask, so `0644` with the usual `022` umask) instead of keeping whatever mode the source had.

@alexander-schranz to your point about `0666` being too open: this is not a raw `0666`. `Filesystem::chmod($file, 0666, \umask())` applies `0666 & ~umask`, which is exactly what `copy()` itself produced before symfony/symfony#64179 (a plain `fopen('w')` file). Deployments that want stricter or group-based permissions keep full control through the umask and the ACL setup from the docs, unchanged.

#### Why?

symfony/symfony#64179 ("preserve source mode when copying files", shipped in the maintained Symfony branches) made `Filesystem::copy()` keep the source file mode. The PHP upload temp file is `0600`, so uploaded media ended up `-rw-------` and any user other than the webserver (e.g. the console user running scripts) got permission denied.

Only 2.6 is affected: 3.0 stores media through Flysystem, whose local adapter applies its own visibility configuration.

The new test uploads a `0600` temp file and asserts the stored file gets `0666 & ~umask`. I verified it both ways against the new `copy()` semantics: without the fix it fails with `0600`, with the fix it passes, and it also passes against the old semantics (no regression).
