### PR TITLE
Select filter in custom entities lost after a page reload

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectFieldFilterType.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/fieldFilterTypes/SelectFieldFilterType.js
@@ -5,6 +5,16 @@ import Checkbox, {CheckboxGroup} from '../../../components/Checkbox';
 import {translate} from '../../../utils/Translator';
 import AbstractFieldFilterType from './AbstractFieldFilterType';
 
+// The keys of the options are always strings, but numeric keys are restored as numbers from the URL. Therefore the
+// values have to be casted to strings again, because they would not match the option keys otherwise.
+function normalizeValues(values: ?Array<string>): Array<string> {
+    if (!values) {
+        return [];
+    }
+
+    return values.map((value) => String(value));
+}
+
 class SelectFieldFilterType extends AbstractFieldFilterType<?Array<string>> {
     @computed get parameterOptions(): Object {
         const {parameters} = this;
@@ -42,7 +52,7 @@ class SelectFieldFilterType extends AbstractFieldFilterType<?Array<string>> {
         const {value} = this;
 
         return (
-            <CheckboxGroup onChange={this.handleChange} values={value || []}>
+            <CheckboxGroup onChange={this.handleChange} values={normalizeValues(value)}>
                 {Object.keys(this.parameterOptions).map((optionKey) => (
                     <Checkbox
                         key={optionKey}
@@ -60,7 +70,9 @@ class SelectFieldFilterType extends AbstractFieldFilterType<?Array<string>> {
             return Promise.resolve(null);
         }
 
-        return Promise.resolve(values.map((value) => translate(this.parameterOptions[value])).join(', '));
+        return Promise.resolve(
+            normalizeValues(values).map((value) => translate(this.parameterOptions[value])).join(', ')
+        );
     }
 }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectFieldFilterType.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/fieldFilterTypes/SelectFieldFilterType.test.js
@@ -134,3 +134,70 @@ test('Return value node observable array options', () => {
         expect(valueNode).toEqual('Option Zero, Option Two');
     });
 });
+
+test('Pass correct props to CheckboxGroup if the values are numbers', () => {
+    const selectFieldFilterType = new SelectFieldFilterType(
+        jest.fn(),
+        {options: {'1': 'Open', '2': 'Approved', '3': 'Rejected'}},
+        // $FlowFixMe: numeric option keys are restored as numbers from the URL
+        [1, 3]
+    );
+
+    const selectFieldFilterTypeForm = mount(selectFieldFilterType.getFormNode());
+
+    expect(selectFieldFilterTypeForm.find('CheckboxGroup').prop('values')).toEqual(['1', '3']);
+
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(0).prop('checked')).toEqual(true);
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(1).prop('checked')).toEqual(false);
+    expect(selectFieldFilterTypeForm.find('Checkbox').at(2).prop('checked')).toEqual(true);
+});
+
+test('Call onChange handler without duplicates if the values are numbers', () => {
+    const changeSpy = jest.fn();
+    const selectFieldFilterType = new SelectFieldFilterType(
+        changeSpy,
+        {options: {'1': 'Open', '2': 'Approved', '3': 'Rejected'}},
+        // $FlowFixMe: numeric option keys are restored as numbers from the URL
+        [1, 3]
+    );
+
+    const selectFieldFilterTypeForm = mount(selectFieldFilterType.getFormNode());
+
+    selectFieldFilterTypeForm.find('Checkbox').at(1).prop('onChange')(true, '2');
+    expect(changeSpy).toHaveBeenLastCalledWith(['1', '3', '2']);
+
+    selectFieldFilterTypeForm.find('Checkbox').at(0).prop('onChange')(false, '1');
+    expect(changeSpy).toHaveBeenLastCalledWith(['3']);
+});
+
+test('Return value node with number values', () => {
+    const selectFieldFilterType = new SelectFieldFilterType(
+        jest.fn(),
+        {options: {'1': 'Open', '2': 'Approved', '3': 'Rejected'}},
+        undefined
+    );
+
+    // $FlowFixMe: numeric option keys are restored as numbers from the URL
+    const valueNodePromise = selectFieldFilterType.getValueNode([1, 3]);
+
+    if (!valueNodePromise) {
+        throw new Error('The getValueNode function must return a promise!');
+    }
+
+    return valueNodePromise.then((valueNode) => {
+        expect(valueNode).toEqual('Open, Rejected');
+    });
+});
+
+test('Pass correct props to CheckboxGroup if the values are an observable array of numbers', () => {
+    const selectFieldFilterType = new SelectFieldFilterType(
+        jest.fn(),
+        {options: {'1': 'Open', '2': 'Approved', '3': 'Rejected'}},
+        // $FlowFixMe: numeric option keys are restored as numbers from the URL
+        observable([1, 3])
+    );
+
+    const selectFieldFilterTypeForm = mount(selectFieldFilterType.getFormNode());
+
+    expect(selectFieldFilterTypeForm.find('CheckboxGroup').prop('values')).toEqual(['1', '3']);
+});


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8346
| Related issues/PRs | #8344
| License | MIT
| Documentation PR | -

#### What's in this PR?

`SelectFieldFilterType` now casts its values to strings before passing them to the `CheckboxGroup` and before looking up the option labels, so they match the option keys again regardless of how the router parsed them.

The public flow signatures and exports are unchanged, and the value that is sent to the API is untouched — filters with non-numeric option keys behave exactly as before.

Added three test cases covering numeric values, including one for an observable array, since the value is stored in an `@observable` by the `FieldFilterItem` and therefore arrives as an observable array at runtime.

#### Why?

The filter values of a list are bound into the URL query (`router.bind('filter', ...)` in `views/List/List.js`). On reload they are parsed back by `tryParse()` in `services/Router/Router.js`, which converts anything numeric into an actual number — so `filter.approval[0]=1` comes back as `1` instead of `"1"`.

The option keys of a `select` filter are always strings though (they come from `Object.keys()`), and the `CheckboxGroup` derives the checked state from `values.includes(child.props.value)`. Since `[1, 2].includes("1")` is `false`, every checkbox was rendered unchecked after a reload, and checking them again appended the string keys next to the still-present numbers. That is why the chip ended up as `Abnahme: Offen, Freigegeben, Offen, Freigegeben` as reported in #8346.

Articles are not 