### PR TITLE
Add ResourceViewUrlGenerator to generate resource detail URLs

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceViewUrlGenerator.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceViewUrlGenerator.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\View;
+
+use Sulu\Bundle\AdminBundle\Exception\ResourceViewNotFoundException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class ResourceViewUrlGenerator implements ResourceViewUrlGeneratorInterface
+{
+    /**
+     * @param array<string, array{views?: array<string, string>}> $resources
+     */
+    public function __construct(
+        private ViewUrlGeneratorInterface $viewUrlGenerator,
+        private array $resources,
+    ) {
+    }
+
+    public function generate(
+        string $resourceKey,
+        string $resourceView,
+        array $viewParameters = [],
+        int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
+    ): string {
+        $viewName = $this->resources[$resourceKey]['views'][$resourceView] ?? null;
+
+        if (null === $viewName) {
+            throw new ResourceViewNotFoundException($resourceKey, $resourceView);
+        }
+
+        return $this->viewUrlGenerator->generate($viewName, $viewParameters, $referenceType);
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceViewUrlGeneratorInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ResourceViewUrlGeneratorInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Admin\View;
+
+use Sulu\Bundle\AdminBundle\Exception\ResourceViewNotFoundException;
+use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
+use Sulu\Bundle\AdminBundle\Exception\ViewParameterNotFoundException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Generates urls to the Sulu Admin frontend application for a given resource,
+ * resolving the target view via the `sulu_admin.resources` configuration
+ * (`sulu_admin.resources.<resourceKey>.views.<resourceView>`).
+ */
+interface ResourceViewUrlGeneratorInterface
+{
+    /**
+     * @param array<string, int|string> $viewParameters
+     * @param UrlGeneratorInterface::ABSOLUTE_URL|UrlGeneratorInterface::ABSOLUTE_PATH|UrlGeneratorInterface::RELATIVE_PATH|UrlGeneratorInterface::NETWORK_PATH $referenceType
+     *
+     * @throws ResourceViewNotFoundException
+     * @throws ViewNotFoundException
+     * @throws ViewParameterNotFoundException
+     */
+    public function generate(
+        string $resourceKey,
+        string $resourceView,
+        array $viewParameters = [],
+        int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
+    ): string;
+}

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGenerator.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ViewUrlGenerator.php
@@ -16,7 +16,7 @@ use Sulu\Route\Domain\Value\RequestAttributeEnum;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class ViewUrlGenerator implements ViewUrlGeneratorInterface
+final class ViewUrlGenerator implements ViewUrlGeneratorInterface
 {
     public function __construct(
         private UrlGeneratorInterface $urlGenerator,

--- a/src/Sulu/Bundle/AdminBundle/Exception/ResourceViewNotFoundException.php
+++ b/src/Sulu/Bundle/AdminBundle/Exception/ResourceViewNotFoundException.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Exception;
+
+/**
+ * An instance of this exception signals that a resource has no view configured
+ * for the requested resource view (e.g. "list" or "detail") under
+ * `sulu_admin.resources.<resourceKey>.views`.
+ */
+class ResourceViewNotFoundException extends \Exception
+{
+    public function __construct(private string $resourceKey, private string $resourceView)
+    {
+        parent::__construct(
+            \sprintf(
+                'The resource "%s" has no view configured for "%s" (sulu_admin.resources.%s.views.%s).',
+                $resourceKey,
+                $resourceView,
+                $resourceKey,
+                $resourceView
+            )
+        );
+    }
+
+    public function getResourceKey(): string
+    {
+        return $this->resourceKey;
+    }
+
+    public function getResourceView(): string
+    {
+        return $this->resourceView;
+    }
+}

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/services.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sulu\Bundle\AdminBundle\Admin\AdminPool;
 use Sulu\Bundle\AdminBundle\Admin\Navigation\NavigationRegistry;
+use Sulu\Bundle\AdminBundle\Admin\View\ResourceViewUrlGenerator;
+use Sulu\Bundle\AdminBundle\Admin\View\ResourceViewUrlGeneratorInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactory;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewRegistry;
@@ -311,6 +313,15 @@ return static function(ContainerConfigurator $container) {
         ->tag('sulu.context', ['context' => 'admin']);
 
     $services->alias(ViewUrlGeneratorInterface::class, 'sulu_admin.view_url_generator');
+
+    $services->set('sulu_admin.resource_view_url_generator', ResourceViewUrlGenerator::class)
+        ->args([
+            new Reference('sulu_admin.view_url_generator'),
+            '%sulu_admin.resources%',
+        ])
+        ->tag('sulu.context', ['context' => 'admin']);
+
+    $services->alias(ResourceViewUrlGeneratorInterface::class, 'sulu_admin.resource_view_url_generator');
 
     $services->set('sulu_admin.navigation_registry', NavigationRegistry::class)
         ->args([

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ResourceViewUrlGeneratorTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/ResourceViewUrlGeneratorTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\AdminBundle\Tests\Unit\Admin\View;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\AdminBundle\Admin\View\ResourceViewUrlGenerator;
+use Sulu\Bundle\AdminBundle\Admin\View\ViewUrlGeneratorInterface;
+use Sulu\Bundle\AdminBundle\Exception\ResourceViewNotFoundException;
+use Sulu\Bundle\AdminBundle\Exception\ViewNotFoundException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ResourceViewUrlGeneratorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<ViewUrlGeneratorInterface>
+     */
+    private ObjectProphecy $viewUrlGenerator;
+
+    public function setUp(): void
+    {
+        $this->viewUrlGenerator = $this->prophesize(ViewUrlGeneratorInterface::class);
+    }
+
+    /**
+     * @param array<string, array{views?: array<string, string>}> $resources
+     */
+    private function createResourceViewUrlGenerator(array $resources): ResourceViewUrlGenerator
+    {
+        return new ResourceViewUrlGenerator($this->viewUrlGenerator->reveal(), $resources);
+    }
+
+    public function testGenerate(): void
+    {
+        $resources = [
+            'contacts' => [
+                'views' => [
+                    'detail' => 'sulu_contact.contact_edit_form.details',
+                ],
+            ],
+        ];
+
+        $this->viewUrlGenerator->generate(
+            'sulu_contact.contact_edit_form.details',
+            ['id' => 1],
+            UrlGeneratorInterface::ABSOLUTE_PATH
+        )->willReturn('/admin/#/contacts/1/details');
+
+        $resourceViewUrlGenerator = $this->createResourceViewUrlGenerator($resources);
+
+        $this->assertSame(
+            '/admin/#/contacts/1/details',
+            $resourceViewUrlGenerator->generate('contacts', 'detail', ['id' => 1])
+        );
+    }
+
+    public function testGenerateWithReferenceType(): void
+    {
+        $resources = [
+            'contacts' => [
+                'views' => [
+                    'detail' => 'sulu_contact.contact_edit_form.details',
+                ],
+            ],
+        ];
+
+        $this->viewUrlGenerator->generate(
+            'sulu_contact.contact_edit_form.details',
+            ['id' => 1],
+            UrlGeneratorInterface::ABSOLUTE_URL
+        )->willReturn('https://example.org/admin/#/contacts/1/details');
+
+        $resourceViewUrlGenerator = $this->createResourceViewUrlGenerator($resources);
+
+        $this->assertSame(
+            'https://example.org/admin/#/contacts/1/details',
+            $resourceViewUrlGenerator->generate('contacts', 'detail', ['id' => 1], UrlGeneratorInterface::ABSOLUTE_URL)
+        );
+    }
+
+    public function testGenerateThrowsExceptionForUnknownResourceKey(): void
+    {
+        $this->expectException(ResourceViewNotFoundException::class);
+
+        $resourceViewUrlGenerator = $this->createResourceViewUrlGenerator([]);
+        $resourceViewUrlGenerator->generate('not_existing', 'detail');
+    }
+
+    public function testGenerateThrowsExceptionForUnconfiguredResourceView(): void
+    {
+        $this->expectException(ResourceViewNotFoundException::class);
+
+        $resources = [
+            'contacts' => [
+                'views' => [
+                    'list' => 'sulu_contact.contacts',
+                ],
+            ],
+        ];
+
+        $resourceViewUrlGenerator = $this->createResourceViewUrlGenerator($resources);
+        $resourceViewUrlGenerator->generate('contacts', 'detail');
+    }
+
+    public function testGeneratePropagatesViewNotFoundException(): void
+    {
+        $this->expectException(ViewNotFoundException::class);
+
+        $resources = [
+            'contacts' => [
+                'views' => [
+                    'detail' => 'sulu_contact.not_existing',
+                ],
+            ],
+        ];
+
+        $this->viewUrlGenerator->generate('sulu_contact.not_existing', [], UrlGeneratorInterface::ABSOLUTE_PATH)
+            ->willThrow(new ViewNotFoundException('sulu_contact.not_existing'));
+
+        $resourceViewUrlGenerator = $this->createResourceViewUrlGenerator($resources);
+        $resourceViewUrlGenerator->generate('contacts', 'detail');
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #9013, #9044
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Adds `ResourceViewUrlGenerator` / `ResourceViewUrlGeneratorInterface` to `Sulu\Bundle\AdminBundle\Admin\View`. It resolves a resource's registered view via the `sulu_admin.resources` config (`sulu_admin.resources.<resourceKey>.views.<resourceView>`) and delegates to `ViewUrlGenerator` for the actual URL.

Registered as service `sulu_admin.resource_view_url_generator`, admin-context only (`sulu.context` tag), same as `sulu_admin.view_url_generator`.

Extracted out of #9044 per discussion on #9013: originally named `ViewResourceUrlGenerator`, renamed to `ResourceViewUrlGenerator` per @alexander-schranz's naming correction.

#### Example Usage

```php
$resourceViewUrlGenerator->generate(
    'pages',
    'detail',
    ['id' => 3, 'webspace' => 'sulu', 'locale' => 'de'],
    UrlGeneratorInterface::ABSOLUTE_URL,
);
// https://example.org/admin/#/webspaces/sulu/pages/de/3
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md <!-- n/a, no BC breaks -->

#### Checks run locally

- `phpunit` (AdminBundle `Admin/View` unit tests) — green
- `php-cs-fixer fix --dry-run` on changed files — clean