### PR TITLE
fix: page_tree_route on articles freezes parent prefix to first saved locale

### DIFF
--- a/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/RoutableDataMapper.php
@@ -104,7 +104,7 @@ class RoutableDataMapper implements DataMapperInterface
         }
 
         $parentRoute = $this->findParentRoute($property, $data[$name], $locale);
-        $routeSlug = $this->extractRouteSlug($property, $data[$name]);
+        $routeSlug = $this->extractRouteSlug($property, $data[$name], $parentRoute);
 
         $route = $localizedDimensionContent->getRoute();
         if (!$route instanceof Route
@@ -200,7 +200,7 @@ class RoutableDataMapper implements DataMapperInterface
         return '' !== $routeData;
     }
 
-    private function extractRouteSlug(FieldMetadata $property, mixed $routeData): string
+    private function extractRouteSlug(FieldMetadata $property, mixed $routeData, ?Route $parentRoute): string
     {
         if ('page_tree_route' === $property->getType()) {
             \assert(
@@ -214,7 +214,7 @@ class RoutableDataMapper implements DataMapperInterface
                 \sprintf('Expected property "%s/page" be an array but "%s" given.', $property->getName(), \get_debug_type($pageData))
             );
 
-            $pagePath = $pageData['path'] ?? null;
+            $pagePath = $parentRoute?->getSlug() ?? $pageData['path'] ?? null;
             \assert(
                 \is_string($pagePath),
                 \sprintf('Expected property "%s/page/path" be string but "%s" given.', $property->getName(), \get_debug_type($pagePath))

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/RoutableDataMapperTest.php
@@ -323,6 +323,85 @@ class RoutableDataMapperTest extends TestCase
         $this->assertSame([], $localizedDimensionContent->getTemplateData());
     }
 
+    public function testMapPageTreeRoutePropertyUsesParentRouteSlugOfCurrentLocale(): void
+    {
+        $uuid = Uuid::v4()->toRfc4122();
+
+        $data = [
+            'url' => [
+                'page' => [
+                    'uuid' => $uuid,
+                    'path' => '/parent-de',
+                ],
+                'suffix' => '/test-en',
+            ],
+        ];
+
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('draft');
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setTemplateKey('default');
+        $localizedDimensionContent->setStage('draft');
+        $localizedDimensionContent->setLocale('en');
+
+        $this->routeRepository->add(Argument::any())->shouldBeCalled();
+        $parentRoute = new Route('pages', $uuid, 'en', '/parent-en', 'sulu-io', null);
+        $this->routeRepository->findOneBy([
+            'resourceKey' => 'pages',
+            'resourceId' => $uuid,
+            'locale' => 'en',
+        ])
+            ->willReturn($parentRoute)
+            ->shouldBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance($this->createTypedFormMetadataWithPageTreeRoute());
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame('/parent-en/test-en', $localizedDimensionContent->getRoute()?->getSlug());
+        $this->assertSame($parentRoute, $localizedDimensionContent->getRoute()?->getParentRoute());
+    }
+
+    public function testMapPageTreeRoutePropertyFallsBackToSubmittedPagePath(): void
+    {
+        $uuid = Uuid::v4()->toRfc4122();
+
+        $data = [
+            'url' => [
+                'page' => [
+                    'uuid' => $uuid,
+                    'path' => '/parent-de',
+                ],
+                'suffix' => '/test-en',
+            ],
+        ];
+
+        $example = new Example();
+        static::setPrivateProperty($example, 'id', 1);
+        $unlocalizedDimensionContent = new ExampleDimensionContent($example);
+        $unlocalizedDimensionContent->setStage('draft');
+        $localizedDimensionContent = new ExampleDimensionContent($example);
+        $localizedDimensionContent->setTemplateKey('default');
+        $localizedDimensionContent->setStage('draft');
+        $localizedDimensionContent->setLocale('en');
+
+        $this->routeRepository->add(Argument::any())->shouldBeCalled();
+        $this->routeRepository->findOneBy([
+            'resourceKey' => 'pages',
+            'resourceId' => $uuid,
+            'locale' => 'en',
+        ])
+            ->willReturn(null)
+            ->shouldBeCalled();
+
+        $mapper = $this->createRouteDataMapperInstance($this->createTypedFormMetadataWithPageTreeRoute());
+        $mapper->map($unlocalizedDimensionContent, $localizedDimensionContent, $data);
+
+        $this->assertSame('/parent-de/test-en', $localizedDimensionContent->getRoute()?->getSlug());
+        $this->assertNull($localizedDimensionContent->getRoute()?->getParentRoute());
+    }
+
     public function testMapPageTreeRoutePropertyClearedThrowsWhenRouteIsMandatory(): void
     {
         $this->expectException(\RuntimeException::class);


### PR DESCRIPTION
Fixes #8770

## Root cause

page_tree_route slug built from submitted source-locale page path

## Changes

- RoutableDataMapper now derives the page_tree_route prefix from the parent Route resolved for the current locale (falling back to the submitted page path only when no localized parent route exists), instead of always using the page path contained in the submitted/copied data.