### PR TITLE
Allow content resolvers to place their output at the root

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,5 +1,16 @@
 # Upgrade
 
+## Unreleased
+
+### Content resolvers can place their output at the root of the content envelope
+
+The `sulu_content.content_resolver` tag accepts an optional `placement` attribute: `root` or
+`extension`. It defaults to `extension`, so existing resolvers are unaffected. A resolver tagged
+`placement: root` additionally requires a `type` attribute and its output lands at `<type>`,
+a sibling of `content`, `view` and `extension`, instead of nested under `extension`. Container
+compilation throws if `type` collides with a reserved envelope/root key or with another
+resolver's root key.
+
 ## 3.0.8
 
 ### Route value is required when saving routable content

--- a/packages/content/src/Application/ContentResolver/ContentResolver.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolver.php
@@ -124,7 +124,7 @@ use Webmozart\Assert\Assert;
  *           | apply optional root property mapping
  *           |
  *           v
- *  array{resource: object, content: array, view: array, extension: array}
+ *  array{resource: object, content: array, view: array, extension: array, ...root-placed resolver keys}
  *
  * @final
  */

--- a/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
+++ b/packages/content/src/Application/ContentResolver/ContentResolverInterface.php
@@ -29,6 +29,7 @@ interface ContentResolverInterface
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
      *     extension: array<string, array<string, mixed>>,
+     *     ...
      * }
      */
     public function resolve(DimensionContentInterface $dimensionContent, ?array $properties = null): array;

--- a/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizer.php
+++ b/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizer.php
@@ -26,8 +26,12 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
 {
+    /**
+     * @param list<string> $rootResolverKeys resolver keys placed at the root of the envelope instead of under `extension`
+     */
     public function __construct(
-        private PropertyAccessorInterface $propertyAccessor
+        private PropertyAccessorInterface $propertyAccessor,
+        private array $rootResolverKeys = [],
     ) {
     }
 
@@ -43,6 +47,7 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
      *     extension: array<string, array<string, mixed>>,
+     *     ...
      * }
      */
     public function normalizeContentViewData(
@@ -62,10 +67,20 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
         $settingsData = $content['settings'] ?? [];
         unset($content['settings'], $view['settings']);
 
+        $rootData = [];
+        foreach ($this->rootResolverKeys as $rootResolverKey) {
+            if (!\array_key_exists($rootResolverKey, $content)) {
+                continue;
+            }
+
+            $rootData[$rootResolverKey] = $content[$rootResolverKey];
+            unset($content[$rootResolverKey], $view[$rootResolverKey]);
+        }
+
         /** @var array<string, array<string, mixed>> $extensionData */
         $extensionData = $content;
 
-        $result = \array_merge(
+        $withSettings = \array_merge(
             [
                 'resource' => $resource,
                 'content' => $templateData,
@@ -75,7 +90,7 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
             $settingsData,
         );
 
-        return $result;
+        return $withSettings + $rootData;
     }
 
     /**
@@ -85,7 +100,8 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
      *     resource: object,
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
-     *     extension: array<string, array<string, mixed>>
+     *     extension: array<string, array<string, mixed>>,
+     *     ...
      * } $contentData
      * @param list<int|string> $path
      */
@@ -164,7 +180,8 @@ class ContentViewDataNormalizer implements ContentViewDataNormalizerInterface
      *     resource: object,
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
-     *     extension: array<string, array<string, mixed>>
+     *     extension: array<string, array<string, mixed>>,
+     *     ...
      * } &$data
      * @param array<string, mixed> $properties
      * @param list<int|string> $path

--- a/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerInterface.php
+++ b/packages/content/src/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerInterface.php
@@ -34,6 +34,7 @@ interface ContentViewDataNormalizerInterface
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
      *     extension: array<string, array<string, mixed>>,
+     *     ...
      * }
      */
     public function normalizeContentViewData(
@@ -49,7 +50,8 @@ interface ContentViewDataNormalizerInterface
      *     resource: object,
      *     content: array<string, mixed>,
      *     view: array<string, mixed>,
-     *     extension: array<string, array<string, mixed>>
+     *     extension: array<string, array<string, mixed>>,
+     *     ...
      * } $contentData
      * @param list<int|string> $path
      */
@@ -63,6 +65,7 @@ interface ContentViewDataNormalizerInterface
      *      content: array<string, mixed>,
      *      view: array<string, mixed>,
      *      extension: array<string, array<string, mixed>>,
+     *      ...
      *  } $data
      * @param array<string, string> $properties
      * @param list<int|string> $path

--- a/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
+++ b/packages/content/src/Application/ContentResolver/Resolver/SettingsResolver.php
@@ -23,6 +23,8 @@ use Sulu\Content\Domain\Model\TemplateInterface;
 use Sulu\Content\Domain\Model\WebspaceInterface;
 
 /**
+ * Adding a key here also requires adding it to ContentResolverPlacementPass::RESERVED_ROOT_KEYS; the two are hand-maintained copies.
+ *
  * @phpstan-type SettingsData array{
  *      availableLocales?: string[]|null,
  *      localizations?: array<string, array{

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/Compiler/ContentResolverPlacementPass.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/Compiler/ContentResolverPlacementPass.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Collects the content resolvers tagged `placement: root` and hands their keys to the normalizer,
+ * which otherwise places every resolver's output under `extension`.
+ *
+ * @internal this class is not part of the public API and should only be called by the Symfony framework classes
+ */
+class ContentResolverPlacementPass implements CompilerPassInterface
+{
+    private const NORMALIZER_ID = 'sulu_content.content_view_data_normalizer';
+
+    private const TAG = 'sulu_content.content_resolver';
+
+    private const PLACEMENT_ROOT = 'root';
+
+    private const PLACEMENT_EXTENSION = 'extension';
+
+    /** The envelope's own keys plus everything SettingsResolver spreads into the root array. */
+    private const RESERVED_ROOT_KEYS = [
+        'resource', 'content', 'view', 'extension', 'settings',
+        'availableLocales', 'localizations', 'mainWebspace', 'template',
+        'author', 'authored', 'shadowBaseLocale', 'lastModified',
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(self::NORMALIZER_ID)) {
+            return;
+        }
+
+        /** @var array<string, string> $rootKeys */
+        $rootKeys = [];
+
+        foreach ($container->findTaggedServiceIds(self::TAG) as $id => $tags) {
+            foreach ($tags as $attributes) {
+                if (!\is_array($attributes)) {
+                    continue;
+                }
+
+                $placement = $attributes['placement'] ?? self::PLACEMENT_EXTENSION;
+
+                if (self::PLACEMENT_EXTENSION === $placement) {
+                    continue;
+                }
+
+                if (self::PLACEMENT_ROOT !== $placement) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'Service "%s" declares unknown placement "%s" on tag "%s"; expected "%s" or "%s".',
+                        $id,
+                        \is_string($placement) ? $placement : \get_debug_type($placement),
+                        self::TAG, self::PLACEMENT_ROOT, self::PLACEMENT_EXTENSION,
+                    ));
+                }
+
+                $type = $attributes['type'] ?? null;
+                if (!\is_string($type) || '' === $type) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'Service "%s" declares placement "%s" without a "type" attribute on tag "%s".',
+                        $id, self::PLACEMENT_ROOT, self::TAG,
+                    ));
+                }
+
+                if (\in_array($type, self::RESERVED_ROOT_KEYS, true)) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'Service "%s" cannot claim root key "%s": the key is reserved by the content envelope.',
+                        $id, $type,
+                    ));
+                }
+
+                if (isset($rootKeys[$type])) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'Service "%s" cannot claim root key "%s": it is already claimed by "%s".',
+                        $id, $type, $rootKeys[$type],
+                    ));
+                }
+
+                $rootKeys[$type] = $id;
+            }
+        }
+
+        $container->getDefinition(self::NORMALIZER_ID)
+            ->setArgument('$rootResolverKeys', \array_keys($rootKeys));
+    }
+}

--- a/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
+++ b/packages/content/src/Infrastructure/Symfony/HttpKernel/SuluContentBundle.php
@@ -18,6 +18,7 @@ use Sulu\Content\Application\PropertyResolver\Resolver\PropertyResolverMetadataA
 use Sulu\Content\Application\ResourceLoader\Loader\ResourceLoaderInterface;
 use Sulu\Content\Domain\Exception\ShadowSourceNotPublishedException;
 use Sulu\Content\Infrastructure\Doctrine\EventListener\RouteCleanupListener;
+use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\ContentResolverPlacementPass;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\ExcerptFormPass;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\ResourceLoaderCacheCompilerPass;
 use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\SeoFormPass;
@@ -134,6 +135,7 @@ final class SuluContentBundle extends AbstractBundle
         $container->addCompilerPass(new ExcerptFormPass());
         $container->addCompilerPass(new SeoFormPass());
         $container->addCompilerPass(new ResourceLoaderCacheCompilerPass());
+        $container->addCompilerPass(new ContentResolverPlacementPass());
 
         $container->registerForAutoconfiguration(ResourceLoaderInterface::class)
             ->addTag('sulu_content.resource_loader');

--- a/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
+++ b/packages/content/tests/Functional/Application/ContentResolver/ContentResolverTest.php
@@ -151,6 +151,29 @@ class ContentResolverTest extends SuluTestCase
         self::assertTrue($seo['hideInSitemap']);
     }
 
+    public function testExistingResolversStillLandUnderExtension(): void
+    {
+        $example = static::createExample([
+            'en' => [
+                'live' => [
+                    'template' => 'full-content',
+                    'title' => 'Lorem Ipsum',
+                    'url' => '/lorem-ipsum',
+                    'excerpt' => ['title' => 'excerpt-title-1'],
+                    'seo' => ['title' => 'seo-title-1'],
+                ],
+            ],
+        ]);
+
+        $dimensionContent = $this->contentAggregator->aggregate($example, ['locale' => 'en', 'stage' => 'live']);
+        $result = $this->contentResolver->resolve($dimensionContent);
+
+        self::assertArrayHasKey('seo', $result['extension']);
+        self::assertArrayHasKey('excerpt', $result['extension']);
+        self::assertArrayNotHasKey('seo', $result);
+        self::assertArrayNotHasKey('excerpt', $result);
+    }
+
     public function testResolveContentWithProperties(): void
     {
         $example0 = static::createExample(

--- a/packages/content/tests/Unit/Content/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentResolver/DataNormalizer/ContentViewDataNormalizerTest.php
@@ -207,4 +207,45 @@ class ContentViewDataNormalizerTest extends TestCase
         // When not root, properties should be mapped under [content] path
         self::assertSame('Test Title', $result['content']['title']);
     }
+
+    public function testRootResolverKeyIsPlacedAtRootInsteadOfExtension(): void
+    {
+        $normalizer = new ContentViewDataNormalizer($this->propertyAccessor, ['product']);
+        $resource = new Example();
+
+        $content = [
+            'template' => ['title' => 'Test Title'],
+            'product' => ['code' => 'NL4FX'],
+            'seo' => ['title' => 'SEO Title'],
+        ];
+
+        $result = $normalizer->normalizeContentViewData($content, ['template' => []], $resource);
+
+        // @phpstan-ignore-next-line offsetAccess.notFound
+        self::assertSame(['code' => 'NL4FX'], $result['product']);
+        self::assertSame(['seo' => ['title' => 'SEO Title']], $result['extension']);
+    }
+
+    public function testRootResolverKeyIsAbsentWhenTheResolverEmittedNothing(): void
+    {
+        $normalizer = new ContentViewDataNormalizer($this->propertyAccessor, ['product']);
+        $resource = new Example();
+
+        $result = $normalizer->normalizeContentViewData(['template' => []], ['template' => []], $resource);
+
+        self::assertArrayNotHasKey('product', $result);
+    }
+
+    public function testWithoutRootResolverKeysEverythingStaysInExtension(): void
+    {
+        $resource = new Example();
+
+        $result = $this->normalizer->normalizeContentViewData(
+            ['template' => [], 'product' => ['code' => 'NL4FX']],
+            ['template' => []],
+            $resource,
+        );
+
+        self::assertSame(['product' => ['code' => 'NL4FX']], $result['extension']);
+    }
 }

--- a/packages/content/tests/Unit/Content/Infrastructure/Symfony/HttpKernel/Compiler/ContentResolverPlacementPassTest.php
+++ b/packages/content/tests/Unit/Content/Infrastructure/Symfony/HttpKernel/Compiler/ContentResolverPlacementPassTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Content\Tests\Unit\Content\Infrastructure\Symfony\HttpKernel\Compiler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sulu\Content\Application\ContentResolver\DataNormalizer\ContentViewDataNormalizer;
+use Sulu\Content\Infrastructure\Symfony\HttpKernel\Compiler\ContentResolverPlacementPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+#[CoversClass(ContentResolverPlacementPass::class)]
+class ContentResolverPlacementPassTest extends TestCase
+{
+    /**
+     * @param array<string, string> ...$tags
+     */
+    private function containerWith(array ...$tags): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition(
+            'sulu_content.content_view_data_normalizer',
+            new Definition(ContentViewDataNormalizer::class),
+        );
+
+        foreach ($tags as $index => $attributes) {
+            $definition = new Definition(\stdClass::class);
+            $definition->addTag('sulu_content.content_resolver', $attributes);
+            $container->setDefinition('resolver_' . $index, $definition);
+        }
+
+        return $container;
+    }
+
+    public function testCollectsRootPlacements(): void
+    {
+        $container = $this->containerWith(
+            ['type' => 'product', 'placement' => 'root'],
+            ['type' => 'seo'],
+        );
+
+        (new ContentResolverPlacementPass())->process($container);
+
+        self::assertSame(
+            ['product'],
+            $container->getDefinition('sulu_content.content_view_data_normalizer')
+                ->getArgument('$rootResolverKeys'),
+        );
+    }
+
+    public function testResolversWithoutPlacementAreNotCollected(): void
+    {
+        $container = $this->containerWith(['type' => 'seo'], ['type' => 'excerpt']);
+
+        (new ContentResolverPlacementPass())->process($container);
+
+        self::assertSame(
+            [],
+            $container->getDefinition('sulu_content.content_view_data_normalizer')
+                ->getArgument('$rootResolverKeys'),
+        );
+    }
+
+    public function testUnknownPlacementThrows(): void
+    {
+        $container = $this->containerWith(['type' => 'product', 'placement' => 'sideways']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/"sideways"/');
+
+        (new ContentResolverPlacementPass())->process($container);
+    }
+
+    public function testRootPlacementCollidingWithAReservedKeyThrows(): void
+    {
+        $container = $this->containerWith(['type' => 'author', 'placement' => 'root']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/reserved/');
+
+        (new ContentResolverPlacementPass())->process($container);
+    }
+
+    public function testRootPlacementCollidingWithSettingsThrows(): void
+    {
+        $container = $this->containerWith(['type' => 'settings', 'placement' => 'root']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/reserved/');
+
+        (new ContentResolverPlacementPass())->process($container);
+    }
+
+    public function testTwoRootResolversSharingATypeThrow(): void
+    {
+        $container = $this->containerWith(
+            ['type' => 'product', 'placement' => 'root'],
+            ['type' => 'product', 'placement' => 'root'],
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/already/');
+
+        (new ContentResolverPlacementPass())->process($container);
+    }
+
+    public function testRootPlacementWithoutATypeThrows(): void
+    {
+        $container = $this->containerWith(['placement' => 'root']);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new ContentResolverPlacementPass())->process($container);
+    }
+
+    public function testDoesNothingWithoutTheNormalizerDefinition(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new ContentResolverPlacementPass())->process($container);
+
+        self::assertFalse($container->hasDefinition('sulu_content.content_view_data_normalizer'));
+    }
+}

--- a/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
+++ b/packages/content/tests/Unit/Infrastructure/Symfony/HttpKernel/SuluContentBundleTest.php
@@ -63,7 +63,7 @@ class SuluContentBundleTest extends AbstractExtensionTestCase
         $passConfig = $containerBuilder->getCompiler()->getPassConfig();
 
         $this->assertSame(
-            4,
+            5,
             \count($passConfig->getPasses()) - $beforeCount
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no 
| New feature? | yes
| BC breaks? | no 
| Deprecations? | no
| License | MIT

#### What's in this PR?

  The `sulu_content.content_resolver` tag now takes an optional `placement` attribute.
  Tag a resolver with `placement: root` and its output ends up next to `content`, `view`
  and `extension` instead of inside `extension`. Default is `extension`, so nothing
  changes for existing resolvers.

  A compiler pass collects the root keys and complains at compile time if a resolver
  uses an unknown placement, forgets its `type`, or claims a key that is already taken.

  #### Why?

  Today everything a resolver returns lands under `extension`. That fits `seo` and
  `excerpt` — they really do extend the content. It fits badly for resolvers that
  return what the resource *is*: a product, an event. Templates then have to dig
  through `content.extension.product`, which says the wrong thing about the data.

  Now a bundle can decide where its data belongs.

#### Example Usage

  ```php
  $services->set('acme_product.product_resolver', ProductResolver::class)
      ->tag('sulu_content.content_resolver', ['type' => 'product', 'placement' => 'root']);

  {{ product.code }}      {# instead of content.extension.product.code #}
```
