### PR TITLE
Fix creating collection in Sulu 2.6

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -368,7 +368,7 @@ class CollectionController extends AbstractRestController implements ClassResour
 
         $this->checkSystemCollection($id, $parent);
 
-        if (!$request->request->has('locale')) {
+        if (!$request->query->has('locale')) {
             throw new MissingParameterException(self::class, 'locale');
         }
 
@@ -376,7 +376,7 @@ class CollectionController extends AbstractRestController implements ClassResour
             $data = [
                 ...$this->getData($request),
                 'id' => $id,
-                'locale' => $request->request->get('locale'),
+                'locale' => $request->query->get('locale'),
             ];
 
             $collection = $this->collectionManager->save($data, $this->getUser()->getId(), $breadcrumb);


### PR DESCRIPTION
Reopens #9027, which was accidentally closed: the branch was rebased onto `3.0`, where this fix already exists via #8989, so the commit became empty and the PR collapsed to zero changes.

The fix belongs on `2.6`. `CollectionController::saveEntity()` reads `locale` from the request body, but it is sent as a query parameter — so creating a collection fails with a `MissingParameterException`.

Original commit and authorship by @alexander-schranz.
