### PR TITLE
Fix version heading of the widened column length upgrade notes

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,6 @@
 # Upgrade
 
-## 3.0.8
+## 3.0.9
 
 ### Widened webspace, slug and template key column lengths
 
@@ -13,6 +13,8 @@ bin/console doctrine:migrations:migrate
 ```
 
 If your database does not support the widened length you can set the `sulu_persistence.legacy_length` to true in your `config/packages/sulu_persistence.yaml`.
+
+## 3.0.8
 
 ### Route value is required when saving routable content
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #8690
| License | MIT
| Documentation PR | -

#### What's in this PR?

Moves the "Widened webspace, slug and template key column lengths" notes from the `3.0.8` section of `UPGRADE-3.x.md` into a new `3.0.9` section.

#### Why?

The notes were added on top of the `3.0.8` section in #8690, but `3.0.8` had already been tagged at that point, so the section describes a release it is not part of. Anyone upgrading from `3.0.8` starts reading at the next section and would skip the required `doctrine:migrations:migrate` run.

After this change the `3.0.8` section is identical to what the `3.0.8` tag shipped.