### PR TITLE
Restore the PHPStan baseline entries for the RelationTrait null comparisons

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32533,6 +32533,18 @@ parameters:
 			path: src/Sulu/Component/Persistence/Tests/Unit/EventSubscriber/ORM/UserBlameSubscriberTest.php
 
 		-
+			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
+			identifier: equal.alwaysTrue
+			count: 2
+			path: src/Sulu/Component/Persistence/RelationTrait.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 2
+			path: src/Sulu/Component/Persistence/RelationTrait.php
+
+		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #9010
| License | MIT
| Documentation PR | -

#### What's in this PR?

Adds the two `phpstan-baseline.neon` entries for `src/Sulu/Component/Persistence/RelationTrait.php` that suppress:

```
126  Loose comparison using == between null and null will always evaluate to true.   (equal.alwaysTrue)
138  Strict comparison using !== between null and null will always evaluate to false. (notIdentical.alwaysFalse)
```

#### Why?

`PHP Lint` fails on 3.0. The trait itself was not changed by the 2.6 backmerge; the baseline was. Before the merge, 3.0 suppressed both errors under `src/Sulu/Bundle/SecurityBundle/UserManager/UserManager.php`. The merge dropped those two entries and did not carry over the equivalents that 2.6 keeps under the trait path, so the errors surfaced unbaselined.

`RelationTrait::compareData()` fills `$matchedEntry` and `$matchedKey` through the by-reference parameters of the `$compare` callback. PHPStan cannot see through a `callable`, so it assumes both stay `null` — the reported comparisons are a false positive, not dead code. The trait is deprecated since 2.6 and `compareData()` has no in-tree callers, so suppressing matches how 2.6 handles it rather than reworking a deprecated public method.

The entries use `count: 2`, because the error is reported once per trait-using class. An over-declared count is harmless here since `reportUnmatchedIgnoredErrors` is `false`, so this holds whether the analysis attributes one or two occurrences.