### PR TITLE
Deliver the media origin and AI disclosure columns as a doctrine migration

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -14,6 +14,16 @@ bin/console doctrine:migrations:migrate
 
 If your database does not support the widened length you can set the `sulu_persistence.legacy_length` to true in your `config/packages/sulu_persistence.yaml`.
 
+### Origin and AI disclosure information for media
+
+Media file versions gained an origin and AI disclosure information, which adds the `origin`, `aiDisclosureDisabled` and
+`aiDisclosureIconVariant` columns to `me_file_versions` and the `aiDisclosureText` column to `me_file_version_meta`.
+Run the new migration to apply the schema change:
+
+```bash
+bin/console doctrine:migrations:migrate
+```
+
 ## 3.0.8
 
 ### Route value is required when saving routable content

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -122,6 +122,17 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
             );
         }
 
+        if ($container->hasExtension('doctrine_migrations')) {
+            $container->prependExtensionConfig(
+                'doctrine_migrations',
+                [
+                    'migrations_paths' => [
+                        'Sulu\\Bundle\\MediaBundle\\Migrations' => __DIR__ . '/../Migrations',
+                    ],
+                ]
+            );
+        }
+
         if ($container->hasExtension('sulu_admin')) {
             $container->prependExtensionConfig(
                 'sulu_admin',

--- a/src/Sulu/Bundle/MediaBundle/Migrations/Version20260820120000.php
+++ b/src/Sulu/Bundle/MediaBundle/Migrations/Version20260820120000.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260820120000 extends AbstractMigration
+{
+    private const FILE_VERSIONS_TABLE = 'me_file_versions';
+
+    private const FILE_VERSION_META_TABLE = 'me_file_version_meta';
+
+    public function getDescription(): string
+    {
+        return 'Add origin and AI disclosure columns to me_file_versions and me_file_version_meta';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable(self::FILE_VERSIONS_TABLE)) {
+            $fileVersions = $schema->getTable(self::FILE_VERSIONS_TABLE);
+
+            if (!$fileVersions->hasColumn('origin')) {
+                $fileVersions->addColumn('origin', Types::STRING, [
+                    'length' => 31,
+                    'notnull' => true,
+                    'default' => 'unknown',
+                ]);
+            }
+
+            if (!$fileVersions->hasColumn('aiDisclosureDisabled')) {
+                $fileVersions->addColumn('aiDisclosureDisabled', Types::BOOLEAN, [
+                    'notnull' => true,
+                    'default' => false,
+                ]);
+            }
+
+            if (!$fileVersions->hasColumn('aiDisclosureIconVariant')) {
+                $fileVersions->addColumn('aiDisclosureIconVariant', Types::STRING, [
+                    'length' => 31,
+                    'notnull' => true,
+                    'default' => 'auto',
+                ]);
+            }
+        }
+
+        if ($schema->hasTable(self::FILE_VERSION_META_TABLE)) {
+            $fileVersionMeta = $schema->getTable(self::FILE_VERSION_META_TABLE);
+
+            if (!$fileVersionMeta->hasColumn('aiDisclosureText')) {
+                $fileVersionMeta->addColumn('aiDisclosureText', Types::TEXT, [
+                    'notnull' => false,
+                ]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable(self::FILE_VERSIONS_TABLE)) {
+            $fileVersions = $schema->getTable(self::FILE_VERSIONS_TABLE);
+
+            foreach (['origin', 'aiDisclosureDisabled', 'aiDisclosureIconVariant'] as $columnName) {
+                if ($fileVersions->hasColumn($columnName)) {
+                    $fileVersions->dropColumn($columnName);
+                }
+            }
+        }
+
+        if ($schema->hasTable(self::FILE_VERSION_META_TABLE)) {
+            $fileVersionMeta = $schema->getTable(self::FILE_VERSION_META_TABLE);
+
+            if ($fileVersionMeta->hasColumn('aiDisclosureText')) {
+                $fileVersionMeta->dropColumn('aiDisclosureText');
+            }
+        }
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Migrations/Version20260820120000Test.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Migrations/Version20260820120000Test.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Functional\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\NullLogger;
+use Sulu\Bundle\MediaBundle\Entity\FileVersion;
+use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Migrations\Version20260820120000;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+
+class Version20260820120000Test extends SuluTestCase
+{
+    private const FILE_VERSIONS_COLUMNS = ['origin', 'aiDisclosureDisabled', 'aiDisclosureIconVariant'];
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        self::purgeDatabase();
+        $this->connection = self::getEntityManager()->getConnection();
+    }
+
+    protected function tearDown(): void
+    {
+        // leave the schema migrated, so a failing assertion does not break the rest of the suite
+        $this->runMigration('up');
+
+        parent::tearDown();
+    }
+
+    public function testDownRemovesColumnsAndUpAddsThemBack(): void
+    {
+        $this->runMigration('down');
+
+        foreach (self::FILE_VERSIONS_COLUMNS as $columnName) {
+            self::assertFalse($this->hasColumn('me_file_versions', $columnName), $columnName);
+        }
+        self::assertFalse($this->hasColumn('me_file_version_meta', 'aiDisclosureText'));
+
+        $this->runMigration('up');
+
+        foreach (self::FILE_VERSIONS_COLUMNS as $columnName) {
+            self::assertTrue($this->hasColumn('me_file_versions', $columnName), $columnName);
+        }
+        self::assertTrue($this->hasColumn('me_file_version_meta', 'aiDisclosureText'));
+    }
+
+    public function testUpBackfillsExistingRowsWithTheDefaults(): void
+    {
+        [$fileVersionId, $fileVersionMetaId] = $this->createFileVersion();
+
+        // the rows survive dropping and re-adding the columns, which is the state of an
+        // installation that already has media and upgrades to the new columns
+        $this->runMigration('down');
+        $this->runMigration('up');
+
+        $fileVersion = $this->fetchRow('me_file_versions', $fileVersionId);
+        self::assertSame('unknown', $fileVersion['origin']);
+        self::assertFalse((bool) $fileVersion['aiDisclosureDisabled']);
+        self::assertSame('auto', $fileVersion['aiDisclosureIconVariant']);
+
+        $fileVersionMeta = $this->fetchRow('me_file_version_meta', $fileVersionMetaId);
+        self::assertNull($fileVersionMeta['aiDisclosureText']);
+    }
+
+    public function testUpIsIdempotent(): void
+    {
+        $this->runMigration('up');
+        $this->runMigration('up');
+
+        foreach (self::FILE_VERSIONS_COLUMNS as $columnName) {
+            self::assertTrue($this->hasColumn('me_file_versions', $columnName), $columnName);
+        }
+        self::assertTrue($this->hasColumn('me_file_version_meta', 'aiDisclosureText'));
+    }
+
+    /**
+     * @param 'down'|'up' $direction
+     */
+    private function runMigration(string $direction): void
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        $fromSchema = $schemaManager->introspectSchema();
+        $toSchema = $schemaManager->introspectSchema();
+
+        $migration = new Version20260820120000($this->connection, new NullLogger());
+        $migration->$direction($toSchema);
+
+        $platform = $this->connection->getDatabasePlatform();
+        $schemaDiff = $schemaManager->createComparator()->compareSchemas($fromSchema, $toSchema);
+
+        foreach ($platform->getAlterSchemaSQL($schemaDiff) as $sql) {
+            $this->connection->executeStatement($sql);
+        }
+    }
+
+    private function hasColumn(string $tableName, string $columnName): bool
+    {
+        return $this->connection->createSchemaManager()->introspectTable($tableName)->hasColumn($columnName);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchRow(string $tableName, int $id): array
+    {
+        $row = $this->connection->createQueryBuilder()
+            ->select('*')
+            ->from($tableName)
+            ->where('id = :id')
+            ->setParameter('id', $id)
+            ->executeQuery()
+            ->fetchAssociative();
+        self::assertIsArray($row);
+
+        return $row;
+    }
+
+    /**
+     * @return array{int, int} file version id and file version meta id
+     */
+    private function createFileVersion(): array
+    {
+        $entityManager = self::getEntityManager();
+
+        $fileVersion = new FileVersion();
+        $fileVersion->setName('migration-test.jpg');
+        $fileVersion->setVersion(1);
+        $fileVersion->setSize(1024);
+        $fileVersion->setMimeType('image/jpeg');
+        $fileVersion->setCreated(new \DateTimeImmutable('2026-08-20'));
+        $fileVersion->setChanged(new \DateTimeImmutable('2026-08-20'));
+        // non-default values, so the assertions prove the migration applied the defaults
+        $fileVersion->setOrigin('ai_generated');
+        $fileVersion->setAiDisclosureDisabled(true);
+        $fileVersion->setAiDisclosureIconVariant('dark');
+
+        $fileVersionMeta = new FileVersionMeta();
+        $fileVersionMeta->setLocale('en');
+        $fileVersionMeta->setTitle('Migration Test');
+        $fileVersionMeta->setAiDisclosureText('Generated with AI');
+        $fileVersionMeta->setFileVersion($fileVersion);
+        $fileVersion->addMeta($fileVersionMeta);
+        $fileVersion->setDefaultMeta($fileVersionMeta);
+
+        $entityManager->persist($fileVersion);
+        $entityManager->persist($fileVersionMeta);
+        $entityManager->flush();
+
+        return [(int) $fileVersion->getId(), (int) $fileVersionMeta->getId()];
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Migrations/Version20260820120000Test.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Migrations/Version20260820120000Test.php
@@ -67,13 +67,20 @@ class Version20260820120000Test extends SuluTestCase
         $this->runMigration('down');
         $this->runMigration('up');
 
-        $fileVersion = $this->fetchRow('me_file_versions', $fileVersionId);
-        self::assertSame('unknown', $fileVersion['origin']);
-        self::assertFalse((bool) $fileVersion['aiDisclosureDisabled']);
-        self::assertSame('auto', $fileVersion['aiDisclosureIconVariant']);
+        // read back through the entity manager, so neither the identifier casing nor the
+        // boolean representation of the database platform leaks into the assertions
+        $entityManager = self::getEntityManager();
+        $entityManager->clear();
 
-        $fileVersionMeta = $this->fetchRow('me_file_version_meta', $fileVersionMetaId);
-        self::assertNull($fileVersionMeta['aiDisclosureText']);
+        $fileVersion = $entityManager->find(FileVersion::class, $fileVersionId);
+        self::assertInstanceOf(FileVersion::class, $fileVersion);
+        self::assertSame('unknown', $fileVersion->getOrigin());
+        self::assertFalse($fileVersion->getAiDisclosureDisabled());
+        self::assertSame('auto', $fileVersion->getAiDisclosureIconVariant());
+
+        $fileVersionMeta = $entityManager->find(FileVersionMeta::class, $fileVersionMetaId);
+        self::assertInstanceOf(FileVersionMeta::class, $fileVersionMeta);
+        self::assertNull($fileVersionMeta->getAiDisclosureText());
     }
 
     public function testUpIsIdempotent(): void
@@ -110,23 +117,6 @@ class Version20260820120000Test extends SuluTestCase
     private function hasColumn(string $tableName, string $columnName): bool
     {
         return $this->connection->createSchemaManager()->introspectTable($tableName)->hasColumn($columnName);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function fetchRow(string $tableName, int $id): array
-    {
-        $row = $this->connection->createQueryBuilder()
-            ->select('*')
-            ->from($tableName)
-            ->where('id = :id')
-            ->setParameter('id', $id)
-            ->executeQuery()
-            ->fetchAssociative();
-        self::assertIsArray($row);
-
-        return $row;
     }
 
     /**


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #9018
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adds `Sulu\Bundle\MediaBundle\Migrations\Version20260820120000` for the columns introduced in #9018, registers a `doctrine_migrations.migrations_paths` entry for the bundle and documents the upgrade step in `UPGRADE-3.x.md`.

The migration adds `origin`, `aiDisclosureDisabled` and `aiDisclosureIconVariant` to `me_file_versions` and `aiDisclosureText` to `me_file_version_meta`.

#### Why?

PR #9018 was merged into 2.6 and documented the schema change as raw MySQL SQL in `UPGRADE-2.x.md`. 3.0 depends on `doctrine/doctrine-migrations-bundle`, so the change belongs in a migration instead, which also makes it work on the PostgreSQL setups 3.0 supports.

The migration goes through the DBAL schema API rather than `addSql()`, so the SQL is rendered per platform. No data migration is needed: MySQL, MariaDB and PostgreSQL all backfill existing rows from the `NOT NULL DEFAULT` on `ADD COLUMN`.

This is the first migration in a `src/Sulu/Bundle/*` bundle, so `SuluMediaExtension::prepend()` registers the path the same way `SuluPageBundle` and `SuluRouteBundle` already do. No `composer.json` change is needed, because the `Sulu\` PSR-4 root already covers the namespace.

#### Tests

`Version20260820120000Test` is a functional test in the MediaBundle suite. Since a DDL migration only mutates the `Schema` object, the test diffs the introspected schema and executes the resulting SQL, which is what doctrine-migrations does at runtime. It covers three things:

- `down()` removes the columns and `up()` adds them back.
- An existing file version row, created before the columns are added, receives the defaults (`unknown`, `false`, `auto`).
- `up()` on an already migrated schema is a no-op.
