### PR TITLE
Add an option to limit the number of images generated in parallel

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -59,6 +59,7 @@ return $config
         [
             'php-ffmpeg/php-ffmpeg',
             'rokka/imagine-vips',
+            'symfony/semaphore',
             'scheb/2fa-backup-code',
             'scheb/2fa-bundle',
             'scheb/2fa-email',

--- a/composer.json
+++ b/composer.json
@@ -156,6 +156,7 @@
         "symfony/notifier": "^6.4 || ^7.1 || ^8.0",
         "symfony/phpunit-bridge": "^6.4 || ^7.1 || ^8.0",
         "symfony/runtime": "^6.4 || ^7.1 || ^8.0",
+        "symfony/semaphore": "^6.4 || ^7.1 || ^8.0",
         "symfony/stopwatch": "^6.4 || ^7.1 || ^8.0",
         "symfony/var-dumper": "^6.4 || ^7.1 || ^8.0",
         "symfony/web-profiler-bundle": "^6.4 || ^7.1 || ^8.0"
@@ -175,6 +176,7 @@
         "scheb/2fa-trusted-device": "< 6.10 || >= 9.0",
         "spomky-labs/otphp": "< 11.1",
         "symfony/notifier": "< 6.4 || >= 9.0",
+        "symfony/semaphore": "< 6.4 || >= 9.0",
         "thecodingmachine/safe": "< 2.0.0"
     },
     "replace": {
@@ -208,7 +210,8 @@
         "scheb/2fa-backup-code": "Needed for two factor authentication backup codes.",
         "scheb/2fa-trusted-device": "Needed to allow trusted devices to skip the two factor authentication.",
         "symfony/notifier": "^6.4 || ^7.1 || ^8.0 - Needed by the SuluNotifierBundle to send notifications",
-        "symfony/monolog-bundle": "^3.1"
+        "symfony/monolog-bundle": "^3.1",
+        "symfony/semaphore": "Needed to limit the number of images generated in parallel (sulu_media.format_manager.parallel_image_generation.limit)."
     },
     "autoload": {
         "psr-4": {

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/Configuration.php
@@ -81,6 +81,16 @@ final class Configuration implements ConfigurationInterface
             ->arrayNode('format_manager')
                 ->addDefaultsIfNotSet()
                 ->children()
+                    ->arrayNode('parallel_image_generation')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->integerNode('limit')
+                                ->info('Maximum number of images generated at the same time by HTTP requests, null means no limit. Requires symfony/semaphore and the framework "semaphore" configuration.')
+                                ->min(1)
+                                ->defaultNull()
+                            ->end()
+                        ->end()
+                    ->end()
                     ->arrayNode('response_headers')
                         ->prototype('scalar')->end()->defaultValue([
                             'Cache-Control' => 'public, immutable, max-age=31536000',

--- a/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
+++ b/src/Sulu/Bundle/MediaBundle/DependencyInjection/SuluMediaExtension.php
@@ -37,6 +37,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Semaphore\SemaphoreFactory;
 
 class SuluMediaExtension extends Extension implements PrependExtensionInterface
 {
@@ -348,6 +349,24 @@ class SuluMediaExtension extends Extension implements PrependExtensionInterface
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.php');
         $loader->load('command.php');
+
+        $formatManagerConfig = $config['format_manager'];
+        \assert(\is_array($formatManagerConfig));
+        $parallelImageGenerationConfig = $formatManagerConfig['parallel_image_generation'];
+        \assert(\is_array($parallelImageGenerationConfig));
+        $parallelImageGenerationLimit = $parallelImageGenerationConfig['limit'];
+        if (null !== $parallelImageGenerationLimit) {
+            \assert(\is_int($parallelImageGenerationLimit));
+
+            if (!\class_exists(SemaphoreFactory::class)) {
+                throw new InvalidConfigurationException(
+                    'The "sulu_media.format_manager.parallel_image_generation.limit" option requires the Semaphore component. Try running "composer require symfony/semaphore" and configure "framework.semaphore".'
+                );
+            }
+
+            $container->setParameter('sulu_media.parallel_image_generation.limit', $parallelImageGenerationLimit);
+            $loader->load('parallel_image_generation.php');
+        }
 
         if (\class_exists(SvgImagine::class)) {
             $loader->load('services_imagine_svg.php');

--- a/src/Sulu/Bundle/MediaBundle/EventListener/ParallelImageGenerationLimiter.php
+++ b/src/Sulu/Bundle/MediaBundle/EventListener/ParallelImageGenerationLimiter.php
@@ -14,8 +14,8 @@ namespace Sulu\Bundle\MediaBundle\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Semaphore\Exception\RuntimeException;
 use Symfony\Component\Semaphore\SemaphoreFactory;
 use Symfony\Component\Semaphore\SemaphoreInterface;
 
@@ -79,7 +79,7 @@ final class ParallelImageGenerationLimiter implements EventSubscriberInterface
         $deadline = \microtime(true) + $this->maxWaitTime;
         while (!$semaphore->acquire()) {
             if (\microtime(true) >= $deadline) {
-                throw new RuntimeException(\sprintf(
+                throw new ServiceUnavailableHttpException($this->maxWaitTime, \sprintf(
                     'No image generation slot became available within %d seconds.',
                     $this->maxWaitTime,
                 ));

--- a/src/Sulu/Bundle/MediaBundle/EventListener/ParallelImageGenerationLimiter.php
+++ b/src/Sulu/Bundle/MediaBundle/EventListener/ParallelImageGenerationLimiter.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Semaphore\Exception\RuntimeException;
+use Symfony\Component\Semaphore\SemaphoreFactory;
+use Symfony\Component\Semaphore\SemaphoreInterface;
+
+/**
+ * Limits the number of HTTP requests generating an image at the same time, to keep the
+ * memory used by the image processing under control when many uncached formats are
+ * requested at once (e.g. a media collection listed in the administration interface
+ * for the first time).
+ *
+ * A request for the image proxy route takes a slot of a shared semaphore before the
+ * controller runs, waiting for a free one if needed, and releases it with the response.
+ * When no slot becomes available within the maximum wait time, the request fails:
+ * the limit is there to protect the server, generating the image anyway would defeat it.
+ *
+ * @internal
+ */
+final class ParallelImageGenerationLimiter implements EventSubscriberInterface
+{
+    public const IMAGE_PROXY_ROUTE = 'sulu_media.website.image.proxy';
+
+    public const SEMAPHORE_RESOURCE = 'sulu_media.parallel_image_generation';
+
+    private const REQUEST_ATTRIBUTE = '_sulu_media_parallel_image_generation_semaphore';
+
+    /**
+     * Microseconds between two attempts to take a free slot.
+     */
+    private const WAIT_INTERVAL = 50000;
+
+    public function __construct(
+        private SemaphoreFactory $semaphoreFactory,
+        private int $limit,
+        /**
+         * Seconds after which a request waiting for a free slot gives up.
+         */
+        private int $maxWaitTime = 60,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if (self::IMAGE_PROXY_ROUTE !== $request->attributes->get('_route')) {
+            return;
+        }
+
+        $semaphore = $this->semaphoreFactory->createSemaphore(self::SEMAPHORE_RESOURCE, $this->limit);
+
+        $deadline = \microtime(true) + $this->maxWaitTime;
+        while (!$semaphore->acquire()) {
+            if (\microtime(true) >= $deadline) {
+                throw new RuntimeException(\sprintf(
+                    'No image generation slot became available within %d seconds.',
+                    $this->maxWaitTime,
+                ));
+            }
+
+            \usleep(self::WAIT_INTERVAL);
+        }
+
+        $request->attributes->set(self::REQUEST_ATTRIBUTE, $semaphore);
+    }
+
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        $request = $event->getRequest();
+        $semaphore = $request->attributes->get(self::REQUEST_ATTRIBUTE);
+        if (!$semaphore instanceof SemaphoreInterface) {
+            return;
+        }
+
+        $request->attributes->remove(self::REQUEST_ATTRIBUTE);
+        $semaphore->release();
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Resources/config/parallel_image_generation.php
+++ b/src/Sulu/Bundle/MediaBundle/Resources/config/parallel_image_generation.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Sulu\Bundle\MediaBundle\EventListener\ParallelImageGenerationLimiter;
+use Symfony\Component\DependencyInjection\Reference;
+
+return static function(ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('sulu_media.parallel_image_generation.limiter', ParallelImageGenerationLimiter::class)
+        ->args([
+            new Reference('semaphore.factory'),
+            '%sulu_media.parallel_image_generation.limit%',
+        ])
+        ->tag('kernel.event_subscriber');
+};

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/DependencyInjection/SuluMediaExtensionTest.php
@@ -16,7 +16,10 @@ use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\MediaBundle\DependencyInjection\SuluMediaExtension;
+use Sulu\Bundle\MediaBundle\EventListener\ParallelImageGenerationLimiter;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Process\ExecutableFinder;
+use Symfony\Component\Semaphore\SemaphoreFactory;
 
 class SuluMediaExtensionTest extends AbstractExtensionTestCase
 {
@@ -87,6 +90,39 @@ class SuluMediaExtensionTest extends AbstractExtensionTestCase
                 'mimeTypes' => ['audio/*'],
             ],
         ]);
+    }
+
+    public function testLoadWithParallelImageGenerationLimit(): void
+    {
+        if (!\class_exists(SemaphoreFactory::class)) {
+            $this->markTestSkipped('Requires symfony/semaphore.');
+        }
+
+        $this->executableFinder->find(Argument::any())->willReturn(true);
+        $this->container->setParameter('kernel.bundles', []);
+
+        $this->load([
+            'format_manager' => [
+                'parallel_image_generation' => [
+                    'limit' => 4,
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasParameter('sulu_media.parallel_image_generation.limit', 4);
+        $this->assertContainerBuilderHasService('sulu_media.parallel_image_generation.limiter', ParallelImageGenerationLimiter::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sulu_media.parallel_image_generation.limiter', 0, new Reference('semaphore.factory'));
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('sulu_media.parallel_image_generation.limiter', 'kernel.event_subscriber');
+    }
+
+    public function testLoadWithoutParallelImageGenerationLimit(): void
+    {
+        $this->executableFinder->find(Argument::any())->willReturn(true);
+        $this->container->setParameter('kernel.bundles', []);
+
+        $this->load([]);
+
+        $this->assertContainerBuilderNotHasService('sulu_media.parallel_image_generation.limiter');
     }
 
     public function testConfigureFileValidator(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/ParallelImageGenerationLimiterTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/ParallelImageGenerationLimiterTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\MediaBundle\Tests\Unit\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sulu\Bundle\MediaBundle\EventListener\ParallelImageGenerationLimiter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Semaphore\Exception\RuntimeException;
+use Symfony\Component\Semaphore\SemaphoreFactory;
+use Symfony\Component\Semaphore\SemaphoreInterface;
+
+class ParallelImageGenerationLimiterTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testImageProxyRequestWaitsForAFreeSlotAndReleasesItWithTheResponse(): void
+    {
+        $semaphore = $this->prophesize(SemaphoreInterface::class);
+        $semaphore->acquire()->willReturn(false, false, true);
+        $semaphore->release()->shouldBeCalledOnce();
+
+        $semaphoreFactory = $this->prophesize(SemaphoreFactory::class);
+        $semaphoreFactory->createSemaphore(ParallelImageGenerationLimiter::SEMAPHORE_RESOURCE, 3)
+            ->willReturn($semaphore->reveal())
+            ->shouldBeCalledOnce();
+
+        $limiter = new ParallelImageGenerationLimiter($semaphoreFactory->reveal(), 3);
+        $request = $this->createRequest(ParallelImageGenerationLimiter::IMAGE_PROXY_ROUTE);
+
+        $limiter->onKernelRequest($this->createRequestEvent($request));
+        $semaphore->release()->shouldNotHaveBeenCalled();
+
+        $limiter->onKernelResponse($this->createResponseEvent($request));
+        $semaphore->release()->shouldHaveBeenCalledOnce();
+
+        // a second response for the same request must not release the slot twice
+        $limiter->onKernelResponse($this->createResponseEvent($request));
+        $semaphore->release()->shouldHaveBeenCalledOnce();
+    }
+
+    public function testOtherRoutesAreNotThrottled(): void
+    {
+        $semaphoreFactory = $this->prophesize(SemaphoreFactory::class);
+        $semaphoreFactory->createSemaphore(Argument::cetera())->shouldNotBeCalled();
+
+        $limiter = new ParallelImageGenerationLimiter($semaphoreFactory->reveal(), 3);
+        $request = $this->createRequest('sulu_media.website.media.download');
+
+        $limiter->onKernelRequest($this->createRequestEvent($request));
+        $limiter->onKernelResponse($this->createResponseEvent($request));
+    }
+
+    public function testSubRequestsAreNotThrottled(): void
+    {
+        $semaphoreFactory = $this->prophesize(SemaphoreFactory::class);
+        $semaphoreFactory->createSemaphore(Argument::cetera())->shouldNotBeCalled();
+
+        $limiter = new ParallelImageGenerationLimiter($semaphoreFactory->reveal(), 3);
+        $request = $this->createRequest(ParallelImageGenerationLimiter::IMAGE_PROXY_ROUTE);
+
+        $limiter->onKernelRequest($this->createRequestEvent($request, HttpKernelInterface::SUB_REQUEST));
+        $limiter->onKernelResponse($this->createResponseEvent($request, HttpKernelInterface::SUB_REQUEST));
+    }
+
+    public function testRequestFailsWhenNoSlotBecomesAvailableInTime(): void
+    {
+        $semaphore = $this->prophesize(SemaphoreInterface::class);
+        $semaphore->acquire()->willReturn(false);
+        $semaphore->release()->shouldNotBeCalled();
+
+        $semaphoreFactory = $this->prophesize(SemaphoreFactory::class);
+        $semaphoreFactory->createSemaphore(ParallelImageGenerationLimiter::SEMAPHORE_RESOURCE, 3)
+            ->willReturn($semaphore->reveal());
+
+        $limiter = new ParallelImageGenerationLimiter($semaphoreFactory->reveal(), 3, 0);
+        $request = $this->createRequest(ParallelImageGenerationLimiter::IMAGE_PROXY_ROUTE);
+
+        $this->expectException(RuntimeException::class);
+
+        $limiter->onKernelRequest($this->createRequestEvent($request));
+    }
+
+    private function createRequest(string $route): Request
+    {
+        $request = Request::create('/uploads/media/sulu-240x/01/photo.jpg');
+        $request->attributes->set('_route', $route);
+
+        return $request;
+    }
+
+    private function createRequestEvent(Request $request, int $requestType = HttpKernelInterface::MAIN_REQUEST): RequestEvent
+    {
+        return new RequestEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, $requestType);
+    }
+
+    private function createResponseEvent(Request $request, int $requestType = HttpKernelInterface::MAIN_REQUEST): ResponseEvent
+    {
+        return new ResponseEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, $requestType, new Response());
+    }
+}

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/ParallelImageGenerationLimiterTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/EventListener/ParallelImageGenerationLimiterTest.php
@@ -19,8 +19,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Semaphore\Exception\RuntimeException;
 use Symfony\Component\Semaphore\SemaphoreFactory;
 use Symfony\Component\Semaphore\SemaphoreInterface;
 
@@ -90,7 +90,7 @@ class ParallelImageGenerationLimiterTest extends TestCase
         $limiter = new ParallelImageGenerationLimiter($semaphoreFactory->reveal(), 3, 0);
         $request = $this->createRequest(ParallelImageGenerationLimiter::IMAGE_PROXY_ROUTE);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(ServiceUnavailableHttpException::class);
 
         $limiter->onKernelRequest($this->createRequestEvent($request));
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8735
| Related issues/PRs | symfony/symfony#59202
| License | MIT
| Documentation PR | sulu/sulu-docs#934

#### What's in this PR?

Implements the server-side throttling of the image generation that @alexander-schranz described in #8735, at the HTTP level:

```yaml
sulu_media:
    format_manager:
        parallel_image_generation:
            limit: 4   # null (default) means no limit, nothing is registered
```

- When the limit is set, the `ParallelImageGenerationLimiter` subscriber is registered (`Resources/config/parallel_image_generation.php`): on `kernel.request`, a main request for the `sulu_media.website.image.proxy` route takes a slot of a `sulu_media.parallel_image_generation` semaphore of size `limit`, waiting for a free one if needed, and releases it on `kernel.response`. It knows nothing about the image converter.
- The semaphore comes from the framework's `semaphore.factory` service, configured with `framework.semaphore`, so any backend of the Semaphore component works (Redis, PDO, flock, ...). `symfony/semaphore` is listed in `suggest`, `require-dev` (for the tests) and `conflict` (`< 6.4 || >= 9.0`, mirroring the supported range like the other optional dependencies).
- When no slot frees up within the max wait time (60s), the request fails with a 503 `ServiceUnavailableHttpException` carrying a `Retry-After` header, so overload surfaces as an explicit, retryable status instead of a generic 500.
- Covered by unit tests of the subscriber and of the extension (the latter skipped when the Semaphore component is not installed).

