### PR TITLE
Sitemap Twig Extension for Sulu 3

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -721,6 +721,82 @@ to better reflect that they come from the page package.
 - `sulu_breadcrumb` → `sulu_page_breadcrumb`
 - `sulu_navigation_is_active` → `sulu_page_navigation_is_active`
 
+### Sitemap Twig functions are based on the sitemap-providers
+
+The `sulu_sitemap` and `sulu_sitemap_url` Twig functions are still available, but `sulu_sitemap` no longer reads
+the pages directly from the removed PHPCR content query. It now returns the urls of every registered sitemap-provider
+(`sulu.sitemap.provider`) instead, which is the same source the XML sitemap (`/sitemap.xml`) is rendered from.
+
+Because of that a human readable sitemap contains pages, articles and every other custom routable entity which
+registers a sitemap-provider, and both sitemaps can not drift apart anymore.
+
+**What changed:**
+
+1. `sulu_sitemap` returns a flat list of `Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl` objects instead of a nested
+   array of page structures. There is no `children` key anymore, because the urls of the different providers do not
+   share a common tree. Use the `sulu_page_navigation_tree` function if a nested page tree is required.
+2. The `loc` of a `SitemapUrl` is already an absolute url, so `sulu_sitemap_url` is not needed for the returned entries.
+3. The second argument of `sulu_sitemap` changed from `webspaceKey` to the `alias` of a single sitemap-provider.
+   The webspace is no longer a parameter, because the sitemap-providers resolve the urls by the host of the current
+   request - the same way the XML sitemap does.
+4. `sulu_sitemap_url` is unchanged and still resolves a slug to an absolute url of the given (or current) webspace
+   and locale.
+5. The new `sulu_sitemap_aliases` function returns the aliases of all registered sitemap-providers.
+
+**Old:**
+
+```twig
+{% macro sitemap(items) %}
+    <ul>
+        {% for item in items %}
+            <li>
+                <a href="{{ sulu_sitemap_url(item.url) }}">{{ item.title }}</a>
+                {% if item.children is not empty %}
+                    {{ _self.sitemap(item.children) }}
+                {% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+{% endmacro %}
+
+{{ _self.sitemap(sulu_sitemap()) }}
+```
+
+**New:**
+
+```twig
+<ul>
+    {% for entry in sulu_sitemap() %}
+        <li><a href="{{ entry.loc }}">{{ entry.title|default(entry.loc) }}</a></li>
+    {% endfor %}
+</ul>
+```
+
+To group the urls by their content type, render one list per sitemap-provider:
+
+```twig
+{% for alias in sulu_sitemap_aliases() %}
+    <h2>{{ alias }}</h2>
+
+    <ul>
+        {% for entry in sulu_sitemap(alias: alias) %}
+            <li><a href="{{ entry.loc }}">{{ entry.title|default(entry.loc) }}</a></li>
+        {% endfor %}
+    </ul>
+{% endfor %}
+```
+
+The `title` of a `SitemapUrl` is optional and is only set by sitemap-providers which support it - the shipped page
+and article providers do. Custom providers can pass it as `title` argument of the `SitemapUrl` constructor.
+
+Sitemap-providers are paginated with `SitemapProviderInterface::PAGE_SIZE` (50000) urls per page. `sulu_sitemap`
+returns the first page by default, further pages can be requested with the third argument.
+
+**If you bridged the missing functions yourself:** projects which registered their own Twig extension providing a
+`sulu_sitemap` function keep their implementation - Twig resolves a function name to the last registered extension,
+and application extensions are registered after the bundle extensions. Remove your own extension to use the shipped
+one. The same applies to a project service definition which reuses the `sulu_website.twig.sitemap` service id.
+
 ### Navigation Twig Extension property filtering
 
 The navigation Twig functions and repository methods now support custom property filtering, and the default properties
@@ -1656,7 +1732,8 @@ Removed classes / services / interfaces / traits:
 - `Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGenerator`
 - `Sulu\Bundle\WebsiteBundle\Sitemap\SitemapGeneratorInterface`
 - `Sulu\Bundle\WebsiteBundle\Twig\Sitemap\MemoizedSitemapTwigExtension`
-- `Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtension`
+- `Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtensionInterface`
+- `Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtension` (re-added with a new API and internal, see "Sitemap Twig functions are based on the sitemap-providers")
 - `Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathInterface`
 - `Sulu\Bundle\WebsiteBundle\Twig\Content\ContentPathTwigExtension` (moved and internal)
 - `Sulu\Bundle\WebsiteBundle\Twig\Content\ContentTwigExtension`

--- a/packages/article/src/Infrastructure/Sulu/Sitemap/ArticlesSitemapProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Sitemap/ArticlesSitemapProvider.php
@@ -34,6 +34,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
  *     changed: \DateTimeImmutable,
  *     locale: string,
  *     availableLocales: string[]|null,
+ *     title: string|null,
  *     slug: string,
  *     uuid: string
  * }
@@ -179,6 +180,7 @@ class ArticlesSitemapProvider extends AbstractSitemapProvider
         $queryBuilder->addSelect('dimensionContent.locale');
 
         $queryBuilder->addSelect('unLocalizedDimensionContent.availableLocales');
+        $queryBuilder->addSelect('dimensionContent.title');
 
         $queryBuilder->addSelect('route.slug');
 
@@ -269,6 +271,7 @@ class ArticlesSitemapProvider extends AbstractSitemapProvider
             $article['locale'],
             $defaultLocale,
             $changed,
+            title: $article['title'] ?? null,
         );
 
         if ($alternateArticle[$article['uuid']] ?? null) {

--- a/packages/page/src/Infrastructure/Sulu/Sitemap/PagesSitemapProvider.php
+++ b/packages/page/src/Infrastructure/Sulu/Sitemap/PagesSitemapProvider.php
@@ -38,6 +38,7 @@ use Symfony\Bundle\SecurityBundle\Security;
  *     changed: \DateTimeImmutable,
  *     locale: string,
  *     availableLocales: string[]|null,
+ *     title: string|null,
  *     slug: string,
  *     uuid: string
  * }
@@ -218,6 +219,7 @@ class PagesSitemapProvider extends AbstractSitemapProvider
         $queryBuilder->addSelect('dimensionContent.locale');
 
         $queryBuilder->addSelect('unLocalizedDimensionContent.availableLocales');
+        $queryBuilder->addSelect('dimensionContent.title');
 
         $queryBuilder->addSelect('route.slug');
 
@@ -310,7 +312,8 @@ class PagesSitemapProvider extends AbstractSitemapProvider
             $url,
             $page['locale'],
             $defaultLocale,
-            $changed
+            $changed,
+            title: $page['title'] ?? null
         );
 
         if ($alternatePages[$page['uuid']] ?? null) {

--- a/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Resources/config/sitemap.php
@@ -12,8 +12,12 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderPool;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrlCollector;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrlCollectorInterface;
 use Sulu\Bundle\WebsiteBundle\Sitemap\XmlSitemapDumper;
 use Sulu\Bundle\WebsiteBundle\Sitemap\XmlSitemapRenderer;
+use Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtension;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 
 return static function(ContainerConfigurator $container) {
@@ -22,6 +26,24 @@ return static function(ContainerConfigurator $container) {
     $services->set('sulu_website.sitemap.pool', SitemapProviderPool::class)
         ->args([tagged_iterator('sulu.sitemap.provider')])
         ->tag('kernel.reset', ['method' => 'reset']);
+
+    $services->set('sulu_website.sitemap.url_collector', SitemapUrlCollector::class)
+        ->args([new Reference('sulu_website.sitemap.pool')]);
+
+    $services->alias(SitemapUrlCollectorInterface::class, 'sulu_website.sitemap.url_collector');
+
+    $services->set('sulu_website.twig.sitemap', SitemapTwigExtension::class)
+        ->args([
+            new Reference('sulu_website.sitemap.url_collector'),
+            new Reference('sulu_website.sitemap.pool'),
+            new Reference('sulu_core.webspace.webspace_manager'),
+            new Reference('request_stack'),
+            new Reference('sulu_core.cache.memoize'),
+            '%kernel.environment%',
+            '%sulu_website.sitemap.cache.lifetime%',
+            new Reference('sulu_core.webspace.request_analyzer', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+        ])
+        ->tag('twig.extension');
 
     $services->set('sulu_website.sitemap.xml_renderer', XmlSitemapRenderer::class)
         ->args([

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderPool.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapProviderPool.php
@@ -22,7 +22,7 @@ class SitemapProviderPool implements SitemapProviderPoolInterface, ResetInterfac
     /**
      * @var SitemapProviderInterface[]
      */
-    private $providers;
+    private $providers = [];
 
     /**
      * @var array<string, Sitemap[]>

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrl.php
@@ -45,6 +45,7 @@ class SitemapUrl
      * @param SitemapUrl::CHANGE_FREQUENCY_* $changefreq frequency of change
      * @param float $priority priority of page in relation to other domains
      * @param array $attributes
+     * @param string|null $title human readable title of the url, used to render a human readable sitemap
      */
     public function __construct(
         private $loc,
@@ -53,7 +54,8 @@ class SitemapUrl
         private ?\DateTimeInterface $lastmod = null,
         private $changefreq = null,
         private $priority = null,
-        private $attributes = []
+        private $attributes = [],
+        private ?string $title = null
     ) {
         $this->addAlternateLink(new SitemapAlternateLink($this->loc, $this->locale));
     }
@@ -146,5 +148,13 @@ class SitemapUrl
     public function getDefaultLocale()
     {
         return $this->defaultLocale;
+    }
+
+    /**
+     * Human readable title of the url, is only set by providers which support it.
+     */
+    public function getTitle(): ?string
+    {
+        return $this->title;
     }
 }

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrlCollector.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrlCollector.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Sitemap;
+
+/**
+ * @internal your code should not create direct dependencies on this implementation,
+ *           use the SitemapUrlCollectorInterface instead
+ */
+class SitemapUrlCollector implements SitemapUrlCollectorInterface
+{
+    public function __construct(
+        private SitemapProviderPoolInterface $sitemapProviderPool,
+    ) {
+    }
+
+    public function collect(
+        string $scheme,
+        string $host,
+        ?string $locale = null,
+        ?string $alias = null,
+        int $page = 1
+    ): array {
+        $providers = null !== $alias
+            ? [$alias => $this->sitemapProviderPool->getProvider($alias)]
+            : $this->sitemapProviderPool->getProviders();
+
+        $sitemapUrls = [];
+
+        foreach ($providers as $provider) {
+            if ($provider->getMaxPage($scheme, $host) < $page) {
+                continue;
+            }
+
+            foreach ($provider->build($page, $scheme, $host) as $sitemapUrl) {
+                if (null !== $locale && $sitemapUrl->getLocale() !== $locale) {
+                    continue;
+                }
+
+                // providers can return urls of other hosts, the xml sitemap template filters them the same way
+                if (!\str_contains($sitemapUrl->getLoc(), $host)) {
+                    continue;
+                }
+
+                $sitemapUrls[] = $sitemapUrl;
+            }
+        }
+
+        return $sitemapUrls;
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrlCollectorInterface.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Sitemap/SitemapUrlCollectorInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Sitemap;
+
+use Sulu\Bundle\WebsiteBundle\Exception\SitemapProviderNotFoundException;
+
+/**
+ * Collects the sitemap-urls of the registered sitemap-providers as a single flat list.
+ *
+ * The XML sitemap is split into one file per provider and page. A human readable sitemap
+ * instead wants to render all urls of a host at once. Because the urls are read from the
+ * same providers which are used to render the XML sitemap, the collected urls contain
+ * pages, articles and every other custom routable entity which registers a sitemap-provider.
+ */
+interface SitemapUrlCollectorInterface
+{
+    /**
+     * @param string $scheme scheme of the current request e.g. "https"
+     * @param string $host host of the current request e.g. "sulu.io"
+     * @param string|null $locale locale to filter the urls by, "null" returns the urls of all locales of the host
+     * @param string|null $alias alias of a single sitemap-provider, "null" collects the urls of all providers
+     * @param int $page page of the sitemap-provider, see SitemapProviderInterface::PAGE_SIZE
+     *
+     * @return SitemapUrl[]
+     *
+     * @throws SitemapProviderNotFoundException if the given alias does not exist
+     */
+    public function collect(
+        string $scheme,
+        string $host,
+        ?string $locale = null,
+        ?string $alias = null,
+        int $page = 1
+    ): array;
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Twig/SitemapTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Functional/Twig/SitemapTwigExtensionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Functional\Twig;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
+use Twig\Environment;
+use Twig\TwigFunction;
+
+class SitemapTwigExtensionTest extends WebsiteTestCase
+{
+    protected function setUp(): void
+    {
+        self::createWebsiteClient();
+    }
+
+    /**
+     * @return iterable<array{0: string}>
+     */
+    public static function provideFunctionName(): iterable
+    {
+        yield ['sulu_sitemap'];
+        yield ['sulu_sitemap_url'];
+        yield ['sulu_sitemap_aliases'];
+    }
+
+    #[DataProvider('provideFunctionName')]
+    public function testFunctionIsRegistered(string $functionName): void
+    {
+        $this->assertInstanceOf(TwigFunction::class, $this->getTwig()->getFunction($functionName));
+    }
+
+    public function testSitemapAliasesContainsTaggedProviders(): void
+    {
+        $aliases = $this->getTwig()->createTemplate('{{ sulu_sitemap_aliases()|join(",") }}')->render();
+
+        $this->assertContains('test', \explode(',', $aliases));
+    }
+
+    public function testSitemapWithoutRequestReturnsEmptyList(): void
+    {
+        $this->assertSame('0', $this->getTwig()->createTemplate('{{ sulu_sitemap()|length }}')->render());
+    }
+
+    private function getTwig(): Environment
+    {
+        /** @var Environment $twig */
+        $twig = self::getContainer()->get('twig');
+
+        return $twig;
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapUrlCollectorTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Sitemap/SitemapUrlCollectorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Sitemap;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\WebsiteBundle\Exception\SitemapProviderNotFoundException;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderPoolInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrlCollector;
+
+class SitemapUrlCollectorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<SitemapProviderPoolInterface>
+     */
+    private ObjectProphecy $sitemapProviderPool;
+
+    private SitemapUrlCollector $sitemapUrlCollector;
+
+    protected function setUp(): void
+    {
+        $this->sitemapProviderPool = $this->prophesize(SitemapProviderPoolInterface::class);
+        $this->sitemapUrlCollector = new SitemapUrlCollector($this->sitemapProviderPool->reveal());
+    }
+
+    public function testCollectAllProviders(): void
+    {
+        $pageUrl = new SitemapUrl('http://sulu.lo/page', 'en', 'en');
+        $articleUrl = new SitemapUrl('http://sulu.lo/article', 'en', 'en');
+
+        $this->sitemapProviderPool->getProviders()->willReturn([
+            'pages' => $this->createProvider(1, [$pageUrl]),
+            'articles' => $this->createProvider(1, [$articleUrl]),
+        ]);
+
+        $result = $this->sitemapUrlCollector->collect('http', 'sulu.lo');
+
+        $this->assertSame([$pageUrl, $articleUrl], $result);
+    }
+
+    public function testCollectSingleProvider(): void
+    {
+        $articleUrl = new SitemapUrl('http://sulu.lo/article', 'en', 'en');
+
+        $this->sitemapProviderPool->getProvider('articles')->willReturn($this->createProvider(1, [$articleUrl]));
+        $this->sitemapProviderPool->getProviders()->shouldNotBeCalled();
+
+        $result = $this->sitemapUrlCollector->collect('http', 'sulu.lo', null, 'articles');
+
+        $this->assertSame([$articleUrl], $result);
+    }
+
+    public function testCollectUnknownProvider(): void
+    {
+        $this->sitemapProviderPool->getProvider('unknown')
+            ->willThrow(new SitemapProviderNotFoundException('unknown', ['pages']));
+
+        $this->expectException(SitemapProviderNotFoundException::class);
+
+        $this->sitemapUrlCollector->collect('http', 'sulu.lo', null, 'unknown');
+    }
+
+    public function testCollectFiltersByLocale(): void
+    {
+        $germanUrl = new SitemapUrl('http://sulu.lo/de/seite', 'de', 'en');
+        $englishUrl = new SitemapUrl('http://sulu.lo/en/page', 'en', 'en');
+
+        $this->sitemapProviderPool->getProviders()->willReturn([
+            'pages' => $this->createProvider(1, [$germanUrl, $englishUrl]),
+        ]);
+
+        $result = $this->sitemapUrlCollector->collect('http', 'sulu.lo', 'de');
+
+        $this->assertSame([$germanUrl], $result);
+    }
+
+    public function testCollectFiltersOtherHosts(): void
+    {
+        $ownHostUrl = new SitemapUrl('http://sulu.lo/page', 'en', 'en');
+        $otherHostUrl = new SitemapUrl('http://other.lo/page', 'en', 'en');
+
+        $this->sitemapProviderPool->getProviders()->willReturn([
+            'pages' => $this->createProvider(1, [$ownHostUrl, $otherHostUrl]),
+        ]);
+
+        $result = $this->sitemapUrlCollector->collect('http', 'sulu.lo');
+
+        $this->assertSame([$ownHostUrl], $result);
+    }
+
+    public function testCollectSkipsProvidersWithoutRequestedPage(): void
+    {
+        $provider = $this->prophesize(SitemapProviderInterface::class);
+        $provider->getMaxPage('http', 'sulu.lo')->willReturn(1);
+        $provider->build(2, 'http', 'sulu.lo')->shouldNotBeCalled();
+
+        $this->sitemapProviderPool->getProviders()->willReturn(['pages' => $provider->reveal()]);
+
+        $result = $this->sitemapUrlCollector->collect('http', 'sulu.lo', null, null, 2);
+
+        $this->assertSame([], $result);
+    }
+
+    /**
+     * @param SitemapUrl[] $sitemapUrls
+     */
+    private function createProvider(int $maxPage, array $sitemapUrls): SitemapProviderInterface
+    {
+        $provider = $this->prophesize(SitemapProviderInterface::class);
+        $provider->getMaxPage('http', 'sulu.lo')->willReturn($maxPage);
+        $provider->build(1, 'http', 'sulu.lo')->willReturn($sitemapUrls);
+
+        return $provider->reveal();
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Sitemap/SitemapTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Sitemap/SitemapTwigExtensionTest.php
@@ -155,13 +155,21 @@ class SitemapTwigExtensionTest extends TestCase
     public function testSitemapAliases(): void
     {
         $this->sitemapProviderPool->getProviders()->willReturn([
-            'pages' => $this->prophesize(SitemapProviderInterface::class)->reveal(),
-            'articles' => $this->prophesize(SitemapProviderInterface::class)->reveal(),
+            'pages' => $this->createProvider('pages'),
+            'articles' => $this->createProvider('articles'),
         ]);
 
         $extension = $this->createExtension();
 
         $this->assertSame(['pages', 'articles'], $extension->sitemapAliasesFunction());
+    }
+
+    private function createProvider(string $alias): SitemapProviderInterface
+    {
+        $provider = $this->prophesize(SitemapProviderInterface::class);
+        $provider->getAlias()->willReturn($alias);
+
+        return $provider->reveal();
     }
 
     private function createExtension(bool $withRequestAnalyzer = true): SitemapTwigExtension
@@ -171,7 +179,7 @@ class SitemapTwigExtensionTest extends TestCase
             $this->sitemapProviderPool->reveal(),
             $this->webspaceManager->reveal(),
             $this->requestStack,
-            new Memoize(new ArrayAdapter(), 3600),
+            new Memoize(new ArrayAdapter(0, false), 3600),
             'prod',
             3600,
             $withRequestAnalyzer ? $this->requestAnalyzer->reveal() : null

--- a/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Sitemap/SitemapTwigExtensionTest.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Tests/Unit/Twig/Sitemap/SitemapTwigExtensionTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Tests\Unit\Twig\Sitemap;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderPoolInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrlCollectorInterface;
+use Sulu\Bundle\WebsiteBundle\Twig\Sitemap\SitemapTwigExtension;
+use Sulu\Component\Cache\Memoize;
+use Sulu\Component\Localization\Localization;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Sulu\Component\Webspace\Webspace;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class SitemapTwigExtensionTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var ObjectProphecy<SitemapUrlCollectorInterface>
+     */
+    private ObjectProphecy $sitemapUrlCollector;
+
+    /**
+     * @var ObjectProphecy<SitemapProviderPoolInterface>
+     */
+    private ObjectProphecy $sitemapProviderPool;
+
+    /**
+     * @var ObjectProphecy<WebspaceManagerInterface>
+     */
+    private ObjectProphecy $webspaceManager;
+
+    /**
+     * @var ObjectProphecy<RequestAnalyzerInterface>
+     */
+    private ObjectProphecy $requestAnalyzer;
+
+    private RequestStack $requestStack;
+
+    protected function setUp(): void
+    {
+        $this->sitemapUrlCollector = $this->prophesize(SitemapUrlCollectorInterface::class);
+        $this->sitemapProviderPool = $this->prophesize(SitemapProviderPoolInterface::class);
+        $this->webspaceManager = $this->prophesize(WebspaceManagerInterface::class);
+        $this->requestAnalyzer = $this->prophesize(RequestAnalyzerInterface::class);
+
+        $this->requestStack = new RequestStack();
+    }
+
+    public function testSitemapUsesCurrentRequestAndLocalization(): void
+    {
+        $this->requestStack->push(Request::create('http://sulu.lo/sitemap'));
+
+        $localization = new Localization('de');
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn($localization);
+
+        $sitemapUrl = new SitemapUrl('http://sulu.lo/de', 'de', 'de', null, null, null, [], 'Homepage');
+        $this->sitemapUrlCollector->collect('http', 'sulu.lo', 'de', null, 1)
+            ->willReturn([$sitemapUrl])
+            ->shouldBeCalledOnce();
+
+        $extension = $this->createExtension();
+
+        $this->assertSame([$sitemapUrl], $extension->sitemapFunction());
+        // the second call is served by the memoize cache
+        $this->assertSame([$sitemapUrl], $extension->sitemapFunction());
+    }
+
+    public function testSitemapWithExplicitArguments(): void
+    {
+        $this->requestStack->push(Request::create('https://sulu.lo/sitemap'));
+
+        $this->requestAnalyzer->getCurrentLocalization()->shouldNotBeCalled();
+
+        $sitemapUrl = new SitemapUrl('https://sulu.lo/en/article', 'en', 'de');
+        $this->sitemapUrlCollector->collect('https', 'sulu.lo', 'en', 'articles', 2)
+            ->willReturn([$sitemapUrl])
+            ->shouldBeCalledOnce();
+
+        $extension = $this->createExtension();
+
+        $this->assertSame([$sitemapUrl], $extension->sitemapFunction('en', 'articles', 2));
+    }
+
+    public function testSitemapWithoutRequest(): void
+    {
+        $this->sitemapUrlCollector->collect(Argument::cetera())->shouldNotBeCalled();
+
+        $extension = $this->createExtension();
+
+        $this->assertSame([], $extension->sitemapFunction());
+    }
+
+    public function testSitemapUrl(): void
+    {
+        $webspace = new Webspace();
+        $webspace->setKey('sulu_io');
+
+        $this->requestAnalyzer->getWebspace()->willReturn($webspace);
+        $this->requestAnalyzer->getCurrentLocalization()->willReturn(new Localization('de'));
+
+        $this->webspaceManager->findUrlByResourceLocator('/products', 'prod', 'de', 'sulu_io')
+            ->willReturn('http://sulu.lo/products');
+
+        $extension = $this->createExtension();
+
+        $this->assertSame('http://sulu.lo/products', $extension->sitemapUrlFunction('/products'));
+    }
+
+    public function testSitemapUrlWithExplicitArguments(): void
+    {
+        $this->requestAnalyzer->getWebspace()->shouldNotBeCalled();
+        $this->requestAnalyzer->getCurrentLocalization()->shouldNotBeCalled();
+
+        $this->webspaceManager->findUrlByResourceLocator('/products', 'prod', 'en', 'other_io')
+            ->willReturn('http://other.lo/en/products');
+
+        $extension = $this->createExtension();
+
+        $this->assertSame(
+            'http://other.lo/en/products',
+            $extension->sitemapUrlFunction('/products', 'en', 'other_io')
+        );
+    }
+
+    public function testSitemapUrlWithoutRequestAnalyzer(): void
+    {
+        $this->webspaceManager->findUrlByResourceLocator(Argument::cetera())->shouldNotBeCalled();
+
+        $extension = $this->createExtension(false);
+
+        $this->assertNull($extension->sitemapUrlFunction('/products'));
+    }
+
+    public function testSitemapAliases(): void
+    {
+        $this->sitemapProviderPool->getProviders()->willReturn([
+            'pages' => $this->prophesize(SitemapProviderInterface::class)->reveal(),
+            'articles' => $this->prophesize(SitemapProviderInterface::class)->reveal(),
+        ]);
+
+        $extension = $this->createExtension();
+
+        $this->assertSame(['pages', 'articles'], $extension->sitemapAliasesFunction());
+    }
+
+    private function createExtension(bool $withRequestAnalyzer = true): SitemapTwigExtension
+    {
+        return new SitemapTwigExtension(
+            $this->sitemapUrlCollector->reveal(),
+            $this->sitemapProviderPool->reveal(),
+            $this->webspaceManager->reveal(),
+            $this->requestStack,
+            new Memoize(new ArrayAdapter(), 3600),
+            'prod',
+            3600,
+            $withRequestAnalyzer ? $this->requestAnalyzer->reveal() : null
+        );
+    }
+}

--- a/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
+++ b/src/Sulu/Bundle/WebsiteBundle/Twig/Sitemap/SitemapTwigExtension.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\WebsiteBundle\Twig\Sitemap;
+
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapProviderPoolInterface;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl;
+use Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrlCollectorInterface;
+use Sulu\Component\Cache\MemoizeInterface;
+use Sulu\Component\Webspace\Analyzer\RequestAnalyzerInterface;
+use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Provides twig functions to render a human readable sitemap.
+ *
+ * @final
+ *
+ * @internal This class is internal and should not be extended or overwritten.
+ *           You can create an own Twig Extension to override the behaviour.
+ */
+class SitemapTwigExtension extends AbstractExtension
+{
+    public function __construct(
+        private SitemapUrlCollectorInterface $sitemapUrlCollector,
+        private SitemapProviderPoolInterface $sitemapProviderPool,
+        private WebspaceManagerInterface $webspaceManager,
+        private RequestStack $requestStack,
+        private MemoizeInterface $memoizeCache,
+        private string $environment,
+        private int $cacheLifetime,
+        private ?RequestAnalyzerInterface $requestAnalyzer = null,
+    ) {
+    }
+
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sulu_sitemap', [$this, 'sitemapFunction']),
+            new TwigFunction('sulu_sitemap_url', [$this, 'sitemapUrlFunction']),
+            new TwigFunction('sulu_sitemap_aliases', [$this, 'sitemapAliasesFunction']),
+        ];
+    }
+
+    /**
+     * Returns the sitemap-urls of the current host, which contains the urls of all registered
+     * sitemap-providers: pages, articles and every other custom routable entity.
+     *
+     * @param string|null $locale locale to filter the urls by, defaults to the locale of the current request
+     * @param string|null $alias alias of a single sitemap-provider e.g. "pages", "null" returns all providers
+     * @param int $page page of the sitemap-provider, see SitemapProviderInterface::PAGE_SIZE
+     *
+     * @return SitemapUrl[]
+     */
+    public function sitemapFunction(?string $locale = null, ?string $alias = null, int $page = 1): array
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null === $request) {
+            return [];
+        }
+
+        $locale ??= $this->requestAnalyzer?->getCurrentLocalization()?->getLocale();
+
+        /** @var SitemapUrl[] $sitemapUrls */
+        $sitemapUrls = $this->memoizeCache->memoizeById(
+            'sulu_sitemap',
+            [$request->getScheme(), $request->getHost(), $locale, $alias, $page],
+            fn (string $scheme, string $host, ?string $locale, ?string $alias, int $page): array => $this->sitemapUrlCollector->collect($scheme, $host, $locale, $alias, $page),
+            $this->cacheLifetime
+        );
+
+        return $sitemapUrls;
+    }
+
+    /**
+     * Returns the absolute url of the given slug, defaults to the webspace and locale of the current request.
+     */
+    public function sitemapUrlFunction(?string $slug, ?string $locale = null, ?string $webspaceKey = null): ?string
+    {
+        $webspaceKey ??= $this->requestAnalyzer?->getWebspace()?->getKey();
+        $locale ??= $this->requestAnalyzer?->getCurrentLocalization()?->getLocale();
+
+        if (null === $locale) {
+            return null;
+        }
+
+        return $this->webspaceManager->findUrlByResourceLocator(
+            $slug,
+            $this->environment,
+            $locale,
+            $webspaceKey
+        );
+    }
+
+    /**
+     * Returns the aliases of all registered sitemap-providers e.g. ["pages", "articles"].
+     *
+     * @return string[]
+     */
+    public function sitemapAliasesFunction(): array
+    {
+        return \array_values(\array_map(
+            static fn (SitemapProviderInterface $provider): string => $provider->getAlias(),
+            $this->sitemapProviderPool->getProviders()
+        ));
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8580
| Related issues/PRs | #8101
| License | MIT
| Documentation PR | [sulu/sulu-docs#](https://github.com/sulu/sulu-docs/pull/936)

#### What's in this PR?

Re-adds the `sulu_sitemap` Twig functions, but backed by the **`SitemapProviderPool`**
(`sulu.sitemap.provider`) instead of the removed PHPCR content query — the same source `/sitemap.xml` is
rendered from.

* `SitemapUrlCollectorInterface` / `SitemapUrlCollector` (`WebsiteBundle/Sitemap`): thin facade over the
  pool. Iterates all providers or a single alias, filters by locale, applies the same host filter as
  `sitemap.xml.twig`, respects `getMaxPage()`.
* `Twig\Sitemap\SitemapTwigExtension` (same FQCN as in 2.x): resolves defaults from `RequestAnalyzer` /
  `RequestStack`, delegates to the collector, memoized via `sulu_core.cache.memoize`. This gives the
  existing but since 3.0 unused `sulu_website.twig.sitemap.cache_lifetime` option a meaning again.
  * `sulu_sitemap(locale = null, alias = null, page = 1)` → `SitemapUrl[]`
  * `sulu_sitemap_url(slug, locale = null, webspaceKey = null)` → unchanged from 2.x
  * `sulu_sitemap_aliases()` → new, lists the registered provider aliases
* `SitemapUrl` gets an optional `title` (appended constructor argument). `PagesSitemapProvider` and
  `ArticlesSitemapProvider` fill it from `dimensionContent.title`, so a rendered sitemap has link text.
* Unit tests for the collector and the extension, a functional test for the wiring, and `UPGRADE-3.x.md`
  notes next to the navigation section.

**Deliberate deviations from 2.x:** a flat `SitemapUrl[]` instead of a nested page tree (urls of different
providers share no hierarchy — `sulu_page_navigation_tree` stays the tool for a page tree), and the second
argument is a provider `alias` instead of `webspaceKey`, because providers are host-addressed in 3.0
(`build($page, $scheme, $host)`). `locale` remains the first argument, so `sulu_sitemap()` and
`sulu_sitemap('de')` keep working as they did in 2.x.

**Why no BC break:** the function names do not exist anywhere in 3.0.x. `SitemapUrl` is only constructed
inside the framework, has no subclasses and no serializer metadata, and the appended argument is optional
(constructors are exempt from LSP checks). The rendered XML stays byte-identical — the template does not
output a title, and `uuid` is already part of the `DISTINCT` select, so the added column cannot change the
row count. Where a project registered its own `sulu_sitemap` bridge, Twig is last-write-wins with
application extensions loaded last, so theirs keeps winning.

#### Why?

In 2.x `sulu_sitemap` was backed by `SitemapGenerator` and a PHPCR content query, so it could only ever
see **pages** — articles and custom routable entities were invisible, and projects hand-maintained a
second list next to `/sitemap.xml`. #8101 removed the extension together with the PHPCR services, and
#8580 asked how people had worked around that gap. Reading from the provider pool closes the gap instead
of reproducing it: every entity that already appears in `/sitemap.xml` now also appears in a human
readable sitemap, and the two cannot drift apart.

#### Example Usage

A flat sitemap page:

```twig
<ul>
    {% for entry in sulu_sitemap() %}
        <li><a href="{{ entry.loc }}">{{ entry.title|default(entry.loc) }}</a></li>
    {% endfor %}
</ul>
```

Grouped per content type:

```twig
{% for alias in sulu_sitemap_aliases() %}
    <h2>{{ ('sitemap.' ~ alias)|trans }}</h2>

    <ul>
        {% for entry in sulu_sitemap(alias: alias) %}
            <li><a href="{{ entry.loc }}">{{ entry.title|default(entry.loc) }}</a></li>
        {% endfor %}
    </ul>
{% endfor %}
```

A custom sitemap-provider only has to pass a title to show up with a readable label:

```php
return [
    new SitemapUrl($url, $locale, $defaultLocale, $event->getChanged(), title: $event->getTitle()),
];
```

#### To Do

- [x] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md — no breaking changes, but `UPGRADE-3.x.md` documents the changed
      `sulu_sitemap` API for projects migrating templates from 2.x