### PR TITLE
fix: NotFoundHttpException instead of 404 page

### DIFF
--- a/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
+++ b/src/Sulu/Bundle/WebsiteBundle/EventListener/RedirectExceptionSubscriber.php
@@ -152,7 +152,7 @@ class RedirectExceptionSubscriber implements EventSubscriberInterface
 
         try {
             return null !== $this->router->matchRequest($request);
-        } catch (ResourceNotFoundException $exception) {
+        } catch (ResourceNotFoundException|NotFoundHttpException $exception) {
             return false;
         }
     }

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Routing/RedirectExceptionSubscriberTest.php
@@ -434,6 +434,43 @@ class RedirectExceptionSubscriberTest extends TestCase
         $this->assertNull($this->event->getResponse());
     }
 
+    public function testRedirectPartialMatchNotAvailable(): void
+    {
+        $portal = new Portal();
+        $portal->setKey('portal');
+        $webspace = new Webspace();
+        $webspace->setKey('webspace');
+        $webspace->setTheme('theme');
+        $portal->setWebspace($webspace);
+        $this->attributes->getAttribute('portal', null)->willReturn($portal);
+
+        $this->attributes->getAttribute('localization', null)->willReturn(null);
+        $this->attributes->getAttribute('matchType', null)->willReturn(RequestAnalyzer::MATCH_TYPE_PARTIAL);
+        $this->attributes->getAttribute('resourceLocator', null)->willReturn('/page-a');
+        $this->attributes->getAttribute('resourceLocatorPrefix', null)->willReturn('');
+        $this->attributes->getAttribute('redirect', null)->willReturn('sulu.lo/{localization}');
+        $this->attributes->getAttribute('portalUrl', null)->willReturn('sulu.lo');
+
+        $localization = new Localization('de');
+        $this->defaultLocaleProvider->getDefaultLocale()->willReturn($localization);
+
+        $this->urlReplacer->replaceCountry(Argument::cetera())->shouldBeCalled()->willReturn(
+            'sulu.lo/{localization}'
+        );
+        $this->urlReplacer->replaceLanguage(Argument::cetera())->shouldBeCalled()->willReturn(
+            'sulu.lo/{localization}'
+        );
+        $this->urlReplacer->replaceLocalization(Argument::cetera())->shouldBeCalled()->willReturn(
+            'sulu.lo/de'
+        );
+
+        $this->router->matchRequest(Argument::type(Request::class))->willThrow(new NotFoundHttpException());
+
+        $this->exceptionListener->redirectPartialMatch($this->event);
+
+        $this->assertNull($this->event->getResponse());
+    }
+
     public function testRedirectPartialMatchForRedirect(): void
     {
         $portal = new Portal();


### PR DESCRIPTION
Fixes #9020

## Root cause

Redirect exception listener lets NotFoundHttpException escape while probing the redirect target

## Changes

- RedirectExceptionSubscriber::matchUrl() now also catches NotFoundHttpException (thrown by the route defaults providers during route matching for unavailable content), so the partial/redirect match probe simply reports 'no match' and the kernel can render the webspace error-404 template instead of crashing inside the kernel.exception listener. Added a regression unit test.