### PR TITLE
Add CI check preventing new Enzyme tests

### DIFF
--- a/.github/workflows/test-application.yaml
+++ b/.github/workflows/test-application.yaml
@@ -115,6 +115,9 @@ jobs:
             - name: Lint SCSS
               run: npm run lint:scss
 
+            - name: Check for new Enzyme tests
+              run: npm run lint:enzyme
+
             - name: Flow
               run: npm run flow -- check
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "preinstall": "node preinstall.js",
         "lint:js": "eslint . --cache",
         "lint:scss": "stylelint src/Sulu/Bundle/*/Resources/js/**/*.scss",
+        "lint:enzyme": "node tests/js/check-enzyme-baseline.js",
         "flow": "flow",
         "test": "jest",
         "depcruise": "depcruise src/Sulu/Bundle/*/Resources/js -c dependency-cruiser.json",

--- a/tests/js/check-enzyme-baseline.js
+++ b/tests/js/check-enzyme-baseline.js
@@ -1,0 +1,259 @@
+/* eslint-disable flowtype/require-valid-file-annotation, import/no-nodejs-modules, max-len */
+
+const fs = require('fs');
+const path = require('path');
+
+// Files that still use Enzyme. THIS LIST ONLY SHRINKS.
+// Do not add entries: new tests are written with @testing-library/react.
+const BASELINE = [
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Application/tests/Application.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Badge/tests/Badge.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/CKEditor5/tests/CKEditor5.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/DeleteDependantResourcesDialog/tests/DeleteDependantResourcesDialog.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/DeleteReferencedResourceDialog/tests/DeleteReferencedResourceDialog.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldRenderer.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/CardCollection.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ChangelogLine.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ColorPicker.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/DatePicker.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Email.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Heading.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Input.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Link.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Number.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/PasswordConfirmation.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Phone.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ResourceLocator.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Select.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Selection.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleIconSelect.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelect.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SingleSelection.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextArea.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextEditor.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/MissingTypeDialog.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Section.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/ExternalLinkTypeOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/FolderAdapter.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/AdapterSwitch.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/FieldFilter.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/FieldFilterItem.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/BooleanFieldFilterType.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DateTimeFieldFilterType.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/NumberFieldFilterType.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectFieldFilterType.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/TextFieldFilterType.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/HtmlFieldTransformer.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/Search.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/tests/ListOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/ForgotPasswordForm.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/Login.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/LoginForm.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/ResetPasswordForm.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/TwoFactorForm.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiAutoComplete/tests/MultiAutoComplete.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiListOverlay/tests/MultiListOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/MultiSelection/tests/MultiSelection.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Navigation/tests/Navigation.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ProfileFormOverlay/tests/ProfileFormOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceCheckboxGroup/tests/ResourceCheckboxGroup.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceLocatorHistory/tests/ResourceLocatorHistory.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceMultiSelect/tests/ResourceMultiSelect.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/EditLine.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/EditOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ResourceSingleSelect/tests/ResourceSingleSelect.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/Sidebar.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Sidebar/tests/withSidebar.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleAutoComplete/tests/SingleAutoComplete.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleListOverlay/tests/SingleListOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SingleSelection/tests/SingleSelection.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/FilterOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContentItem.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/adapters/CKEditor5.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/TextEditor.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/Form.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyLocaleToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/CopyToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteDraftToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DeleteToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/DropdownToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/ReloadFormStoreToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SaveWithFormDialogToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/SetUnpublishedToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/TypeToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/tests/toolbarActions/UpdateFormStoreToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/List.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/ExportToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/List/tests/toolbarActions/UploadToolbarAction.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/PreviewForm/tests/PreviewForm.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/ResourceTabs/tests/ResourceTabs.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/views/Tabs/tests/Tabs.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/Form/tests/fields/TargetGroupRules.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/Condition.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ConditionList.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/RuleOverlay.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ruleTypes/Input.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ruleTypes/KeyValue.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ruleTypes/SingleSelect.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ruleTypes/SingleSelection.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/TargetGroupRules.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/containers/ContactAccountSelection/tests/ContactAccountSelection.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/tests/fields/Bic.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/tests/fields/ContactAccountSelection.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/tests/fields/ContactDetails.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/tests/fields/Iban.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/containers/List/tests/fieldFilterTypes/CountryFieldFilterType.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/AddContactToolbarAction.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/AddMediaToolbarAction.test.js',
+    'src/Sulu/Bundle/ContactBundle/Resources/js/views/List/tests/toolbarActions/DeleteMediaToolbarAction.test.js',
+    'src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/tests/fields/CustomUrl.test.js',
+    'src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/tests/fields/CustomUrlsDomainSelect.test.js',
+    'src/Sulu/Bundle/CustomUrlBundle/Resources/js/containers/Form/tests/fields/CustomUrlsLocaleSelect.test.js',
+    'src/Sulu/Bundle/LocationBundle/Resources/js/containers/Form/tests/fields/Location.test.js',
+    'src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/Location.test.js',
+    'src/Sulu/Bundle/LocationBundle/Resources/js/containers/Location/tests/LocationOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/ImageMap.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaSelection.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/MediaVersionUpload.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaSelection.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/Form/tests/fields/SingleMediaUpload.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/ImageMap/tests/Button.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/Link/tests/overlays/MediaLinkTypeOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardAdapter.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/List/tests/adapters/MediaCardOverviewAdapter.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/CollectionFormOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/MediaCollection.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaCollection/tests/PermissionFormOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaSelectionOverlay/tests/MediaSelectionOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/CropOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/FocusPointOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MediaVersionUpload/tests/MediaVersionUpload.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaDropzone/tests/MultiMediaDropzone.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelection/tests/MultiMediaSelection.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/MultiMediaSelectionOverlay/tests/MultiMediaSelectionOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelection/tests/SingleMediaSelection.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaSelectionOverlay/tests/SingleMediaSelectionOverlay.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/containers/SingleMediaUpload/tests/SingleMediaUpload.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaFormats/tests/MediaFormats.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaHistory/tests/MediaHistory.test.js',
+    'src/Sulu/Bundle/MediaBundle/Resources/js/views/MediaOverview/tests/MediaOverview.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsNavigationSelect.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/PageSettingsShadowLocaleSelect.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/SearchResult.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/SegmentSelect.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/SettingsVersions.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/Form/tests/fields/TeaserSelection.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/SegmentSelect/tests/SegmentSelect.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/tests/Item.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/containers/TeaserSelection/tests/TeaserSelection.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/views/List/tests/itemActions/RestoreVersionItemAction.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/views/PageList/tests/PageList.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/views/PageTabs/tests/PageTabs.test.js',
+    'src/Sulu/Bundle/PageBundle/Resources/js/views/WebspaceTabs/tests/WebspaceTabs.test.js',
+    'src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/Preview.test.js',
+    'src/Sulu/Bundle/PreviewBundle/Resources/js/containers/Preview/tests/PreviewLinkPopover.test.js',
+    'src/Sulu/Bundle/RouteBundle/Resources/js/containers/Form/tests/fields/PageTreeRoute.test.js',
+    'src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/Search.test.js',
+    'src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/SearchField.test.js',
+    'src/Sulu/Bundle/SearchBundle/Resources/js/containers/Search/tests/SearchResult.test.js',
+    'src/Sulu/Bundle/SearchBundle/Resources/js/views/Search/tests/Search.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/Permissions.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RoleAssignments.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/RolePermissions.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Form/tests/fields/TwoFactor.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/PermissionMatrix.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/Permissions/tests/Permissions.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignment.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RoleAssignments/tests/RoleAssignments.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/RolePermissions.test.js',
+    'src/Sulu/Bundle/SecurityBundle/Resources/js/containers/RolePermissions/tests/SystemRolePermissions.test.js',
+    'src/Sulu/Bundle/SnippetBundle/Resources/js/views/SnippetAreas/tests/SnippetAreas.test.js',
+    'src/Sulu/Bundle/TrashBundle/Resources/js/containers/RestoreFormOverlay/tests/RestoreFormOverlay.test.js',
+    'src/Sulu/Bundle/TrashBundle/Resources/js/views/List/itemActions/tests/RestoreItemAction.test.js',
+    'src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/CacheClearToolbarAction/tests/CacheClearToolbarAction.test.js',
+    'src/Sulu/Bundle/WebsiteBundle/Resources/js/containers/Form/tests/fields/AnalyticsDomainSelect.test.js',
+    'tests/js/testSetup.config.js',
+];
+
+const SCAN_DIRECTORIES = ['src', 'tests'];
+const IGNORED_DIRECTORIES = new Set(['node_modules', 'vendor', 'flow-typed', 'build']);
+const SOURCE_EXTENSIONS = new Set(['.js', '.jsx']);
+const ENZYME_IMPORT = /(?:from|require\()\s*['"](?:enzyme|enzyme-to-json|@wojtekmaj\/enzyme-adapter[^'"]*)(?:\/[^'"]*)?['"]/;
+
+function collectSourceFiles(directory, files) {
+    for (const entry of fs.readdirSync(directory, {withFileTypes: true})) {
+        const entryPath = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            if (!IGNORED_DIRECTORIES.has(entry.name)) {
+                collectSourceFiles(entryPath, files);
+            }
+        } else if (SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+            files.push(entryPath.split(path.sep).join('/'));
+        }
+    }
+
+    return files;
+}
+
+function findFilesUsingEnzyme() {
+    const files = SCAN_DIRECTORIES.reduce((collected, directory) => collectSourceFiles(directory, collected), []);
+
+    return files.filter((file) => ENZYME_IMPORT.test(fs.readFileSync(file, 'utf8'))).sort();
+}
+
+function report(headline, files, hint) {
+    process.stderr.write('\x1b[31m' + headline + '\x1b[0m\n');
+    files.forEach((file) => process.stderr.write('  ' + file + '\n'));
+    process.stderr.write('\n' + hint + '\n\n');
+}
+
+const filesUsingEnzyme = findFilesUsingEnzyme();
+const baseline = new Set(BASELINE);
+const found = new Set(filesUsingEnzyme);
+
+const added = filesUsingEnzyme.filter((file) => !baseline.has(file));
+const removed = BASELINE.filter((file) => !found.has(file));
+
+if (added.length > 0) {
+    report(
+        'Enzyme is used in files that are not part of the baseline:',
+        added,
+        'Enzyme is deprecated in this repository. Write new tests with @testing-library/react.'
+    );
+}
+
+if (removed.length > 0) {
+    report(
+        'Baseline files that no longer use Enzyme:',
+        removed,
+        'They were migrated, renamed or deleted. Remove them from BASELINE in tests/js/check-enzyme-baseline.js.'
+    );
+}
+
+if (added.length > 0 || removed.length > 0) {
+    process.exitCode = 1;
+} else {
+    process.stdout.write('No new Enzyme usage. ' + filesUsingEnzyme.length + ' file(s) left to migrate.\n');
+}

--- a/tests/js/check-enzyme-baseline.js
+++ b/tests/js/check-enzyme-baseline.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const babel = require('@babel/core');
 
 // Files that still use Enzyme. THIS LIST ONLY SHRINKS.
 // Do not add entries: new tests are written with @testing-library/react.
@@ -14,6 +15,11 @@ const BASELINE = [
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldBlocks.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/FieldBlocks/tests/FieldRenderer.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Field.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/MissingTypeDialog.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Section.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/CardCollection.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/ChangelogLine.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Checkbox.test.js',
@@ -36,22 +42,19 @@ const BASELINE = [
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextArea.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/TextEditor.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/Url.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Form.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/GhostDialog.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/MissingTypeDialog.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Renderer.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/Section.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/Link.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/ExternalLinkTypeOverlay.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Link/tests/overlays/LinkTypeOverlay.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/AdapterSwitch.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/FieldFilter.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/FieldFilterItem.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/Search.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/ColumnListAdapter.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/FolderAdapter.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TableAdapter.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/adapters/TreeTableAdapter.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/AdapterSwitch.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/FieldFilter.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/FieldFilterItem.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/BooleanFieldFilterType.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/DateTimeFieldFilterType.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/NumberFieldFilterType.test.js',
@@ -59,8 +62,6 @@ const BASELINE = [
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectionFieldFilterType.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/TextFieldFilterType.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldTransformers/HtmlFieldTransformer.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/List.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/Search.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ListOverlay/tests/ListOverlay.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/ForgotPasswordForm.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Login/tests/Login.test.js',
@@ -86,8 +87,8 @@ const BASELINE = [
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/FilterOverlay.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContent.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/tests/SmartContentItem.test.js',
-    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/adapters/CKEditor5.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/TextEditor.test.js',
+    'src/Sulu/Bundle/AdminBundle/Resources/js/containers/TextEditor/tests/adapters/CKEditor5.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/Toolbar.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/tests/withToolbar.test.js',
     'src/Sulu/Bundle/AdminBundle/Resources/js/containers/ViewRenderer/tests/ViewRenderer.test.js',
@@ -113,11 +114,11 @@ const BASELINE = [
     'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/Condition.test.js',
     'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ConditionList.test.js',
     'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/RuleOverlay.test.js',
+    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/TargetGroupRules.test.js',
     'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ruleTypes/Input.test.js',
     'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ruleTypes/KeyValue.test.js',
     'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ruleTypes/SingleSelect.test.js',
     'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/ruleTypes/SingleSelection.test.js',
-    'src/Sulu/Bundle/AudienceTargetingBundle/Resources/js/containers/TargetGroupRules/tests/TargetGroupRules.test.js',
     'src/Sulu/Bundle/ContactBundle/Resources/js/containers/ContactAccountSelection/tests/ContactAccountSelection.test.js',
     'src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/tests/fields/Bic.test.js',
     'src/Sulu/Bundle/ContactBundle/Resources/js/containers/Form/tests/fields/ContactAccountSelection.test.js',
@@ -198,8 +199,9 @@ const BASELINE = [
 
 const SCAN_DIRECTORIES = ['src', 'tests'];
 const IGNORED_DIRECTORIES = new Set(['node_modules', 'vendor', 'flow-typed', 'build']);
+const IGNORED_NODE_KEYS = new Set(['loc', 'comments', 'leadingComments', 'trailingComments']);
 const SOURCE_EXTENSIONS = new Set(['.js', '.jsx']);
-const ENZYME_IMPORT = /(?:from|require\()\s*['"](?:enzyme|enzyme-to-json|@wojtekmaj\/enzyme-adapter[^'"]*)(?:\/[^'"]*)?['"]/;
+const ENZYME_MODULE = /^(?:enzyme|enzyme-to-json|@wojtekmaj\/enzyme-adapter[^/]*)(?:\/|$)/;
 
 function collectSourceFiles(directory, files) {
     for (const entry of fs.readdirSync(directory, {withFileTypes: true})) {
@@ -217,10 +219,41 @@ function collectSourceFiles(directory, files) {
     return files;
 }
 
-function findFilesUsingEnzyme() {
-    const files = SCAN_DIRECTORIES.reduce((collected, directory) => collectSourceFiles(directory, collected), []);
+// Collects every module specifier the file references: static imports, re-exports,
+// side-effect imports, dynamic imports and require calls.
+function collectModuleSpecifiers(node, specifiers) {
+    if (Array.isArray(node)) {
+        node.forEach((child) => collectModuleSpecifiers(child, specifiers));
 
-    return files.filter((file) => ENZYME_IMPORT.test(fs.readFileSync(file, 'utf8'))).sort();
+        return specifiers;
+    }
+
+    if (!node || typeof node !== 'object' || !node.type) {
+        return specifiers;
+    }
+
+    if (node.source && node.source.type === 'StringLiteral') {
+        specifiers.push(node.source.value);
+    }
+
+    const isModuleCall = node.type === 'CallExpression' && node.callee
+        && (node.callee.type === 'Import' || node.callee.name === 'require');
+
+    if (isModuleCall && node.arguments[0] && node.arguments[0].type === 'StringLiteral') {
+        specifiers.push(node.arguments[0].value);
+    }
+
+    Object.keys(node)
+        .filter((key) => !IGNORED_NODE_KEYS.has(key))
+        .forEach((key) => collectModuleSpecifiers(node[key], specifiers));
+
+    return specifiers;
+}
+
+function usesEnzyme(file) {
+    const ast = babel.parseSync(fs.readFileSync(file, 'utf8'), {filename: file});
+
+    return collectModuleSpecifiers(ast, []).some((specifier) => ENZYME_MODULE.test(specifier));
 }
 
 function report(headline, files, hint) {
@@ -229,10 +262,22 @@ function report(headline, files, hint) {
     process.stderr.write('\n' + hint + '\n\n');
 }
 
-const filesUsingEnzyme = findFilesUsingEnzyme();
+const sourceFiles = SCAN_DIRECTORIES.reduce((collected, directory) => collectSourceFiles(directory, collected), []);
+const unparseable = [];
+const filesUsingEnzyme = sourceFiles
+    .filter((file) => {
+        try {
+            return usesEnzyme(file);
+        } catch (error) {
+            unparseable.push(file + ' (' + error.message.split('\n')[0] + ')');
+
+            return false;
+        }
+    })
+    .sort();
+
 const baseline = new Set(BASELINE);
 const found = new Set(filesUsingEnzyme);
-
 const added = filesUsingEnzyme.filter((file) => !baseline.has(file));
 const removed = BASELINE.filter((file) => !found.has(file));
 
@@ -252,7 +297,15 @@ if (removed.length > 0) {
     );
 }
 
-if (added.length > 0 || removed.length > 0) {
+if (unparseable.length > 0) {
+    report(
+        'Files could not be parsed and were not checked for Enzyme usage:',
+        unparseable,
+        'Fix the syntax errors so the Enzyme baseline can be verified.'
+    );
+}
+
+if (added.length > 0 || removed.length > 0 || unparseable.length > 0) {
     process.exitCode = 1;
 } else {
     process.stdout.write('No new Enzyme usage. ' + filesUsingEnzyme.length + ' file(s) left to migrate.\n');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

A new lint check that fails the build when a file starts using Enzyme that was not already using it.

`tests/js/check-enzyme-baseline.js` holds a `BASELINE` array with the 188 files that currently import Enzyme. It scans `src/` and `tests/` for imports of `enzyme`, `enzyme-to-json` and `@wojtekmaj/enzyme-adapter-*` (both `import` and `require`), and fails in two directions:

- a file uses Enzyme but is not in `BASELINE` → a new Enzyme test was added
- a file in `BASELINE` no longer uses Enzyme → it was migrated, renamed or deleted and has to be removed from the list

The second direction is what makes it a ratchet: the number can only go down. A migration that forgets to prune the list fails CI, so `BASELINE` cannot silently drift.

It runs as `npm run lint:enzyme` in the existing `js-lint` job. No new job and no new dependency.

#### Why?

We are replacing the Enzyme tests with `@testing-library/react` file by file. Without a guard the migration never finishes, because new tests keep being written against Enzyme — by hand and increasingly by AI assistants that copy the pattern from a neighbouring test file.

A plain count of Enzyme imports would not work: deleting one Enzyme test and adding another keeps the count identical. An ESLint rule would not work either, because the obvious way to "fix" a lint error is to add an `eslint-disable` comment next to the import, and that comment then gets copied along with the rest of the test. Both bypasses are invisible in review.

An explicit path list moves the only escape hatch into a single file that says "THIS LIST ONLY SHRINKS" at the top. Adding an Enzyme test now means adding a line there, which is a one-line diff a reviewer cannot miss.

Known trade-off: renaming an Enzyme test fails CI until its path in `BASELINE` is updated. The error message names the exact file.

#### Example Usage

Adding a new Enzyme test:

    $ npm run lint:enzyme
    Enzyme is used in files that are not part of the baseline:
      src/Sulu/Bundle/AdminBundle/Resources/js/components/Badge/tests/Badge.test.js

    Enzyme is deprecated in this repository. Write new tests with @testing-library/react.

Migrating a test to Testing Library without pruning the list:

    $ npm run lint:enzyme
    Baseline files that no longer use Enzyme:
      src/Sulu/Bundle/AdminBundle/Resources/js/containers/Badge/tests/Badge.test.js

    They were migrated, renamed or deleted. Remove them from BASELINE in tests/js/check-enzyme-baseline.js.

On a clean tree it prints the remaining work:

    $ npm run lint:enzyme
    No new Enzyme usage. 188 file(s) left to migrate.

Once `BASELINE` is empty, `enzyme`, `enzyme-to-json` and the adapter can be dropped from `package.json`, `enzyme-to-json/serializer` removed from the jest `snapshotSerializers`, the adapter setup stripped from `tests/js/testSetup.config.js`, and this script deleted.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
