### PR TITLE
Stop the form loader and show an error when the metadata request fails

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/stores/ResourceFormStore.js
@@ -117,6 +117,9 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
     @observable types: { [key: string]: SchemaType } = {};
     @observable schemaLoading: boolean = true;
     @observable typesLoading: boolean = true;
+    @observable schemaForbidden: boolean = false;
+    @observable schemaNotFound: boolean = false;
+    @observable schemaUnexpectedError: boolean = false;
     schemaDisposer: ?() => void;
     metadataOptions: ?{[string]: any};
 
@@ -129,7 +132,8 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
         this.metadataOptions = metadataOptions;
 
         metadataStore.getSchemaTypes(this.formKey, this.metadataOptions)
-            .then(this.handleSchemaTypeResponse);
+            .then(this.handleSchemaTypeResponse)
+            .catch(this.handleSchemaError);
     }
 
     destroy() {
@@ -173,8 +177,32 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
             Promise.all([
                 metadataStore.getSchema(this.formKey, this.type, this.metadataOptions),
                 metadataStore.getJsonSchema(this.formKey, this.type, this.metadataOptions),
-            ]).then(this.handleSchemaResponse);
+            ]).then(this.handleSchemaResponse).catch(this.handleSchemaError);
         });
+    };
+
+    /**
+     * The metadata requests fail e.g. when the user is not allowed to see one of the resources the form
+     * references (a 403): stop the loader and report the error like a failed data request would,
+     * instead of leaving the form in an infinite loading state.
+     */
+    @action handleSchemaError = (error: Object) => {
+        this.typesLoading = false;
+        this.setSchemaLoading(false);
+
+        const status = error && error.status;
+        if (status === 403) {
+            this.schemaForbidden = true;
+        } else if (status === 404) {
+            this.schemaNotFound = true;
+        } else {
+            log.error(
+                'ResourceFormStore failed to load the metadata of the "' + this.formKey + '" form'
+                + (status ? ' with status code "' + status + '"' : ''),
+                error
+            );
+            this.schemaUnexpectedError = true;
+        }
     };
 
     handleSchemaResponse = ([schema, jsonSchema]: [Schema, Object]) => {
@@ -310,15 +338,15 @@ export default class ResourceFormStore extends AbstractFormStore implements Form
     }
 
     @computed get forbidden(): boolean {
-        return this.resourceStore.forbidden;
+        return this.resourceStore.forbidden || this.schemaForbidden;
     }
 
     @computed get notFound(): boolean {
-        return this.resourceStore.notFound;
+        return this.resourceStore.notFound || this.schemaNotFound;
     }
 
     @computed get unexpectedError(): boolean {
-        return this.resourceStore.unexpectedError;
+        return this.resourceStore.unexpectedError || this.schemaUnexpectedError;
     }
 
     @computed get dirty(): boolean {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/stores/ResourceFormStore.test.js
@@ -8,6 +8,7 @@ import conditionDataProviderRegistry from '../../registries/conditionDataProvide
 jest.mock('loglevel', () => ({
     warn: jest.fn(),
     info: jest.fn(),
+    error: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -54,6 +55,48 @@ beforeEach(() => {
     metadataStore.getJsonSchema = jest.fn().mockReturnValue(Promise.resolve({}));
     // $FlowFixMe
     metadataStore.getSchemaTypes = jest.fn().mockReturnValue(Promise.resolve(null));
+});
+
+test('Should stop loading and be marked as forbidden if the schema request fails with a 403', () => {
+    const schemaPromise = Promise.reject({status: 403});
+    metadataStore.getSchema.mockReturnValueOnce(schemaPromise);
+
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '1'), 'snippets');
+    expect(resourceFormStore.schemaLoading).toEqual(true);
+
+    return new Promise((resolve) => when(() => !resourceFormStore.schemaLoading, resolve)).then(() => {
+        expect(resourceFormStore.loading).toEqual(false);
+        expect(resourceFormStore.forbidden).toEqual(true);
+        expect(resourceFormStore.notFound).toEqual(false);
+        expect(resourceFormStore.unexpectedError).toEqual(false);
+        resourceFormStore.destroy();
+    });
+});
+
+test('Should stop loading and be marked as not found if the json schema request fails with a 404', () => {
+    const jsonSchemaPromise = Promise.reject({status: 404});
+    metadataStore.getJsonSchema.mockReturnValueOnce(jsonSchemaPromise);
+
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '1'), 'snippets');
+
+    return new Promise((resolve) => when(() => !resourceFormStore.schemaLoading, resolve)).then(() => {
+        expect(resourceFormStore.notFound).toEqual(true);
+        expect(resourceFormStore.forbidden).toEqual(false);
+        resourceFormStore.destroy();
+    });
+});
+
+test('Should stop loading and be marked as unexpected error if the schema types request fails', () => {
+    const schemaTypesPromise = Promise.reject({status: 500});
+    metadataStore.getSchemaTypes.mockReturnValueOnce(schemaTypesPromise);
+
+    const resourceFormStore = new ResourceFormStore(new ResourceStore('snippets', '1'), 'snippets');
+
+    return new Promise((resolve) => when(() => !resourceFormStore.typesLoading, resolve)).then(() => {
+        expect(resourceFormStore.schemaLoading).toEqual(false);
+        expect(resourceFormStore.unexpectedError).toEqual(true);
+        resourceFormStore.destroy();
+    });
 });
 
 test('Create data object for schema', (done) => {


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8609
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

`ResourceFormStore` now attaches a `.catch` to both metadata request chains (schema types, and schema + JSON schema). When one of them fails, the new `handleSchemaError` action stops the loader and flags the store as forbidden (403), not found (404) or unexpected error (anything else, logged with `log.error`). The `forbidden`, `notFound` and `unexpectedError` computeds combine these flags with the ones of the underlying `ResourceStore`, so the existing hints of the `Form` container are displayed.

Three tests cover the 403, 404 and 500 cases.

#### Why?

When the metadata request of a form fails, for instance with a 403 because the user is not allowed to access a resource referenced by the form, the store never left the loading state and the admin showed an infinite loader without any feedback (see #8609). The form now reports the error the same way a failing data request does.
