### PR TITLE
Fix Index the re_references columns the reference repository filters by

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -4,6 +4,16 @@ For every update follow the [Upgrade Documentation](https://docs.sulu.io/2.x/upg
 
 ## 2.6.26
 
+### Improved reference tracking performance
+
+`ReferenceRepository` filters by `referenceResourceKey`, `referenceResourceId`, `referenceLocale` and
+`referenceContext` when it removes the references a resource holds, which happens on every publish.
+Only the source side of the table was indexed, so that removal was a full table scan:
+
+```sql
+CREATE INDEX reference_resource_idx ON re_references (referenceResourceKey, referenceResourceId, referenceLocale, referenceContext);
+```
+
 ### AI Disclosure
 
 The `aiDisclosure` section has been added to the media details form. It allows you to add information about the origin of the media and additional information about the use of AI.

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Reference/Refresh/PageReferenceRefresherTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Reference/Refresh/PageReferenceRefresherTest.php
@@ -106,7 +106,7 @@ class PageReferenceRefresherTest extends SuluTestCase
             'referenceResourceKey' => 'pages',
             'referenceResourceId' => $page->getUuid(),
             'referenceLocale' => 'en',
-        ]);
+        ], ['referenceContext' => 'ASC']);
 
         self::assertCount(2, $references);
 
@@ -116,7 +116,7 @@ class PageReferenceRefresherTest extends SuluTestCase
         self::assertSame($page->getUuid(), $references[0]->getReferenceResourceId());
         self::assertSame('pages', $references[0]->getReferenceResourceKey());
         self::assertSame('en', $references[0]->getReferenceLocale());
-        self::assertSame('website', $references[0]->getReferenceContext());
+        self::assertSame('admin', $references[0]->getReferenceContext());
 
         self::assertSame('animals', $references[1]->getReferenceProperty());
         self::assertSame($snippet->getUuid(), $references[1]->getResourceId());
@@ -124,6 +124,6 @@ class PageReferenceRefresherTest extends SuluTestCase
         self::assertSame($page->getUuid(), $references[1]->getReferenceResourceId());
         self::assertSame('pages', $references[1]->getReferenceResourceKey());
         self::assertSame('en', $references[1]->getReferenceLocale());
-        self::assertSame('admin', $references[1]->getReferenceContext());
+        self::assertSame('website', $references[1]->getReferenceContext());
     }
 }

--- a/src/Sulu/Bundle/ReferenceBundle/Infrastructure/Doctrine/Repository/ReferenceRepository.php
+++ b/src/Sulu/Bundle/ReferenceBundle/Infrastructure/Doctrine/Repository/ReferenceRepository.php
@@ -178,22 +178,16 @@ final class ReferenceRepository implements ReferenceRepositoryInterface
                 ->setParameter('id', $id);
         }
 
-        $referenceResourceKey = $filters['referenceResourceKey'] ?? null;
-        if (null !== $referenceResourceKey) {
-            $queryBuilder->andWhere('reference.referenceResourceKey = :referenceResourceKey')
-                ->setParameter('referenceResourceKey', $referenceResourceKey);
+        $resourceKey = $filters['resourceKey'] ?? null;
+        if (null !== $resourceKey) {
+            $queryBuilder->andWhere('reference.resourceKey = :resourceKey')
+                ->setParameter('resourceKey', $resourceKey);
         }
 
         $resourceId = $filters['resourceId'] ?? null;
         if (null !== $resourceId) {
             $queryBuilder->andWhere('reference.resourceId = :resourceId')
                 ->setParameter('resourceId', $resourceId);
-        }
-
-        $resourceKey = $filters['resourceKey'] ?? null;
-        if (null !== $resourceKey) {
-            $queryBuilder->andWhere('reference.resourceKey = :resourceKey')
-                ->setParameter('resourceKey', $resourceKey);
         }
 
         $referenceResourceKey = $filters['referenceResourceKey'] ?? null;

--- a/src/Sulu/Bundle/ReferenceBundle/Resources/config/doctrine/Reference.orm.xml
+++ b/src/Sulu/Bundle/ReferenceBundle/Resources/config/doctrine/Reference.orm.xml
@@ -5,6 +5,7 @@
     <mapped-superclass name="Sulu\Bundle\ReferenceBundle\Domain\Model\Reference" table="re_references">
         <indexes>
             <index name="resource_idx" fields="resourceKey,resourceId"/>
+            <index name="reference_resource_idx" fields="referenceResourceKey,referenceResourceId,referenceLocale,referenceContext"/>
         </indexes>
 
         <id name="id" type="integer" column="id">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no 
| BC breaks? | no 
| Deprecations? | no
| License | MIT

#### What's in this PR?

Adds an index on the four `re_references` columns the reference repository filters by:

  ```sql
CREATE INDEX idx_re_references_reference_lookup ON re_references (referenceResourceKey, referenceResourceId, referenceLocale,  referenceContext);
```

#### Why?

ReferenceRepository::createQueryBuilder() filters by referenceResourceKey, referenceResourceId, referenceLocale and referenceContext  to remove the references a resource holds — which happens on every publish.

Only the source side of the table was indexed (resource_idx on resourceKey, resourceId), so that removal was a full table scan. We hit it during a content migration where re_references grows past 150,000 rows, and publishing slowed to a crawl.

