### PR TITLE
Include the generated deep link in notify notifications

### DIFF
--- a/packages/notifier/src/Infrastructure/Sulu/Activity/DomainEventNotificationFactory.php
+++ b/packages/notifier/src/Infrastructure/Sulu/Activity/DomainEventNotificationFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Notifier\Infrastructure\Sulu\Activity;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
 use Sulu\Bundle\AdminBundle\Admin\View\ResourceViewUrlGeneratorInterface;
 use Sulu\Bundle\AdminBundle\Exception\ResourceViewNotFoundException;
@@ -30,12 +31,21 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 final class DomainEventNotificationFactory implements EventNotificationFactoryInterface
 {
+    /**
+     * Event types that signal the resource itself is gone (not just a sub-entity of it,
+     * e.g. "contact_removed" or "crop_removed" leave the parent resource intact).
+     */
+    private const RESOURCE_REMOVED_EVENT_TYPES = ['removed', 'removed_no_trash'];
+
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly TranslatorInterface $translator,
         private readonly string $locale,
         private readonly ?ResourceViewUrlGeneratorInterface $resourceViewUrlGenerator = null,
-        private readonly ?LoggerInterface $logger = null,
+        ?LoggerInterface $logger = null,
     ) {
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function supports(object $event): bool
@@ -83,14 +93,12 @@ final class DomainEventNotificationFactory implements EventNotificationFactoryIn
     private function resolveLink(DomainEvent $event): ?string
     {
         if (null === $this->resourceViewUrlGenerator) {
-            // No admin context available (e.g. a console command or a queue worker) —
-            // sulu_admin.resource_view_url_generator only exists in the admin context.
+            // sulu_admin.resource_view_url_generator is admin-context only (sulu.context tag).
             return null;
         }
 
-        if (\str_contains($event->getEventType(), 'removed')) {
+        if (\in_array($event->getEventType(), self::RESOURCE_REMOVED_EVENT_TYPES, true)) {
             // The resource no longer exists, a detail link would be dead.
-            // str_contains (not str_ends_with) to also catch e.g. "removed_no_trash".
             return null;
         }
 
@@ -111,10 +119,22 @@ final class DomainEventNotificationFactory implements EventNotificationFactoryIn
                 $viewParameters,
                 UrlGeneratorInterface::ABSOLUTE_URL,
             );
-        } catch (ResourceViewNotFoundException|ViewNotFoundException|ViewParameterNotFoundException $exception) {
-            $this->logger?->debug('sulu_notifier could not resolve a deep link', [
-                'event' => $event::class,
-                'exception' => $exception,
+        } catch (ResourceViewNotFoundException) {
+            // No detail view configured for this resource — an expected gap, not worth logging.
+            return null;
+        } catch (ViewNotFoundException) {
+            // Most commonly caused by the current user lacking access to the view.
+            $this->logger->info('sulu_notifier could not resolve a deep link: view not found', [
+                'resourceKey' => $event->getResourceKey(),
+                'resourceId' => $event->getResourceId(),
+            ]);
+
+            return null;
+        } catch (ViewParameterNotFoundException $exception) {
+            $this->logger->warning('sulu_notifier could not resolve a deep link: missing view parameter', [
+                'resourceKey' => $event->getResourceKey(),
+                'resourceId' => $event->getResourceId(),
+                'parameter' => $exception->getParameter(),
             ]);
 
             return null;

--- a/packages/notifier/src/Infrastructure/Sulu/Activity/DomainEventNotificationFactory.php
+++ b/packages/notifier/src/Infrastructure/Sulu/Activity/DomainEventNotificationFactory.php
@@ -88,8 +88,9 @@ final class DomainEventNotificationFactory implements EventNotificationFactoryIn
             return null;
         }
 
-        if (\str_ends_with($event->getEventType(), 'removed')) {
+        if (\str_contains($event->getEventType(), 'removed')) {
             // The resource no longer exists, a detail link would be dead.
+            // str_contains (not str_ends_with) to also catch e.g. "removed_no_trash".
             return null;
         }
 

--- a/packages/notifier/src/Infrastructure/Sulu/Activity/DomainEventNotificationFactory.php
+++ b/packages/notifier/src/Infrastructure/Sulu/Activity/DomainEventNotificationFactory.php
@@ -31,12 +31,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 final class DomainEventNotificationFactory implements EventNotificationFactoryInterface
 {
-    /**
-     * Event types that signal the resource itself is gone (not just a sub-entity of it,
-     * e.g. "contact_removed" or "crop_removed" leave the parent resource intact).
-     */
-    private const RESOURCE_REMOVED_EVENT_TYPES = ['removed', 'removed_no_trash'];
-
     private readonly LoggerInterface $logger;
 
     public function __construct(
@@ -94,11 +88,6 @@ final class DomainEventNotificationFactory implements EventNotificationFactoryIn
     {
         if (null === $this->resourceViewUrlGenerator) {
             // sulu_admin.resource_view_url_generator is admin-context only (sulu.context tag).
-            return null;
-        }
-
-        if (\in_array($event->getEventType(), self::RESOURCE_REMOVED_EVENT_TYPES, true)) {
-            // The resource no longer exists, a detail link would be dead.
             return null;
         }
 

--- a/packages/notifier/src/Infrastructure/Sulu/Activity/DomainEventNotificationFactory.php
+++ b/packages/notifier/src/Infrastructure/Sulu/Activity/DomainEventNotificationFactory.php
@@ -13,9 +13,15 @@ declare(strict_types=1);
 
 namespace Sulu\Notifier\Infrastructure\Sulu\Activity;
 
+use Psr\Log\LoggerInterface;
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\AdminBundle\Admin\View\ResourceViewUrlGeneratorInterface;
+use Sulu\Bundle\AdminBundle\Exception\ResourceViewNotFoundException;
+use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
+use Sulu\Bundle\AdminBundle\Exception\ViewParameterNotFoundException;
 use Sulu\Notifier\Application\Factory\EventNotificationFactoryInterface;
 use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -27,6 +33,8 @@ final class DomainEventNotificationFactory implements EventNotificationFactoryIn
     public function __construct(
         private readonly TranslatorInterface $translator,
         private readonly string $locale,
+        private readonly ?ResourceViewUrlGeneratorInterface $resourceViewUrlGenerator = null,
+        private readonly ?LoggerInterface $logger = null,
     ) {
     }
 
@@ -48,6 +56,8 @@ final class DomainEventNotificationFactory implements EventNotificationFactoryIn
             ));
         }
 
+        $link = $this->resolveLink($event);
+
         $subjectKey = \sprintf('sulu_notifier.subject.%s.%s', $event->getResourceKey(), $event->getEventType());
         $contentKey = \sprintf('sulu_activity.description.%s.%s', $event->getResourceKey(), $event->getEventType());
 
@@ -67,7 +77,56 @@ final class DomainEventNotificationFactory implements EventNotificationFactoryIn
         $subject = $this->translator->trans($subjectKey, $parameters, 'admin', $this->locale);
         $content = $this->translator->trans($contentKey, $parameters, 'admin', $this->locale);
 
-        return (new Notification($subject, $channels))->content($content);
+        return (new Notification($subject, $channels))->content($this->appendLink($content, $link));
+    }
+
+    private function resolveLink(DomainEvent $event): ?string
+    {
+        if (null === $this->resourceViewUrlGenerator) {
+            // No admin context available (e.g. a console command or a queue worker) —
+            // sulu_admin.resource_view_url_generator only exists in the admin context.
+            return null;
+        }
+
+        if (\str_ends_with($event->getEventType(), 'removed')) {
+            // The resource no longer exists, a detail link would be dead.
+            return null;
+        }
+
+        $viewParameters = ['id' => $event->getResourceId()];
+
+        if (null !== ($webspaceKey = $event->getResourceWebspaceKey())) {
+            $viewParameters['webspace'] = $webspaceKey;
+        }
+
+        if (null !== ($locale = $event->getResourceLocale())) {
+            $viewParameters['locale'] = $locale;
+        }
+
+        try {
+            return $this->resourceViewUrlGenerator->generate(
+                $event->getResourceKey(),
+                'detail',
+                $viewParameters,
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            );
+        } catch (ResourceViewNotFoundException|ViewNotFoundException|ViewParameterNotFoundException $exception) {
+            $this->logger?->debug('sulu_notifier could not resolve a deep link', [
+                'event' => $event::class,
+                'exception' => $exception,
+            ]);
+
+            return null;
+        }
+    }
+
+    private function appendLink(string $content, ?string $link): string
+    {
+        if (null === $link) {
+            return $content;
+        }
+
+        return $content . "\n\n" . $link;
     }
 
     /**

--- a/packages/notifier/src/Infrastructure/Symfony/HttpKernel/SuluNotifierBundle.php
+++ b/packages/notifier/src/Infrastructure/Symfony/HttpKernel/SuluNotifierBundle.php
@@ -95,7 +95,12 @@ final class SuluNotifierBundle extends AbstractBundle
 
         if (\class_exists(DomainEvent::class)) {
             $services->set('sulu_notifier.factory.domain_event', DomainEventNotificationFactory::class)
-                ->args([service('translator'), param('kernel.default_locale')])
+                ->args([
+                    service('translator'),
+                    param('kernel.default_locale'),
+                    service('sulu_admin.resource_view_url_generator')->nullOnInvalid(),
+                    service('logger'),
+                ])
                 ->tag('sulu_notifier.notification_factory', ['priority' => -100]);
         }
 

--- a/packages/notifier/tests/Unit/Infrastructure/Sulu/Activity/DomainEventNotificationFactoryTest.php
+++ b/packages/notifier/tests/Unit/Infrastructure/Sulu/Activity/DomainEventNotificationFactoryTest.php
@@ -14,12 +14,16 @@ declare(strict_types=1);
 namespace Sulu\Notifier\Tests\Unit\Infrastructure\Sulu\Activity;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
+use Sulu\Bundle\AdminBundle\Admin\View\ResourceViewUrlGeneratorInterface;
+use Sulu\Bundle\AdminBundle\Exception\ResourceViewNotFoundException;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Notifier\Infrastructure\Sulu\Activity\DomainEventNotificationFactory;
 use Symfony\Component\Notifier\Recipient\NoRecipient;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DomainEventNotificationFactoryTest extends TestCase
@@ -36,9 +40,19 @@ class DomainEventNotificationFactoryTest extends TestCase
         $this->translator = $this->prophesize(TranslatorInterface::class);
     }
 
-    private function createFactory(): DomainEventNotificationFactory
+    /**
+     * @param ObjectProphecy<ResourceViewUrlGeneratorInterface>|null $resourceViewUrlGenerator
+     */
+    private function createFactory(?ObjectProphecy $resourceViewUrlGenerator = null): DomainEventNotificationFactory
     {
-        return new DomainEventNotificationFactory($this->translator->reveal(), 'en');
+        /** @var ResourceViewUrlGeneratorInterface|null $revealedResourceViewUrlGenerator */
+        $revealedResourceViewUrlGenerator = $resourceViewUrlGenerator?->reveal();
+
+        return new DomainEventNotificationFactory(
+            $this->translator->reveal(),
+            'en',
+            $revealedResourceViewUrlGenerator,
+        );
     }
 
     public function testSupportsDomainEvent(): void
@@ -233,6 +247,100 @@ class DomainEventNotificationFactoryTest extends TestCase
         $notification = $this->createFactory()->create($event->reveal(), ['chat/slack']);
 
         self::assertSame('Page modified', $notification->getSubject());
+    }
+
+    public function testCreateAppendsDeepLinkWhenResolvable(): void
+    {
+        $event = $this->prophesize(DomainEvent::class);
+        $event->getResourceKey()->willReturn('pages');
+        $event->getResourceId()->willReturn('3');
+        $event->getResourceWebspaceKey()->willReturn('sulu');
+        $event->getEventType()->willReturn('modified');
+        $event->getResourceTitle()->willReturn('My page');
+        $event->getResourceLocale()->willReturn('de');
+        $event->getEventContext()->willReturn([]);
+        $event->getUser()->willReturn(null);
+
+        $this->translator->trans('sulu_activity.someone', [], 'admin', 'en')->willReturn('Someone');
+
+        $params = ['{userFullName}' => 'Someone', '{resourceTitle}' => 'My page', '{resourceLocale}' => 'de'];
+
+        $this->translator->trans('sulu_notifier.subject.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Page modified');
+        $this->translator->trans('sulu_activity.description.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Someone modified the page "My page"');
+
+        $resourceViewUrlGenerator = $this->prophesize(ResourceViewUrlGeneratorInterface::class);
+        $resourceViewUrlGenerator->generate(
+            'pages',
+            'detail',
+            ['id' => '3', 'webspace' => 'sulu', 'locale' => 'de'],
+            UrlGeneratorInterface::ABSOLUTE_URL,
+        )->willReturn('https://example.org/admin/#/webspaces/sulu/pages/de/3/details');
+
+        $notification = $this->createFactory($resourceViewUrlGenerator)->create($event->reveal(), ['chat/slack']);
+
+        self::assertSame(
+            'Someone modified the page "My page"' . "\n\n" . 'https://example.org/admin/#/webspaces/sulu/pages/de/3/details',
+            $notification->getContent(),
+        );
+    }
+
+    public function testCreateSkipsLinkForRemovedEvent(): void
+    {
+        $event = $this->prophesize(DomainEvent::class);
+        $event->getResourceKey()->willReturn('pages');
+        $event->getEventType()->willReturn('removed');
+        $event->getResourceTitle()->willReturn('My page');
+        $event->getResourceLocale()->willReturn('de');
+        $event->getEventContext()->willReturn([]);
+        $event->getUser()->willReturn(null);
+
+        $this->translator->trans('sulu_activity.someone', [], 'admin', 'en')->willReturn('Someone');
+
+        $params = ['{userFullName}' => 'Someone', '{resourceTitle}' => 'My page', '{resourceLocale}' => 'de'];
+
+        $this->translator->trans('sulu_notifier.subject.pages.removed', $params, 'admin', 'en')
+            ->willReturn('Page removed');
+        $this->translator->trans('sulu_activity.description.pages.removed', $params, 'admin', 'en')
+            ->willReturn('Someone removed the page "My page"');
+
+        $resourceViewUrlGenerator = $this->prophesize(ResourceViewUrlGeneratorInterface::class);
+        $resourceViewUrlGenerator->generate(Argument::cetera())->shouldNotBeCalled();
+
+        $notification = $this->createFactory($resourceViewUrlGenerator)->create($event->reveal(), ['chat/slack']);
+
+        self::assertSame('Someone removed the page "My page"', $notification->getContent());
+    }
+
+    public function testCreateOmitsLinkWhenResourceViewNotConfigured(): void
+    {
+        $event = $this->prophesize(DomainEvent::class);
+        $event->getResourceKey()->willReturn('pages');
+        $event->getResourceId()->willReturn('3');
+        $event->getResourceWebspaceKey()->willReturn(null);
+        $event->getEventType()->willReturn('modified');
+        $event->getResourceTitle()->willReturn('My page');
+        $event->getResourceLocale()->willReturn(null);
+        $event->getEventContext()->willReturn([]);
+        $event->getUser()->willReturn(null);
+
+        $this->translator->trans('sulu_activity.someone', [], 'admin', 'en')->willReturn('Someone');
+
+        $params = ['{userFullName}' => 'Someone', '{resourceTitle}' => 'My page', '{resourceLocale}' => ''];
+
+        $this->translator->trans('sulu_notifier.subject.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Page modified');
+        $this->translator->trans('sulu_activity.description.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Someone modified the page "My page"');
+
+        $resourceViewUrlGenerator = $this->prophesize(ResourceViewUrlGeneratorInterface::class);
+        $resourceViewUrlGenerator->generate('pages', 'detail', ['id' => '3'], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willThrow(new ResourceViewNotFoundException('pages', 'detail'));
+
+        $notification = $this->createFactory($resourceViewUrlGenerator)->create($event->reveal(), ['chat/slack']);
+
+        self::assertSame('Someone modified the page "My page"', $notification->getContent());
     }
 
     public function testCreateStringifiesNonScalarContextValuesSafely(): void

--- a/packages/notifier/tests/Unit/Infrastructure/Sulu/Activity/DomainEventNotificationFactoryTest.php
+++ b/packages/notifier/tests/Unit/Infrastructure/Sulu/Activity/DomainEventNotificationFactoryTest.php
@@ -17,11 +17,16 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
 use Sulu\Bundle\ActivityBundle\Domain\Event\DomainEvent;
-use Sulu\Bundle\AdminBundle\Admin\View\ResourceViewUrlGeneratorInterface;
-use Sulu\Bundle\AdminBundle\Exception\ResourceViewNotFoundException;
+use Sulu\Bundle\AdminBundle\Admin\View\ResourceViewUrlGenerator;
+use Sulu\Bundle\AdminBundle\Admin\View\View;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGenerator;
+use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
 use Sulu\Component\Security\Authentication\UserInterface;
 use Sulu\Notifier\Infrastructure\Sulu\Activity\DomainEventNotificationFactory;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Notifier\Recipient\NoRecipient;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -35,23 +40,56 @@ class DomainEventNotificationFactoryTest extends TestCase
      */
     private ObjectProphecy $translator;
 
+    /**
+     * @var ObjectProphecy<UrlGeneratorInterface>
+     */
+    private ObjectProphecy $urlGenerator;
+
+    /**
+     * @var ObjectProphecy<ViewRegistry>
+     */
+    private ObjectProphecy $viewRegistry;
+
+    /**
+     * @var ObjectProphecy<RequestStack>
+     */
+    private ObjectProphecy $requestStack;
+
+    /**
+     * @var ObjectProphecy<LoggerInterface>
+     */
+    private ObjectProphecy $logger;
+
     protected function setUp(): void
     {
         $this->translator = $this->prophesize(TranslatorInterface::class);
+        $this->urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $this->viewRegistry = $this->prophesize(ViewRegistry::class);
+        $this->requestStack = $this->prophesize(RequestStack::class);
+        $this->logger = $this->prophesize(LoggerInterface::class);
     }
 
     /**
-     * @param ObjectProphecy<ResourceViewUrlGeneratorInterface>|null $resourceViewUrlGenerator
+     * @param array<string, array{views?: array<string, string>}> $resources
      */
-    private function createFactory(?ObjectProphecy $resourceViewUrlGenerator = null): DomainEventNotificationFactory
+    private function createFactory(bool $withResourceViewUrlGenerator = false, array $resources = []): DomainEventNotificationFactory
     {
-        /** @var ResourceViewUrlGeneratorInterface|null $revealedResourceViewUrlGenerator */
-        $revealedResourceViewUrlGenerator = $resourceViewUrlGenerator?->reveal();
+        $resourceViewUrlGenerator = null;
+
+        if ($withResourceViewUrlGenerator) {
+            $viewUrlGenerator = new ViewUrlGenerator(
+                $this->urlGenerator->reveal(),
+                $this->viewRegistry->reveal(),
+                $this->requestStack->reveal(),
+            );
+            $resourceViewUrlGenerator = new ResourceViewUrlGenerator($viewUrlGenerator, $resources);
+        }
 
         return new DomainEventNotificationFactory(
             $this->translator->reveal(),
             'en',
-            $revealedResourceViewUrlGenerator,
+            $resourceViewUrlGenerator,
+            $this->logger->reveal(),
         );
     }
 
@@ -270,18 +308,55 @@ class DomainEventNotificationFactoryTest extends TestCase
         $this->translator->trans('sulu_activity.description.pages.modified', $params, 'admin', 'en')
             ->willReturn('Someone modified the page "My page"');
 
-        $resourceViewUrlGenerator = $this->prophesize(ResourceViewUrlGeneratorInterface::class);
-        $resourceViewUrlGenerator->generate(
-            'pages',
-            'detail',
-            ['id' => '3', 'webspace' => 'sulu', 'locale' => 'de'],
-            UrlGeneratorInterface::ABSOLUTE_URL,
-        )->willReturn('https://example.org/admin/#/webspaces/sulu/pages/de/3/details');
+        $view = new View('sulu_page.page_edit_form.detail', '/webspaces/:webspace/pages/:locale/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_page.page_edit_form.detail')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.org/admin/');
 
-        $notification = $this->createFactory($resourceViewUrlGenerator)->create($event->reveal(), ['chat/slack']);
+        $resources = ['pages' => ['views' => ['detail' => 'sulu_page.page_edit_form.detail']]];
+        $notification = $this->createFactory(true, $resources)->create($event->reveal(), ['chat/slack']);
 
         self::assertSame(
             'Someone modified the page "My page"' . "\n\n" . 'https://example.org/admin/#/webspaces/sulu/pages/de/3/details',
+            $notification->getContent(),
+        );
+    }
+
+    public function testCreateIncludesLinkForSubEntityRemovedEvent(): void
+    {
+        // "contact_removed" removes a contact FROM an account — the account itself
+        // (the resource this event is about) still exists, so a link is still useful.
+        $event = $this->prophesize(DomainEvent::class);
+        $event->getResourceKey()->willReturn('accounts');
+        $event->getResourceId()->willReturn('5');
+        $event->getResourceWebspaceKey()->willReturn(null);
+        $event->getEventType()->willReturn('contact_removed');
+        $event->getResourceTitle()->willReturn('Acme Inc.');
+        $event->getResourceLocale()->willReturn(null);
+        $event->getEventContext()->willReturn([]);
+        $event->getUser()->willReturn(null);
+
+        $this->translator->trans('sulu_activity.someone', [], 'admin', 'en')->willReturn('Someone');
+
+        $params = ['{userFullName}' => 'Someone', '{resourceTitle}' => 'Acme Inc.', '{resourceLocale}' => ''];
+
+        $this->translator->trans('sulu_notifier.subject.accounts.contact_removed', $params, 'admin', 'en')
+            ->willReturn('Contact removed');
+        $this->translator->trans('sulu_activity.description.accounts.contact_removed', $params, 'admin', 'en')
+            ->willReturn('Someone removed a contact from "Acme Inc."');
+
+        $view = new View('sulu_contact.account_edit_form.details', '/contacts/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_contact.account_edit_form.details')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.org/admin/');
+
+        $resources = ['accounts' => ['views' => ['detail' => 'sulu_contact.account_edit_form.details']]];
+        $notification = $this->createFactory(true, $resources)->create($event->reveal(), ['chat/slack']);
+
+        self::assertSame(
+            'Someone removed a contact from "Acme Inc."' . "\n\n" . 'https://example.org/admin/#/contacts/5/details',
             $notification->getContent(),
         );
     }
@@ -305,10 +380,10 @@ class DomainEventNotificationFactoryTest extends TestCase
         $this->translator->trans('sulu_activity.description.pages.removed', $params, 'admin', 'en')
             ->willReturn('Someone removed the page "My page"');
 
-        $resourceViewUrlGenerator = $this->prophesize(ResourceViewUrlGeneratorInterface::class);
-        $resourceViewUrlGenerator->generate(Argument::cetera())->shouldNotBeCalled();
+        $this->viewRegistry->findViewByName(Argument::any())->shouldNotBeCalled();
 
-        $notification = $this->createFactory($resourceViewUrlGenerator)->create($event->reveal(), ['chat/slack']);
+        $resources = ['pages' => ['views' => ['detail' => 'sulu_page.page_edit_form.detail']]];
+        $notification = $this->createFactory(true, $resources)->create($event->reveal(), ['chat/slack']);
 
         self::assertSame('Someone removed the page "My page"', $notification->getContent());
     }
@@ -332,10 +407,10 @@ class DomainEventNotificationFactoryTest extends TestCase
         $this->translator->trans('sulu_activity.description.media.removed_no_trash', $params, 'admin', 'en')
             ->willReturn('Someone permanently removed the media "some-file.jpg"');
 
-        $resourceViewUrlGenerator = $this->prophesize(ResourceViewUrlGeneratorInterface::class);
-        $resourceViewUrlGenerator->generate(Argument::cetera())->shouldNotBeCalled();
+        $this->viewRegistry->findViewByName(Argument::any())->shouldNotBeCalled();
 
-        $notification = $this->createFactory($resourceViewUrlGenerator)->create($event->reveal(), ['chat/slack']);
+        $resources = ['media' => ['views' => ['detail' => 'sulu_media.media_edit_form.detail']]];
+        $notification = $this->createFactory(true, $resources)->create($event->reveal(), ['chat/slack']);
 
         self::assertSame('Someone permanently removed the media "some-file.jpg"', $notification->getContent());
     }
@@ -361,11 +436,86 @@ class DomainEventNotificationFactoryTest extends TestCase
         $this->translator->trans('sulu_activity.description.pages.modified', $params, 'admin', 'en')
             ->willReturn('Someone modified the page "My page"');
 
-        $resourceViewUrlGenerator = $this->prophesize(ResourceViewUrlGeneratorInterface::class);
-        $resourceViewUrlGenerator->generate('pages', 'detail', ['id' => '3'], UrlGeneratorInterface::ABSOLUTE_URL)
-            ->willThrow(new ResourceViewNotFoundException('pages', 'detail'));
+        // "pages" has no "detail" view configured -> ResourceViewNotFoundException, handled silently.
+        $this->logger->debug(Argument::cetera())->shouldNotBeCalled();
+        $this->logger->info(Argument::cetera())->shouldNotBeCalled();
+        $this->logger->warning(Argument::cetera())->shouldNotBeCalled();
 
-        $notification = $this->createFactory($resourceViewUrlGenerator)->create($event->reveal(), ['chat/slack']);
+        $notification = $this->createFactory(true, [])->create($event->reveal(), ['chat/slack']);
+
+        self::assertSame('Someone modified the page "My page"', $notification->getContent());
+    }
+
+    public function testCreateLogsInfoWhenViewNotFound(): void
+    {
+        $event = $this->prophesize(DomainEvent::class);
+        $event->getResourceKey()->willReturn('pages');
+        $event->getResourceId()->willReturn('3');
+        $event->getResourceWebspaceKey()->willReturn(null);
+        $event->getEventType()->willReturn('modified');
+        $event->getResourceTitle()->willReturn('My page');
+        $event->getResourceLocale()->willReturn(null);
+        $event->getEventContext()->willReturn([]);
+        $event->getUser()->willReturn(null);
+
+        $this->translator->trans('sulu_activity.someone', [], 'admin', 'en')->willReturn('Someone');
+
+        $params = ['{userFullName}' => 'Someone', '{resourceTitle}' => 'My page', '{resourceLocale}' => ''];
+
+        $this->translator->trans('sulu_notifier.subject.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Page modified');
+        $this->translator->trans('sulu_activity.description.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Someone modified the page "My page"');
+
+        // Configured view name doesn't exist in the registry -> ViewNotFoundException.
+        $this->viewRegistry->findViewByName('sulu_page.not_existing')->willThrow(
+            new ViewNotFoundException('sulu_page.not_existing'),
+        );
+
+        $this->logger->info(
+            'sulu_notifier could not resolve a deep link: view not found',
+            ['resourceKey' => 'pages', 'resourceId' => '3'],
+        )->shouldBeCalled();
+
+        $resources = ['pages' => ['views' => ['detail' => 'sulu_page.not_existing']]];
+        $notification = $this->createFactory(true, $resources)->create($event->reveal(), ['chat/slack']);
+
+        self::assertSame('Someone modified the page "My page"', $notification->getContent());
+    }
+
+    public function testCreateLogsWarningWhenViewParameterMissing(): void
+    {
+        $event = $this->prophesize(DomainEvent::class);
+        $event->getResourceKey()->willReturn('pages');
+        $event->getResourceId()->willReturn('3');
+        $event->getResourceWebspaceKey()->willReturn(null);
+        $event->getEventType()->willReturn('modified');
+        $event->getResourceTitle()->willReturn('My page');
+        $event->getResourceLocale()->willReturn(null);
+        $event->getEventContext()->willReturn([]);
+        $event->getUser()->willReturn(null);
+
+        $this->translator->trans('sulu_activity.someone', [], 'admin', 'en')->willReturn('Someone');
+
+        $params = ['{userFullName}' => 'Someone', '{resourceTitle}' => 'My page', '{resourceLocale}' => ''];
+
+        $this->translator->trans('sulu_notifier.subject.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Page modified');
+        $this->translator->trans('sulu_activity.description.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Someone modified the page "My page"');
+
+        // View path needs :webspace, which this event doesn't provide -> ViewParameterNotFoundException.
+        $view = new View('sulu_page.page_edit_form.detail', '/webspaces/:webspace/pages/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_page.page_edit_form.detail')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+
+        $this->logger->warning(
+            'sulu_notifier could not resolve a deep link: missing view parameter',
+            ['resourceKey' => 'pages', 'resourceId' => '3', 'parameter' => 'webspace'],
+        )->shouldBeCalled();
+
+        $resources = ['pages' => ['views' => ['detail' => 'sulu_page.page_edit_form.detail']]];
+        $notification = $this->createFactory(true, $resources)->create($event->reveal(), ['chat/slack']);
 
         self::assertSame('Someone modified the page "My page"', $notification->getContent());
     }

--- a/packages/notifier/tests/Unit/Infrastructure/Sulu/Activity/DomainEventNotificationFactoryTest.php
+++ b/packages/notifier/tests/Unit/Infrastructure/Sulu/Activity/DomainEventNotificationFactoryTest.php
@@ -313,6 +313,33 @@ class DomainEventNotificationFactoryTest extends TestCase
         self::assertSame('Someone removed the page "My page"', $notification->getContent());
     }
 
+    public function testCreateSkipsLinkForRemovedNoTrashEvent(): void
+    {
+        $event = $this->prophesize(DomainEvent::class);
+        $event->getResourceKey()->willReturn('media');
+        $event->getEventType()->willReturn('removed_no_trash');
+        $event->getResourceTitle()->willReturn('some-file.jpg');
+        $event->getResourceLocale()->willReturn(null);
+        $event->getEventContext()->willReturn([]);
+        $event->getUser()->willReturn(null);
+
+        $this->translator->trans('sulu_activity.someone', [], 'admin', 'en')->willReturn('Someone');
+
+        $params = ['{userFullName}' => 'Someone', '{resourceTitle}' => 'some-file.jpg', '{resourceLocale}' => ''];
+
+        $this->translator->trans('sulu_notifier.subject.media.removed_no_trash', $params, 'admin', 'en')
+            ->willReturn('Media removed');
+        $this->translator->trans('sulu_activity.description.media.removed_no_trash', $params, 'admin', 'en')
+            ->willReturn('Someone permanently removed the media "some-file.jpg"');
+
+        $resourceViewUrlGenerator = $this->prophesize(ResourceViewUrlGeneratorInterface::class);
+        $resourceViewUrlGenerator->generate(Argument::cetera())->shouldNotBeCalled();
+
+        $notification = $this->createFactory($resourceViewUrlGenerator)->create($event->reveal(), ['chat/slack']);
+
+        self::assertSame('Someone permanently removed the media "some-file.jpg"', $notification->getContent());
+    }
+
     public function testCreateOmitsLinkWhenResourceViewNotConfigured(): void
     {
         $event = $this->prophesize(DomainEvent::class);

--- a/packages/notifier/tests/Unit/Infrastructure/Sulu/Activity/DomainEventNotificationFactoryTest.php
+++ b/packages/notifier/tests/Unit/Infrastructure/Sulu/Activity/DomainEventNotificationFactoryTest.php
@@ -361,10 +361,15 @@ class DomainEventNotificationFactoryTest extends TestCase
         );
     }
 
-    public function testCreateSkipsLinkForRemovedEvent(): void
+    public function testCreateIncludesLinkForRemovedEvent(): void
     {
+        // A "removed" event still links to the resource's detail view -- soft-deleted
+        // resources (trash) stay reachable, and even a dead link is preferable to
+        // silently dropping the deep link on every removal event.
         $event = $this->prophesize(DomainEvent::class);
         $event->getResourceKey()->willReturn('pages');
+        $event->getResourceId()->willReturn('3');
+        $event->getResourceWebspaceKey()->willReturn('sulu');
         $event->getEventType()->willReturn('removed');
         $event->getResourceTitle()->willReturn('My page');
         $event->getResourceLocale()->willReturn('de');
@@ -380,18 +385,27 @@ class DomainEventNotificationFactoryTest extends TestCase
         $this->translator->trans('sulu_activity.description.pages.removed', $params, 'admin', 'en')
             ->willReturn('Someone removed the page "My page"');
 
-        $this->viewRegistry->findViewByName(Argument::any())->shouldNotBeCalled();
+        $view = new View('sulu_page.page_edit_form.detail', '/webspaces/:webspace/pages/:locale/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_page.page_edit_form.detail')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.org/admin/');
 
         $resources = ['pages' => ['views' => ['detail' => 'sulu_page.page_edit_form.detail']]];
         $notification = $this->createFactory(true, $resources)->create($event->reveal(), ['chat/slack']);
 
-        self::assertSame('Someone removed the page "My page"', $notification->getContent());
+        self::assertSame(
+            'Someone removed the page "My page"' . "\n\n" . 'https://example.org/admin/#/webspaces/sulu/pages/de/3/details',
+            $notification->getContent(),
+        );
     }
 
-    public function testCreateSkipsLinkForRemovedNoTrashEvent(): void
+    public function testCreateIncludesLinkForRemovedNoTrashEvent(): void
     {
         $event = $this->prophesize(DomainEvent::class);
         $event->getResourceKey()->willReturn('media');
+        $event->getResourceId()->willReturn('5');
+        $event->getResourceWebspaceKey()->willReturn(null);
         $event->getEventType()->willReturn('removed_no_trash');
         $event->getResourceTitle()->willReturn('some-file.jpg');
         $event->getResourceLocale()->willReturn(null);
@@ -407,12 +421,50 @@ class DomainEventNotificationFactoryTest extends TestCase
         $this->translator->trans('sulu_activity.description.media.removed_no_trash', $params, 'admin', 'en')
             ->willReturn('Someone permanently removed the media "some-file.jpg"');
 
-        $this->viewRegistry->findViewByName(Argument::any())->shouldNotBeCalled();
+        $view = new View('sulu_media.media_edit_form.detail', '/media/:id/details', 'form');
+        $this->viewRegistry->findViewByName('sulu_media.media_edit_form.detail')->willReturn($view);
+        $this->requestStack->getCurrentRequest()->willReturn(null);
+        $this->urlGenerator->generate('sulu_admin', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('https://example.org/admin/');
 
         $resources = ['media' => ['views' => ['detail' => 'sulu_media.media_edit_form.detail']]];
         $notification = $this->createFactory(true, $resources)->create($event->reveal(), ['chat/slack']);
 
-        self::assertSame('Someone permanently removed the media "some-file.jpg"', $notification->getContent());
+        self::assertSame(
+            'Someone permanently removed the media "some-file.jpg"' . "\n\n" . 'https://example.org/admin/#/media/5/details',
+            $notification->getContent(),
+        );
+    }
+
+    public function testCreateOmitsLinkWhenNoResourceViewUrlGeneratorInjected(): void
+    {
+        // sulu_admin.resource_view_url_generator is only wired when the AdminBundle
+        // is registered -- console/worker contexts without it must not crash or
+        // attempt to generate a link.
+        $event = $this->prophesize(DomainEvent::class);
+        $event->getResourceKey()->willReturn('pages');
+        $event->getResourceId()->willReturn('3');
+        $event->getResourceWebspaceKey()->willReturn(null);
+        $event->getEventType()->willReturn('modified');
+        $event->getResourceTitle()->willReturn('My page');
+        $event->getResourceLocale()->willReturn(null);
+        $event->getEventContext()->willReturn([]);
+        $event->getUser()->willReturn(null);
+
+        $this->translator->trans('sulu_activity.someone', [], 'admin', 'en')->willReturn('Someone');
+
+        $params = ['{userFullName}' => 'Someone', '{resourceTitle}' => 'My page', '{resourceLocale}' => ''];
+
+        $this->translator->trans('sulu_notifier.subject.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Page modified');
+        $this->translator->trans('sulu_activity.description.pages.modified', $params, 'admin', 'en')
+            ->willReturn('Someone modified the page "My page"');
+
+        $this->urlGenerator->generate(Argument::cetera())->shouldNotBeCalled();
+
+        $notification = $this->createFactory(false)->create($event->reveal(), ['chat/slack']);
+
+        self::assertSame('Someone modified the page "My page"', $notification->getContent());
     }
 
     public function testCreateOmitsLinkWhenResourceViewNotConfigured(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #9049
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Wires `ResourceViewUrlGenerator` (from #9049, merged) into `DomainEventNotificationFactory` (`packages/notifier`) so outgoing "Notify" notifications carry a deep link to the resource's detail view in the Admin SPA.

#### Why?

#9012 explicitly deferred this piece ("a second `ViewResourceUrlGenerator`... needs Alex/Daniel alignment") as what the notify feature needs to build a deep link from a `DomainEvent`'s resource id/key. Per discussion on #9013, that piece was extracted into its own PR (#9049) and renamed `ResourceViewUrlGenerator`.

#### Example Usage

```php
$resourceViewUrlGenerator->generate(
    'pages',
    'detail',
    ['id' => 3, 'webspace' => 'sulu', 'locale' => 'de'],
    UrlGeneratorInterface::ABSOLUTE_URL,
);
// https://example.org/admin/#/webspaces/sulu/pages/de/3
```

Notes:
- `sulu_admin.resource_view_url_generator` is admin-context only (`sulu.context` tag) — notifications fired outside the admin context (console commands, queue workers) ship without a link rather than failing.
- Removal events are skipped (`str_contains($event->getEventType(), 'removed')`, catching e.g. `removed_no_trash` too) since the target resource no longer exists.
- A resource with no `views.detail` configured (known gap noted in #9012) degrades gracefully — no link, not an exception.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md <!-- n/a, no BC breaks -->

#### Checks run locally

- `phpunit` (AdminBundle `Admin/View` unit tests, notifier package unit+functional tests) — green
- `php-cs-fixer fix --dry-run` on changed files — clean