### PR TITLE
Allow to view all collection in tree selection view

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -169,7 +169,12 @@ class CollectionController extends AbstractRestController implements ClassResour
     {
         $depth = $request->query->getInt('depth');
         $parentId = $request->query->get('parentId', null);
-        $limit = $this->listRestHelper->getLimit();
+
+        // allow disabling pagination for tree handling
+        $limit = $request->query->get('limit', null);
+        if (!is_null($limit)) {
+            $limit = (int) $limit;
+        }
 
         /** @var int $offset */
         $offset = $this->listRestHelper->getOffset();

--- a/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
+++ b/src/Sulu/Bundle/MediaBundle/Controller/CollectionController.php
@@ -172,7 +172,7 @@ class CollectionController extends AbstractRestController implements ClassResour
 
         // allow disabling pagination for tree handling
         $limit = $request->query->get('limit', null);
-        if (!is_null($limit)) {
+        if (!\is_null($limit)) {
             $limit = (int) $limit;
         }
 

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -399,6 +399,37 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertCount(26, $collections);
     }
 
+    public function testCGetListsAllCollectionsIfNoLimitIsGivenWithFlatParameterSet(): void
+    {
+        for ($i = 1; $i <= 25; ++$i) {
+            $this->createCollection(
+                $this->collectionType1,
+                ['en-gb' => 'Test Collection ' . $i, 'de' => 'Test Kollektion ' . $i]
+            );
+        }
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/collections?' . \http_build_query([
+                'locale' => 'en-gb',
+                'flat' => true
+            ])
+        );
+
+        /** @var string $responseContent */
+        $responseContent = $this->client->getResponse()->getContent();
+        /** @var object{_embedded: object{collections: list<\stdClass>}} $response */
+        $response = \json_decode($responseContent, false, 512, \JSON_THROW_ON_ERROR);
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->assertNotEmpty($response->_embedded->collections);
+
+        /** @var \stdClass[] $collections */
+        $collections = $response->_embedded->collections;
+
+        $this->assertCount(26, $collections);
+    }
+
     public function testCGetPaginatedFlat(): void
     {
         for ($i = 1; $i < 8; ++$i) {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -388,7 +388,7 @@ class CollectionControllerTest extends SuluTestCase
         /** @var string $responseContent */
         $responseContent = $this->client->getResponse()->getContent();
         /** @var object{_embedded: object{collections: list<\stdClass>}} $response */
-        $response = \json_decode($responseContent, false, 512, JSON_THROW_ON_ERROR);
+        $response = \json_decode($responseContent, false, 512, \JSON_THROW_ON_ERROR);
         $this->assertHttpStatusCode(200, $this->client->getResponse());
 
         $this->assertNotEmpty($response->_embedded->collections);

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -369,6 +369,36 @@ class CollectionControllerTest extends SuluTestCase
         $this->assertSame('Z Last Test Collection', $collections[\array_key_last($collections)]->title);
     }
 
+    public function testCGetListsAllCollectionsIfNoLimitIsGiven(): void
+    {
+        for ($i = 1; $i <= 25; ++$i) {
+            $this->createCollection(
+                $this->collectionType1,
+                ['en-gb' => 'Test Collection ' . $i, 'de' => 'Test Kollektion ' . $i]
+            );
+        }
+
+        $this->client->jsonRequest(
+            'GET',
+            '/api/collections?' . \http_build_query([
+                'locale' => 'en-gb',
+            ])
+        );
+
+        /** @var string $responseContent */
+        $responseContent = $this->client->getResponse()->getContent();
+        /** @var object{_embedded: object{collections: list<\stdClass>}} $response */
+        $response = \json_decode($responseContent, false, 512, JSON_THROW_ON_ERROR);
+        $this->assertHttpStatusCode(200, $this->client->getResponse());
+
+        $this->assertNotEmpty($response->_embedded->collections);
+
+        /** @var \stdClass[] $collections */
+        $collections = $response->_embedded->collections;
+
+        $this->assertCount(26, $collections);
+    }
+
     public function testCGetPaginatedFlat(): void
     {
         for ($i = 1; $i < 8; ++$i) {

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Controller/CollectionControllerTest.php
@@ -412,7 +412,7 @@ class CollectionControllerTest extends SuluTestCase
             'GET',
             '/api/collections?' . \http_build_query([
                 'locale' => 'en-gb',
-                'flat' => true
+                'flat' => true,
             ])
         );
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT

#### What's in this PR?

This PR allows to select any collection for example during moving of images, not only one of the first 10 collections.

#### Why?

Since the latest release there was a minor bug when opening the collection selection tree view. Only the first 10 items were displayed for selection because of an enforced limit of 10 by the ListRestHelper. This PR circumvents this problem as discussed.
