### PR TITLE
Fix wrongly nested content views when no data for a slash root exists

### DIFF
--- a/packages/content/src/Application/MetadataResolver/MetadataResolver.php
+++ b/packages/content/src/Application/MetadataResolver/MetadataResolver.php
@@ -100,10 +100,13 @@ class MetadataResolver
     private function nestContentViews(array $contentViews, array $data): array
     {
         $flatSlashRoots = [];
-        foreach (\array_keys($data) as $key) {
-            if (\str_contains($key, '/')) {
+        $nestedRoots = [];
+        foreach ($data as $key => $value) {
+            if (\is_string($key) && \str_contains($key, '/')) {
                 [$root] = \explode('/', $key, 2);
                 $flatSlashRoots[$root] = true;
+            } elseif (\is_array($value)) {
+                $nestedRoots[$key] = true;
             }
         }
 
@@ -118,7 +121,12 @@ class MetadataResolver
             /** @var string $root */
             $root = \array_shift($segments);
 
-            if (isset($flatSlashRoots[$root])) {
+            // Only nest into a root when the data actually provides a nested array
+            // for it. A flat slash key (e.g. "seo/title") keeps the flat structure,
+            // and a root without any data at all stays flat as well - otherwise the
+            // properties would be wrongly nested one level too deep when no value has
+            // been saved yet (e.g. seo data before any seo value is set).
+            if (isset($flatSlashRoots[$root]) || !isset($nestedRoots[$root])) {
                 $result[$key] = $view;
                 continue;
             }

--- a/packages/content/tests/Unit/Content/Application/MetadataResolver/MetadataResolverTest.php
+++ b/packages/content/tests/Unit/Content/Application/MetadataResolver/MetadataResolverTest.php
@@ -166,4 +166,37 @@ class MetadataResolverTest extends TestCase
         self::assertSame('Excerpt Title', $result['excerpt/title']->getContent());
         self::assertNull($result['excerpt/description']->getContent());
     }
+
+    public function testResolveFlatSlashPathsStayFlatWhenNoDataForRootExists(): void
+    {
+        $propertyResolverProvider = new PropertyResolverProvider(
+            new \ArrayIterator(['default' => new DefaultPropertyResolver()])
+        );
+        $metadataResolver = new MetadataResolver($propertyResolverProvider);
+
+        $fieldMetadata1 = new FieldMetadata('seo/title');
+        $fieldMetadata1->setType('text_line');
+
+        $fieldMetadata2 = new FieldMetadata('seo/description');
+        $fieldMetadata2->setType('text_line');
+
+        // No "seo" data at all (e.g. seo properties before any seo value has been
+        // saved). The properties must stay flat instead of being nested one level
+        // too deep into a "seo" root.
+        $result = $metadataResolver->resolveItems(
+            [
+                'seo/title' => $fieldMetadata1,
+                'seo/description' => $fieldMetadata2,
+            ],
+            ['seoNoIndex' => false],
+            'en',
+        );
+
+        self::assertCount(2, $result);
+        self::assertArrayHasKey('seo/title', $result);
+        self::assertArrayHasKey('seo/description', $result);
+        self::assertArrayNotHasKey('seo', $result);
+        self::assertNull($result['seo/title']->getContent());
+        self::assertNull($result['seo/description']->getContent());
+    }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | #8665

#### What's in this PR?

`MetadataResolver::nestContentViews()` groups content views with slash-separated
property paths (e.g. `seo/title`) into a nested root. Until now that decision was
based solely on whether the `$data` array contained matching keys. When a
slash-path property had **no matching data at all**, the properties were nested
one level too deep.

This is most visible for the **seo extension before any seo value has been
saved**. The resolved `seo` extension came out as:

```
seo => [ seo => [ title, description, keywords, canonicalUrl, ... ], noIndex, noFollow, hideInSitemap ]
```

instead of the expected flat structure:

```
seo => [ title, description, keywords, canonicalUrl, noIndex, noFollow, hideInSitemap ]
```

As soon as any seo value is stored, the structure becomes flat again, which makes
the bug easy to miss. Templates relying on `extension.seo.title` therefore
silently resolved to `null` on pages/articles that never had seo data saved
(and any custom `content_seo_form` properties were unreachable in the same way).

#### Why?

Nesting is now only applied when the data actually provides a **nested array** for
the root. Flat slash keys keep the flat structure (unchanged), and a root without
any data now stays flat as well, restoring the pre-#8665 behaviour instead of
defaulting to a nested shape. Covered by a new unit test in `MetadataResolverTest`
(`testResolveFlatSlashPathsStayFlatWhenNoDataForRootExists`).