### PR TITLE
Sort template groups alphabetically

### DIFF
--- a/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
+++ b/packages/article/tests/Unit/Infrastructure/Sulu/Admin/ArticleAdminTest.php
@@ -262,6 +262,32 @@ class ArticleAdminTest extends TestCase
         $this->assertContains('sulu_admin.copy_locale', $subActionTypes);
     }
 
+    public function testConfigureViewsKeepsTheGroupOrderOfTheGroupProvider(): void
+    {
+        $this->localizationManager->getLocales()->willReturn(['en']);
+        $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE)->willReturn([
+            'default' => (new FormGroup('default', 'Default'))->withTemplate('article'),
+            'blog-group' => (new FormGroup('blog-group', 'Blog'))->withTemplate('blog'),
+            'news-group' => (new FormGroup('news-group', 'News'))->withTemplate('news'),
+        ]);
+
+        $this->securityChecker->hasPermission(Argument::cetera())->willReturn(true);
+
+        $viewCollection = new ViewCollection();
+        $this->articleAdmin->configureViews($viewCollection);
+
+        $listViewNames = \array_values(\array_filter(
+            \array_keys($viewCollection->all()),
+            static fn (string $viewName) => \str_starts_with($viewName, ArticleAdmin::LIST_VIEW . '_'),
+        ));
+
+        $this->assertSame([
+            ArticleAdmin::LIST_VIEW . '_default',
+            ArticleAdmin::LIST_VIEW . '_blog-group',
+            ArticleAdmin::LIST_VIEW . '_news-group',
+        ], $listViewNames);
+    }
+
     public function testConfigureViewsWithSingleGroupAndNoPermission(): void
     {
         $this->localizationManager->getLocales()->willReturn(['en']);

--- a/src/Sulu/Bundle/AdminBundle/Metadata/GroupProvider.php
+++ b/src/Sulu/Bundle/AdminBundle/Metadata/GroupProvider.php
@@ -13,6 +13,7 @@ namespace Sulu\Bundle\AdminBundle\Metadata;
 
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
+use Sulu\Component\Util\SortUtils;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class GroupProvider implements GroupProviderInterface
@@ -39,6 +40,20 @@ final readonly class GroupProvider implements GroupProviderInterface
             }
             $groups[$group] = $groups[$group]->withTemplate($form->getKey());
         }
+
+        $compareTitles = SortUtils::createLocaleAwareComparator($this->translator->getLocale());
+
+        \uasort($groups, static function(FormGroup $a, FormGroup $b) use ($compareTitles): int {
+            if (GroupProviderInterface::DEFAULT_GROUP === $a->identifier) {
+                return -1;
+            }
+
+            if (GroupProviderInterface::DEFAULT_GROUP === $b->identifier) {
+                return 1;
+            }
+
+            return $compareTitles($a->title, $b->title) ?: \strcmp($a->identifier, $b->identifier);
+        });
 
         return $groups;
     }

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/Metadata/GroupProviderTest.php
@@ -52,6 +52,7 @@ class GroupProviderTest extends TestCase
         $this->container = $this->prophesize(ContainerInterface::class);
         $this->metadataProvider = $this->prophesize(MetadataProviderInterface::class);
         $this->translator = $this->prophesize(TranslatorInterface::class);
+        $this->translator->getLocale()->willReturn('en');
 
         $this->metadataProviderRegistry = new MetadataProviderRegistry($this->container->reveal());
         $this->groupProvider = new GroupProvider($this->metadataProviderRegistry, $this->translator->reveal());
@@ -222,6 +223,154 @@ class GroupProviderTest extends TestCase
 
         $this->assertSame(['article', 'news'], $groups['content']->templates);
         $this->assertSame(['blog'], $groups['default']->templates);
+    }
+
+    public function testGetGroupsAreSortedAlphabeticallyByTitle(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        foreach (['news' => 'news', 'article' => 'content', 'blog' => 'blog'] as $key => $group) {
+            $formMetadata = new FormMetadata();
+            $formMetadata->setKey($key);
+            $formMetadata->setGroup($group);
+            $typedFormMetadata->addForm($key, $formMetadata);
+        }
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
+            ->willReturnArgument(0);
+
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertSame(['blog', 'content', 'news'], \array_keys($groups));
+    }
+
+    public function testGetGroupsPlacesDefaultGroupFirst(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        foreach (['news' => 'news', 'article' => null, 'blog' => 'blog'] as $key => $group) {
+            $formMetadata = new FormMetadata();
+            $formMetadata->setKey($key);
+            $formMetadata->setGroup($group);
+            $typedFormMetadata->addForm($key, $formMetadata);
+        }
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')
+            ->willReturnArgument(0);
+
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertSame(['default', 'blog', 'news'], \array_keys($groups));
+    }
+
+    public function testGetGroupsAreSortedByTitleNotByIdentifier(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        foreach (['alpha-template' => 'alpha', 'zebra-template' => 'zebra'] as $key => $group) {
+            $formMetadata = new FormMetadata();
+            $formMetadata->setKey($key);
+            $formMetadata->setGroup($group);
+            $typedFormMetadata->addForm($key, $formMetadata);
+        }
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::exact('sulu_admin.template_group.alpha'), [], 'admin')
+            ->willReturn('Zebra Group');
+        $this->translator->trans(\Prophecy\Argument::exact('sulu_admin.template_group.zebra'), [], 'admin')
+            ->willReturn('Alpha Group');
+
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertSame(['zebra', 'alpha'], \array_keys($groups));
+    }
+
+    public function testGetGroupsFallBackToTheIdentifierWhenTitlesAreEqual(): void
+    {
+        $typedFormMetadata = new TypedFormMetadata();
+        foreach (['zebra-template' => 'zebra', 'alpha-template' => 'alpha'] as $key => $group) {
+            $formMetadata = new FormMetadata();
+            $formMetadata->setKey($key);
+            $formMetadata->setGroup($group);
+            $typedFormMetadata->addForm($key, $formMetadata);
+        }
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->trans(\Prophecy\Argument::any(), [], 'admin')->willReturn('Same Title');
+
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertSame(['alpha', 'zebra'], \array_keys($groups));
+    }
+
+    /**
+     * @param string[] $expectedOrder
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('collationProvider')]
+    public function testGetGroupsSortNonAsciiTitlesWithTheCollationOfTheTranslatorLocale(string $locale, array $expectedOrder): void
+    {
+        if (!\class_exists(\Collator::class)) {
+            $this->markTestSkipped('The intl extension is required for locale aware collation.');
+        }
+
+        $typedFormMetadata = new TypedFormMetadata();
+        foreach (['zoo-template' => 'zoo', 'doctors-template' => 'doctors'] as $key => $group) {
+            $formMetadata = new FormMetadata();
+            $formMetadata->setKey($key);
+            $formMetadata->setGroup($group);
+            $typedFormMetadata->addForm($key, $formMetadata);
+        }
+
+        $this->container->has('form')->willReturn(true);
+        $this->container->get('form')->willReturn($this->metadataProvider->reveal());
+
+        $this->metadataProvider
+            ->getMetadata(ArticleInterface::TEMPLATE_TYPE, '', [])
+            ->willReturn($typedFormMetadata);
+
+        $this->translator->getLocale()->willReturn($locale);
+        $this->translator->trans(\Prophecy\Argument::exact('sulu_admin.template_group.zoo'), [], 'admin')
+            ->willReturn('Zoo');
+        $this->translator->trans(\Prophecy\Argument::exact('sulu_admin.template_group.doctors'), [], 'admin')
+            ->willReturn('Ärzte');
+
+        $groups = $this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE);
+
+        $this->assertSame($expectedOrder, \array_keys($groups));
+    }
+
+    /**
+     * @return array<string, array{string, string[]}>
+     */
+    public static function collationProvider(): array
+    {
+        return [
+            'german_sorts_umlaut_with_its_base_letter' => ['de', ['doctors', 'zoo']],
+            'swedish_sorts_umlaut_after_z' => ['sv', ['zoo', 'doctors']],
+        ];
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('groupTitleProvider')]

--- a/src/Sulu/Component/Util/SortUtils.php
+++ b/src/Sulu/Component/Util/SortUtils.php
@@ -129,28 +129,40 @@ final class SortUtils
             $getComparableValue = fn ($item) => $item;
         }
 
-        // Collator class requires intl extension
-        $collator = \class_exists(\Collator::class) ? new \Collator($locale) : null;
+        $comparator = self::createLocaleAwareComparator($locale);
 
         $sortMethod = $isList ? '\usort' : '\uasort';
 
-        $sortMethod($array, function(mixed $itemA, mixed $itemB) use ($collator, $getComparableValue) {
+        $sortMethod($array, function(mixed $itemA, mixed $itemB) use ($comparator, $getComparableValue) {
             $valueA = (string) $getComparableValue($itemA);
             $valueB = (string) $getComparableValue($itemB);
 
-            if ($collator) {
-                $result = $collator->compare($valueA, $valueB);
-            } else {
-                $result = \strcmp($valueA, $valueB);
-            }
-
-            if (false === $result) {
-                throw new \InvalidArgumentException('Comparison of the strings "%s" and "%s" failed.');
-            }
-
-            return $result;
+            return $comparator($valueA, $valueB);
         });
 
         return $array;
+    }
+
+    /**
+     * Returns a comparator for two strings that compares locale aware if the intl extension is loaded,
+     * and falls back to a binary comparison otherwise. The returned comparator throws an
+     * \InvalidArgumentException if the comparison of the values fails.
+     *
+     * @return callable(string, string): int
+     */
+    public static function createLocaleAwareComparator(string $locale): callable
+    {
+        // Collator class requires intl extension
+        $collator = \class_exists(\Collator::class) ? new \Collator($locale) : null;
+
+        return static function(string $valueA, string $valueB) use ($collator): int {
+            $result = $collator ? $collator->compare($valueA, $valueB) : \strcmp($valueA, $valueB);
+
+            if (false === $result) {
+                throw new \InvalidArgumentException(\sprintf('Comparison of the strings "%s" and "%s" failed.', $valueA, $valueB));
+            }
+
+            return $result;
+        };
     }
 }

--- a/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
+++ b/src/Sulu/Component/Util/Tests/Unit/SortUtilsTest.php
@@ -169,6 +169,31 @@ class SortUtilsTest extends TestCase
         SortUtils::multisort($collection, 'somefink');
     }
 
+    public function testCreateLocaleAwareComparatorSortsUmlautsNextToTheirBaseLetter(): void
+    {
+        if (!\class_exists(\Collator::class)) {
+            $this->markTestSkipped('The intl extension is required for locale aware collation.');
+        }
+
+        $comparator = SortUtils::createLocaleAwareComparator('de');
+
+        $array = ['D', 'A', 'Ê', 'E', 'Ä', 'M'];
+        \usort($array, $comparator);
+
+        $this->assertSame(['A', 'Ä', 'D', 'E', 'Ê', 'M'], $array);
+    }
+
+    public function testCreateLocaleAwareComparatorFallsBackToBinaryComparisonWithoutIntl(): void
+    {
+        if (\class_exists(\Collator::class)) {
+            $this->markTestSkipped('This test covers the fallback used when the intl extension is not loaded.');
+        }
+
+        $comparator = SortUtils::createLocaleAwareComparator('de');
+
+        $this->assertSame(\strcmp('A', 'B'), $comparator('A', 'B'));
+    }
+
     public function testSortLocaleAwareSimpleArray(): void
     {
         $array = ['D', 'A', 'Ê', 'E', 'Ä', 'M'];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

`GroupProvider::getGroups()` now returns the implicit `default` group first and every other group sorted by its
displayed title. Sorting happens in the provider, so it covers the article list tabs, the group entries in the smart
content type filter and the order of the registered per-group security contexts at once. No admin class needs a tab
order of its own.

#### Why?

The template group tabs came out in the order the template XML files happen to be read from disk. That order is
neither stable nor meaningful to an editor, and it differs between environments.

Nothing has to be adjusted in a project. The only visible change is the order of the article group tabs, which is
noted in `UPGRADE-3.x.md`.

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
