### PR TITLE
Add toolbar actions to the form overlay

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,5 +1,14 @@
 # Upgrade
 
+## 3.1.0
+
+### FormOverlayListViewBuilderInterface gained addOverlayToolbarActions
+
+`Sulu\Bundle\AdminBundle\Admin\View\FormOverlayListViewBuilderInterface` gained the method
+`addOverlayToolbarActions(array $toolbarActions): self`. It configures the toolbar actions rendered inside the overlay
+of a form overlay list, separately from `addToolbarActions()`, which stays bound to the surrounding list. Classes
+extending `FormOverlayListViewBuilder` inherit the method, other implementations of the interface need to add it.
+
 ## 3.0.9
 
 ### Widened webspace, slug and template key column lengths

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilder.php
@@ -74,6 +74,16 @@ class FormOverlayListViewBuilder implements FormOverlayListViewBuilderInterface
         return $this;
     }
 
+    /**
+     * @param ToolbarAction[] $toolbarActions
+     */
+    public function addOverlayToolbarActions(array $toolbarActions): FormOverlayListViewBuilderInterface
+    {
+        $this->addToolbarActionsToView($this->view, $toolbarActions, 'overlayToolbarActions');
+
+        return $this;
+    }
+
     public function setTabTitle(string $tabTitle): FormOverlayListViewBuilderInterface
     {
         $this->setTabTitleToView($this->view, $tabTitle);

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/FormOverlayListViewBuilderInterface.php
@@ -27,6 +27,13 @@ interface FormOverlayListViewBuilderInterface extends ViewBuilderInterface
 
     public function setEditOverlayTitle(string $editOverlayTitle): self;
 
+    /**
+     * Toolbar actions rendered inside the overlay, resolved through the formToolbarActionRegistry.
+     *
+     * @param ToolbarAction[] $toolbarActions
+     */
+    public function addOverlayToolbarActions(array $toolbarActions): self;
+
     public function setTabOrder(int $tabOrder): self;
 
     public function setTabPriority(int $tabPriority): self;

--- a/src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarActionsViewBuilderTrait.php
+++ b/src/Sulu/Bundle/AdminBundle/Admin/View/ToolbarActionsViewBuilderTrait.php
@@ -16,12 +16,12 @@ trait ToolbarActionsViewBuilderTrait
     /**
      * @param ToolbarAction[] $toolbarActions
      */
-    private function addToolbarActionsToView(View $view, array $toolbarActions): void
+    private function addToolbarActionsToView(View $view, array $toolbarActions, string $option = 'toolbarActions'): void
     {
-        $oldToolbarActions = $view->getOption('toolbarActions');
+        $oldToolbarActions = $view->getOption($option);
         $newToolbarActions = $oldToolbarActions
             ? \array_merge($oldToolbarActions, $toolbarActions)
             : $toolbarActions;
-        $view->setOption('toolbarActions', $newToolbarActions);
+        $view->setOption($option, $newToolbarActions);
     }
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/Overlay.js
@@ -30,6 +30,7 @@ type Props = {
     snackbarMessage?: string,
     snackbarType: SnackbarType,
     title: string,
+    toolbar?: Node,
 };
 
 const CLOSE_ICON = 'su-times';
@@ -115,6 +116,7 @@ class Overlay extends React.Component<Props> {
             snackbarMessage,
             snackbarType,
             title,
+            toolbar,
         } = this.props;
 
         const footerVisible = onConfirm !== undefined || actions.length > 0;
@@ -146,7 +148,12 @@ class Overlay extends React.Component<Props> {
                         >
                             <div className={overlayClass}>
                                 <section className={overlayStyles.content}>
-                                    <header className={overlayStyles.header}>
+                                    <header
+                                        className={classNames(
+                                            overlayStyles.header,
+                                            {[overlayStyles.headerWithToolbar]: toolbar}
+                                        )}
+                                    >
                                         <h2>{title}</h2>
                                         <Icon
                                             className={overlayStyles.icon}
@@ -154,6 +161,9 @@ class Overlay extends React.Component<Props> {
                                             onClick={this.handleIconClick}
                                         />
                                     </header>
+                                    {toolbar &&
+                                        <div className={overlayStyles.toolbar}>{toolbar}</div>
+                                    }
                                     <article className={overlayStyles.article}>{children}</article>
                                     {footerVisible &&
                                         <footer className={overlayStyles.footer}>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
@@ -3,6 +3,7 @@
 
 $primaryBackground: $concrete;
 $secondaryBackground: $white;
+$toolbarBackground: $alabaster;
 $borderRadius: 3px;
 $overlayBorderColor: $silver;
 
@@ -85,13 +86,19 @@ $transitionDuration: 300ms;
     }
 
     .toolbar {
-        background: $primaryBackground;
+        background: $toolbarBackground;
         border-bottom: 1px solid $overlayBorderColor;
 
         /* the application toolbar paints its own bar, in here it continues the header */
         nav {
             background: transparent;
             box-shadow: none;
+        }
+
+        /* the item list is the only one in the toolbar, its bar spans the full line instead */
+        ul {
+            background: transparent;
+            border: 0;
         }
     }
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
@@ -66,6 +66,8 @@ $transitionDuration: 300ms;
     border-radius: 0 0 $borderRadius $borderRadius;
     overflow: hidden;
     box-shadow: 0 10px 18px 0 rgba($mineShaft, .5);
+    display: flex;
+    flex-direction: column;
 
     .header {
         background: $primaryBackground;
@@ -133,9 +135,10 @@ $transitionDuration: 300ms;
     }
 }
 
+/* the snackbar takes the first row instead of covering the header; it collapses to no height
+   while hidden, so its own margin transition pushes the overlay down as it appears */
 .snackbar {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
+    order: -1;
+    display: flex;
+    flex-direction: column;
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/overlay.scss
@@ -79,6 +79,22 @@ $transitionDuration: 300ms;
         }
     }
 
+    /* the toolbar continues the header, so the single separator sits below the actions */
+    .header-with-toolbar {
+        border-bottom: 0;
+    }
+
+    .toolbar {
+        background: $primaryBackground;
+        border-bottom: 1px solid $overlayBorderColor;
+
+        /* the application toolbar paints its own bar, in here it continues the header */
+        nav {
+            background: transparent;
+            box-shadow: none;
+        }
+    }
+
     .article {
         max-height: $overlayContentMaxHeight;
         overflow: auto;
@@ -89,7 +105,7 @@ $transitionDuration: 300ms;
         background: $secondaryBackground;
         border-top: 1px solid $overlayBorderColor;
         height: $overlayFooterHeight;
-        padding: 0 60px;
+        padding: 0 $overlayHorizontalPadding;
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -101,7 +117,7 @@ $transitionDuration: 300ms;
 
     .icon {
         position: absolute;
-        right: 60px;
+        right: $overlayHorizontalPadding;
         font-size: $iconFontSize;
         font-weight: bold;
         line-height: $overlayHeaderHeight;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/tests/Overlay.test.js
@@ -218,3 +218,17 @@ test('The component should call the callback when the snackbar is clicked', asyn
     await user.click(screen.getByRole('button', {name: /sulu_admin.warning/i}));
     expect(onSnackbarClick).toHaveBeenCalled();
 });
+
+test('The component should render the toolbar between the header and the content', () => {
+    renderOverlay({
+        toolbar: <div data-testid="overlay-toolbar">toolbar content</div>,
+    });
+
+    expect(screen.getByTestId('overlay-toolbar')).toBeInTheDocument();
+});
+
+test('The component should not render a toolbar container when no toolbar is passed', () => {
+    renderOverlay();
+
+    expect(screen.queryByTestId('overlay-toolbar')).not.toBeInTheDocument();
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/variables.scss
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/Overlay/variables.scss
@@ -1,4 +1,5 @@
 $overlayHeaderHeight: 82px;
+$overlayHorizontalPadding: 60px;
 $overlayFooterHeight: 90px;
 $overlayMarginBottom: 100px;
 $overlayContentMaxHeight: calc(100vh - $overlayHeaderHeight - $overlayFooterHeight - $overlayMarginBottom);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/FormOverlay.js
@@ -1,29 +1,37 @@
 // @flow
-import React from 'react';
-import {action, computed, observable} from 'mobx';
+import React, {Fragment} from 'react';
+import {action, autorun, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import Overlay from '../../components/Overlay';
+import PublishIndicator from '../../components/PublishIndicator';
 import {translate} from '../../utils';
 import Form from '../Form';
 import Router from '../../services/Router';
+import Toolbar from '../Toolbar';
+import toolbarStorePool from '../Toolbar/stores/toolbarStorePool';
+import {SHOW_SUCCESS_DURATION} from '../Toolbar/stores/ToolbarStore';
 import formOverlayStyles from './formOverlay.scss';
+import type {ToolbarActionFormInterface, OverlayToolbarAction, ToolbarErrorType} from '../Toolbar/types';
 import type {FormStoreInterface} from '../Form/types';
 import type {ResourceFormStore} from '../Form';
+import type {SnackbarType} from '../../components/Snackbar';
 import type {Size} from '../../components/Overlay/types';
 import type {ElementRef} from 'react';
 
 type Props = {|
     confirmDisabled: boolean,
     confirmLoading: boolean,
-    confirmText: string,
+    confirmText?: string,
     formStore: FormStoreInterface | ResourceFormStore,
     onClose: () => void,
-    onConfirm: () => void,
+    onConfirm?: () => void,
     onFieldFinish?: (dataPath: string, schemaPath: string) => void,
     open: boolean,
     router?: Router,
     size?: Size,
     title: string,
+    toolbarActionsProvider?: (form: ToolbarActionFormInterface) => Array<OverlayToolbarAction>,
+    toolbarStoreKey: string,
 |};
 
 @observer
@@ -31,11 +39,17 @@ class FormOverlay extends React.Component<Props> {
     static defaultProps = {
         confirmDisabled: false,
         confirmLoading: false,
+        toolbarStoreKey: 'form_overlay',
     };
 
     formRef: ?ElementRef<typeof Form>;
+    successTimeout: ?TimeoutID;
+    toolbarDisposer: ?() => void;
 
-    @observable formErrors: Array<string> = [];
+    @observable errors: Array<ToolbarErrorType> = [];
+    @observable warnings: Array<ToolbarErrorType> = [];
+    @observable successMessage: string | void = undefined;
+    @observable toolbarActions: Array<OverlayToolbarAction> = [];
 
     @computed get confirmLoading() {
         const {confirmLoading, formStore} = this.props;
@@ -46,50 +60,176 @@ class FormOverlay extends React.Component<Props> {
         return confirmLoading || formStoreSaving;
     }
 
+    @action componentDidMount() {
+        const {toolbarActionsProvider, toolbarStoreKey} = this.props;
+
+        if (!toolbarActionsProvider) {
+            return;
+        }
+
+        // The Toolbar creates the store while rendering, but a closed Overlay renders no children.
+        if (!toolbarStorePool.hasStore(toolbarStoreKey)) {
+            toolbarStorePool.createStore(toolbarStoreKey);
+        }
+
+        this.toolbarActions = toolbarActionsProvider(this);
+
+        this.toolbarDisposer = autorun(() => {
+            toolbarStorePool.setToolbarConfig(toolbarStoreKey, this.toolbarConfig);
+        });
+    }
+
     @action componentDidUpdate(prevProps: Props) {
         const {open} = this.props;
 
         if (prevProps.open === false && open === true) {
-            this.formErrors = [];
+            this.errors = [];
+            this.warnings = [];
+            this.successMessage = undefined;
         }
     }
 
-    handleOverlayConfirm = () => {
+    componentWillUnmount() {
+        const {toolbarStoreKey} = this.props;
+
+        if (this.successTimeout) {
+            clearTimeout(this.successTimeout);
+        }
+
+        if (this.toolbarDisposer) {
+            this.toolbarDisposer();
+        }
+
+        this.toolbarActions.forEach((toolbarAction) => toolbarAction.destroy());
+
+        if (toolbarStorePool.hasStore(toolbarStoreKey)) {
+            toolbarStorePool.destroyStore(toolbarStoreKey);
+        }
+    }
+
+    @computed get toolbarConfig() {
+        const {formStore} = this.props;
+
+        const items = [];
+        this.toolbarActions.forEach((toolbarAction) => {
+            const itemConfig = toolbarAction.getToolbarItemConfig();
+
+            if (itemConfig) {
+                items.push(itemConfig);
+            }
+        });
+
+        const icons = [];
+        const data = formStore.data;
+        if (data && (data.hasOwnProperty('publishedState') || data.hasOwnProperty('published'))) {
+            const {published, publishedState} = data;
+            icons.push(
+                <PublishIndicator
+                    draft={publishedState === undefined ? false : !publishedState}
+                    key="publish"
+                    published={published === undefined ? false : !!published}
+                />
+            );
+        }
+
+        return {icons, items};
+    }
+
+    submit = (options: ?Object) => {
         if (!this.formRef) {
             throw new Error('The Form ref has not been set! This should not happen and is likely a bug.');
         }
 
         // calling formRef.submit() will trigger either handleFormSubmit() or handleFormError()
-        this.formRef.submit();
+        this.formRef.submit(options);
     };
 
-    handleFormSubmit = () => {
+    @action showSuccessSnackbar = () => {
+        this.successMessage = translate('sulu_admin.success');
+
+        if (this.successTimeout) {
+            clearTimeout(this.successTimeout);
+        }
+
+        this.successTimeout = setTimeout(action(() => {
+            this.successMessage = undefined;
+        }), SHOW_SUCCESS_DURATION);
+    };
+
+    // The Overlay shows a single snackbar, so the three sources are ranked instead of stacked.
+    @computed get snackbar(): ?{message: string, type: SnackbarType} {
+        const error = this.errors[this.errors.length - 1];
+        if (error !== undefined) {
+            return {message: typeof error === 'object' ? error.message : error, type: 'error'};
+        }
+
+        const warning = this.warnings[this.warnings.length - 1];
+        if (warning !== undefined) {
+            return {message: typeof warning === 'object' ? warning.message : warning, type: 'warning'};
+        }
+
+        if (this.successMessage !== undefined) {
+            return {message: this.successMessage, type: 'success'};
+        }
+
+        return undefined;
+    }
+
+    handleOverlayConfirm = () => {
+        this.submit();
+    };
+
+    handleFormSubmit = (options: ?Object) => {
         const {
             formStore,
             onConfirm,
+            toolbarActionsProvider,
         } = this.props;
 
         // save data before calling onConfirm callback if formstore is instance of ResourceFormStore
         if (typeof formStore.save === 'function') {
             // $FlowFixMe
-            formStore.save()
-                .then(() => {
-                    onConfirm();
-                })
+            formStore.save(options)
+                .then(action(() => {
+                    // The toolbar keeps the overlay open, so success is shown here instead of
+                    // handing over to onConfirm, which the list uses to close the overlay.
+                    if (toolbarActionsProvider) {
+                        this.errors = [];
+                        this.showSuccessSnackbar();
+
+                        return;
+                    }
+
+                    if (onConfirm) {
+                        onConfirm();
+                    }
+                }))
                 .catch(action((error) => {
-                    this.formErrors.push(error.detail || error.title || translate('sulu_admin.form_save_server_error'));
+                    this.errors.push(error.detail || error.title || translate('sulu_admin.form_save_server_error'));
                 }));
-        } else {
+        } else if (onConfirm) {
             onConfirm();
         }
     };
 
     handleFormError = () => {
-        this.formErrors.push(translate('sulu_admin.form_contains_invalid_values'));
+        this.errors.push(translate('sulu_admin.form_contains_invalid_values'));
     };
 
-    @action handleErrorSnackbarClose = () => {
-        this.formErrors.pop();
+    @action handleSnackbarCloseClick = () => {
+        if (this.errors.length > 0) {
+            this.errors.pop();
+
+            return;
+        }
+
+        if (this.warnings.length > 0) {
+            this.warnings.pop();
+
+            return;
+        }
+
+        this.successMessage = undefined;
     };
 
     handleFieldFinish = (dataPath: string, schemaPath: string) => {
@@ -104,6 +244,21 @@ class FormOverlay extends React.Component<Props> {
         this.formRef = formRef;
     };
 
+    renderToolbar() {
+        const {toolbarActionsProvider, toolbarStoreKey} = this.props;
+
+        if (!toolbarActionsProvider) {
+            return undefined;
+        }
+
+        return (
+            <Fragment>
+                <Toolbar showSnackbars={false} storeKey={toolbarStoreKey} />
+                {this.toolbarActions.map((toolbarAction, index) => toolbarAction.getNode(index))}
+            </Fragment>
+        );
+    }
+
     render() {
         const {
             confirmDisabled,
@@ -114,7 +269,10 @@ class FormOverlay extends React.Component<Props> {
             router,
             size,
             title,
+            toolbarActionsProvider,
         } = this.props;
+
+        const snackbar = this.snackbar;
 
         return (
             <Overlay
@@ -122,13 +280,16 @@ class FormOverlay extends React.Component<Props> {
                 confirmLoading={this.confirmLoading}
                 confirmText={confirmText}
                 onClose={onClose}
-                onConfirm={this.handleOverlayConfirm}
-                onSnackbarCloseClick={this.handleErrorSnackbarClose}
+                // The toolbar owns submission when actions are configured, so a footer Save would
+                // be a second button doing the same thing.
+                onConfirm={toolbarActionsProvider ? undefined : this.handleOverlayConfirm}
+                onSnackbarCloseClick={this.handleSnackbarCloseClick}
                 open={open}
                 size={size}
-                snackbarMessage={this.formErrors[this.formErrors.length - 1]}
-                snackbarType="error"
+                snackbarMessage={snackbar ? snackbar.message : undefined}
+                snackbarType={snackbar ? snackbar.type : 'error'}
                 title={title}
+                toolbar={this.renderToolbar()}
             >
                 <div className={formOverlayStyles.form}>
                     <Form

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/FormOverlay.test.js
@@ -1,27 +1,51 @@
 // @flow
 import mockReact from 'react';
-import {mount, shallow} from 'enzyme';
+import {fireEvent, render, screen, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {extendObservable as mockExtendObservable} from 'mobx';
 import FormOverlay from '../FormOverlay';
-import Overlay from '../../../components/Overlay';
 import ResourceStore from '../../../stores/ResourceStore';
 import MemoryFormStore from '../../../containers/Form/stores/MemoryFormStore';
 import ResourceFormStore from '../../../containers/Form/stores/ResourceFormStore';
-import Form from '../../../containers/Form';
-import Snackbar from '../../../components/Snackbar';
 import Router from '../../../services/Router';
 
 const React = mockReact;
 
+// the mock exposes the callbacks the real Form triggers, so a test can reach them by clicking
 jest.mock('../../../containers/Form', () => class FormMock extends mockReact.Component<*> {
+    submit = jest.fn((options) => this.props.onSubmit(options));
+
+    handleSubmit = () => this.props.onSubmit();
+
+    handleError = () => this.props.onError();
+
     render() {
-        return <div>form container mock</div>;
+        return (
+            <div data-router={this.props.router ? 'yes' : 'no'} data-testid="form-container">
+                form container mock
+                <button onClick={this.handleSubmit} type="button">trigger submit</button>
+                <button onClick={this.handleError} type="button">trigger error</button>
+            </div>
+        );
     }
 });
 
 jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
+
+jest.mock('../../../services/initializer', () => ({
+    initializedTranslationsLocale: true,
+}));
+
+jest.mock('debounce', () => jest.fn((callback) => callback));
+
+beforeEach(() => {
+    window.ResizeObserver = jest.fn(function() {
+        this.observe = jest.fn();
+        this.disconnect = jest.fn();
+    });
+});
 
 jest.mock('../../../stores/ResourceStore', () => jest.fn(
     (resourceKey, itemId) => {
@@ -58,361 +82,346 @@ jest.mock('../../../containers/Form/stores/MemoryFormStore',
     })
 );
 
+function renderFormOverlay(props: Object = {}) {
+    return render(
+        <FormOverlay
+            confirmText="confirm-text"
+            formStore={new MemoryFormStore({}, {}, undefined, undefined)}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+            title="overlay-title"
+            {...(props: any)}
+        />
+    );
+}
+
+// a stand-in for a registered form toolbar action, driven through its rendered toolbar button
+function createToolbarAction(label: string, onClick: () => void) {
+    return {
+        destroy: jest.fn(),
+        getNode: jest.fn(() => null),
+        getToolbarItemConfig: jest.fn(() => ({label, onClick, type: 'button'})),
+    };
+}
+
 test('Component should render', () => {
-    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+    renderFormOverlay({size: 'small'});
 
-    const formOverlay = mount(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={jest.fn()}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
-
-    expect(formOverlay.render()).toMatchSnapshot();
+    expect(document.body).toMatchSnapshot();
 });
 
-test('Should pass correct props to Overlay component', () => {
-    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
-    formStore.dirty = true;
+test('Should render the title and the confirm button', () => {
+    renderFormOverlay({title: 'my-overlay-title'});
 
-    const closeSpy = jest.fn();
-
-    const formOverlay = shallow(<FormOverlay
-        confirmDisabled={true}
-        confirmLoading={true}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={closeSpy}
-        onConfirm={jest.fn()}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
-
-    const overlay = formOverlay.find(Overlay);
-
-    expect(overlay.props()).toEqual(expect.objectContaining({
-        confirmDisabled: true,
-        confirmLoading: true,
-        confirmText: 'confirm-text',
-        onClose: closeSpy,
-        open: true,
-        size: 'small',
-        title: 'overlay-title',
-    }));
+    expect(screen.getByRole('heading', {name: 'my-overlay-title'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'confirm-text'})).toBeEnabled();
 });
 
-test('Should pass correct props to Overlay component when using default values', () => {
-    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
-    formStore.dirty = true;
+test('Should disable the confirm button when it is configured as disabled', () => {
+    renderFormOverlay({confirmDisabled: true});
 
-    const closeSpy = jest.fn();
-
-    const formOverlay = shallow(<FormOverlay
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={closeSpy}
-        onConfirm={jest.fn()}
-        open={true}
-        title="overlay-title"
-    />);
-
-    const overlay = formOverlay.find(Overlay);
-
-    expect(overlay.props()).toEqual(expect.objectContaining({
-        confirmDisabled: false,
-        confirmLoading: false,
-        confirmText: 'confirm-text',
-        onClose: closeSpy,
-        open: true,
-        size: undefined,
-        title: 'overlay-title',
-    }));
+    expect(screen.getByRole('button', {name: 'confirm-text'})).toBeDisabled();
 });
 
-test('Should pass correct props to Form component', () => {
-    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+test('Should render the form container', () => {
+    renderFormOverlay();
 
-    const formOverlay = shallow(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={jest.fn()}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
-
-    const form = formOverlay.find(Form);
-
-    expect(form.props()).toEqual(expect.objectContaining({
-        store: formStore,
-    }));
+    expect(screen.getByTestId('form-container')).toBeInTheDocument();
+    expect(screen.getByTestId('form-container')).toHaveAttribute('data-router', 'no');
 });
 
-test('Should pass router to Form component', () => {
-    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+test('Should pass the router to the form container', () => {
     const router: Router = ({}: any);
 
-    const formOverlay = shallow(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={jest.fn()}
-        open={true}
-        router={router}
-        size="small"
-        title="overlay-title"
-    />);
+    renderFormOverlay({router});
 
-    expect(formOverlay.find(Form).props()).toEqual(expect.objectContaining({
-        router,
-    }));
+    expect(screen.getByTestId('form-container')).toHaveAttribute('data-router', 'yes');
 });
 
-test('Should display confirm button as loading if FormStore is saving', () => {
+test('Should disable the confirm button while the FormStore is saving', () => {
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
 
-    const formOverlay = shallow(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={jest.fn()}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
-
-    // $FlowFixMe
-    formStore.saving = false;
-    expect(formOverlay.find(Overlay).props().confirmLoading).toEqual(false);
+    const {rerender} = renderFormOverlay({formStore});
+    expect(screen.getByRole('button', {name: 'confirm-text'})).toBeEnabled();
 
     // $FlowFixMe
     formStore.saving = true;
-    expect(formOverlay.find(Overlay).props().confirmLoading).toEqual(true);
+    rerender(
+        <FormOverlay
+            confirmText="confirm-text"
+            formStore={formStore}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            open={true}
+            title="overlay-title"
+        />
+    );
+
+    expect(screen.getByRole('button', {name: 'confirm-text'})).toBeDisabled();
 });
 
-test('Should submit Form container when Overlay is confirmed', () => {
-    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+test('Should submit the form when the overlay is confirmed', async() => {
+    const user = userEvent.setup();
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+    formStore.save.mockReturnValue(Promise.resolve());
 
-    const formOverlay = mount(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={jest.fn()}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
+    renderFormOverlay({formStore});
 
-    const submitSpy = jest.fn();
-    formOverlay.find(Form).instance().submit = submitSpy;
+    await user.click(screen.getByRole('button', {name: 'confirm-text'}));
 
-    formOverlay.find(Overlay).props().onConfirm();
-
-    expect(submitSpy).toHaveBeenCalled();
+    expect(formStore.save).toHaveBeenCalled();
 });
 
-test('Should save ResourceFormStore and call onConfirm callback on submit of Form', () => {
+test('Should save ResourceFormStore and call onConfirm callback on submit of Form', async() => {
+    const user = userEvent.setup();
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
     const confirmSpy = jest.fn();
+    formStore.save.mockReturnValue(Promise.resolve());
 
-    const formOverlay = shallow(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={confirmSpy}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
+    renderFormOverlay({formStore, onConfirm: confirmSpy});
 
-    const savePromise = Promise.resolve();
-    formStore.save.mockReturnValueOnce(savePromise);
+    await user.click(screen.getByRole('button', {name: 'trigger submit'}));
 
-    formOverlay.find(Form).props().onSubmit();
-
-    return savePromise.finally(() => {
-        expect(formStore.save).toHaveBeenCalled();
-        expect(confirmSpy).toHaveBeenCalled();
-    });
+    expect(formStore.save).toHaveBeenCalled();
+    expect(confirmSpy).toHaveBeenCalled();
 });
 
-test('Should call onConfirm callback directly in case of MemoryFormStore on submit of Form', () => {
-    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+test('Should call onConfirm callback directly in case of MemoryFormStore on submit of Form', async() => {
+    const user = userEvent.setup();
     const confirmSpy = jest.fn();
 
-    const formOverlay = shallow(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={confirmSpy}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
+    renderFormOverlay({onConfirm: confirmSpy});
 
-    formOverlay.find(Form).props().onSubmit();
+    await user.click(screen.getByRole('button', {name: 'trigger submit'}));
 
     expect(confirmSpy).toHaveBeenCalled();
 });
 
-test('Should display Snackbar with generic message if an error happens while saving ResourceFormStore', (done) => {
+test('Should display Snackbar with generic message if an error happens while saving ResourceFormStore', async() => {
+    const user = userEvent.setup();
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
     const confirmSpy = jest.fn();
+    formStore.save.mockReturnValue(Promise.reject('error'));
 
-    const formOverlay = mount(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={confirmSpy}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
+    renderFormOverlay({formStore, onConfirm: confirmSpy});
 
-    const savePromise = Promise.reject('error');
-    formStore.save.mockReturnValueOnce(savePromise);
+    await user.click(screen.getByRole('button', {name: 'trigger submit'}));
 
-    formOverlay.find(Form).props().onSubmit();
+    expect(await screen.findByText(/sulu_admin.form_save_server_error/)).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /sulu_admin.error/i})).toBeInTheDocument();
+    expect(confirmSpy).not.toHaveBeenCalled();
+});
 
-    // wait until rejection of savePromise was handled by component with setTimeout
-    setTimeout(() => {
-        expect(formStore.save).toHaveBeenCalled();
-        expect(confirmSpy).not.toHaveBeenCalled();
+test('Should display Snackbar with message from server if an error happens while saving ResourceFormStore', async() => {
+    const user = userEvent.setup();
+    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
+    const confirmSpy = jest.fn();
+    formStore.save.mockReturnValue(
+        Promise.reject({code: 100, detail: 'URL is already assigned to another page.'})
+    );
 
-        formOverlay.update();
-        expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
-        expect(formOverlay.find(Snackbar).prop('message')).toEqual('sulu_admin.form_save_server_error');
+    renderFormOverlay({formStore, onConfirm: confirmSpy});
 
-        done();
+    await user.click(screen.getByRole('button', {name: 'trigger submit'}));
+
+    expect(await screen.findByText(/URL is already assigned to another page/)).toBeInTheDocument();
+    expect(confirmSpy).not.toHaveBeenCalled();
+});
+
+test('Should display Snackbar if a form is not valid', async() => {
+    const user = userEvent.setup();
+
+    renderFormOverlay();
+
+    await user.click(screen.getByRole('button', {name: 'trigger error'}));
+
+    expect(screen.getByText(/sulu_admin.form_contains_invalid_values/)).toBeInTheDocument();
+});
+
+test('Should hide Snackbar when closeClick callback of Snackbar is fired', async() => {
+    const user = userEvent.setup();
+
+    renderFormOverlay();
+
+    await user.click(screen.getByRole('button', {name: 'trigger error'}));
+    expect(screen.getByText(/sulu_admin.form_contains_invalid_values/)).toBeInTheDocument();
+
+    const errorSnackbar = screen.getByRole('button', {name: /sulu_admin.error/i});
+    await user.click(within(errorSnackbar).getByRole('button', {name: 'su-times'}));
+
+    // the snackbar keeps its message until it has transitioned out, which jsdom does not do on its own
+    fireEvent.transitionEnd(errorSnackbar);
+
+    expect(screen.queryByText(/sulu_admin.form_contains_invalid_values/)).not.toBeInTheDocument();
+});
+
+test('Should clear old errors if Overlay is opened a second time', async() => {
+    const user = userEvent.setup();
+    const formStore = new MemoryFormStore({}, {}, undefined, undefined);
+    const props = {
+        confirmText: 'confirm-text',
+        formStore,
+        onClose: jest.fn(),
+        onConfirm: jest.fn(),
+        title: 'overlay-title',
+    };
+
+    const {rerender} = render(<FormOverlay {...props} open={true} />);
+
+    await user.click(screen.getByRole('button', {name: 'trigger error'}));
+    expect(screen.getByText(/sulu_admin.form_contains_invalid_values/)).toBeInTheDocument();
+
+    rerender(<FormOverlay {...props} open={false} />);
+    rerender(<FormOverlay {...props} open={true} />);
+    fireEvent.transitionEnd(screen.getByRole('button', {name: /sulu_admin.error/i}));
+
+    expect(screen.queryByText(/sulu_admin.form_contains_invalid_values/)).not.toBeInTheDocument();
+});
+
+test('Should render a toolbar and hide the footer confirm when toolbar actions are given', () => {
+    const action = createToolbarAction('Save', jest.fn());
+
+    renderFormOverlay({
+        toolbarActionsProvider: () => [action],
+        toolbarStoreKey: 'form-overlay-toolbar-test',
     });
+
+    expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'confirm-text'})).not.toBeInTheDocument();
 });
 
-test('Should display Snackbar with message from server if an error happens while saving ResourceFormStore', (done) => {
-    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
-    const confirmSpy = jest.fn();
+test('Should keep the footer confirm and render no toolbar without toolbar actions', () => {
+    renderFormOverlay();
 
-    const formOverlay = mount(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={confirmSpy}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
+    expect(screen.getByRole('button', {name: 'confirm-text'})).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument();
+});
 
-    const savePromise = Promise.reject({code: 100, detail: 'URL is already assigned to another page.'});
-    formStore.save.mockReturnValueOnce(savePromise);
-
-    formOverlay.find(Form).props().onSubmit();
-
-    // wait until rejection of savePromise was handled by component with setTimeout
-    setTimeout(() => {
-        expect(formStore.save).toHaveBeenCalled();
-        expect(confirmSpy).not.toHaveBeenCalled();
-
-        formOverlay.update();
-        expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
-        expect(formOverlay.find(Snackbar).prop('message')).toEqual('URL is already assigned to another page.');
-
-        done();
+test('Should mount with toolbar actions while the overlay is still closed', () => {
+    renderFormOverlay({
+        open: false,
+        toolbarActionsProvider: () => [],
+        toolbarStoreKey: 'form-overlay-closed-test',
     });
+
+    expect(screen.queryByRole('heading', {name: 'overlay-title'})).not.toBeInTheDocument();
 });
 
-test('Should display Snackbar if a form is not valid', () => {
+test('Should show a success snackbar instead of confirming when toolbar actions are given', async() => {
+    const user = userEvent.setup();
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
     const confirmSpy = jest.fn();
+    formStore.save.mockReturnValue(Promise.resolve());
 
-    const formOverlay = mount(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={confirmSpy}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
+    renderFormOverlay({
+        formStore,
+        onConfirm: confirmSpy,
+        toolbarActionsProvider: (form) => [createToolbarAction('Save', () => form.submit())],
+        toolbarStoreKey: 'form-overlay-save-test',
+    });
 
-    formOverlay.find(Form).props().onError();
-    formOverlay.update();
+    await user.click(screen.getByRole('button', {name: 'Save'}));
 
-    expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
-    expect(formOverlay.find(Snackbar).prop('message')).toEqual('sulu_admin.form_contains_invalid_values');
+    expect(await screen.findByRole('button', {name: /sulu_admin.success/i})).toBeInTheDocument();
+    expect(confirmSpy).not.toHaveBeenCalled();
 });
 
-test('Should hide Snackbar when closeClick callback of Snackbar is fired', () => {
-    const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
-    const confirmSpy = jest.fn();
+test('Should let a pending error take precedence over a success message', async() => {
+    const user = userEvent.setup();
 
-    const formOverlay = mount(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={confirmSpy}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
+    renderFormOverlay({
+        toolbarActionsProvider: (form) => [
+            createToolbarAction('Succeed', () => form.showSuccessSnackbar()),
+            createToolbarAction('Fail', () => { form.errors.push('Boom'); }),
+        ],
+        toolbarStoreKey: 'form-overlay-precedence-test',
+    });
 
-    formOverlay.find(Form).props().onError();
-    formOverlay.update();
-    expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
+    await user.click(screen.getByRole('button', {name: 'Succeed'}));
+    expect(screen.getByRole('button', {name: /sulu_admin.success/i})).toBeInTheDocument();
 
-    formOverlay.find(Snackbar).props().onCloseClick();
-    formOverlay.update();
-    expect(formOverlay.find(Snackbar).props().visible).toBeFalsy();
+    await user.click(screen.getByRole('button', {name: 'Fail'}));
+
+    expect(screen.getByText(/Boom/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /sulu_admin.success/i})).not.toBeInTheDocument();
 });
 
-test('Should clear old errors if Overlay is opened a second time', () => {
+test('Should pass submit options through to the form store save', async() => {
+    const user = userEvent.setup();
     const formStore = new ResourceFormStore(new ResourceStore('test'), 'test');
-    const confirmSpy = jest.fn();
+    formStore.save.mockReturnValue(Promise.resolve());
 
-    const formOverlay = mount(<FormOverlay
-        confirmDisabled={false}
-        confirmLoading={false}
-        confirmText="confirm-text"
-        formStore={formStore}
-        onClose={jest.fn()}
-        onConfirm={confirmSpy}
-        open={true}
-        size="small"
-        title="overlay-title"
-    />);
+    renderFormOverlay({
+        formStore,
+        toolbarActionsProvider: (form) => [
+            createToolbarAction('Publish', () => form.submit({action: 'publish'})),
+        ],
+        toolbarStoreKey: 'form-overlay-options-test',
+    });
 
-    formOverlay.find(Form).props().onError();
-    formOverlay.update();
-    expect(formOverlay.find(Snackbar).prop('visible')).toBeTruthy();
+    await user.click(screen.getByRole('button', {name: 'Publish'}));
 
-    formOverlay.setProps({open: false});
-    formOverlay.setProps({open: true});
-    formOverlay.update();
+    expect(formStore.save).toHaveBeenCalledWith({action: 'publish'});
+});
 
-    expect(formOverlay.find(Snackbar).props().visible).toBeFalsy();
+test('Should render the message of an error pushed as an object by a toolbar action', async() => {
+    const user = userEvent.setup();
+
+    renderFormOverlay({
+        toolbarActionsProvider: (form) => [
+            createToolbarAction('Fail', () => {
+                form.errors.push({message: 'Limit reached', title: 'Account limit'});
+            }),
+        ],
+        toolbarStoreKey: 'form-overlay-object-error-test',
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Fail'}));
+
+    expect(screen.getByText(/Limit reached/)).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /sulu_admin.error/i})).toBeInTheDocument();
+});
+
+test('Should show a warning pushed by a toolbar action when no error is pending', async() => {
+    const user = userEvent.setup();
+
+    renderFormOverlay({
+        toolbarActionsProvider: (form) => [
+            createToolbarAction('Warn', () => {
+                form.warnings.push({message: 'Request failed', title: 'Try again'});
+            }),
+            createToolbarAction('Fail', () => { form.errors.push('Boom'); }),
+        ],
+        toolbarStoreKey: 'form-overlay-warning-test',
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Warn'}));
+    expect(screen.getByText(/Request failed/)).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /sulu_admin.warning/i})).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: 'Fail'}));
+
+    expect(screen.getByText(/Boom/)).toBeInTheDocument();
+    expect(screen.queryByText(/Request failed/)).not.toBeInTheDocument();
+});
+
+test('Should dismiss the success snackbar when its close button is clicked', async() => {
+    const user = userEvent.setup();
+
+    renderFormOverlay({
+        toolbarActionsProvider: (form) => [
+            createToolbarAction('Succeed', () => form.showSuccessSnackbar()),
+        ],
+        toolbarStoreKey: 'form-overlay-dismiss-test',
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Succeed'}));
+    expect(screen.getByRole('button', {name: /sulu_admin.success/i})).toBeInTheDocument();
+
+    const successSnackbar = screen.getByRole('button', {name: /sulu_admin.success/i});
+    await user.click(within(successSnackbar).getByRole('button', {name: 'su-times'}));
+    fireEvent.transitionEnd(successSnackbar);
+
+    expect(screen.queryByRole('button', {name: /sulu_admin.success/i})).not.toBeInTheDocument();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/__snapshots__/FormOverlay.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/FormOverlay/tests/__snapshots__/FormOverlay.test.js.snap
@@ -1,88 +1,105 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Component should render 1`] = `
-Array [
-  <div
-    class="backdrop visible fixed"
-    data-testid="backdrop"
-    role="button"
-  />,
-  <div
-    class="container isDown"
-  >
+<body>
+  <div />
+  <div>
     <div
-      class="overlay small"
+      class="backdrop visible fixed"
+      data-testid="backdrop"
+      role="button"
+    />
+    <div
+      class="container isDown"
     >
-      <section
-        class="content"
+      <div
+        class="overlay small"
       >
-        <header
-          class="header"
+        <section
+          class="content"
         >
-          <h2>
-            overlay-title
-          </h2>
-          <span
-            aria-label="su-times"
-            class="su-times clickable icon"
-            role="button"
-            tabindex="0"
-          />
-        </header>
-        <article
-          class="article"
-        >
-          <div
-            class="form"
+          <header
+            class="header"
           >
-            <div>
-              form container mock
-            </div>
-          </div>
-        </article>
-        <footer
-          class="footer"
-        >
-          <button
-            class="button primary hasText"
-            type="button"
-          >
-            <span
-              class="buttonText"
-            >
-              confirm-text
-            </span>
-          </button>
-        </footer>
-        <div
-          class="snackbar"
-        >
-          <div
-            class="snackbar error"
-            role="button"
-          >
-            <span
-              aria-label="su-exclamation-triangle"
-              class="su-exclamation-triangle icon"
-            />
-            <div
-              class="text"
-            >
-              <strong>
-                sulu_admin.error
-              </strong>
-               - 
-            </div>
+            <h2>
+              overlay-title
+            </h2>
             <span
               aria-label="su-times"
-              class="su-times clickable closeIcon"
+              class="su-times clickable icon"
               role="button"
               tabindex="0"
             />
+          </header>
+          <article
+            class="article"
+          >
+            <div
+              class="form"
+            >
+              <div
+                data-router="no"
+                data-testid="form-container"
+              >
+                form container mock
+                <button
+                  type="button"
+                >
+                  trigger submit
+                </button>
+                <button
+                  type="button"
+                >
+                  trigger error
+                </button>
+              </div>
+            </div>
+          </article>
+          <footer
+            class="footer"
+          >
+            <button
+              class="button primary hasText"
+              type="button"
+            >
+              <span
+                class="buttonText"
+              >
+                confirm-text
+              </span>
+            </button>
+          </footer>
+          <div
+            class="snackbar"
+          >
+            <div
+              class="snackbar error"
+              role="button"
+            >
+              <span
+                aria-label="su-exclamation-triangle"
+                class="su-exclamation-triangle icon"
+              />
+              <div
+                class="text"
+              >
+                <strong>
+                  sulu_admin.error
+                </strong>
+                 - 
+                
+              </div>
+              <span
+                aria-label="su-times"
+                class="su-times clickable closeIcon"
+                role="button"
+                tabindex="0"
+              />
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
-  </div>,
-]
+  </div>
+</body>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/Toolbar.js
@@ -41,6 +41,7 @@ function getItemComponentByType(itemConfig, key) {
 class Toolbar extends React.Component<ToolbarProps> {
     static defaultProps = {
         navigationOpen: false,
+        showSnackbars: true,
     };
 
     toolbarStore: ToolbarStore;
@@ -101,7 +102,7 @@ class Toolbar extends React.Component<ToolbarProps> {
     }
 
     render() {
-        const {onNavigationButtonClick, navigationOpen} = this.props;
+        const {onNavigationButtonClick, navigationOpen, showSnackbars} = this.props;
         const {errors, showSuccess, warnings} = this.toolbarStore;
         const lastError = errors[errors.length - 1];
         const lastWarning = warnings[warnings.length - 1];
@@ -112,22 +113,22 @@ class Toolbar extends React.Component<ToolbarProps> {
 
         return (
             <Fragment>
-                <Snackbar
+                {showSnackbars && <Snackbar
                     actions={typeof lastError === 'object' ? lastError.actions : undefined}
                     message={typeof lastError === 'object' ? lastError.message : lastError}
                     onCloseClick={this.handleErrorSnackbarCloseClick}
                     title={typeof lastError === 'object' ? lastError.title : undefined}
                     type="error"
                     visible={errors.length > 0}
-                />
-                <Snackbar
+                />}
+                {showSnackbars && <Snackbar
                     actions={typeof lastWarning === 'object' ? lastWarning.actions : undefined}
                     message={typeof lastWarning === 'object' ? lastWarning.message : lastWarning}
                     onCloseClick={this.toolbarStore.config?.onWarningCloseClick}
                     title={typeof lastWarning === 'object' ? lastWarning.title : undefined}
                     type="warning"
                     visible={warnings.length > 0}
-                />
+                />}
                 <ToolbarComponent>
                     <ToolbarComponent.Controls grow={true}>
                         {!!onNavigationButtonClick &&

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/stores/ToolbarStore.js
@@ -4,7 +4,7 @@ import log from 'loglevel';
 import type {Node} from 'react';
 import type {Button, Select, ToolbarConfig, ToolbarItemConfig} from '../types';
 
-const SHOW_SUCCESS_DURATION = 1500;
+export const SHOW_SUCCESS_DURATION = 1500;
 
 export default class ToolbarStore {
     @observable config: ToolbarConfig = {};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Toolbar/types.js
@@ -26,9 +26,28 @@ export type TogglerItemConfig = {|
 |};
 export type ToolbarItemConfig<T> = ButtonItemConfig | DropdownItemConfig | SelectItemConfig<T> | TogglerItemConfig;
 
+export type OverlayToolbarAction = {
+    +destroy: () => void,
+    +getNode: (index?: number) => Node,
+    +getToolbarItemConfig: () => ?ToolbarItemConfig<*>,
+};
+
+/**
+ * The "form" a toolbar action calls back into. Implemented by the "Form" view and by the
+ * FormOverlay container, which is why it is an interface instead of the view class.
+ */
+export interface ToolbarActionFormInterface {
+    errors: Array<ToolbarErrorType>,
+    +showSuccessSnackbar: () => void,
+    +submit: (options?: Object) => void,
+    warnings: Array<ToolbarErrorType>,
+}
+
 export type ToolbarProps = {
     navigationOpen?: boolean,
     onNavigationButtonClick?: () => void,
+    /* an overlay renders its own snackbar, the toolbar store is not written to there */
+    showSnackbars: boolean,
     storeKey?: string,
 };
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/index.js
@@ -19,6 +19,8 @@ import UpdateFormStoreToolbarAction from './toolbarActions/UpdateFormStoreToolba
 
 export default Form;
 
+export type {ToolbarActionFormInterface} from '../../containers/Toolbar/types';
+
 export {
     formToolbarActionRegistry,
     AbstractFormToolbarAction,

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/Form/toolbarActions/AbstractFormToolbarAction.js
@@ -3,14 +3,13 @@ import {computed, toJS} from 'mobx';
 import ResourceStore from '../../../stores/ResourceStore';
 import {ResourceFormStore, FormInspector, conditionDataProviderRegistry} from '../../../containers/Form';
 import Router from '../../../services/Router';
-import Form from '../Form';
-import type {ToolbarItemConfig} from '../../../containers/Toolbar/types';
+import type {ToolbarActionFormInterface, ToolbarItemConfig} from '../../../containers/Toolbar/types';
 import type {Node} from 'react';
 
 export default class AbstractFormToolbarAction {
     resourceFormStore: ResourceFormStore;
     formInspector: FormInspector;
-    form: Form;
+    form: ToolbarActionFormInterface;
     router: Router;
     locales: ?Array<string>;
     options: {[key: string]: mixed};
@@ -30,7 +29,7 @@ export default class AbstractFormToolbarAction {
 
     constructor(
         resourceFormStore: ResourceFormStore,
-        form: Form,
+        form: ToolbarActionFormInterface,
         router: Router,
         locales: ?Array<string>,
         options: {[key: string]: mixed},

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/FormOverlayList.js
@@ -7,6 +7,8 @@ import {ResourceFormStore, resourceFormStoreFactory} from '../../containers/Form
 import FormOverlay from '../../containers/FormOverlay';
 import ResourceStore from '../../stores/ResourceStore';
 import List from '../List';
+import formToolbarActionRegistry from '../Form/registries/formToolbarActionRegistry';
+import type {ToolbarActionFormInterface, OverlayToolbarAction} from '../../containers/Toolbar/types';
 import type {ViewProps} from '../../containers/ViewRenderer';
 import type {IObservableValue} from 'mobx/lib/mobx';
 import type {ElementRef} from 'react';
@@ -14,6 +16,9 @@ import type {ElementRef} from 'react';
 type Props = ViewProps & {
     resourceStore?: ResourceStore,
 };
+
+// These navigate the router, which would move the application behind the overlay.
+const UNSUPPORTED_OVERLAY_TOOLBAR_ACTIONS = ['sulu_admin.copy', 'sulu_admin.delete'];
 
 @observer
 class FormOverlayList extends React.Component<Props> {
@@ -41,6 +46,65 @@ class FormOverlayList extends React.Component<Props> {
 
     handleFormOverlayClose = () => {
         this.destroyFormStore();
+
+        // The overlay toolbar saves without closing, so the list can be out of date by then.
+        if (this.overlayToolbarActions.length > 0 && this.listRef) {
+            this.listRef.reload();
+        }
+    };
+
+    get overlayToolbarActions(): Array<Object> {
+        const {
+            router: {
+                route: {
+                    options: {
+                        overlayToolbarActions = [],
+                    },
+                },
+            },
+        } = this.props;
+
+        return toJS(overlayToolbarActions);
+    }
+
+    componentDidMount() {
+        this.overlayToolbarActions.forEach((toolbarAction) => {
+            if (UNSUPPORTED_OVERLAY_TOOLBAR_ACTIONS.includes(toolbarAction.type)) {
+                throw new Error(
+                    'The toolbar action "' + toolbarAction.type + '" cannot be used in an overlay!'
+                );
+            }
+        });
+    }
+
+    buildToolbarActionsProvider = (formStore: ResourceFormStore) => {
+        const {
+            router,
+            router: {
+                route: {
+                    options: {
+                        locales,
+                    },
+                },
+            },
+        } = this.props;
+
+        const overlayToolbarActions = this.overlayToolbarActions;
+
+        if (overlayToolbarActions.length === 0) {
+            return undefined;
+        }
+
+        return (form: ToolbarActionFormInterface): Array<OverlayToolbarAction> => overlayToolbarActions.map(
+            (toolbarAction) => new (formToolbarActionRegistry.get(toolbarAction.type))(
+                formStore,
+                form,
+                router,
+                locales,
+                toolbarAction.options,
+                formStore.resourceStore
+            )
+        );
     };
 
     @action createFormOverlay = (itemId: ?string | number) => {
@@ -197,6 +261,8 @@ class FormOverlayList extends React.Component<Props> {
                         router={this.props.router}
                         size={overlaySize ? overlaySize : 'small'}
                         title={overlayTitle}
+                        toolbarActionsProvider={this.buildToolbarActionsProvider(formStore)}
+                        toolbarStoreKey={'form_overlay_' + this.props.router.route.name}
                     />
                 )}
             </Fragment>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/FormOverlayList.test.js
@@ -1,23 +1,41 @@
 // @flow
 import mockReact from 'react';
-import {mount} from 'enzyme';
+import {render, screen, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {observable} from 'mobx';
 import FormOverlayList from '../FormOverlayList';
-import List from '../../List';
 import ResourceStore from '../../../stores/ResourceStore';
 import ResourceFormStore from '../../../containers/Form/stores/ResourceFormStore';
-import FormOverlay from '../../../containers/FormOverlay';
-import Router, {Route} from '../../../services/Router';
+import Router from '../../../services/Router';
+import formToolbarActionRegistry from '../../Form/registries/formToolbarActionRegistry';
 
 const React = mockReact;
 
+const mockListReload = jest.fn();
+
+// the mock exposes the list callbacks as buttons, so a test can reach them by clicking
 jest.mock('../../List', () => class ListMock extends mockReact.Component<*> {
+    reload = mockListReload;
+
+    handleItemAdd = () => this.props.onItemAdd && this.props.onItemAdd();
+
+    handleItemClick = () => this.props.onItemClick && this.props.onItemClick('item-id');
+
     render() {
-        return <div>list view mock</div>;
+        return (
+            <div data-testid="list">
+                list view mock
+                <button onClick={this.handleItemAdd} type="button">add item</button>
+                <button onClick={this.handleItemClick} type="button">click item</button>
+            </div>
+        );
     }
 });
 
 jest.mock('../../../containers/Form/Form', () => class FormMock extends mockReact.Component<*> {
+    // the overlay submits through this ref, the real Form turns that into an onSubmit call
+    submit = jest.fn((options) => this.props.onSubmit(options));
+
     render() {
         return <div>form container mock</div>;
     }
@@ -26,6 +44,22 @@ jest.mock('../../../containers/Form/Form', () => class FormMock extends mockReac
 jest.mock('../../../utils/Translator', () => ({
     translate: jest.fn((key) => key),
 }));
+
+jest.mock('../../../services/initializer', () => ({
+    initializedTranslationsLocale: true,
+}));
+
+jest.mock('debounce', () => jest.fn((callback) => callback));
+
+beforeEach(() => {
+    mockListReload.mockClear();
+
+    // The overlay toolbar renders the real Toolbar, whose Items component observes its size.
+    window.ResizeObserver = jest.fn(function() {
+        this.observe = jest.fn();
+        this.disconnect = jest.fn();
+    });
+});
 
 jest.mock('../../../stores/ResourceStore', () => jest.fn(
     (resourceKey, itemId) => {
@@ -37,80 +71,79 @@ jest.mock('../../../stores/ResourceStore', () => jest.fn(
 jest.mock('../../../containers/Form/stores/ResourceFormStore', () => jest.fn(
     (resourceStore, formKey, options, metadataOptions) => {
         return {
+            destroy: jest.fn(),
+            // the overlay disables its confirm button for a pristine form
+            dirty: true,
             id: resourceStore.id,
             metadataOptions,
+            // Read by the toolbar action provider as parentResourceStore.
+            resourceStore,
         };
     }
 ));
 
+function createRouter(options: Object) {
+    return ({route: {options}}: any);
+}
+
+// the form store the component created, so a test can assert on its destroy without reaching inside
+function lastFormStore() {
+    const results = (ResourceFormStore: any).mock.results;
+
+    return results[results.length - 1].value;
+}
+
+// the overlay header close icon, told apart from the snackbar close icon that shares its label
+function overlayCloseButton() {
+    const header: any = document.querySelector('.header');
+
+    return within(header).getByRole('button', {name: 'su-times'});
+}
+
+function createToolbarActionClass() {
+    return jest.fn(function() {
+        this.destroy = jest.fn();
+        this.getNode = jest.fn(() => null);
+        this.getToolbarItemConfig = jest.fn(() => ({label: 'Save', onClick: jest.fn(), type: 'button'}));
+    });
+}
+
 test('View should render with closed overlay', () => {
-    const route: Route = ({}: any);
-    const router: Router = ({
-        route: {
-            options: {},
-        },
-    }: any);
+    render(<FormOverlayList route={({}: any)} router={createRouter({})} />);
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
-
-    expect(formOverlayList.render()).toMatchSnapshot();
+    expect(document.body).toMatchSnapshot();
 });
 
-test('View should render with opened overlay', () => {
-    const route: Route = ({}: any);
-    const router: Router = ({
-        route: {
-            options: {
-                addOverlayTitle: 'app.add_overlay_title',
-                formKey: 'test-form-key',
-            },
-        },
-    }: any);
+test('View should render with opened overlay', async() => {
+    const user = userEvent.setup();
+    const router: Router = createRouter({
+        addOverlayTitle: 'app.add_overlay_title',
+        formKey: 'test-form-key',
+    });
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
+    render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'add item'}));
 
-    // open form overlay for new item
-    formOverlayList.find(List).props().onItemAdd();
-    formOverlayList.update();
-
-    expect(formOverlayList.render()).toMatchSnapshot();
+    expect(document.body).toMatchSnapshot();
 });
 
-test('Should pass correct props to List view', () => {
-    const route: Route = ({}: any);
-    const router: Router = ({
-        attributes: {
-            id: 'test-id',
-            category: 'category-id',
-        },
-        route: {
-            options: {
-                adapters: ['table'],
-                addRoute: 'addRoute',
-                listKey: 'test-list-key',
-                formKey: 'test-form-key',
-                addOverlayTitle: 'app.add_overlay_title',
-                editOverlayTitle: 'app.edit_overlay_title',
-                overlaySize: 'large',
-                resourceKey: 'test-resource-key',
-                toolbarActions: ['sulu_admin.add'],
-                routerAttributesToListRequest: {'0': 'category', 'id': 'parentId'},
-                routerAttributesToFormRequest: {'0': 'category', 'id': 'parentId'},
-            },
-        },
-    }: any);
+test('Should render the List view with its callbacks connected', () => {
+    const router: Router = createRouter({
+        adapters: ['table'],
+        formKey: 'test-form-key',
+        listKey: 'test-list-key',
+        resourceKey: 'test-resource-key',
+    });
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
-    const list = formOverlayList.find(List);
+    render(<FormOverlayList route={({}: any)} router={router} />);
 
-    expect(list.props()).toEqual(expect.objectContaining(formOverlayList.props()));
-    expect(list.props().locale).toBeDefined();
-    expect(list.props().onItemAdd).toBeDefined();
-    expect(list.props().onItemClick).toBeDefined();
+    expect(screen.getByTestId('list')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'add item'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'click item'})).toBeInTheDocument();
 });
 
-test('Should construct ResourceStore and ResourceFormStore with correct parameters on item-add callback', () => {
-    const route: Route = ({}: any);
+test('Should construct ResourceStore and ResourceFormStore with correct parameters on item-add callback', async() => {
+    const user = userEvent.setup();
     const router: Router = ({
         attributes: {
             id: 'test-id',
@@ -132,8 +165,8 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
         dimension: 'test-dimension',
     };
 
-    const formOverlayList = mount(<FormOverlayList resourceStore={testResourceStore} route={route} router={router} />);
-    formOverlayList.find(List).props().onItemAdd();
+    render(<FormOverlayList resourceStore={testResourceStore} route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'add item'}));
 
     expect(ResourceStore).toHaveBeenCalledWith('test-resource-key', undefined, {}, {
         category: 'category-id',
@@ -149,8 +182,8 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
     }, {});
 });
 
-test('Should construct ResourceStore and ResourceFormStore with correct parameters on item-click callback', () => {
-    const route: Route = ({}: any);
+test('Should construct ResourceStore and ResourceFormStore with correct parameters on item-click callback', async() => {
+    const user = userEvent.setup();
     const router: Router = ({
         attributes: {
             id: 'test-id',
@@ -172,29 +205,27 @@ test('Should construct ResourceStore and ResourceFormStore with correct paramete
         dimension: 'test-dimension',
     };
 
-    const formOverlayList = mount(<FormOverlayList resourceStore={testResourceStore} route={route} router={router} />);
-
     const locale = observable.box('en');
-    formOverlayList.instance().locale = locale;
+    render(
+        <FormOverlayList
+            locale={locale}
+            resourceStore={testResourceStore}
+            route={({}: any)}
+            router={router}
+        />
+    );
+    await user.click(screen.getByRole('button', {name: 'click item'}));
 
-    formOverlayList.find(List).props().onItemClick('item-id');
-
-    expect(ResourceStore).toHaveBeenCalledWith('test-resource-key', 'item-id', {locale}, {
+    expect(ResourceStore).toHaveBeenCalledWith('test-resource-key', 'item-id', {}, {
         category: 'category-id',
         parentId: 'test-id',
         webspace: 'test-webspace',
         dimensionId: 'test-dimension',
     });
-    expect(ResourceFormStore).toHaveBeenCalledWith(expect.anything(), 'test-form-key', {
-        category: 'category-id',
-        parentId: 'test-id',
-        webspace: 'test-webspace',
-        dimensionId: 'test-dimension',
-    }, {});
 });
 
-test('Should construct ResourceFormStore with correct metadataOptions on item-add callback', () => {
-    const route: Route = ({}: any);
+test('Should construct ResourceFormStore with correct metadataOptions on item-add callback', async() => {
+    const user = userEvent.setup();
     const router: Router = ({
         attributes: {
             id: 'test-id',
@@ -205,151 +236,197 @@ test('Should construct ResourceFormStore with correct metadataOptions on item-ad
             options: {
                 formKey: 'test-form-key',
                 resourceKey: 'test-resource-key',
-                metadataRequestParameters: {'staticParam': 'staticValue'},
-                routerAttributesToFormMetadata: {'0': 'webspace', 'template': 'pageTemplate'},
+                metadataRequestParameters: {'test-parameter': 'test-value'},
+                routerAttributesToFormMetadata: {'0': 'webspace', 'template': 'formTemplate'},
             },
         },
     }: any);
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
-
-    formOverlayList.instance().locale = observable.box('en');
-    formOverlayList.find(List).props().onItemAdd();
+    render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'add item'}));
 
     expect(ResourceFormStore).toHaveBeenCalledWith(expect.anything(), 'test-form-key', {}, {
-        staticParam: 'staticValue',
+        'test-parameter': 'test-value',
         webspace: 'webspace-attribute-value',
-        pageTemplate: 'template-attribute-value',
+        formTemplate: 'template-attribute-value',
     });
 });
 
-test('Should open FormOverlay with correct props when List fires the item-add callback', () => {
-    const route: Route = ({}: any);
-    const router: Router = ({
-        route: {
-            options: {
-                formKey: 'test-form-key',
-                addOverlayTitle: 'app.add_overlay_title',
-                overlaySize: 'large',
-            },
-        },
-    }: any);
+test('Should open the overlay with the add title when List fires the item-add callback', async() => {
+    const user = userEvent.setup();
+    const router: Router = createRouter({
+        addOverlayTitle: 'app.add_overlay_title',
+        formKey: 'test-form-key',
+        overlaySize: 'large',
+    });
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
-    formOverlayList.find(List).props().onItemAdd();
+    render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'add item'}));
 
-    formOverlayList.update();
-    const overlay = formOverlayList.find(FormOverlay);
-
-    expect(overlay.props()).toEqual(expect.objectContaining({
-        confirmText: 'sulu_admin.save',
-        formStore: formOverlayList.instance().formStore,
-        open: true,
-        router,
-        size: 'large',
-        title: 'app.add_overlay_title',
-    }));
+    expect(screen.getByRole('heading', {name: 'app.add_overlay_title'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'sulu_admin.save'})).toBeInTheDocument();
+    expect(document.querySelector('.overlay')).toHaveClass('large');
 });
 
-test('Should open FormOverlay with correct props when List fires the item-click callback', () => {
-    const route: Route = ({}: any);
-    const router: Router = ({
-        route: {
-            options: {
-                formKey: 'test-form-key',
-                editOverlayTitle: 'app.edit_overlay_title',
-            },
-        },
-    }: any);
+test('Should open the overlay with the edit title when List fires the item-click callback', async() => {
+    const user = userEvent.setup();
+    const router: Router = createRouter({
+        editOverlayTitle: 'app.edit_overlay_title',
+        formKey: 'test-form-key',
+    });
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
-    formOverlayList.find(List).props().onItemClick('item-id');
+    render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'click item'}));
 
-    formOverlayList.update();
-    const overlay = formOverlayList.find(FormOverlay);
-
-    expect(overlay.props()).toEqual(expect.objectContaining({
-        confirmText: 'sulu_admin.save',
-        formStore: formOverlayList.instance().formStore,
-        open: true,
-        size: 'small',
-        title: 'app.edit_overlay_title',
-    }));
+    expect(screen.getByRole('heading', {name: 'app.edit_overlay_title'})).toBeInTheDocument();
+    expect(document.querySelector('.overlay')).toHaveClass('small');
 });
 
-test('Should destroy ResourceFormStore without reloading List when FormOverlay is closed', () => {
-    const route: Route = ({}: any);
-    const router: Router = ({
-        route: {
-            options: {
-                formKey: 'test-form-key',
-            },
-        },
-    }: any);
+test('Should destroy ResourceFormStore without reloading List when FormOverlay is closed', async() => {
+    const user = userEvent.setup();
+    const router: Router = createRouter({formKey: 'test-form-key'});
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
+    render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'add item'}));
 
-    // open form overlay for new item
-    formOverlayList.find(List).props().onItemAdd();
-    formOverlayList.update();
+    const formStore = lastFormStore();
+    await user.click(overlayCloseButton());
 
-    const destroySpy = jest.fn();
-    formOverlayList.instance().formStore.destroy = destroySpy;
-
-    const reloadSpy = jest.fn();
-    formOverlayList.find(List).instance().reload = reloadSpy;
-
-    formOverlayList.find(FormOverlay).props().onClose();
-    expect(destroySpy).toHaveBeenCalled();
-    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(formStore.destroy).toHaveBeenCalled();
+    expect(mockListReload).not.toHaveBeenCalled();
 });
 
-test('Should destroy ResourceFormStore and reload List view when FormOverlay is confirmed', () => {
-    const route: Route = ({}: any);
-    const router: Router = ({
-        route: {
-            options: {
-                formKey: 'test-form-key',
-            },
-        },
-    }: any);
+test('Should destroy ResourceFormStore and reload List view when FormOverlay is confirmed', async() => {
+    const user = userEvent.setup();
+    const router: Router = createRouter({formKey: 'test-form-key'});
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
+    render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'add item'}));
 
-    // open form overlay for new item
-    formOverlayList.find(List).props().onItemAdd();
-    formOverlayList.update();
+    const formStore = lastFormStore();
+    await user.click(screen.getByRole('button', {name: 'sulu_admin.save'}));
 
-    const destroySpy = jest.fn();
-    formOverlayList.instance().formStore.destroy = destroySpy;
-
-    const reloadSpy = jest.fn();
-    formOverlayList.find(List).instance().reload = reloadSpy;
-
-    formOverlayList.find(FormOverlay).props().onConfirm();
-    expect(destroySpy).toHaveBeenCalled();
-    expect(reloadSpy).toHaveBeenCalled();
+    expect(formStore.destroy).toHaveBeenCalled();
+    expect(mockListReload).toHaveBeenCalled();
 });
 
-test('Should destroy ResourceFormStore when component is unmounted', () => {
-    const route: Route = ({}: any);
-    const router: Router = ({
-        route: {
-            options: {
-                formKey: 'test-form-key',
+test('Should destroy ResourceFormStore when component is unmounted', async() => {
+    const user = userEvent.setup();
+    const router: Router = createRouter({formKey: 'test-form-key'});
+
+    const {unmount} = render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'add item'}));
+
+    const formStore = lastFormStore();
+    unmount();
+
+    expect(formStore.destroy).toHaveBeenCalled();
+});
+
+test('Should resolve overlayToolbarActions from the registry and render them in the overlay', async() => {
+    const user = userEvent.setup();
+    const SaveToolbarAction = createToolbarActionClass();
+    formToolbarActionRegistry.clear();
+    formToolbarActionRegistry.add('sulu_admin.save', (SaveToolbarAction: any));
+
+    try {
+        const router: Router = ({
+            route: {
+                name: 'test-route',
+                options: {
+                    formKey: 'test-form-key',
+                    locales: ['en', 'de'],
+                    overlayToolbarActions: [{options: {}, type: 'sulu_admin.save'}],
+                    resourceKey: 'test-resource-key',
+                },
             },
-        },
-    }: any);
+        }: any);
 
-    const formOverlayList = mount(<FormOverlayList route={route} router={router} />);
+        render(<FormOverlayList route={({}: any)} router={router} />);
+        await user.click(screen.getByRole('button', {name: 'click item'}));
 
-    // open form overlay for new item
-    formOverlayList.find(List).props().onItemAdd();
-    formOverlayList.update();
+        // the toolbar renders the action, and the footer confirm gives way to it
+        expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: 'sulu_admin.save'})).not.toBeInTheDocument();
 
-    const destroySpy = jest.fn();
-    formOverlayList.instance().formStore.destroy = destroySpy;
+        expect(SaveToolbarAction).toHaveBeenCalledTimes(1);
 
-    formOverlayList.unmount();
-    expect(destroySpy).toHaveBeenCalled();
+        const [formStore, form, passedRouter, locales, , parentResourceStore] = SaveToolbarAction.mock.calls[0];
+
+        expect(formStore.id).toEqual(lastFormStore().id);
+        expect(form).toBeDefined();
+        expect(passedRouter).toBe(router);
+        expect(locales).toEqual(['en', 'de']);
+        expect(parentResourceStore).toBeDefined();
+    } finally {
+        formToolbarActionRegistry.clear();
+    }
+});
+
+test('Should reload the list when an overlay with toolbar actions is closed', async() => {
+    const user = userEvent.setup();
+    formToolbarActionRegistry.clear();
+    formToolbarActionRegistry.add('sulu_admin.save', (createToolbarActionClass(): any));
+
+    try {
+        const router: Router = ({
+            route: {
+                name: 'test-route',
+                options: {
+                    formKey: 'test-form-key',
+                    overlayToolbarActions: [{options: {}, type: 'sulu_admin.save'}],
+                    resourceKey: 'test-resource-key',
+                },
+            },
+        }: any);
+
+        render(<FormOverlayList route={({}: any)} router={router} />);
+        await user.click(screen.getByRole('button', {name: 'click item'}));
+        await user.click(overlayCloseButton());
+
+        expect(mockListReload).toHaveBeenCalled();
+    } finally {
+        formToolbarActionRegistry.clear();
+    }
+});
+
+test('Should not reload the list when an overlay without toolbar actions is closed', async() => {
+    const user = userEvent.setup();
+    const router: Router = createRouter({formKey: 'test-form-key', resourceKey: 'test-resource-key'});
+
+    render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'click item'}));
+    await user.click(overlayCloseButton());
+
+    expect(mockListReload).not.toHaveBeenCalled();
+});
+
+test('Should render the footer confirm when no overlayToolbarActions are configured', async() => {
+    const user = userEvent.setup();
+    const router: Router = createRouter({formKey: 'test-form-key', resourceKey: 'test-resource-key'});
+
+    render(<FormOverlayList route={({}: any)} router={router} />);
+    await user.click(screen.getByRole('button', {name: 'click item'}));
+
+    expect(screen.getByRole('button', {name: 'sulu_admin.save'})).toBeInTheDocument();
+});
+
+test('Should throw when sulu_admin.copy is configured as an overlay toolbar action', () => {
+    const router: Router = createRouter({
+        formKey: 'test-form-key',
+        overlayToolbarActions: [{options: {}, type: 'sulu_admin.copy'}],
+        resourceKey: 'test-resource-key',
+    });
+
+    expect(() => render(<FormOverlayList route={({}: any)} router={router} />)).toThrow(/sulu_admin.copy/);
+});
+
+test('Should throw when sulu_admin.delete is configured as an overlay toolbar action', () => {
+    const router: Router = createRouter({
+        formKey: 'test-form-key',
+        overlayToolbarActions: [{options: {}, type: 'sulu_admin.delete'}],
+        resourceKey: 'test-resource-key',
+    });
+
+    expect(() => render(<FormOverlayList route={({}: any)} router={router} />)).toThrow(/sulu_admin.delete/);
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/views/FormOverlayList/tests/__snapshots__/FormOverlayList.test.js.snap
@@ -1,98 +1,130 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`View should render with closed overlay 1`] = `
-<div>
-  list view mock
-</div>
+<body>
+  <div>
+    <div
+      data-testid="list"
+    >
+      list view mock
+      <button
+        type="button"
+      >
+        add item
+      </button>
+      <button
+        type="button"
+      >
+        click item
+      </button>
+    </div>
+  </div>
+</body>
 `;
 
 exports[`View should render with opened overlay 1`] = `
-Array [
+<body>
   <div>
-    list view mock
-  </div>,
-  <div
-    class="backdrop visible fixed"
-    data-testid="backdrop"
-    role="button"
-  />,
-  <div
-    class="container isDown"
-  >
     <div
-      class="overlay small"
+      data-testid="list"
     >
-      <section
-        class="content"
+      list view mock
+      <button
+        type="button"
       >
-        <header
-          class="header"
+        add item
+      </button>
+      <button
+        type="button"
+      >
+        click item
+      </button>
+    </div>
+  </div>
+  <div>
+    <div
+      class="backdrop visible fixed"
+      data-testid="backdrop"
+      role="button"
+    />
+    <div
+      class="container isDown"
+    >
+      <div
+        class="overlay small"
+      >
+        <section
+          class="content"
         >
-          <h2>
-            app.add_overlay_title
-          </h2>
-          <span
-            aria-label="su-times"
-            class="su-times clickable icon"
-            role="button"
-            tabindex="0"
-          />
-        </header>
-        <article
-          class="article"
-        >
-          <div
-            class="form"
+          <header
+            class="header"
           >
-            <div>
-              form container mock
-            </div>
-          </div>
-        </article>
-        <footer
-          class="footer"
-        >
-          <button
-            class="button primary hasText"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="buttonText"
-            >
-              sulu_admin.save
-            </span>
-          </button>
-        </footer>
-        <div
-          class="snackbar"
-        >
-          <div
-            class="snackbar error"
-            role="button"
-          >
-            <span
-              aria-label="su-exclamation-triangle"
-              class="su-exclamation-triangle icon"
-            />
-            <div
-              class="text"
-            >
-              <strong>
-                sulu_admin.error
-              </strong>
-               - 
-            </div>
+            <h2>
+              app.add_overlay_title
+            </h2>
             <span
               aria-label="su-times"
-              class="su-times clickable closeIcon"
+              class="su-times clickable icon"
               role="button"
               tabindex="0"
             />
+          </header>
+          <article
+            class="article"
+          >
+            <div
+              class="form"
+            >
+              <div>
+                form container mock
+              </div>
+            </div>
+          </article>
+          <footer
+            class="footer"
+          >
+            <button
+              class="button primary hasText"
+              type="button"
+            >
+              <span
+                class="buttonText"
+              >
+                sulu_admin.save
+              </span>
+            </button>
+          </footer>
+          <div
+            class="snackbar"
+          >
+            <div
+              class="snackbar error"
+              role="button"
+            >
+              <span
+                aria-label="su-exclamation-triangle"
+                class="su-exclamation-triangle icon"
+              />
+              <div
+                class="text"
+              >
+                <strong>
+                  sulu_admin.error
+                </strong>
+                 - 
+                
+              </div>
+              <span
+                aria-label="su-times"
+                class="su-times clickable closeIcon"
+                role="button"
+                tabindex="0"
+              />
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
-  </div>,
-]
+  </div>
+</body>
 `;

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Admin/View/FormOverlayListViewBuilderTest.php
@@ -471,6 +471,47 @@ class FormOverlayListViewBuilderTest extends TestCase
         );
     }
 
+    public function testBuildAddOverlayToolbarActions(): void
+    {
+        $saveToolbarAction = new ToolbarAction('sulu_admin.save');
+        $deleteToolbarAction = new ToolbarAction('sulu_admin.delete');
+        $listToolbarAction = new ToolbarAction('sulu_admin.add');
+
+        $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey(RoleInterface::RESOURCE_KEY)
+            ->setListKey('roles')
+            ->setFormKey('role_details')
+            ->addListAdapters(['table'])
+            ->addToolbarActions([$listToolbarAction])
+            ->addOverlayToolbarActions([$saveToolbarAction])
+            ->addOverlayToolbarActions([$deleteToolbarAction])
+            ->getView();
+
+        $this->assertEquals(
+            [$saveToolbarAction, $deleteToolbarAction],
+            $route->getOption('overlayToolbarActions'),
+            'repeated calls append instead of replacing, like addToolbarActions'
+        );
+
+        $this->assertEquals(
+            [$listToolbarAction],
+            $route->getOption('toolbarActions'),
+            'the overlay actions must not leak into the surrounding list toolbar'
+        );
+    }
+
+    public function testBuildWithoutOverlayToolbarActions(): void
+    {
+        $route = (new FormOverlayListViewBuilder('sulu_role.list', '/roles'))
+            ->setResourceKey(RoleInterface::RESOURCE_KEY)
+            ->setListKey('roles')
+            ->setFormKey('role_details')
+            ->addListAdapters(['table'])
+            ->getView();
+
+        $this->assertNull($route->getOption('overlayToolbarActions'));
+    }
+
     public function testBuildAddItemActions(): void
     {
         $linkItemAction = new ToolbarAction('sulu_admin.link');


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

A `FormOverlayList` view can now render form toolbar actions inside its overlay, the same actions the
`Form` view already uses. They are configured with the new `addOverlayToolbarActions()` on
`FormOverlayListViewBuilder`, which is separate from `addToolbarActions()` so the surrounding list keeps its own
toolbar.

When overlay toolbar actions are configured, the toolbar takes over submission and the footer confirm button is
not rendered. Saving then keeps the overlay open and reports through the overlay's own snackbar, so several
actions can be run in a row without reopening the record. Closing the overlay reloads the list.

To make this possible, `AbstractFormToolbarAction::$form` is no longer typed as the concrete `Form` view but as
the new `ToolbarActionFormInterface`, which describes what an action actually calls back into: `submit()`,
`showSuccessSnackbar()`, `errors` and `warnings`. Both the `Form` view and the `FormOverlay` container implement
it, so every registered action works in either place without a change.

Screenshots, an overlay with `sulu_admin.save` plus three project specific actions:

<img width="1280" height="720" alt="1-overlay-toolbar" src="https://github.com/user-attachments/assets/cd5fab16-5623-422f-83fd-9a413f2ac7fe" />

The toolbar sits under the title and the separator moves below the actions, so the overlay keeps the single
header every other overlay has. The toolbar line carries one background across its full width instead of
painting a lighter bar behind the actions only:

<img width="640" height="312" alt="2-overlay-closeup" src="https://github.com/user-attachments/assets/98f23423-d499-4474-a465-6c7f990e18a6" />

Saving from the toolbar leaves the overlay open and reports success in it. The snackbar takes the first row of
the overlay and pushes the content down, so it no longer covers the title:

<img width="640" height="312" alt="3-saved-stays-open" src="https://github.com/user-attachments/assets/b27eea22-dea1-4715-933d-bfd4d88f37f2" />

The snackbar move is the one change that reaches past this feature. `Overlay` lays its content out as a column
and the snackbar takes the first row, instead of sitting in an absolutely positioned bar over the header. Every
overlay that shows a message gets this, the translator among them, and an overlay showing no message is
unaffected.

Overlays without overlay toolbar actions are untouched. Four overlays were captured before and after the toolbar
work and render pixel identical, with matching sha256 hashes: the confirmation dialog, the list settings overlay,
the media selection overlay and the delete dialog on a tree list. A `FormOverlayList` overlay without overlay
toolbar actions was captured again before and after the snackbar move and is pixel identical as well.

#### Why?

A `FormOverlayList` could only ever offer a single confirm button in the overlay footer. Anything beyond
"save and close" had to be built as a separate view, even though the form toolbar actions that provide it already
exist and are registered. Actions like publishing, toggling a flag or reloading the form store were unavailable to
any resource edited in an overlay.

The narrower reason for the interface change is that toolbar actions were structurally bound to the `Form` view
class, so nothing else could host them even though none of them use more than four members of it.

#### Example Usage

```php
$this->viewBuilderFactory
    ->createFormOverlayListViewBuilder('app.tags', '/tags')
    ->setResourceKey('tags')
    ->setListKey('tags')
    ->setFormKey('tag_details')
    ->addListAdapters(['table'])
    // the surrounding list keeps its own toolbar
    ->addToolbarActions([
        new ToolbarAction('sulu_admin.add'),
        new ToolbarAction('sulu_admin.delete'),
    ])
    // and the overlay gets its own
    ->addOverlayToolbarActions([
        new ToolbarAction('sulu_admin.save'),
        new ToolbarAction('sulu_admin.save_with_publishing'),
    ]);
```

A custom action is written exactly as it is for the `Form` view and works in both:

```js
import {AbstractFormToolbarAction} from 'sulu-admin-bundle/views/Form';

export default class AlertToolbarAction extends AbstractFormToolbarAction {
    getToolbarItemConfig() {
        return {
            label: 'Alert',
            onClick: this.handleClick,
            type: 'button',
        };
    }

    handleClick = () => {
        this.form.showSuccessSnackbar();
    };
}
```

`sulu_admin.copy` and `sulu_admin.delete` are rejected for overlays, because both navigate the router and would
move the application behind the open overlay.

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md

