### PR TITLE
Fix multilingual properties not working in preview

### DIFF
--- a/packages/content/src/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
@@ -32,7 +32,8 @@ class TemplateDataMapper implements DataMapperInterface
         DimensionContentInterface $localizedDimensionContent,
         array $data
     ): void {
-        if (!$localizedDimensionContent instanceof TemplateInterface
+        if (
+            !$localizedDimensionContent instanceof TemplateInterface
             || !$unlocalizedDimensionContent instanceof TemplateInterface
         ) {
             return;
@@ -72,8 +73,16 @@ class TemplateDataMapper implements DataMapperInterface
             return;
         }
 
-        $unlocalizedDimensionContent->setTemplateData($unlocalizedData);
         $localizedDimensionContent->setTemplateKey($template);
+        // preview uses the same dimension content so we can just merge it, otherwise unlocalizedData is lost/overwritten by localized content
+        if ($unlocalizedDimensionContent === $localizedDimensionContent) {
+            $localizedDimensionContent->setTemplateData(
+                \array_merge($unlocalizedData, $localizedData)
+            );
+
+            return;
+        }
+        $unlocalizedDimensionContent->setTemplateData($unlocalizedData);
         $localizedDimensionContent->setTemplateData($localizedData);
     }
 

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
@@ -40,7 +40,9 @@ class TemplateDataMapperTest extends TestCase
         ?string $defaultTemplateKey = null,
     ): TemplateDataMapper {
         $container = new Container();
-        $container->set('form', new class($this->createTypedFormMetadata($properties, $defaultTemplateKey)) implements MetadataProviderInterface {
+        $container->set(
+            'form',
+            new class ($this->createTypedFormMetadata($properties, $defaultTemplateKey)) implements MetadataProviderInterface {
             public function __construct(private readonly TypedFormMetadata $typedFormMetadata)
             {
             }
@@ -49,7 +51,8 @@ class TemplateDataMapperTest extends TestCase
             {
                 return $this->typedFormMetadata;
             }
-        });
+            }
+        );
         $metadataProviderRegistry = new MetadataProviderRegistry($container);
 
         return new TemplateDataMapper($metadataProviderRegistry);
@@ -165,7 +168,7 @@ class TemplateDataMapperTest extends TestCase
         $templateMapper->map($localizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertSame('template-key', $localizedDimensionContent->getTemplateKey());
-        $this->assertSame(['title' => 'Test Localized'], $localizedDimensionContent->getTemplateData());
+        $this->assertSame(['unlocalizedField' => 'Test Unlocalized', 'title' => 'Test Localized'], $localizedDimensionContent->getTemplateData());
     }
 
     public function testMapNestedPropertyData(): void

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
@@ -43,14 +43,14 @@ class TemplateDataMapperTest extends TestCase
         $container->set(
             'form',
             new class ($this->createTypedFormMetadata($properties, $defaultTemplateKey)) implements MetadataProviderInterface {
-            public function __construct(private readonly TypedFormMetadata $typedFormMetadata)
-            {
-            }
+                public function __construct(private readonly TypedFormMetadata $typedFormMetadata)
+                {
+                }
 
-            public function getMetadata(string $key, string $locale, array $metadataOptions): TypedFormMetadata
-            {
-                return $this->typedFormMetadata;
-            }
+                public function getMetadata(string $key, string $locale, array $metadataOptions): TypedFormMetadata
+                {
+                    return $this->typedFormMetadata;
+                }
             }
         );
         $metadataProviderRegistry = new MetadataProviderRegistry($container);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #8574
| Related issues/PRs | #8591
| License | MIT
| Documentation PR | 

#### What's in this PR?

Currently on Sulu 3.0 properties that have set `multilingual=false` are discarded and never applied in preview. This PR fixes it by merging unlocalized and localized content in `Sulu\Content\Application\ContentDataMapper\DataMapper\TemplateDataMapper::map()` when the `$unlocalizedDimensionContent` and `$localizedDimensionContent` are the same.

#### Why?

Upon noticing problem with preview not being updated from a clean refresh in #9043 I spotted another issue mentioned in #8574. This PR should fix that without any side effects like #8591. But please correct me if I'm wrong because I didn't study the Sulu core very deeply.
 
