### PR TITLE
Move the language switcher resolution into the route package

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -2,6 +2,18 @@
 
 ## 3.0.9
 
+### Language switcher resolution moved to the route package
+
+The `localizations` passed to website templates are now resolved by the new `sulu_route.language_switcher_provider`
+service (`Sulu\Route\Application\LanguageSwitcher\LanguageSwitcherProviderInterface`), which relies on the
+`sulu_route.site_locale_provider` service (`SiteLocaleProviderInterface`, decorated by the page package to return the
+localizations of the webspace). The `ContentController` therefore no longer subscribes to the `sulu_route.route_repository`,
+`sulu_route.route_generator` and `sulu_core.webspace.webspace_manager` services: subclasses relying on
+`$this->container->get()` for one of them have to add it back to their own `getSubscribedServices()`.
+
+`Sulu\Content\Infrastructure\Sulu\Route\Exception\WebspaceUrlNotFoundException` now extends the new
+`Sulu\Route\Domain\Exception\WebspaceUrlNotFoundException`, which is the exception the route generator contract declares.
+
 ### Widened webspace, slug and template key column lengths
 
 The `webspace`/`webspaceKey`, `slug`, `templateKey` and navigation-context/additional-webspace `name` columns

--- a/packages/content/src/Infrastructure/Sulu/Route/Exception/WebspaceUrlNotFoundException.php
+++ b/packages/content/src/Infrastructure/Sulu/Route/Exception/WebspaceUrlNotFoundException.php
@@ -11,17 +11,8 @@
 
 namespace Sulu\Content\Infrastructure\Sulu\Route\Exception;
 
-/**
- * @internal
- */
-class WebspaceUrlNotFoundException extends \RuntimeException
+use Sulu\Route\Domain\Exception\WebspaceUrlNotFoundException as RouteWebspaceUrlNotFoundException;
+
+class WebspaceUrlNotFoundException extends RouteWebspaceUrlNotFoundException
 {
-    public function __construct(string $slug, string $locale, string $site, int $code = 0, ?\Throwable $previous = null)
-    {
-        parent::__construct(
-            \sprintf('No url found for "%s" in locale "%s" and site "%s".', $slug, $locale, $site),
-            $code,
-            $previous,
-        );
-    }
 }

--- a/packages/content/src/UserInterface/Controller/Website/ContentController.php
+++ b/packages/content/src/UserInterface/Controller/Website/ContentController.php
@@ -15,16 +15,12 @@ namespace Sulu\Content\UserInterface\Controller\Website;
 
 use Sulu\Bundle\HttpCacheBundle\CacheLifetime\CacheLifetimeEnhancerInterface;
 use Sulu\Bundle\PreviewBundle\Preview\Preview;
-use Sulu\Component\Localization\Localization;
 use Sulu\Component\Webspace\Analyzer\Attributes\RequestAttributes;
-use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Sulu\Content\Application\ContentResolver\ContentResolverInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Domain\Model\RoutableInterface;
-use Sulu\Content\Infrastructure\Sulu\Route\Exception\WebspaceUrlNotFoundException;
-use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
-use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+use Sulu\Route\Application\LanguageSwitcher\LanguageSwitcherProviderInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -150,23 +146,18 @@ class ContentController extends AbstractController
         $services['sulu_content.content_resolver'] = ContentResolverInterface::class;
         $services['sulu_http_cache.cache_lifetime.enhancer'] = CacheLifetimeEnhancerInterface::class;
 
-        $services['sulu_route.route_repository'] = RouteRepositoryInterface::class;
-        $services['sulu_route.route_generator'] = RouteGeneratorInterface::class;
-        $services['sulu_core.webspace.webspace_manager'] = WebspaceManagerInterface::class;
+        $services['sulu_route.language_switcher_provider'] = LanguageSwitcherProviderInterface::class;
 
         return $services;
     }
 
     /**
-     * TODO maybe we move this into a content website resolver service, depending on route localization switcher service.
-     *      see https://github.com/sulu/sulu/issues/8175.
-     *
      * @param T $object
      *
      * @return array<string, array{
-     *      url: string,
-     *      locale: string,
-     *      alternate: bool
+     *     url: string,
+     *     locale: string,
+     *     alternate: bool,
      * }>
      */
     private function resolveSuluLocalizations(DimensionContentInterface $object, string $webspaceKey): array
@@ -175,55 +166,12 @@ class ContentController extends AbstractController
             return [];
         }
 
-        $webspaceLocales = $this->container->get('sulu_core.webspace.webspace_manager')
-            ->getWebspaceCollection()
-            ->getWebspace($webspaceKey)
-            ?->getAllLocalizations() ?? [];
-
-        $localizations = [];
-        foreach ($webspaceLocales as $webspaceLocale) {
-            $locale = $webspaceLocale->getLocale(Localization::UNDERSCORE);
-            try {
-                $localizations[$locale] = [
-                    'url' => $this->container->get('sulu_route.route_generator')->generate(
-                        '/',
-                        $locale,
-                        $webspaceKey,
-                    ),
-                    'locale' => $locale,
-                    'alternate' => false,
-                ];
-            } catch (WebspaceUrlNotFoundException) {
-                continue;
-            }
-        }
-
-        $routes = [];
-        foreach ($this->container->get('sulu_route.route_repository')->findBy([
-            'resourceKey' => $object::getResourceKey(),
-            'resourceId' => (string) $object->getResource()->getId(),
-            'locales' => $object->getAvailableLocales() ?? [],
-        ]) as $route) {
-            $routes[] = $route;
-        }
-
-        foreach ($routes as $route) {
-            $locale = $route->getLocale();
-            try {
-                $localizations[$locale] = [
-                    'url' => $this->container->get('sulu_route.route_generator')->generate(
-                        $route->getSlug(),
-                        $route->getLocale(),
-                        $webspaceKey,
-                    ),
-                    'locale' => $locale,
-                    'alternate' => true,
-                ];
-            } catch (WebspaceUrlNotFoundException) {
-                continue;
-            }
-        }
-
-        return $localizations;
+        return $this->container->get('sulu_route.language_switcher_provider')->provide(
+            $object::getResourceKey(),
+            (string) $object->getResource()->getId(),
+            $webspaceKey,
+            $object->getAvailableLocales() ?? [],
+            true,
+        );
     }
 }

--- a/packages/page/src/Infrastructure/Sulu/Route/WebspaceSiteLocaleProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Route/WebspaceSiteLocaleProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Infrastructure\Sulu\Route;
+
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Route\Application\LanguageSwitcher\SiteLocaleProviderInterface;
+
+/**
+ * Resolves the locales of a site from the localizations of the webspace with the same key.
+ *
+ * @final
+ */
+class WebspaceSiteLocaleProvider implements SiteLocaleProviderInterface
+{
+    public function __construct(
+        private readonly WebspaceManagerInterface $webspaceManager,
+        private readonly SiteLocaleProviderInterface $inner,
+    ) {
+    }
+
+    public function provide(string $site): array
+    {
+        $webspace = $this->webspaceManager->getWebspaceCollection()->getWebspace($site);
+
+        if (null === $webspace) {
+            return $this->inner->provide($site);
+        }
+
+        return \array_map(
+            static fn (Localization $localization): string => $localization->getLocale(Localization::UNDERSCORE),
+            $webspace->getAllLocalizations(),
+        );
+    }
+}

--- a/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
+++ b/packages/page/src/Infrastructure/Symfony/HttpKernel/SuluPageBundle.php
@@ -71,6 +71,7 @@ use Sulu\Page\Infrastructure\Sulu\HttpCache\EventSubscriber\PageCacheInvalidatio
 use Sulu\Page\Infrastructure\Sulu\Reference\PageReferenceRefresher;
 use Sulu\Page\Infrastructure\Sulu\Route\PageRouteDefaultsProvider;
 use Sulu\Page\Infrastructure\Sulu\Route\PageWebspaceRouteGenerator;
+use Sulu\Page\Infrastructure\Sulu\Route\WebspaceSiteLocaleProvider;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageIndexListener;
 use Sulu\Page\Infrastructure\Sulu\Search\AdminPageReindexProvider;
 use Sulu\Page\Infrastructure\Sulu\Search\Visitor\AdminPageReindexProviderEnhancerInterface;
@@ -368,6 +369,14 @@ final class SuluPageBundle extends AbstractBundle
                 new Reference('request_stack'),
             ])
             ->tag('sulu_route.webspace_route_generator', ['webspace' => '.default']);
+
+        $services->set('sulu_page.webspace_site_locale_provider')
+            ->class(WebspaceSiteLocaleProvider::class)
+            ->decorate('sulu_route.site_locale_provider')
+            ->args([
+                new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('.inner'),
+            ]);
 
         $services->set('sulu_page.webspace_route_mode_typed_form_metadata_visitor')
             ->class(WebspaceRouteModeTypedFormMetadataVisitor::class)

--- a/packages/page/tests/Unit/Infrastructure/Sulu/Route/WebspaceSiteLocaleProviderTest.php
+++ b/packages/page/tests/Unit/Infrastructure/Sulu/Route/WebspaceSiteLocaleProviderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Page\Tests\Unit\Infrastructure\Sulu\Route;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Manager\WebspaceCollection;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Sulu\Page\Infrastructure\Sulu\Route\WebspaceSiteLocaleProvider;
+use Sulu\Route\Application\LanguageSwitcher\SiteLocaleProviderInterface;
+
+#[CoversClass(WebspaceSiteLocaleProvider::class)]
+class WebspaceSiteLocaleProviderTest extends TestCase
+{
+    public function testProvideReturnsTheLocalizationsOfTheWebspace(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+        $en = new Localization('en');
+        $enUs = new Localization('en', 'us');
+        $en->addChild($enUs);
+        $webspace->addLocalization($en);
+        $webspace->addLocalization(new Localization('de'));
+
+        $provider = new WebspaceSiteLocaleProvider($this->createWebspaceManager($webspace), $this->createInnerProvider());
+
+        $this->assertSame(['en', 'en_us', 'de'], $provider->provide('sulu_io'));
+    }
+
+    public function testProvideFallsBackToTheInnerProviderForUnknownSites(): void
+    {
+        $provider = new WebspaceSiteLocaleProvider($this->createWebspaceManager(), $this->createInnerProvider());
+
+        $this->assertSame(['fr'], $provider->provide('unknown'));
+    }
+
+    private function createWebspaceManager(?Webspace $webspace = null): WebspaceManagerInterface
+    {
+        $webspaceManager = $this->createMock(WebspaceManagerInterface::class);
+        $webspaceManager->method('getWebspaceCollection')
+            ->willReturn(new WebspaceCollection(null !== $webspace ? [$webspace->getKey() => $webspace] : []));
+
+        return $webspaceManager;
+    }
+
+    private function createInnerProvider(): SiteLocaleProviderInterface
+    {
+        return new class() implements SiteLocaleProviderInterface {
+            public function provide(string $site): array
+            {
+                return ['fr'];
+            }
+        };
+    }
+}

--- a/packages/route/src/Application/LanguageSwitcher/LanguageSwitcherProvider.php
+++ b/packages/route/src/Application/LanguageSwitcher/LanguageSwitcherProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Application\LanguageSwitcher;
+
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
+use Sulu\Route\Domain\Exception\WebspaceUrlNotFoundException;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+
+/**
+ * @final
+ */
+class LanguageSwitcherProvider implements LanguageSwitcherProviderInterface
+{
+    public function __construct(
+        private readonly RouteRepositoryInterface $routeRepository,
+        private readonly RouteGeneratorInterface $routeGenerator,
+        private readonly SiteLocaleProviderInterface $siteLocaleProvider,
+    ) {
+    }
+
+    public function provide(
+        string $resourceKey,
+        string $resourceId,
+        string $site,
+        array $publishedLocales,
+        bool $fallbackToStartpage = false,
+    ): array {
+        $localizations = [];
+
+        if ($fallbackToStartpage) {
+            foreach ($this->siteLocaleProvider->provide($site) as $locale) {
+                try {
+                    $localizations[$locale] = [
+                        'url' => $this->routeGenerator->generate('/', $locale, $site),
+                        'locale' => $locale,
+                        'alternate' => false,
+                    ];
+                } catch (WebspaceUrlNotFoundException) {
+                    continue;
+                }
+            }
+        }
+
+        $routes = $this->routeRepository->findBy([
+            'resourceKey' => $resourceKey,
+            'resourceId' => $resourceId,
+            'locales' => $publishedLocales,
+        ]);
+
+        foreach ($routes as $route) {
+            $locale = $route->getLocale();
+
+            try {
+                $localizations[$locale] = [
+                    'url' => $this->routeGenerator->generate($route->getSlug(), $locale, $site),
+                    'locale' => $locale,
+                    'alternate' => true,
+                ];
+            } catch (WebspaceUrlNotFoundException) {
+                continue;
+            }
+        }
+
+        return $localizations;
+    }
+}

--- a/packages/route/src/Application/LanguageSwitcher/LanguageSwitcherProviderInterface.php
+++ b/packages/route/src/Application/LanguageSwitcher/LanguageSwitcherProviderInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Application\LanguageSwitcher;
+
+/**
+ * Provides the URLs of a resource in every locale, as needed by a language switcher.
+ */
+interface LanguageSwitcherProviderInterface
+{
+    /**
+     * @param string[] $publishedLocales The locales the resource is available in
+     * @param bool $fallbackToStartpage Whether the locales of the site without a translation of the resource
+     *                                  should point to the start page of the site in that locale
+     *
+     * @return array<string, array{
+     *     url: string,
+     *     locale: string,
+     *     alternate: bool,
+     * }> The entries indexed by locale, "alternate" being true when the URL points to the resource itself
+     */
+    public function provide(
+        string $resourceKey,
+        string $resourceId,
+        string $site,
+        array $publishedLocales,
+        bool $fallbackToStartpage = false,
+    ): array;
+}

--- a/packages/route/src/Application/LanguageSwitcher/SiteLocaleProviderInterface.php
+++ b/packages/route/src/Application/LanguageSwitcher/SiteLocaleProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Application\LanguageSwitcher;
+
+/**
+ * Provides the locales a site (e.g. a webspace) is available in.
+ */
+interface SiteLocaleProviderInterface
+{
+    /**
+     * @return string[]
+     */
+    public function provide(string $site): array;
+}

--- a/packages/route/src/Application/Routing/Generator/RouteGeneratorInterface.php
+++ b/packages/route/src/Application/Routing/Generator/RouteGeneratorInterface.php
@@ -12,12 +12,14 @@
 namespace Sulu\Route\Application\Routing\Generator;
 
 use Sulu\Route\Domain\Exception\MissingRequestContextParameterException;
+use Sulu\Route\Domain\Exception\WebspaceUrlNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 interface RouteGeneratorInterface
 {
     /**
      * @throws MissingRequestContextParameterException
+     * @throws WebspaceUrlNotFoundException When no URL can be generated for the slug in the given locale and webspace
      */
     public function generate(string $slug, ?string $locale = null, ?string $webspace = null, int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH): string;
 }

--- a/packages/route/src/Domain/Exception/WebspaceUrlNotFoundException.php
+++ b/packages/route/src/Domain/Exception/WebspaceUrlNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Domain\Exception;
+
+/**
+ * Thrown by a route generator when no URL can be built for a slug in a locale and site.
+ */
+class WebspaceUrlNotFoundException extends \RuntimeException
+{
+    public function __construct(string $slug, string $locale, string $site, int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(
+            \sprintf('No url found for "%s" in locale "%s" and site "%s".', $slug, $locale, $site),
+            $code,
+            $previous,
+        );
+    }
+}

--- a/packages/route/src/Infrastructure/Symfony/HttpKernel/KernelSiteLocaleProvider.php
+++ b/packages/route/src/Infrastructure/Symfony/HttpKernel/KernelSiteLocaleProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Infrastructure\Symfony\HttpKernel;
+
+use Sulu\Route\Application\LanguageSwitcher\SiteLocaleProviderInterface;
+
+/**
+ * Falls back to the locales enabled in the kernel ("framework.enabled_locales") for every site.
+ *
+ * @final
+ */
+class KernelSiteLocaleProvider implements SiteLocaleProviderInterface
+{
+    /**
+     * @param string[] $enabledLocales
+     */
+    public function __construct(
+        private readonly array $enabledLocales,
+    ) {
+    }
+
+    public function provide(string $site): array
+    {
+        return $this->enabledLocales;
+    }
+}

--- a/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
+++ b/packages/route/src/Infrastructure/Symfony/HttpKernel/SuluRouteBundle.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sulu\Route\Infrastructure\Symfony\HttpKernel;
 
+use Sulu\Route\Application\LanguageSwitcher\LanguageSwitcherProvider;
+use Sulu\Route\Application\LanguageSwitcher\LanguageSwitcherProviderInterface;
+use Sulu\Route\Application\LanguageSwitcher\SiteLocaleProviderInterface;
 use Sulu\Route\Application\MessageHandler\RemoveRouteHistoryMessageHandler;
 use Sulu\Route\Application\ResourceLocator\PathCleanup\PathCleanup;
 use Sulu\Route\Application\ResourceLocator\PathCleanup\PathCleanupInterface;
@@ -133,6 +136,24 @@ final class SuluRouteBundle extends AbstractBundle
 
         $services->alias(RouteSchemaEvaluatorInterface::class, 'sulu_route.route_schema_evaluator')
             ->public();
+
+        $services->set('sulu_route.site_locale_provider')
+            ->class(KernelSiteLocaleProvider::class)
+            ->args([
+                '%kernel.enabled_locales%',
+            ]);
+
+        $services->alias(SiteLocaleProviderInterface::class, 'sulu_route.site_locale_provider');
+
+        $services->set('sulu_route.language_switcher_provider')
+            ->class(LanguageSwitcherProvider::class)
+            ->args([
+                new Reference('sulu_route.route_repository'),
+                new Reference('sulu_route.route_generator'),
+                new Reference('sulu_route.site_locale_provider'),
+            ]);
+
+        $services->alias(LanguageSwitcherProviderInterface::class, 'sulu_route.language_switcher_provider');
 
         $services->alias(RouteGeneratorInterface::class, 'sulu_route.route_generator')
             ->public();

--- a/packages/route/tests/Unit/Application/LanguageSwitcher/LanguageSwitcherProviderTest.php
+++ b/packages/route/tests/Unit/Application/LanguageSwitcher/LanguageSwitcherProviderTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Tests\Unit\Application\LanguageSwitcher;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Route\Application\LanguageSwitcher\LanguageSwitcherProvider;
+use Sulu\Route\Application\LanguageSwitcher\SiteLocaleProviderInterface;
+use Sulu\Route\Application\Routing\Generator\RouteGeneratorInterface;
+use Sulu\Route\Domain\Exception\WebspaceUrlNotFoundException;
+use Sulu\Route\Domain\Model\Route;
+use Sulu\Route\Domain\Repository\RouteRepositoryInterface;
+
+#[CoversClass(LanguageSwitcherProvider::class)]
+class LanguageSwitcherProviderTest extends TestCase
+{
+    public function testProvideReturnsTheRoutesOfThePublishedLocales(): void
+    {
+        $routeRepository = $this->createMock(RouteRepositoryInterface::class);
+        $routeRepository->expects($this->once())
+            ->method('findBy')
+            ->with(['resourceKey' => 'pages', 'resourceId' => '123', 'locales' => ['en', 'de']])
+            ->willReturn([
+                new Route('pages', '123', 'en', '/about-us', 'sulu_io'),
+                new Route('pages', '123', 'de', '/ueber-uns', 'sulu_io'),
+            ]);
+
+        $provider = new LanguageSwitcherProvider($routeRepository, $this->createRouteGenerator(), $this->createSiteLocaleProvider(['en', 'de', 'fr']));
+
+        $this->assertSame([
+            'en' => ['url' => 'https://sulu.io/en/about-us', 'locale' => 'en', 'alternate' => true],
+            'de' => ['url' => 'https://sulu.io/de/ueber-uns', 'locale' => 'de', 'alternate' => true],
+        ], $provider->provide('pages', '123', 'sulu_io', ['en', 'de']));
+    }
+
+    public function testProvideFallsBackToTheStartpageForTheOtherLocalesOfTheSite(): void
+    {
+        $routeRepository = $this->createMock(RouteRepositoryInterface::class);
+        $routeRepository->method('findBy')
+            ->willReturn([new Route('pages', '123', 'en', '/about-us', 'sulu_io')]);
+
+        $provider = new LanguageSwitcherProvider($routeRepository, $this->createRouteGenerator(), $this->createSiteLocaleProvider(['en', 'de', 'fr']));
+
+        $this->assertSame([
+            'en' => ['url' => 'https://sulu.io/en/about-us', 'locale' => 'en', 'alternate' => true],
+            'de' => ['url' => 'https://sulu.io/de/', 'locale' => 'de', 'alternate' => false],
+            'fr' => ['url' => 'https://sulu.io/fr/', 'locale' => 'fr', 'alternate' => false],
+        ], $this->sortByLocale($provider->provide('pages', '123', 'sulu_io', ['en'], true)));
+    }
+
+    public function testProvideSkipsTheLocalesWithoutUrl(): void
+    {
+        $routeRepository = $this->createMock(RouteRepositoryInterface::class);
+        $routeRepository->method('findBy')
+            ->willReturn([
+                new Route('pages', '123', 'en', '/about-us', 'sulu_io'),
+                new Route('pages', '123', 'it', '/chi-siamo', 'sulu_io'),
+            ]);
+
+        $provider = new LanguageSwitcherProvider($routeRepository, $this->createRouteGenerator(['it']), $this->createSiteLocaleProvider(['en', 'it']));
+
+        $this->assertSame([
+            'en' => ['url' => 'https://sulu.io/en/about-us', 'locale' => 'en', 'alternate' => true],
+        ], $provider->provide('pages', '123', 'sulu_io', ['en', 'it'], true));
+    }
+
+    public function testProvideOnlyReturnsTheStartpagesWhenTheResourceHasNoRoute(): void
+    {
+        $routeRepository = $this->createMock(RouteRepositoryInterface::class);
+        $routeRepository->method('findBy')->willReturn([]);
+
+        $provider = new LanguageSwitcherProvider($routeRepository, $this->createRouteGenerator(), $this->createSiteLocaleProvider(['en']));
+
+        $this->assertSame([], $provider->provide('pages', '123', 'sulu_io', []));
+        $this->assertSame([
+            'en' => ['url' => 'https://sulu.io/en/', 'locale' => 'en', 'alternate' => false],
+        ], $provider->provide('pages', '123', 'sulu_io', [], true));
+    }
+
+    /**
+     * @param string[] $localesWithoutUrl
+     */
+    private function createRouteGenerator(array $localesWithoutUrl = []): RouteGeneratorInterface
+    {
+        $routeGenerator = $this->createMock(RouteGeneratorInterface::class);
+        $routeGenerator->method('generate')
+            ->willReturnCallback(static function(string $slug, ?string $locale, ?string $site) use ($localesWithoutUrl): string {
+                if (\in_array($locale, $localesWithoutUrl, true)) {
+                    throw new WebspaceUrlNotFoundException($slug, (string) $locale, (string) $site);
+                }
+
+                return 'https://sulu.io/' . $locale . $slug;
+            });
+
+        return $routeGenerator;
+    }
+
+    /**
+     * @param string[] $locales
+     */
+    private function createSiteLocaleProvider(array $locales): SiteLocaleProviderInterface
+    {
+        return new class($locales) implements SiteLocaleProviderInterface {
+            /**
+             * @param string[] $locales
+             */
+            public function __construct(private readonly array $locales)
+            {
+            }
+
+            public function provide(string $site): array
+            {
+                return 'sulu_io' === $site ? $this->locales : [];
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $localizations
+     *
+     * @return array<string, mixed>
+     */
+    private function sortByLocale(array $localizations): array
+    {
+        \ksort($localizations);
+        $sorted = [];
+        foreach (['en', 'de', 'fr'] as $locale) {
+            if (isset($localizations[$locale])) {
+                $sorted[$locale] = $localizations[$locale];
+            }
+        }
+
+        return $sorted;
+    }
+}

--- a/packages/route/tests/Unit/Infrastructure/Symfony/HttpKernel/KernelSiteLocaleProviderTest.php
+++ b/packages/route/tests/Unit/Infrastructure/Symfony/HttpKernel/KernelSiteLocaleProviderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Route\Tests\Unit\Infrastructure\Symfony\HttpKernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Route\Infrastructure\Symfony\HttpKernel\KernelSiteLocaleProvider;
+
+#[CoversClass(KernelSiteLocaleProvider::class)]
+class KernelSiteLocaleProviderTest extends TestCase
+{
+    public function testProvideReturnsTheEnabledLocalesForEverySite(): void
+    {
+        $provider = new KernelSiteLocaleProvider(['en', 'de']);
+
+        $this->assertSame(['en', 'de'], $provider->provide('sulu_io'));
+        $this->assertSame(['en', 'de'], $provider->provide('other'));
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8175
| Related issues/PRs | #8173
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Implements the design sketched in #8175: the `localizations` passed to the website templates are no longer computed inside `ContentController`, but by a service of the route package.

**Route package**

- `SiteLocaleProviderInterface::provide(string $site): array` returns the locales a site is available in. The default implementation, `KernelSiteLocaleProvider` (`sulu_route.site_locale_provider`), returns the locales enabled in the kernel (`framework.enabled_locales`).
- `LanguageSwitcherProviderInterface::provide(string $resourceKey, string $resourceId, string $site, array $publishedLocales, bool $fallbackToStartpage = false): array` returns the `locale => [url, locale, alternate]` entries the language switcher needs. `LanguageSwitcherProvider` (`sulu_route.language_switcher_provider`) builds them from the route repository, the route generator and the site locale provider, exactly like the controller did (start page of every site locale when `$fallbackToStartpage` is set, then the routes of the published locales, skipping the locales without URL).
- A new `Sulu\Route\Domain\Exception\WebspaceUrlNotFoundException`, now declared as `@throws` on `RouteGeneratorInterface::generate()`, so that the route package can catch it without depending on the content package. The existing content exception extends it, nothing changes for the code throwing or catching it today.

**Page package**

- `WebspaceSiteLocaleProvider` decorates `sulu_route.site_locale_provider` and returns the localizations of the webspace with the same key as the site, falling back to the inner provider for unknown sites.

**Content package**

- `ContentController::resolveSuluLocalizations()` delegates to the provider with `fallbackToStartpage: true`, and the controller no longer subscribes to `sulu_route.route_repository`, `sulu_route.route_generator` and `sulu_core.webspace.webspace_manager` (noted in `UPGRADE-3.x.md` for subclasses that would fetch one of them from the container; I can keep the three subscriptions if you prefer a zero-impact change).

The behavior is unchanged, including the route query when a resource has no published locale yet (the `ExampleProfilerWebsiteTest` query list caught my first attempt at skipping it). Unit tests cover the provider (routes of the published locales, start page fallback, locales without URL, resource without route), the kernel fallback and the webspace decorator; the content and page functional suites are green locally.

#### Why?

As discussed in #8173, the content resolution should not depend on a request, and the language switcher logic that was temporarily moved into the controller deserved a reusable, decoratable service: headless or custom controllers can now call `sulu_route.language_switcher_provider` directly, and a project can override where the site locales come from.
