### PR TITLE
fix: Teaser selection compatibility with internal links

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleTeaserProvider.php
@@ -156,7 +156,8 @@ class ArticleTeaserProvider implements TeaserProviderInterface
 
     protected function resolveTitle(ArticleDimensionContentInterface $dimensionContent): ?string
     {
-        $title = $dimensionContent->getExcerptTitle() ?? $dimensionContent->getTitle();
+        $excerptTitle = $dimensionContent->getExcerptTitle();
+        $title = '' !== ($excerptTitle ?? '') ? $excerptTitle : $dimensionContent->getTitle();
 
         return '' !== ($title ?? '') ? $title : null;
     }

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleTeaserProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleTeaserProviderTest.php
@@ -116,6 +116,28 @@ class ArticleTeaserProviderTest extends WebsiteTestCase
         $this->assertSame('Article Without Excerpt Title', $teasers[0]->getTitle());
     }
 
+    public function testFindReturnsArticleTitleWhenExcerptTitleIsEmptyString(): void
+    {
+        $article = self::createArticle([
+            'en' => [
+                'live' => [
+                    'title' => 'Article With Empty Excerpt Title',
+                    'template' => 'article',
+                    'url' => '/empty-excerpt-title',
+                    'mainWebspace' => 'blog',
+                    'excerpt' => [
+                        'title' => '',
+                    ],
+                ],
+            ],
+        ]);
+
+        $teasers = $this->teaserProvider->find([$article->getUuid()], 'en');
+
+        $this->assertCount(1, $teasers);
+        $this->assertSame('Article With Empty Excerpt Title', $teasers[0]->getTitle());
+    }
+
     public function testFindReturnsTeaserWithMediaId(): void
     {
         $collection = self::createCollection();

--- a/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Content/PageTeaserProvider.php
@@ -162,7 +162,8 @@ class PageTeaserProvider implements TeaserProviderInterface
 
     protected function resolveTitle(PageDimensionContentInterface $dimensionContent): ?string
     {
-        $title = $dimensionContent->getExcerptTitle() ?? $dimensionContent->getTitle();
+        $excerptTitle = $dimensionContent->getExcerptTitle();
+        $title = '' !== ($excerptTitle ?? '') ? $excerptTitle : $dimensionContent->getTitle();
 
         return '' !== ($title ?? '') ? $title : null;
     }

--- a/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageTeaserProviderTest.php
+++ b/packages/page/tests/Functional/Infrastructure/Sulu/Content/PageTeaserProviderTest.php
@@ -114,6 +114,67 @@ class PageTeaserProviderTest extends WebsiteTestCase
         $this->assertSame('Page Without Excerpt Title', $teasers[0]->getTitle());
     }
 
+    public function testFindReturnsPageTitleWhenExcerptTitleIsEmptyString(): void
+    {
+        $page = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Page With Empty Excerpt Title',
+                    'url' => '/empty-excerpt-title',
+                    'template' => 'default',
+                    'excerpt' => [
+                        'title' => '',
+                    ],
+                ],
+            ],
+        ]);
+
+        $teasers = $this->teaserProvider->find([$page->getUuid()], 'en');
+
+        $this->assertCount(1, $teasers);
+        $this->assertSame('Page With Empty Excerpt Title', $teasers[0]->getTitle());
+    }
+
+    public function testFindReturnsPageTitleForInternalPageLinkWithoutTargetExcerptTitle(): void
+    {
+        $targetPage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Link Target Page',
+                    'url' => '/link-target-without-excerpt',
+                    'template' => 'default',
+                    'excerpt' => [
+                        'title' => '',
+                    ],
+                ],
+            ],
+        ]);
+
+        $linkPage = self::createPage([
+            'en' => [
+                'live' => [
+                    'title' => 'Internal Link Page',
+                    'url' => '/internal-link-without-excerpt',
+                    'template' => 'default',
+                    'linkOn' => true,
+                    'linkData' => [
+                        'href' => $targetPage->getUuid(),
+                        'provider' => 'page',
+                    ],
+                    'excerpt' => [
+                        'title' => '',
+                    ],
+                ],
+            ],
+        ]);
+
+        $teasers = $this->teaserProvider->find([$linkPage->getUuid()], 'en');
+
+        $this->assertCount(1, $teasers);
+        $this->assertSame('Internal Link Page', $teasers[0]->getTitle());
+        $this->assertStringEndsWith('/link-target-without-excerpt', $teasers[0]->getUrl());
+    }
+
     public function testFindReturnsTeaserWithMediaId(): void
     {
         $collection = self::createCollection();


### PR DESCRIPTION
Fixes #8766

## Root cause

Teaser title resolution treats empty-string excerpt title as a valid value

## Changes

- Fall back to the content title when the excerpt title is an empty string, not only when it is null, in PageTeaserProvider::resolveTitle and the identical ArticleTeaserProvider::resolveTitle; added functional regression tests covering an empty excerpt title and an internal page link whose target has an empty excerpt title.