### PR TITLE
Add navigation tests for unpublished, draft-only and ghost pages

### DIFF
--- a/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Doctrine/Repository/NavigationRepositoryTest.php
@@ -14,9 +14,13 @@ declare(strict_types=1);
 namespace Sulu\Page\Tests\Functional\Infrastructure\Doctrine\Repository;
 
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Content\Domain\Model\WorkflowInterface;
+use Sulu\Messenger\Infrastructure\Symfony\Messenger\FlushMiddleware\EnableFlushStamp;
+use Sulu\Page\Application\Message\ApplyWorkflowTransitionPageMessage;
 use Sulu\Page\Domain\Model\Page;
 use Sulu\Page\Domain\Repository\NavigationRepositoryInterface;
 use Sulu\Page\Tests\Traits\CreatePageTrait;
+use Symfony\Component\Messenger\Envelope;
 
 class NavigationRepositoryTest extends SuluTestCase
 {
@@ -141,6 +145,87 @@ class NavigationRepositoryTest extends SuluTestCase
             $this->assertCount(1, $result);
             $this->assertArrayNotHasKey('title', $result[0]);
         }
+    }
+
+    public function testGetNavigationTreeSkipsUnpublishedPages(): void
+    {
+        $draftOnly = self::createPage([
+            'en' => [
+                'draft' => [
+                    'parentId' => $this->parent->getUuid(),
+                    'template' => 'default',
+                    'title' => 'Draft Only Page',
+                    'url' => '/draft-only',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        $unpublished = self::createPage([
+            'en' => [
+                'live' => [
+                    'parentId' => $this->parent->getUuid(),
+                    'template' => 'default',
+                    'title' => 'Unpublished Page',
+                    'url' => '/unpublished',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        $messageBus = self::getContainer()->get('sulu_message_bus');
+        $messageBus->dispatch(new Envelope(
+            new ApplyWorkflowTransitionPageMessage(
+                identifier: ['uuid' => $unpublished->getUuid()],
+                locale: 'en',
+                transitionName: WorkflowInterface::WORKFLOW_TRANSITION_UNPUBLISH
+            ),
+            [new EnableFlushStamp()]
+        ));
+
+        $result = $this->navigationRepository->getNavigationTree(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            2,
+            $this->getDefaultProperties()
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertSame('Parent Page', $result[0]['title']);
+        \assert(\is_array($result[0]['children']));
+        $childTitles = \array_column($result[0]['children'], 'title');
+        $this->assertNotContains('Unpublished Page', $childTitles);
+        $this->assertNotContains('Draft Only Page', $childTitles);
+    }
+
+    public function testGetNavigationTreeSkipsPagesNotPublishedInTheRequestedLocale(): void
+    {
+        self::createPage([
+            'de' => [
+                'live' => [
+                    'parentId' => $this->parent->getUuid(),
+                    'template' => 'default',
+                    'title' => 'Nur Deutsch',
+                    'url' => '/nur-deutsch',
+                    'navigationContexts' => ['main'],
+                ],
+            ],
+        ]);
+
+        $result = $this->navigationRepository->getNavigationTree(
+            'main',
+            'en',
+            'sulu-io',
+            null,
+            2,
+            $this->getDefaultProperties()
+        );
+
+        $this->assertCount(1, $result);
+        \assert(\is_array($result[0]['children']));
+        $this->assertNotContains('Nur Deutsch', \array_column($result[0]['children'], 'title'));
     }
 
     public function testGetNavigationFlatByUuid(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | #
| Related issues/PRs | sulu/SuluHeadlessBundle#164, #8923
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Two functional tests locking the navigation behavior for pages that must not appear in it:

- a published page that gets unpublished, and a draft-only page that was never published, are both excluded (and don't crash the resolution);
- a page published only in another locale (ghost) is excluded from the navigation requested in a locale it is not published in.

#### Why?

sulu/SuluHeadlessBundle#164 reported the navigation API crashing with `FormMetadataProvider::getMetadata(): Argument #2 ($locale) must be of type string, null given` on sulu 3.0.6 when an unpublished page was part of the navigation: the dimension content aggregate of such a page came out without a locale. The stack goes entirely through sulu/sulu (`NavigationRepository::resolvePageContent()` → `TemplateResolver`), and the behavior was fixed by #8923, shipped in 3.0.8 — all three scenarios pass on the current 3.0 branch.

Nothing covered these cases in `NavigationRepositoryTest` though, and a future regression of the ghost/shadow handling would crash every headless navigation again, so this locks them in.

Note: #9022 touches the same test file; whichever is merged second will need a trivial rebase.
