### PR TITLE
Update the phpstan baseline counts drifted from newer dependency versions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -80829,13 +80829,13 @@ parameters:
 		-
 			message: '#^Loose comparison using \=\= between null and null will always evaluate to true\.$#'
 			identifier: equal.alwaysTrue
-			count: 1
+			count: 2
 			path: src/Sulu/Component/Persistence/RelationTrait.php
 
 		-
 			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
 			identifier: notIdentical.alwaysFalse
-			count: 1
+			count: 2
 			path: src/Sulu/Component/Persistence/RelationTrait.php
 
 		-
@@ -90411,5 +90411,5 @@ parameters:
 		-
 			message: '#^Call to function array_key_exists\(\) with ''model'' and array\{model\: class\-string, repository\?\: class\-string\} will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
+			count: 12
 			path: src/Sulu/Bundle/PersistenceBundle/DependencyInjection/PersistenceExtensionTrait.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #
| License | MIT
| Documentation PR |

#### What's in this PR?

Updates the counts in `phpstan-baseline.neon` for two pre-existing, already-ignored findings: the `array_key_exists()` check in `PersistenceExtensionTrait.php` (1 → 12) and the two null comparisons in `RelationTrait.php` (1 → 2 each). No source code changes.

#### Why?

The `PHP Lint` CI job installs the highest allowed dependency versions instead of a locked set (`ramsey/composer-install` with `dependency-versions: highest`), and PHPStan analyses a trait once per class using it. With the currently resolvable dependency graph, PHPStan now reaches 12 classes using `PersistenceExtensionTrait` and 2 using `RelationTrait`, up from the 1 each the baseline still expects, so the exact-count check fails. This currently fails `PHP Lint` on every PR, unrelated to what the PR actually changes (reproduced locally with `composer update` mirroring CI's install strategy, and also currently failing the same way on #9053 and #9061, neither of which touches these files).

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
