### PR TITLE
Fix collection creating by backport 3.0 changes to 2.6

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -90407,3 +90407,9 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/phpstan/object-manager.php
+
+		-
+			message: '#^Call to function array_key_exists\(\) with ''model'' and array\{model\: class\-string, repository\?\: class\-string\} will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -20065,12 +20065,6 @@ parameters:
 			path: src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\CustomUrlBundle\\Controller\\CustomUrlController\:\:getRequestParameter\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/CustomUrlBundle/Controller/CustomUrlController.php
-
-		-
 			message: '#^Parameter \#1 \$webspaceKey of static method Sulu\\Bundle\\CustomUrlBundle\\Admin\\CustomUrlAdmin\:\:getCustomUrlSecurityContext\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -25717,12 +25711,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Controller/MediaController.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Controller\\MediaFormatController\:\:getRequestParameter\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Controller/MediaFormatController.php
-
-		-
 			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -29467,36 +29455,6 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:createCollectionType\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:createCollectionType\(\) has parameter \$description with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:createCollectionType\(\) has parameter \$id with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:createCollectionType\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:createCollectionType\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:createMediaType\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -29551,27 +29509,9 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
 
 		-
-			message: '#^Parameter \#1 \$collectionType of method Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:createCollection\(\) expects Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType, mixed given\.$#'
-			identifier: argument.type
-			count: 7
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
 			message: '#^Parameter \#1 \$datetime of function strtotime expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 20
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Parameter \#1 \$description of method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType\:\:setDescription\(\) expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Parameter \#1 \$id of method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType\:\:setId\(\) expects int, mixed given\.$#'
-			identifier: argument.type
-			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
 
 		-
@@ -29587,13 +29527,7 @@ parameters:
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
 
 		-
-			message: '#^Parameter \#1 \$key of method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType\:\:setKey\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Parameter \#1 \$name of method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType\:\:setName\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$key of method Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType\:\:setKey\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -29601,7 +29535,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$object of method Doctrine\\Persistence\\ObjectManager\:\:persist\(\) expects object, mixed given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
 
 		-
@@ -29672,18 +29606,6 @@ parameters:
 
 		-
 			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:\$collection1 \(Sulu\\Bundle\\MediaBundle\\Entity\\Collection\) does not accept mixed\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:\$collectionType1 \(Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType\) does not accept mixed\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
-
-		-
-			message: '#^Property Sulu\\Bundle\\MediaBundle\\Tests\\Functional\\Controller\\CollectionControllerTest\:\:\$collectionType2 \(Sulu\\Bundle\\MediaBundle\\Entity\\CollectionType\) does not accept mixed\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -46387,12 +46309,6 @@ parameters:
 			path: src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PreviewLinkController.php
 
 		-
-			message: '#^Method Sulu\\Bundle\\PreviewBundle\\UserInterface\\Controller\\PublicPreviewController\:\:getRequestParameter\(\) should return string but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Sulu/Bundle/PreviewBundle/UserInterface/Controller/PublicPreviewController.php
-
-		-
 			message: '#^Parameter \#1 \$objects of method Sulu\\Bundle\\ReferenceBundle\\Infrastructure\\Symfony\\DependencyInjection\\SuluReferenceExtension\:\:configurePersistence\(\) expects array\<string, array\{model\: class\-string, repository\?\: class\-string\}\>, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -57093,12 +57009,6 @@ parameters:
 		-
 			message: '#^Method Sulu\\Bundle\\TrashBundle\\UserInterface\\Controller\\Admin\\TrashItemController\:\:__construct\(\) has parameter \$restoreConfigurationProviderLocator with generic class Symfony\\Component\\DependencyInjection\\ServiceLocator but does not specify its types\: T$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
-
-		-
-			message: '#^Method Sulu\\Bundle\\TrashBundle\\UserInterface\\Controller\\Admin\\TrashItemController\:\:getRequestParameter\(\) should return string but returns mixed\.$#'
-			identifier: return.type
 			count: 1
 			path: src/Sulu/Bundle/TrashBundle/UserInterface/Controller/Admin/TrashItemController.php
 
@@ -90497,9 +90407,3 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/phpstan/object-manager.php
-
-		-
-			message: '#^Call to function array_key_exists\(\) with ''model'' and array\{model\: class\-string, repository\?\: class\-string\} will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -368,7 +368,7 @@ class CollectionController extends AbstractRestController implements ClassResour
 
         $this->checkSystemCollection($id, $parent);
 
-        if (!$request->request->has('locale')) {
+        if (!$request->query->has('locale')) {
             throw new MissingParameterException(self::class, 'locale');
         }
 
@@ -376,7 +376,7 @@ class CollectionController extends AbstractRestController implements ClassResour
             $data = [
                 ...$this->getData($request),
                 'id' => $id,
-                'locale' => $request->request->get('locale'),
+                'locale' => $request->query->get('locale'),
             ];
 
             $collection = $this->collectionManager->save($data, $this->getUser()->getId(), $breadcrumb);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -229,7 +229,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->em->flush();
     }
 
-    private function createCollectionType($id, $key, $name, $description = '')
+    private function createCollectionType(int $id, ?string $key, string $name, string $description = ''): CollectionType
     {
         $collectionType = new CollectionType();
         $collectionType->setId($id);
@@ -383,7 +383,7 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections?' . \http_build_query([
                 'page' => 3,
                 'limit' => 3,
-                'flat' => true,
+                'flat' => 'true',
                 'locale' => 'en-gb',
             ])
         );
@@ -418,10 +418,7 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'GET',
-            '/api/collections?page=1&limit=4&flat=true',
-            [
-                'locale' => 'de',
-            ]
+            '/api/collections?page=1&limit=4&flat=true&locale=de'
         );
 
         $this->assertHttpStatusCode(200, $this->client->getResponse());
@@ -460,7 +457,7 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections?' . \http_build_query([
                 'page' => 1,
                 'limit' => 4,
-                'flat' => true,
+                'flat' => 'true',
                 'sortBy' => 'title',
                 'sortOrder' => 'DESC',
                 'locale' => 'de',
@@ -492,7 +489,7 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
                 'parentId' => 'root',
-                'flat' => true,
+                'flat' => 'true',
             ])
         );
 
@@ -513,8 +510,8 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
                 'parentId' => 'root',
-                'flat' => true,
-                'includeRoot' => true,
+                'flat' => 'true',
+                'includeRoot' => 'true',
             ])
         );
 
@@ -543,7 +540,7 @@ class CollectionControllerTest extends SuluTestCase
             '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
                 'parentId' => $collection->getId(),
-                'flat' => true,
+                'flat' => 'true',
             ])
         );
 
@@ -601,7 +598,7 @@ class CollectionControllerTest extends SuluTestCase
                 'sortBy' => 'title',
                 'page' => 1,
                 'limit' => 2,
-                'includeRoot' => true,
+                'includeRoot' => 'true',
                 'locale' => 'en-gb',
             ])
         );
@@ -628,7 +625,7 @@ class CollectionControllerTest extends SuluTestCase
                 'sortBy' => 'title',
                 'page' => 1,
                 'limit' => 2,
-                'includeRoot' => true,
+                'includeRoot' => 'true',
                 'parentId' => $this->collection1->getId(),
                 'locale' => 'en-gb',
             ])
@@ -749,7 +746,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->client->jsonRequest(
             'GET',
             '/api/collections?' . \http_build_query([
-                'flat' => true,
+                'flat' => 'true',
                 'locale' => 'en-gb',
             ])
         );
@@ -851,7 +848,7 @@ class CollectionControllerTest extends SuluTestCase
             'GET',
             '/api/collections/' . $this->collection1->getId() . '?' . \http_build_query([
                 'depth' => 1,
-                'children' => true,
+                'children' => 'true',
                 'locale' => 'en-gb',
             ])
         );
@@ -882,7 +879,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->client->jsonRequest(
             'GET',
             '/api/collections?' . \http_build_query([
-                'flat' => true,
+                'flat' => 'true',
                 'depth' => 2,
                 'locale' => 'en-gb',
             ])
@@ -1606,7 +1603,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->client->jsonRequest(
             'GET',
             '/api/collections?' . \http_build_query([
-                'flat' => true,
+                'flat' => 'true',
                 'locale' => 'en-gb',
             ])
         );
@@ -1625,7 +1622,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->client->jsonRequest(
             'GET',
             '/api/collections?' . \http_build_query([
-                'flat' => true,
+                'flat' => 'true',
                 'depth' => 1,
                 'locale' => 'en-gb',
             ])
@@ -1649,7 +1646,7 @@ class CollectionControllerTest extends SuluTestCase
         $this->client->jsonRequest(
             'GET',
             '/api/collections?' . \http_build_query([
-                'flat' => true,
+                'flat' => 'true',
                 'depth' => 2,
                 'locale' => 'en-gb',
             ])
@@ -1784,7 +1781,7 @@ class CollectionControllerTest extends SuluTestCase
             'GET',
             '/api/collections/' . $ids[6] . '?' . \http_build_query([
                 'locale' => 'en-gb',
-                'breadcrumb' => true,
+                'breadcrumb' => 'true',
             ])
         );
 
@@ -1821,7 +1818,7 @@ class CollectionControllerTest extends SuluTestCase
             'GET',
             '/api/collections/' . $ids[3] . '?' . \http_build_query([
                 'depth' => 1,
-                'children' => true,
+                'children' => 'true',
                 'locale' => 'en-gb',
             ])
         );
@@ -1842,7 +1839,7 @@ class CollectionControllerTest extends SuluTestCase
             'GET',
             '/api/collections/' . $ids[3] . '?' . \http_build_query([
                 'depth' => 2,
-                'children' => true,
+                'children' => 'true',
                 'locale' => 'en-gb',
             ])
         );

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -708,9 +708,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'style' => [
                     'type' => 'circle',
                     'color' => $generateColor,
@@ -805,9 +806,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'style' => [
                     'type' => 'circle',
                     'color' => $generateColor,
@@ -921,9 +923,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->request(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'style' => [
                     'type' => 'circle',
                     'color' => $generateColor,
@@ -952,9 +955,10 @@ class CollectionControllerTest extends SuluTestCase
     {
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'title' => 'Test Collection 2',
                 'type' => [
                     'id' => $this->collectionType1->getId(),
@@ -1071,7 +1075,9 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
+            '/api/collections?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
             [
                 'style' => [
                     'type' => 'circle',
@@ -1082,7 +1088,6 @@ class CollectionControllerTest extends SuluTestCase
                 ],
                 'title' => 'Test Collection 2',
                 'description' => 'This Description 2 is only for testing',
-                'locale' => 'en-gb',
             ]
         );
 
@@ -1099,7 +1104,9 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $this->collection1->getId(),
+            '/api/collections/' . $this->collection1->getId() . '?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
             [
                 'style' => [
                     'type' => 'circle',
@@ -1110,7 +1117,6 @@ class CollectionControllerTest extends SuluTestCase
                 ],
                 'title' => 'Test Collection changed',
                 'description' => 'This Description is only for testing changed',
-                'locale' => 'en-gb',
             ]
         );
 
@@ -1211,7 +1217,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $childCollection->getId() . '?breadcrumb=true',
+            '/api/collections/' . $childCollection->getId() . '?' . \http_build_query([
+                'locale' => 'en-gb',
+                'breadcrumb' => 'true',
+            ]),
             [
                 'style' => [
                     'type' => 'circle',
@@ -1222,7 +1231,6 @@ class CollectionControllerTest extends SuluTestCase
                 ],
                 'title' => 'Test Child Collection changed',
                 'description' => 'This Description is only for testing changed',
-                'locale' => 'en-gb',
             ]
         );
 
@@ -1246,7 +1254,9 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $childCollection->getId(),
+            '/api/collections/' . $childCollection->getId() . '?' . \http_build_query([
+                'locale' => 'en-gb',
+            ]),
             [
                 'style' => [
                     'type' => 'circle',
@@ -1255,7 +1265,6 @@ class CollectionControllerTest extends SuluTestCase
                 'type' => ['id' => $this->collectionType1->getId()],
                 'title' => 'Test Child Collection changed',
                 'description' => 'This Description is only for testing changed',
-                'locale' => 'en-gb',
             ]
         );
 
@@ -1281,9 +1290,10 @@ class CollectionControllerTest extends SuluTestCase
         // Test put with only details
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $this->collection1->getId(),
-            [
+            '/api/collections/' . $this->collection1->getId() . '?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'style' => [
                     'type' => 'quader',
                     'color' => '#00ccff',
@@ -1316,9 +1326,10 @@ class CollectionControllerTest extends SuluTestCase
     {
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/404',
-            [
+            '/api/collections/404?' . \http_build_query([
                 'locale' => 'en',
+            ]),
+            [
                 'style' => [
                     'type' => 'quader',
                     'color' => '#00ccff',
@@ -1914,9 +1925,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'POST',
-            '/api/collections',
-            [
+            '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'type' => [
                     'id' => $this->collectionType1->getId(),
                 ],
@@ -1937,9 +1949,10 @@ class CollectionControllerTest extends SuluTestCase
 
         $this->client->jsonRequest(
             'PUT',
-            '/api/collections/' . $collectionId,
-            [
+            '/api/collections/' . $collectionId . '?' . \http_build_query([
                 'locale' => 'en-gb',
+            ]),
+            [
                 'type' => [
                     'id' => $this->collectionType1->getId(),
                 ],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no <!-- if yes add them to the UPGRADE.md file -->
| Fixed tickets | fixes # <!-- add issue number here e.g.: #5730 -->
| Related issues/PRs | # <!-- add issue or PR number here e.g.: #5730 -->
| License | MIT
| Documentation PR | sulu/sulu-docs# <!-- add docs PR number here e.g.: sulu/sulu-docs#615 -->

#### What's in this PR?

Fix collection creating by backport 3.0 changes to 2.6.

#### Why?

This is a dev only issue, this was already fixed on 3.0-dev but not 2.6-dev so this backports it.
