### PR TITLE
Add template groups for snippets

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -2,6 +2,57 @@
 
 ## 3.0.9
 
+### Template groups for snippets
+
+Snippet templates now support the `<group>` element that articles already use. Every group gets its own tab in the
+snippet list, its own add and edit views and its own permission context, and the snippet list, the selection overlays
+and the smart content can be filtered by group.
+
+```diff
+ <!-- config/templates/snippets/footer.xml -->
+ <key>footer</key>
++<group>layout</group>
+```
+
+The group title comes from the translation key `sulu_admin.template_group.<group>` and falls back to
+`ucfirst(<group>)`. Templates without a `<group>` land in the implicit `default` group.
+
+**The admin URLs of snippets changed.** The list is now a tab view at `/snippets` with one child per group, so a
+snippet that used to live at `/snippets/de/<id>` is now at `/snippets/de/<group>/<id>`. Bookmarked links have to be
+recreated. The view names changed the same way: `sulu_snippet.snippet.list`, `sulu_snippet.snippet.add_tabs` and
+`sulu_snippet.snippet.edit_tabs` now carry a `_<group>` suffix, and the unsuffixed edit and add views no longer exist.
+
+As soon as more than one group exists, each custom group registers its own security context
+`sulu.snippet.snippets_<group>` and the navigation entry, the views and the list toolbar actions of that group are
+gated on it. The umbrella `sulu.snippet.snippets` is still required in every setup, because `SnippetController`
+reports it as its security context, and it keeps gating single-group setups and the implicit `default` group, whose
+per-group context is intentionally never registered. Review every role with snippet permissions after upgrading and
+grant the new per-group contexts where needed.
+
+The snippet selection and the snippets smart content accept a new `groups` param next to the existing `templateKeys`:
+
+```xml
+<property name="mySnippets" type="snippet_selection">
+    <params>
+        <param name="groups" value="layout"/>
+    </params>
+</property>
+```
+
+For the snippets smart content provider the UI type filter now selects groups instead of template keys, matching the
+article providers. The deprecated `types` param of a `smart_content` with `provider="snippets"` therefore has to be
+renamed to `groups`, not to `templateKeys`.
+
+The admin search index stores the group of a snippet and its per-group security context, so run the reindex for both
+kernels after deploying:
+
+```bash
+bin/console cmsig:seal:reindex
+```
+
+Restoring a snippet or an article from the trash now returns to the list instead of the edit form, because the edit
+view is split per group and the restore response does not carry the template of the restored entity.
+
 ### Widened webspace, slug and template key column lengths
 
 The `webspace`/`webspaceKey`, `slug`, `templateKey` and navigation-context/additional-webspace `name` columns

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,54 +4,18 @@
 
 ### Template groups for snippets
 
-Snippet templates now support the `<group>` element that articles already use. Every group gets its own tab in the
-snippet list, its own add and edit views and its own permission context, and the snippet list, the selection overlays
-and the smart content can be filtered by group.
+Snippet templates can now declare a `<group>` element, mirroring articles. This changes existing snippet admin
+behavior:
 
-```diff
- <!-- config/templates/snippets/footer.xml -->
- <key>footer</key>
-+<group>layout</group>
-```
-
-The group title comes from the translation key `sulu_admin.template_group.<group>` and falls back to
-`ucfirst(<group>)`. Templates without a `<group>` land in the implicit `default` group.
-
-**The admin URLs of snippets changed.** The list is now a tab view at `/snippets` with one child per group, so a
-snippet that used to live at `/snippets/de/<id>` is now at `/snippets/de/<group>/<id>`. Bookmarked links have to be
-recreated. The view names changed the same way: `sulu_snippet.snippet.list`, `sulu_snippet.snippet.add_tabs` and
-`sulu_snippet.snippet.edit_tabs` now carry a `_<group>` suffix, and the unsuffixed edit and add views no longer exist.
-
-As soon as more than one group exists, each custom group registers its own security context
-`sulu.snippet.snippets_<group>` and the navigation entry, the views and the list toolbar actions of that group are
-gated on it. The umbrella `sulu.snippet.snippets` is still required in every setup, because `SnippetController`
-reports it as its security context, and it keeps gating single-group setups and the implicit `default` group, whose
-per-group context is intentionally never registered. Review every role with snippet permissions after upgrading and
-grant the new per-group contexts where needed.
-
-The snippet selection and the snippets smart content accept a new `groups` param next to the existing `templateKeys`:
-
-```xml
-<property name="mySnippets" type="snippet_selection">
-    <params>
-        <param name="groups" value="layout"/>
-    </params>
-</property>
-```
-
-For the snippets smart content provider the UI type filter now selects groups instead of template keys, matching the
-article providers. The deprecated `types` param of a `smart_content` with `provider="snippets"` therefore has to be
-renamed to `groups`, not to `templateKeys`.
-
-The admin search index stores the group of a snippet and its per-group security context, so run the reindex for both
-kernels after deploying:
+- The snippet list, add and edit view names now carry a `_<group>` suffix (e.g. `sulu_snippet.snippet.edit_tabs_default`),
+  and the list URL gained a `/<group>` segment: `/snippets/de/<id>` becomes `/snippets/de/default/<id>`.
+- Every group beyond the implicit `default` registers its own security context `sulu.snippet.snippets_<group>`. Review
+  roles with snippet permissions after upgrading and grant the new contexts where needed.
+- The admin search index now stores each snippet's group, so run the reindex for both kernels after deploying:
 
 ```bash
 bin/console cmsig:seal:reindex
 ```
-
-Restoring a snippet or an article from the trash now returns to the list instead of the edit form, because the edit
-view is split per group and the restore response does not carry the template of the restored entity.
 
 ### Widened webspace, slug and template key column lengths
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -2,21 +2,6 @@
 
 ## 3.0.9
 
-### Template groups for snippets
-
-Snippet templates can now declare a `<group>` element, mirroring articles. This changes existing snippet admin
-behavior:
-
-- The snippet list, add and edit view names now carry a `_<group>` suffix (e.g. `sulu_snippet.snippet.edit_tabs_default`),
-  and the list URL gained a `/<group>` segment: `/snippets/de/<id>` becomes `/snippets/de/default/<id>`.
-- Every group beyond the implicit `default` registers its own security context `sulu.snippet.snippets_<group>`. Review
-  roles with snippet permissions after upgrading and grant the new contexts where needed.
-- The admin search index now stores each snippet's group, so run the reindex for both kernels after deploying:
-
-```bash
-bin/console cmsig:seal:reindex
-```
-
 ### Widened webspace, slug and template key column lengths
 
 The `webspace`/`webspaceKey`, `slug`, `templateKey` and navigation-context/additional-webspace `name` columns

--- a/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
+++ b/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
@@ -197,9 +197,8 @@ final class ArticleTrashItemHandler implements
             }
         }
 
-        $context = $allLocales ? ['locales' => $allLocales] : [];
-
         Assert::notEmpty($allLocales, 'Expected to find at least one restored locale for the article.');
+        $context = ['locales' => $allLocales];
         $result = new ArticleRestoreResult($article->getUuid(), $this->resolveGroup($templateKey), $allLocales[0]);
 
         if ('translation' === $trashItem->getRestoreType()) {

--- a/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
@@ -36,9 +36,18 @@ class SnippetAreas extends React.Component<ViewProps> {
         this.cacheClearToolbarAction = new CacheClearToolbarAction(webspace);
     }
 
-    @action handleSnippetClick = (snippetUuid: string) => {
+    @action handleSnippetClick = (areaKey: string) => {
         const {router, route} = this.props;
-        const {snippetEditView} = route.options;
+        const {snippetEditViews = {}} = route.options;
+        const {snippetUuid, templateKey} = this.snippetAreaStore.snippetAreas[areaKey];
+        const snippetEditView = snippetEditViews[templateKey];
+
+        if (!snippetEditView) {
+            throw new Error(
+                'No snippet edit view was registered for the template "' + templateKey + '"! '
+                + 'This should not happen and is likely a bug.'
+            );
+        }
 
         router.navigate(snippetEditView, {id: snippetUuid});
     };
@@ -123,7 +132,7 @@ class SnippetAreas extends React.Component<ViewProps> {
                                                     className={snippetAreasStyles.titleButton}
                                                     onClick={this.handleSnippetClick}
                                                     skin="text"
-                                                    value={snippetUuid}
+                                                    value={key}
                                                 >
                                                     {snippetTitle}
                                                 </Button>

--- a/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
@@ -40,6 +40,14 @@ class SnippetAreas extends React.Component<ViewProps> {
         const {router, route} = this.props;
         const {snippetEditViews = {}} = route.options;
         const {snippetUuid, templateKey} = this.snippetAreaStore.snippetAreas[areaKey];
+
+        if (!templateKey) {
+            throw new Error(
+                'The snippet assigned to the area "' + areaKey + '" has no template key! '
+                + 'This should not happen and is likely a bug.'
+            );
+        }
+
         const snippetEditView = snippetEditViews[templateKey];
 
         if (!snippetEditView) {

--- a/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
@@ -41,6 +41,10 @@ class SnippetAreas extends React.Component<ViewProps> {
         const {snippetEditViews = {}} = route.options;
         const {snippetUuid, templateKey} = this.snippetAreaStore.snippetAreas[areaKey];
 
+        if (!templateKey) {
+            return;
+        }
+
         router.navigate(snippetEditViews[templateKey], {id: snippetUuid});
     };
 

--- a/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/SnippetAreas.js
@@ -41,23 +41,7 @@ class SnippetAreas extends React.Component<ViewProps> {
         const {snippetEditViews = {}} = route.options;
         const {snippetUuid, templateKey} = this.snippetAreaStore.snippetAreas[areaKey];
 
-        if (!templateKey) {
-            throw new Error(
-                'The snippet assigned to the area "' + areaKey + '" has no template key! '
-                + 'This should not happen and is likely a bug.'
-            );
-        }
-
-        const snippetEditView = snippetEditViews[templateKey];
-
-        if (!snippetEditView) {
-            throw new Error(
-                'No snippet edit view was registered for the template "' + templateKey + '"! '
-                + 'This should not happen and is likely a bug.'
-            );
-        }
-
-        router.navigate(snippetEditView, {id: snippetUuid});
+        router.navigate(snippetEditViews[templateKey], {id: snippetUuid});
     };
 
     @action handleAddClick = (areaKey: string) => {

--- a/packages/snippet/assets/js/views/SnippetAreas/tests/SnippetAreas.test.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/tests/SnippetAreas.test.js
@@ -233,7 +233,10 @@ test('Navigate when selected default snippet is clicked', () => {
         path: '/snippet-areas',
         type: 'snippet_areas',
         options: {
-            snippetEditView: 'sulu_snippet.edit_form',
+            snippetEditViews: {
+                'snippet-alternate': 'sulu_snippet.snippet.edit_tabs_alternate-group',
+                'snippet': 'sulu_snippet.snippet.edit_tabs_default',
+            },
         },
     });
     const router = new Router();
@@ -244,7 +247,8 @@ test('Navigate when selected default snippet is clicked', () => {
             default: {
                 snippetTitle: 'Default Snippet',
                 snippetUuid: 'some-uuid',
-                key: 1,
+                key: 'default',
+                templateKey: 'snippet',
                 title: 'Default',
             },
         };
@@ -255,7 +259,51 @@ test('Navigate when selected default snippet is clicked', () => {
     const snippetAreas = mount(<SnippetAreas route={route} router={router} />);
     snippetAreas.find('Button[className="titleButton"] button').simulate('click');
 
-    expect(router.navigate).toHaveBeenCalledWith('sulu_snippet.edit_form', {id: 'some-uuid'});
+    expect(router.navigate).toHaveBeenCalledWith(
+        'sulu_snippet.snippet.edit_tabs_default',
+        {id: 'some-uuid'}
+    );
+});
+
+test('Navigate to the edit view of the template group of the selected default snippet', () => {
+    const SnippetAreas = require('../SnippetAreas').default;
+    const SnippetAreaStore = require('../stores/SnippetAreaStore');
+
+    const route = new Route({
+        name: 'snippet_areas',
+        path: '/snippet-areas',
+        type: 'snippet_areas',
+        options: {
+            snippetEditViews: {
+                'snippet-alternate': 'sulu_snippet.snippet.edit_tabs_alternate-group',
+                'snippet': 'sulu_snippet.snippet.edit_tabs_default',
+            },
+        },
+    });
+    const router = new Router();
+
+    // $FlowFixMe
+    SnippetAreaStore.mockImplementation(function() {
+        this.snippetAreas = {
+            alternate: {
+                snippetTitle: 'Alternate Snippet',
+                snippetUuid: 'other-uuid',
+                key: 'alternate',
+                templateKey: 'snippet-alternate',
+                title: 'Alternate',
+            },
+        };
+
+        this.save = jest.fn();
+    });
+
+    const snippetAreas = mount(<SnippetAreas route={route} router={router} />);
+    snippetAreas.find('Button[className="titleButton"] button').simulate('click');
+
+    expect(router.navigate).toHaveBeenCalledWith(
+        'sulu_snippet.snippet.edit_tabs_alternate-group',
+        {id: 'other-uuid'}
+    );
 });
 
 test('Should use CacheClearToolbarAction for cache clearing', () => {

--- a/packages/snippet/assets/js/views/SnippetAreas/types.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/types.js
@@ -4,6 +4,6 @@ export type SnippetArea = {
     key: string,
     snippetTitle: ?string,
     snippetUuid: ?string,
-    templateKey: string,
+    templateKey: ?string,
     title: string,
 };

--- a/packages/snippet/assets/js/views/SnippetAreas/types.js
+++ b/packages/snippet/assets/js/views/SnippetAreas/types.js
@@ -4,6 +4,6 @@ export type SnippetArea = {
     key: string,
     snippetTitle: ?string,
     snippetUuid: ?string,
-    template: string,
+    templateKey: string,
     title: string,
 };

--- a/packages/snippet/config/lists/snippet_areas.xml
+++ b/packages/snippet/config/lists/snippet_areas.xml
@@ -90,11 +90,22 @@
             <joins ref="ghostDimensionContent"/>
         </property>
 
-        <property name="templateKey" translation="sulu_admin.type" visibility="yes">
-            <field-name>templateKey</field-name>
-            <entity-name>dimensionContent</entity-name>
+        <case-property name="templateKey" translation="sulu_admin.type" visibility="yes">
+            <field>
+                <field-name>templateKey</field-name>
+                <entity-name>dimensionContent</entity-name>
 
-            <joins ref="dimensionContent"/>
-        </property>
+                <joins ref="dimensionContent"/>
+            </field>
+
+            <field>
+                <field-name>templateKey</field-name>
+                <entity-name>ghostDimensionContent</entity-name>
+
+                <joins ref="ghostDimensionContent"/>
+            </field>
+
+            <transformer type="string"/>
+        </case-property>
     </properties>
 </list>

--- a/packages/snippet/config/lists/snippets.xml
+++ b/packages/snippet/config/lists/snippets.xml
@@ -175,7 +175,7 @@
 
             <filter type="select">
                 <params>
-                    <param name="options" type="expression" value="service('sulu_snippet.template_select_provider').getFilterValues(locale)" />
+                    <param name="options" type="expression" value="service('sulu_snippet.template_select_provider').getFilterValues(locale, templates ?? null)" />
                 </params>
             </filter>
         </case-property>

--- a/packages/snippet/config/lists/snippets.xml
+++ b/packages/snippet/config/lists/snippets.xml
@@ -175,7 +175,7 @@
 
             <filter type="select">
                 <params>
-                    <param name="options" type="expression" value="service('sulu_snippet.template_select_provider').getFilterValues(locale, templates ?? null)" />
+                    <param name="options" type="expression" value="service('sulu_snippet.template_select_provider').getFilterValues(locale)" />
                 </params>
             </filter>
         </case-property>

--- a/packages/snippet/src/Infrastructure/Sulu/Admin/Provider/SnippetTemplateSelectProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Admin/Provider/SnippetTemplateSelectProvider.php
@@ -28,15 +28,23 @@ class SnippetTemplateSelectProvider
     }
 
     /**
+     * @param string|null $templates comma separated template keys the list is restricted to
+     *
      * @return mixed[]
      */
-    public function getFilterValues(string $locale): array
+    public function getFilterValues(string $locale, ?string $templates = null): array
     {
         /** @var TypedFormMetadata $metadata */
         $metadata = $this->formMetadataProvider->getMetadata(SnippetDimensionContent::getTemplateType(), $locale, []);
 
+        $templateKeys = null === $templates ? [] : \array_filter(\explode(',', $templates));
+
         $options = [];
         foreach ($metadata->getForms() as $key => $form) {
+            if ([] !== $templateKeys && !\in_array($key, $templateKeys, true)) {
+                continue;
+            }
+
             $options[$key] = $form->getTitle($locale);
         }
 

--- a/packages/snippet/src/Infrastructure/Sulu/Admin/Provider/SnippetTemplateSelectProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Admin/Provider/SnippetTemplateSelectProvider.php
@@ -16,6 +16,7 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Admin\Provider;
 use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\TypedFormMetadata;
 use Sulu\Bundle\AdminBundle\Metadata\MetadataProviderInterface;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContent;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @internal
@@ -23,20 +24,25 @@ use Sulu\Snippet\Domain\Model\SnippetDimensionContent;
 class SnippetTemplateSelectProvider
 {
     public function __construct(
-        private MetadataProviderInterface $formMetadataProvider
+        private MetadataProviderInterface $formMetadataProvider,
+        private RequestStack $requestStack,
     ) {
     }
 
     /**
-     * @param string|null $templates comma separated template keys the list is restricted to
+     * The "templates" request parameter, restricting the options to a group's template keys, is optional:
+     * it is only present when this endpoint is called for a grouped snippet list view. Reading it from the
+     * current request (instead of an expression-language argument) keeps the metadata list expression in
+     * snippets.xml free of an undefined-variable lookup when the parameter is absent.
      *
      * @return mixed[]
      */
-    public function getFilterValues(string $locale, ?string $templates = null): array
+    public function getFilterValues(string $locale): array
     {
         /** @var TypedFormMetadata $metadata */
         $metadata = $this->formMetadataProvider->getMetadata(SnippetDimensionContent::getTemplateType(), $locale, []);
 
+        $templates = $this->requestStack->getCurrentRequest()?->query->get('templates');
         $templateKeys = null === $templates ? [] : \array_filter(\explode(',', $templates));
 
         $options = [];

--- a/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAdmin.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAdmin.php
@@ -19,6 +19,8 @@ use Sulu\Bundle\AdminBundle\Admin\View\DropdownToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ToolbarAction;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Component\Localization\Manager\LocalizationManagerInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
@@ -48,143 +50,224 @@ class SnippetAdmin extends Admin
         private SecurityCheckerInterface $securityChecker,
         private LocalizationManagerInterface $localizationManager,
         private ActivityViewBuilderFactoryInterface $activityViewBuilderFactory,
+        private GroupProviderInterface $groupProvider,
     ) {
     }
 
     public function configureNavigationItems(NavigationItemCollection $navigationItemCollection): void
     {
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
-            $navigationItem = new NavigationItem('sulu_snippet.snippets');
-            $navigationItem->setPosition(15);
-            $navigationItem->setIcon('su-snippet');
-            $navigationItem->setView(static::LIST_VIEW);
+        $groups = $this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE);
 
-            $navigationItemCollection->add($navigationItem);
+        $hasGroupWithEditPermission = false;
+        foreach ($groups as $group) {
+            if ($this->securityChecker->hasPermission($this->resolveSecurityContext($groups, $group), PermissionTypes::EDIT)) {
+                $hasGroupWithEditPermission = true;
+                break;
+            }
         }
+
+        if (!$hasGroupWithEditPermission) {
+            return;
+        }
+
+        $navigationItem = new NavigationItem('sulu_snippet.snippets');
+        $navigationItem->setPosition(15);
+        $navigationItem->setIcon('su-snippet');
+        $navigationItem->setView(static::LIST_VIEW);
+
+        $navigationItemCollection->add($navigationItem);
     }
 
     public function configureViews(ViewCollection $viewCollection): void
     {
-        $bundlePrefix = 'sulu_snippet.';
         $locales = $this->localizationManager->getLocales();
         $resourceKey = SnippetInterface::RESOURCE_KEY;
 
+        $viewCollection->add(
+            $this->viewBuilderFactory->createTabViewBuilder(static::LIST_VIEW, '/' . $resourceKey)
+                ->addRouterAttributesToBlacklist(['active', 'filter', 'limit', 'page', 'search', 'sortColumn', 'sortOrder']),
+        );
+
+        $groups = $this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE);
+        foreach ($groups as $group) {
+            $securityContext = $this->resolveSecurityContext($groups, $group);
+            $this->configureGroupViews($group, $locales, $resourceKey, $viewCollection, $securityContext);
+        }
+    }
+
+    /**
+     * @param array<string, FormGroup> $groups
+     */
+    private function resolveSecurityContext(array $groups, FormGroup $group): string
+    {
+        if (1 === \count($groups) || GroupProviderInterface::DEFAULT_GROUP === $group->identifier) {
+            return static::SECURITY_CONTEXT;
+        }
+
+        return static::getSnippetSecurityContext($group->identifier);
+    }
+
+    /**
+     * @param string[] $locales
+     */
+    private function configureGroupViews(FormGroup $group, array $locales, string $resourceKey, ViewCollection $viewCollection, string $securityContext): void
+    {
+        if (!$this->securityChecker->hasPermission($securityContext, PermissionTypes::EDIT)) {
+            return;
+        }
+
+        $groupIdentifier = $group->identifier;
+        $templateKeys = \implode(',', $group->templates);
+
         $listToolbarActions = [];
 
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::ADD)) {
+        if ($this->securityChecker->hasPermission($securityContext, PermissionTypes::ADD)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.add');
         }
 
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::DELETE)) {
+        if ($this->securityChecker->hasPermission($securityContext, PermissionTypes::DELETE)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.delete');
         }
 
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::VIEW)) {
+        if ($this->securityChecker->hasPermission($securityContext, PermissionTypes::VIEW)) {
             $listToolbarActions[] = new ToolbarAction('sulu_admin.export');
         }
 
-        if ($this->securityChecker->hasPermission(static::SECURITY_CONTEXT, PermissionTypes::EDIT)) {
+        $viewCollection->add(
+            $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW . '_' . $groupIdentifier, '/:locale/' . $groupIdentifier)
+                ->setResourceKey($resourceKey)
+                ->setListKey($resourceKey)
+                ->setTitle($group->title)
+                ->addListAdapters(['table'])
+                ->setTabTitle($group->title)
+                ->addLocales($locales)
+                ->addRequestParameters(['templateKeys' => $templateKeys])
+                ->addMetadataRequestParameters(['templates' => $templateKeys])
+                ->setDefaultLocale($locales[0] ?? '')
+                ->setAddView(static::ADD_TABS_VIEW . '_' . $groupIdentifier)
+                ->setEditView(static::EDIT_TABS_VIEW . '_' . $groupIdentifier)
+                ->addToolbarActions($listToolbarActions)
+                ->setParent(static::LIST_VIEW),
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_TABS_VIEW . '_' . $groupIdentifier, '/' . $resourceKey . '/:locale/' . $groupIdentifier . '/add')
+                ->setResourceKey($resourceKey)
+                ->addLocales($locales)
+                ->setBackView(static::LIST_VIEW . '_' . $groupIdentifier),
+        );
+        $viewCollection->add(
+            $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_TABS_VIEW . '_' . $groupIdentifier, '/' . $resourceKey . '/:locale/' . $groupIdentifier . '/:id') // TODO should be uuid
+                ->setResourceKey($resourceKey)
+                ->addLocales($locales)
+                ->setBackView(static::LIST_VIEW . '_' . $groupIdentifier)
+                ->setTitleProperty('title'),
+        );
+
+        $formToolbarActions = $this->contentViewBuilderFactory->getDefaultToolbarActions(SnippetInterface::class);
+        $formToolbarActions['delete'] = new DropdownToolbarAction(
+            'sulu_admin.delete',
+            'su-trash-alt',
+            [
+                new ToolbarAction(
+                    'sulu_admin.delete',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.delete)',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.delete',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.delete)',
+                        'delete_locale' => true,
+                    ]
+                ),
+            ]
+        );
+        $formToolbarActions['edit'] = new DropdownToolbarAction(
+            'sulu_admin.edit',
+            'su-pen',
+            [
+                new ToolbarAction(
+                    'sulu_admin.copy',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.edit)',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.copy_locale',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.edit)',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.delete_draft',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.live)',
+                    ]
+                ),
+                new ToolbarAction(
+                    'sulu_admin.set_unpublished',
+                    [
+                        'visible_condition' => '(!_permissions || _permissions.live)',
+                    ]
+                ),
+            ]
+        );
+
+        $viewBuilders = $this->contentViewBuilderFactory->createViews(
+            SnippetInterface::class,
+            static::EDIT_TABS_VIEW . '_' . $groupIdentifier,
+            static::ADD_TABS_VIEW . '_' . $groupIdentifier,
+            $securityContext,
+            toolbarActions: $formToolbarActions,
+        );
+
+        if (0 === \count($viewBuilders)) {
+            return;
+        }
+
+        foreach ($viewBuilders as $viewBuilder) {
+            $viewCollection->add($viewBuilder);
+        }
+
+        $this->addMetadataRequestParameters(
+            $viewCollection,
+            static::EDIT_TABS_VIEW . '_' . $groupIdentifier . '.content',
+            ['templates' => $templateKeys]
+        );
+
+        $this->addMetadataRequestParameters(
+            $viewCollection,
+            static::ADD_TABS_VIEW . '_' . $groupIdentifier . '.content',
+            ['templates' => $templateKeys]
+        );
+
+        $insightsResourceTabViewName = static::EDIT_TABS_VIEW . '_' . $groupIdentifier . '.insights';
+        if ($viewCollection->has($insightsResourceTabViewName) && $this->activityViewBuilderFactory->hasActivityListPermission()) {
             $viewCollection->add(
-                $this->viewBuilderFactory->createListViewBuilder(static::LIST_VIEW, '/' . $resourceKey . '/:locale')
-                    ->setResourceKey($resourceKey)
-                    ->setListKey($resourceKey)
-                    ->setTitle($bundlePrefix . $resourceKey)
-                    ->addListAdapters(['table'])
-                    ->addLocales($locales)
-                    ->setDefaultLocale($locales[0])
-                    ->setAddView(static::ADD_TABS_VIEW)
-                    ->setEditView(static::EDIT_TABS_VIEW)
-                    ->addToolbarActions($listToolbarActions)
+                $this->activityViewBuilderFactory
+                    ->createActivityListViewBuilder(
+                        $insightsResourceTabViewName . '.activity',
+                        '/activities',
+                        SnippetInterface::RESOURCE_KEY,
+                    )
+                    ->setParent($insightsResourceTabViewName),
             );
-            $viewCollection->add(
-                $this->viewBuilderFactory->createResourceTabViewBuilder(static::ADD_TABS_VIEW, '/' . $resourceKey . '/:locale/add')
-                    ->setResourceKey($resourceKey)
-                    ->addLocales($locales)
-                    ->setBackView(static::LIST_VIEW)
-            );
-            $viewCollection->add(
-                $this->viewBuilderFactory->createResourceTabViewBuilder(static::EDIT_TABS_VIEW, '/' . $resourceKey . '/:locale/:id') // TODO should be uuid
-                    ->setResourceKey($resourceKey)
-                    ->addLocales($locales)
-                    ->setBackView(static::LIST_VIEW)
-                    ->setTitleProperty('title')
-            );
+        }
+    }
 
-            $formToolbarActions = $this->contentViewBuilderFactory->getDefaultToolbarActions(SnippetInterface::class);
-            $formToolbarActions['delete'] = new DropdownToolbarAction(
-                'sulu_admin.delete',
-                'su-trash-alt',
-                [
-                    new ToolbarAction(
-                        'sulu_admin.delete',
-                        [
-                            'visible_condition' => '(!_permissions || _permissions.delete)',
-                        ]
-                    ),
-                    new ToolbarAction(
-                        'sulu_admin.delete',
-                        [
-                            'visible_condition' => '(!_permissions || _permissions.delete)',
-                            'delete_locale' => true,
-                        ]
-                    ),
-                ]
-            );
-            $formToolbarActions['edit'] = new DropdownToolbarAction(
-                'sulu_admin.edit',
-                'su-pen',
-                [
-                    new ToolbarAction(
-                        'sulu_admin.copy',
-                        [
-                            'visible_condition' => '(!_permissions || _permissions.edit)',
-                        ]
-                    ),
-                    new ToolbarAction(
-                        'sulu_admin.copy_locale',
-                        [
-                            'visible_condition' => '(!_permissions || _permissions.edit)',
-                        ]
-                    ),
-                    new ToolbarAction(
-                        'sulu_admin.delete_draft',
-                        [
-                            'visible_condition' => '(!_permissions || _permissions.live)',
-                        ]
-                    ),
-                    new ToolbarAction(
-                        'sulu_admin.set_unpublished',
-                        [
-                            'visible_condition' => '(!_permissions || _permissions.live)',
-                        ]
-                    ),
-                ]
-            );
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function addMetadataRequestParameters(ViewCollection $viewCollection, string $viewName, array $metadata): void
+    {
+        if (!$viewCollection->has($viewName)) {
+            return;
+        }
 
-            $viewBuilders = $this->contentViewBuilderFactory->createViews(
-                SnippetInterface::class,
-                static::EDIT_TABS_VIEW,
-                static::ADD_TABS_VIEW,
-                static::SECURITY_CONTEXT,
-                toolbarActions: $formToolbarActions,
-            );
-
-            foreach ($viewBuilders as $viewBuilder) {
-                $viewCollection->add($viewBuilder);
-            }
-
-            if ($this->activityViewBuilderFactory->hasActivityListPermission()) {
-                $insightsResourceTabViewName = SnippetAdmin::EDIT_TABS_VIEW . '.insights';
-                $viewCollection->add(
-                    $this->activityViewBuilderFactory
-                        ->createActivityListViewBuilder(
-                            $insightsResourceTabViewName . '.activity',
-                            '/activities',
-                            SnippetInterface::RESOURCE_KEY
-                        )
-                        ->setParent($insightsResourceTabViewName)
-                );
-            }
+        $view = $viewCollection->get($viewName);
+        if (\method_exists($view, 'addMetadataRequestParameters')) {
+            $view->addMetadataRequestParameters($metadata);
         }
     }
 
@@ -193,18 +276,44 @@ class SnippetAdmin extends Admin
      */
     public function getSecurityContexts()
     {
+        $groupSecurityContexts = [];
+        $groups = $this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE);
+        if (1 !== \count($groups)) {
+            foreach ($groups as $group) {
+                if (GroupProviderInterface::DEFAULT_GROUP === $group->identifier) {
+                    continue;
+                }
+
+                $groupSecurityContexts[static::getSnippetSecurityContext($group->identifier)] = [
+                    PermissionTypes::VIEW,
+                    PermissionTypes::ADD,
+                    PermissionTypes::EDIT,
+                    PermissionTypes::DELETE,
+                    PermissionTypes::LIVE,
+                ];
+            }
+        }
+
         return [
             self::SULU_ADMIN_SECURITY_SYSTEM => [
-                'Snippet' => [
-                    static::SECURITY_CONTEXT => [
-                        PermissionTypes::VIEW,
-                        PermissionTypes::ADD,
-                        PermissionTypes::EDIT,
-                        PermissionTypes::DELETE,
-                        PermissionTypes::LIVE,
+                'Snippet' => \array_merge(
+                    [
+                        static::SECURITY_CONTEXT => [
+                            PermissionTypes::VIEW,
+                            PermissionTypes::ADD,
+                            PermissionTypes::EDIT,
+                            PermissionTypes::DELETE,
+                            PermissionTypes::LIVE,
+                        ],
                     ],
-                ],
+                    $groupSecurityContexts,
+                ),
             ],
         ];
+    }
+
+    public static function getSnippetSecurityContext(string $groupIdentifier): string
+    {
+        return \sprintf('%s_%s', static::SECURITY_CONTEXT, $groupIdentifier);
     }
 }

--- a/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAreaAdmin.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Admin/SnippetAreaAdmin.php
@@ -16,11 +16,13 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Admin;
 use Sulu\Bundle\AdminBundle\Admin\Admin;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewBuilderFactoryInterface;
 use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Component\Security\Authorization\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Webspace\Manager\WebspaceManagerInterface;
 use Sulu\Component\Webspace\Webspace;
 use Sulu\Page\Infrastructure\Sulu\Admin\PageAdmin;
+use Sulu\Snippet\Domain\Model\SnippetInterface;
 
 /**
  * @final
@@ -38,6 +40,7 @@ class SnippetAreaAdmin extends Admin
         private ViewBuilderFactoryInterface $viewBuilderFactory,
         private SecurityCheckerInterface $securityChecker,
         private WebspaceManagerInterface $webspaceManager,
+        private GroupProviderInterface $groupProvider,
     ) {
     }
 
@@ -50,12 +53,28 @@ class SnippetAreaAdmin extends Admin
         $viewCollection->add(
             $this->viewBuilderFactory
                 ->createViewBuilder('sulu_snippet.snippet_areas', '/snippet-areas', 'sulu_snippet.snippet_areas')
-                ->setOption('snippetEditView', SnippetAdmin::EDIT_TABS_VIEW)
+                ->setOption('snippetEditViews', $this->getSnippetEditViews())
                 ->setOption('tabTitle', 'sulu_snippet.webspace_default_snippets')
                 ->setOption('tabOrder', 3072)
                 ->setParent(PageAdmin::WEBSPACE_TABS_VIEW)
                 ->addRerenderAttribute('webspace'),
         );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getSnippetEditViews(): array
+    {
+        $snippetEditViews = [];
+
+        foreach ($this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE) as $group) {
+            foreach ($group->templates as $templateKey) {
+                $snippetEditViews[$templateKey] = SnippetAdmin::EDIT_TABS_VIEW . '_' . $group->identifier;
+            }
+        }
+
+        return $snippetEditViews;
     }
 
     public function getSecurityContexts()

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
@@ -14,6 +14,7 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Content;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\Builder;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\BuilderInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfigurationInterface;
@@ -91,6 +92,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         private DimensionContentQueryEnhancer $dimensionContentQueryEnhancer,
         private SmartContentQueryEnhancer $smartContentQueryEnhancer,
         EntityManagerInterface $entityManager,
+        private GroupProviderInterface $groupProvider,
     ) {
         $this->entityRepository = $entityManager->getRepository(SnippetInterface::class);
         $this->entityDimensionContentRepository = $entityManager->getRepository(SnippetDimensionContentInterface::class);
@@ -118,7 +120,16 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
                     ['column' => 'created', 'title' => 'sulu_admin.created'],
                     ['column' => 'title', 'title' => 'sulu_admin.title'],
                 ]
-            );
+            )
+            ->enableTypes(\array_values(\array_map(
+                function($group) {
+                    return [
+                        'title' => $group->title,
+                        'type' => $group->identifier,
+                    ];
+                },
+                $this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE),
+            )));
     }
 
     /**
@@ -271,14 +282,34 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
 
     /**
      * @param array<string> $existingTemplateKeys
-     * @param array<string> $filterTemplateKeys
+     * @param array<string> $filterGroupIdentifiers
      * @param array<string, mixed> $params
      *
      * @return list<string>|null null = no overlap with the requested filters
      */
-    private function resolveTemplateKeys(array $existingTemplateKeys, array $filterTemplateKeys, array $params): ?array
+    private function resolveTemplateKeys(array $existingTemplateKeys, array $filterGroupIdentifiers, array $params): ?array
     {
-        $templateKeys = \array_values(\array_unique(\array_merge($existingTemplateKeys, $filterTemplateKeys)));
+        $xmlGroupIdentifiers = $this->parseListParameter($params['groups'] ?? null);
+
+        if ([] !== $xmlGroupIdentifiers && [] !== $filterGroupIdentifiers) {
+            $groupIdentifiers = \array_values(\array_intersect($filterGroupIdentifiers, $xmlGroupIdentifiers));
+            if ([] === $groupIdentifiers) {
+                return null;
+            }
+        } else {
+            $groupIdentifiers = $filterGroupIdentifiers ?: $xmlGroupIdentifiers;
+        }
+
+        $templateKeys = \array_values($existingTemplateKeys);
+        if ([] !== $groupIdentifiers) {
+            $templatesFromGroups = $this->expandGroupsToTemplates($groupIdentifiers);
+            $templateKeys = [] !== $templateKeys
+                ? \array_values(\array_intersect($templateKeys, $templatesFromGroups))
+                : $templatesFromGroups;
+            if ([] === $templateKeys) {
+                return null;
+            }
+        }
 
         $xmlTemplateKeys = $this->parseListParameter($params['templateKeys'] ?? null);
         if ([] !== $xmlTemplateKeys) {
@@ -291,6 +322,23 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         }
 
         return $templateKeys;
+    }
+
+    /**
+     * @param array<string> $identifiers
+     *
+     * @return list<string>
+     */
+    private function expandGroupsToTemplates(array $identifiers): array
+    {
+        $templates = [];
+        foreach ($this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE) as $group) {
+            if (\in_array($group->identifier, $identifiers, true)) {
+                $templates = \array_merge($templates, \array_filter($group->templates, 'is_string'));
+            }
+        }
+
+        return \array_values(\array_unique($templates));
     }
 
     /**

--- a/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Content/SnippetSmartContentProvider.php
@@ -24,6 +24,7 @@ use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Content\Infrastructure\Doctrine\DimensionContentQueryEnhancer;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
+use Sulu\Snippet\Infrastructure\Sulu\Admin\SnippetAdmin;
 use Sulu\Snippet\Infrastructure\Sulu\Content\ResourceLoader\SnippetResourceLoader;
 
 /**
@@ -129,7 +130,12 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
                     ];
                 },
                 $this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE),
-            )));
+            )))
+            ->enableView(
+                SnippetAdmin::EDIT_TABS_VIEW . '_{group}',
+                ['id' => 'id', 'locale' => 'locale'],
+                ['group' => 'group'],
+            );
     }
 
     /**
@@ -170,7 +176,7 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
      *     changed?: 'asc'|'desc',
      * } $sortBys
      *
-     * @return array<array{id: string, title: string}>
+     * @return array<array{id: string, title: string, group: string, locale: string}>
      */
     public function findFlatBy(array $filters, array $sortBys, array $params = []): array
     {
@@ -200,19 +206,35 @@ readonly class SnippetSmartContentProvider implements SmartContentProviderInterf
         // We need the distinct here, because joins due to tags/categories can lead to duplicate results
         $queryBuilder->select('DISTINCT snippet.uuid as id');
         $queryBuilder->addSelect('filterDimensionContent.title');
+        $queryBuilder->addSelect('filterDimensionContent.templateKey');
         $this->smartContentQueryEnhancer->addOrderBySelects($queryBuilder);
 
         $this->smartContentQueryEnhancer->addPagination($queryBuilder, $filters['offset'] ?? 0, $filters['limit']);
 
-        /** @var array{id: string, title: string, changed?: string, authored?: string}[] $queryResult */
+        /** @var array{id: string, title: string, templateKey: string|null, changed?: string, authored?: string}[] $queryResult */
         $queryResult = $queryBuilder->getQuery()->getArrayResult();
 
-        /** @var array{id: string, title: string}[] $result */
+        // built once and reused for every result, instead of calling getGroups() per item
+        $groupByTemplateKey = [];
+        foreach ($this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE) as $group) {
+            foreach ($group->templates as $template) {
+                $groupByTemplateKey[$template] = $group->identifier;
+            }
+        }
+
+        /** @var array{id: string, title: string, group: string, locale: string}[] $result */
         $result = \array_map(
-            static fn (array $item) => [
-                'id' => $item['id'],
-                'title' => $item['title'],
-            ],
+            function(array $item) use ($groupByTemplateKey, $filters) {
+                $templateKey = $item['templateKey'];
+
+                return [
+                    'id' => $item['id'],
+                    'title' => $item['title'],
+                    'group' => (\is_string($templateKey) ? $groupByTemplateKey[$templateKey] ?? null : null)
+                        ?? GroupProviderInterface::DEFAULT_GROUP,
+                    'locale' => $filters['locale'],
+                ];
+            },
             $queryResult
         );
 

--- a/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
@@ -17,6 +17,8 @@ use CmsIg\Seal\Reindex\ReindexConfig;
 use CmsIg\Seal\Reindex\ReindexProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Content\Domain\Model\DimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetDimensionContentInterface;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
@@ -30,6 +32,7 @@ use Sulu\Snippet\Infrastructure\Sulu\Search\Visitor\AdminSnippetReindexProviderE
  *     created: \DateTimeImmutable,
  *     title: string,
  *     locale: string,
+ *     templateKey: string,
  * }
  *
  * @internal this class is internal no backwards compatibility promise is given for this class
@@ -47,6 +50,7 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
      */
     public function __construct(
         EntityManagerInterface $entityManager,
+        private readonly GroupProviderInterface $groupProvider,
         private readonly iterable $enhancers = [],
     ) {
         $this->dimensionContentRepository = $entityManager->getRepository(SnippetDimensionContentInterface::class);
@@ -61,9 +65,26 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
     public function provide(ReindexConfig $reindexConfig): \Generator
     {
         $snippets = $this->loadSnippets($reindexConfig->getIdentifiers());
+        /** @var FormGroup[] $groups */
+        $groups = $this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE);
 
         /** @var Snippet $snippet */
         foreach ($snippets as $snippet) {
+            $groupIdentifier = null;
+
+            foreach ($groups as $group) {
+                if (\in_array($snippet['templateKey'], $group->templates)) {
+                    $groupIdentifier = $group->identifier;
+                    break;
+                }
+            }
+
+            $groupIdentifier ??= GroupProviderInterface::DEFAULT_GROUP;
+            $securityContext = SnippetAdmin::getSnippetSecurityContext($groupIdentifier);
+            if (1 === \count($groups) || GroupProviderInterface::DEFAULT_GROUP === $groupIdentifier) {
+                $securityContext = SnippetAdmin::SECURITY_CONTEXT;
+            }
+
             $data = [
                 'id' => SnippetInterface::RESOURCE_KEY . '__' . ((string) $snippet['snippetId']) . '__' . $snippet['locale'],
                 'resourceKey' => SnippetInterface::RESOURCE_KEY,
@@ -72,7 +93,10 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
                 'createdAt' => $snippet['created']->format('c'),
                 'title' => $snippet['title'],
                 'locale' => $snippet['locale'],
-                'securityContext' => SnippetAdmin::SECURITY_CONTEXT,
+                'metadata' => [
+                    'group' => $groupIdentifier,
+                ],
+                'securityContext' => $securityContext,
             ];
 
             foreach ($this->enhancers as $enhancer) {
@@ -96,6 +120,7 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
             ->addSelect('dimensionContent.changed')
             ->addSelect('dimensionContent.title')
             ->addSelect('dimensionContent.locale')
+            ->addSelect('dimensionContent.templateKey')
             ->where('dimensionContent.stage = :stage')
             ->andWhere('dimensionContent.locale IS NOT NULL')
             ->andWhere('dimensionContent.version = :version');

--- a/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Search/AdminSnippetReindexProvider.php
@@ -73,7 +73,7 @@ final class AdminSnippetReindexProvider implements ReindexProviderInterface
             $groupIdentifier = null;
 
             foreach ($groups as $group) {
-                if (\in_array($snippet['templateKey'], $group->templates)) {
+                if (\in_array($snippet['templateKey'], $group->templates, true)) {
                     $groupIdentifier = $group->identifier;
                     break;
                 }

--- a/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetRestoreResult.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetRestoreResult.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Infrastructure\Sulu\Trash;
+
+/**
+ * @internal
+ */
+final class SnippetRestoreResult
+{
+    public function __construct(
+        private string $id,
+        private string $group,
+        private string $locale,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+}

--- a/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
@@ -214,10 +214,11 @@ final class SnippetTrashItemHandler implements
 
     public function getConfiguration(): RestoreConfiguration
     {
+        // the restore response carries no template, so the group of the edit view cannot be resolved
         return new RestoreConfiguration(
             null,
-            SnippetAdmin::EDIT_TABS_VIEW,
-            ['id' => 'id'],
+            SnippetAdmin::LIST_VIEW,
+            [],
             null, // TODO serialization group?
         );
     }

--- a/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
@@ -197,9 +197,8 @@ final class SnippetTrashItemHandler implements
             }
         }
 
-        $context = $allLocales ? ['locales' => $allLocales] : [];
-
         Assert::notEmpty($allLocales, 'Expected to find at least one restored locale for the snippet.');
+        $context = ['locales' => $allLocales];
         $result = new SnippetRestoreResult($snippet->getUuid(), $this->resolveGroup($templateKey), $allLocales[0]);
 
         if ('translation' === $trashItem->getRestoreType()) {

--- a/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
+++ b/packages/snippet/src/Infrastructure/Sulu/Trash/SnippetTrashItemHandler.php
@@ -15,6 +15,7 @@ namespace Sulu\Snippet\Infrastructure\Sulu\Trash;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
@@ -53,6 +54,7 @@ final class SnippetTrashItemHandler implements
         private ContentMergerInterface $contentMerger,
         private iterable $snippetMappers,
         private DomainEventCollectorInterface $domainEventCollector,
+        private GroupProviderInterface $groupProvider,
     ) {
     }
 
@@ -169,6 +171,8 @@ final class SnippetTrashItemHandler implements
         $allLocales = [];
         /** @var string|null $snippetTitle */
         $snippetTitle = null;
+        /** @var string|null $templateKey */
+        $templateKey = null;
         Assert::isArray($dimensionContents, 'Expected dimensionContents to be an array');
         foreach ($dimensionContents as $dimensionContentData) {
             Assert::isArray($dimensionContentData, 'Expected dimensionContentData to be an array');
@@ -183,12 +187,20 @@ final class SnippetTrashItemHandler implements
                 $allLocales[] = $dimensionContentData['locale'];
             }
 
+            if (null === $templateKey && \array_key_exists('template', $dimensionContentData) && $dimensionContentData['template']) {
+                Assert::string($dimensionContentData['template']);
+                $templateKey = $dimensionContentData['template'];
+            }
+
             foreach ($this->snippetMappers as $snippetMapper) {
                 $snippetMapper->mapSnippetData($snippet, $dimensionContentData);
             }
         }
 
         $context = $allLocales ? ['locales' => $allLocales] : [];
+
+        Assert::notEmpty($allLocales, 'Expected to find at least one restored locale for the snippet.');
+        $result = new SnippetRestoreResult($snippet->getUuid(), $this->resolveGroup($templateKey), $allLocales[0]);
 
         if ('translation' === $trashItem->getRestoreType()) {
             foreach ($allLocales as $locale) {
@@ -199,7 +211,7 @@ final class SnippetTrashItemHandler implements
                 ));
             }
 
-            return $snippet;
+            return $result;
         }
 
         $this->domainEventCollector->collect(new SnippetRestoredEvent(
@@ -209,17 +221,35 @@ final class SnippetTrashItemHandler implements
             $restoreData,
         ));
 
-        return $snippet;
+        return $result;
     }
 
     public function getConfiguration(): RestoreConfiguration
     {
-        // the restore response carries no template, so the group of the edit view cannot be resolved
         return new RestoreConfiguration(
             null,
-            SnippetAdmin::LIST_VIEW,
-            [],
-            null, // TODO serialization group?
+            SnippetAdmin::EDIT_TABS_VIEW . '_{group}',
+            ['id' => 'id', 'locale' => 'locale'],
+            null,
+            ['group' => 'group'],
         );
+    }
+
+    private function resolveGroup(?string $templateKey): string
+    {
+        if (null === $templateKey) {
+            return GroupProviderInterface::DEFAULT_GROUP;
+        }
+
+        // resolve the template key -> group identifier mapping once instead of per item,
+        // to avoid re-fetching and re-sorting the groups for every single result
+        $groupByTemplateKey = [];
+        foreach ($this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE) as $group) {
+            foreach ($group->templates as $template) {
+                $groupByTemplateKey[$template] = $group->identifier;
+            }
+        }
+
+        return $groupByTemplateKey[$templateKey] ?? GroupProviderInterface::DEFAULT_GROUP;
     }
 }

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -243,6 +243,7 @@ final class SuluSnippetBundle extends AbstractBundle
                 new Reference('sulu_security.security_checker'),
                 new Reference('sulu.core.localization_manager'),
                 new Reference('sulu_activity.activity_list_view_builder_factory'),
+                new Reference('sulu_admin.metadata_group_provider'),
             ])
             ->tag('sulu.context', ['context' => 'admin'])
             ->tag('sulu.admin');
@@ -253,6 +254,7 @@ final class SuluSnippetBundle extends AbstractBundle
                 new Reference('sulu_admin.view_builder_factory'),
                 new Reference('sulu_security.security_checker'),
                 new Reference('sulu_core.webspace.webspace_manager'),
+                new Reference('sulu_admin.metadata_group_provider'),
             ])
             ->tag('sulu.context', ['context' => 'admin'])
             ->tag('sulu.admin');
@@ -311,6 +313,7 @@ final class SuluSnippetBundle extends AbstractBundle
                 new Reference('sulu_snippet.snippet_repository'),
                 new Reference('sulu_message_bus'),
                 new Reference('serializer'),
+                new Reference('sulu_admin.metadata_group_provider'),
                 // additional services to be removed when no longer needed
                 new Reference('sulu_content.content_manager'),
                 new Reference('sulu_core.list_builder.field_descriptor_factory'),
@@ -377,6 +380,7 @@ final class SuluSnippetBundle extends AbstractBundle
                 new Reference('sulu_content.dimension_content_query_enhancer'),
                 new Reference('sulu_admin.smart_content_query_enhancer'),
                 new Reference('doctrine.orm.entity_manager'),
+                new Reference('sulu_admin.metadata_group_provider'),
             ])
             ->tag('sulu_content.smart_content_provider', ['type' => SnippetInterface::RESOURCE_KEY]);
 
@@ -448,6 +452,7 @@ final class SuluSnippetBundle extends AbstractBundle
             ->class(AdminSnippetReindexProvider::class)
             ->args([
                 new Reference('doctrine.orm.entity_manager'),
+                new Reference('sulu_admin.metadata_group_provider'),
                 tagged_iterator('sulu_snippet.admin_snippet_reindex_provider_enhancer'),
             ])
             ->tag('cmsig_seal.reindex_provider');
@@ -568,7 +573,10 @@ final class SuluSnippetBundle extends AbstractBundle
                                 'name' => 'sulu_snippet.snippets',
                                 'icon' => 'su-snippet',
                                 'route' => [
-                                    'name' => 'sulu_snippet.snippet.edit_tabs',
+                                    'name' => SnippetAdmin::EDIT_TABS_VIEW . '_{group}',
+                                    'resultToRouteName' => [
+                                        'metadata.group' => 'group',
+                                    ],
                                     'resultToRoute' => [
                                         'resourceId' => 'id',
                                         'locale' => 'locale',

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -426,6 +426,7 @@ final class SuluSnippetBundle extends AbstractBundle
                     new Reference('sulu_content.content_merger'),
                     tagged_iterator('sulu_snippet.snippet_mapper'),
                     new Reference('sulu_activity.domain_event_collector'),
+                    new Reference('sulu_admin.metadata_group_provider'),
                 ])
                 ->tag('sulu_trash.store_trash_item_handler')
                 ->tag('sulu_trash.restore_trash_item_handler')

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -511,6 +511,16 @@ final class SuluSnippetBundle extends AbstractBundle
                             'snippet_selection' => [
                                 'default_type' => 'list_overlay',
                                 'resource_key' => 'snippets',
+                                'view' => [
+                                    'name' => SnippetAdmin::EDIT_TABS_VIEW . '_{group}',
+                                    'result_to_view' => [
+                                        'id' => 'id',
+                                        'locale' => 'locale',
+                                    ],
+                                    'result_to_view_name' => [
+                                        '_group' => 'group',
+                                    ],
+                                ],
                                 'types' => [
                                     'list_overlay' => [
                                         'adapter' => 'table',
@@ -527,6 +537,16 @@ final class SuluSnippetBundle extends AbstractBundle
                             'single_snippet_selection' => [
                                 'default_type' => 'list_overlay',
                                 'resource_key' => 'snippets',
+                                'view' => [
+                                    'name' => SnippetAdmin::EDIT_TABS_VIEW . '_{group}',
+                                    'result_to_view' => [
+                                        'id' => 'id',
+                                        'locale' => 'locale',
+                                    ],
+                                    'result_to_view_name' => [
+                                        '_group' => 'group',
+                                    ],
+                                ],
                                 'types' => [
                                     'list_overlay' => [
                                         'adapter' => 'table',

--- a/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
+++ b/packages/snippet/src/Infrastructure/Symfony/HttpKernel/SuluSnippetBundle.php
@@ -264,6 +264,7 @@ final class SuluSnippetBundle extends AbstractBundle
             ->public()
             ->args([
                 new Reference('sulu_admin.form_metadata_provider'),
+                new Reference('request_stack'),
             ]);
 
         $services->set('sulu_snippet.snippet_area_normalizer', SnippetAreaNormalizer::class)

--- a/packages/snippet/src/Infrastructure/Symfony/Normalizer/SnippetAreaNormalizer.php
+++ b/packages/snippet/src/Infrastructure/Symfony/Normalizer/SnippetAreaNormalizer.php
@@ -81,8 +81,11 @@ final class SnippetAreaNormalizer implements NormalizerInterface
 
         /** @var SnippetInterface|null $snippet */
         $snippet = $data->getSnippet();
-        $normalizedData['snippetTitle'] = $this->getTitle($snippet, $locale);
+        $snippetDimensionContent = $this->resolveDimensionContent($snippet, $locale);
+        $normalizedData['snippetTitle'] = $snippetDimensionContent?->getTitle();
         $normalizedData['snippetUuid'] = $snippet?->getId();
+        // required by the frontend to resolve the group-specific edit view after assigning a snippet
+        $normalizedData['templateKey'] = $snippetDimensionContent?->getTemplateKey();
         $normalizedData['title'] = $title;
 
         // Why would this would be false?
@@ -91,7 +94,7 @@ final class SnippetAreaNormalizer implements NormalizerInterface
         return $normalizedData;
     }
 
-    private function getTitle(?SnippetInterface $snippet, string $locale): ?string
+    private function resolveDimensionContent(?SnippetInterface $snippet, string $locale): ?SnippetDimensionContentInterface
     {
         if (null === $snippet) {
             return null;
@@ -109,7 +112,7 @@ final class SnippetAreaNormalizer implements NormalizerInterface
 
         $localizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $locale]);
         if (null !== $localizedDimensionContent) {
-            return $localizedDimensionContent->getTitle();
+            return $localizedDimensionContent;
         }
 
         $unlocalizedDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => null]);
@@ -117,10 +120,9 @@ final class SnippetAreaNormalizer implements NormalizerInterface
             return null;
         }
 
-        $locale = $unlocalizedDimensionContent->getGhostLocale() ?? $unlocalizedDimensionContent->getAvailableLocales()[0] ?? null;
-        $ghostLocaleDimensionContent = $dimensionContentCollection->getDimensionContent(['locale' => $locale]);
+        $ghostLocale = $unlocalizedDimensionContent->getGhostLocale() ?? $unlocalizedDimensionContent->getAvailableLocales()[0] ?? null;
 
-        return $ghostLocaleDimensionContent?->getTitle();
+        return $dimensionContentCollection->getDimensionContent(['locale' => $ghostLocale]);
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -117,8 +117,28 @@ final class SnippetController implements SecuredControllerInterface
         }
 
         $templateKeysParam = $request->query->getString('templateKeys');
-        $templateKeys = \array_filter(\explode(',', $templateKeysParam));
-        $templateKeys = \array_unique(\array_merge($templateKeys, $groupTemplateKeys));
+        $requestedTemplateKeys = \array_filter(\explode(',', $templateKeysParam));
+        $templateKeys = \array_unique(\array_merge($requestedTemplateKeys, $groupTemplateKeys));
+
+        $templateFilterRequested = [] !== $groupIdentifiers || [] !== $requestedTemplateKeys;
+        if ($templateFilterRequested && 0 === \count($templateKeys)) {
+            // the requested groups/templateKeys did not resolve to any known template key, so the
+            // filter must not be dropped silently (an empty `in()` call has no effect on the query
+            // and would return every snippet instead of none)
+            $listRepresentation = new PaginatedRepresentation(
+                [],
+                SnippetInterface::RESOURCE_KEY,
+                (int) $listBuilder->getCurrentPage(),
+                (int) $listBuilder->getLimit(),
+                0,
+            );
+
+            return new JsonResponse($this->normalizer->normalize(
+                $listRepresentation->toArray(),
+                'json',
+                ['sulu_admin' => true, 'sulu_admin_snippet' => true, 'sulu_admin_snippet_list' => true],
+            ));
+        }
 
         if (0 !== \count($templateKeys)) {
             $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Snippet\UserInterface\Controller\Admin;
 
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilderFactoryInterface;
@@ -62,6 +63,7 @@ final class SnippetController implements SecuredControllerInterface
         private SnippetRepositoryInterface $snippetRepository,
         MessageBusInterface $messageBus,
         private NormalizerInterface $normalizer,
+        private GroupProviderInterface $groupProvider,
         private ContentManagerInterface $contentManager,
         private FieldDescriptorFactoryInterface $fieldDescriptorFactory,
         private DoctrineListBuilderFactoryInterface $listBuilderFactory,
@@ -104,8 +106,19 @@ final class SnippetController implements SecuredControllerInterface
         }
         $listBuilder->setParameter('locale', $this->getLocale($request));
 
+        $groupsParam = $request->query->getString('groups');
+        $groupIdentifiers = \array_filter(\explode(',', $groupsParam));
+
+        $groupTemplateKeys = [];
+        foreach ($this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE) as $group) {
+            if (\in_array($group->identifier, $groupIdentifiers, true)) {
+                $groupTemplateKeys = \array_merge($groupTemplateKeys, $group->templates);
+            }
+        }
+
         $templateKeysParam = $request->query->getString('templateKeys');
         $templateKeys = \array_filter(\explode(',', $templateKeysParam));
+        $templateKeys = \array_unique(\array_merge($templateKeys, $groupTemplateKeys));
 
         if (0 !== \count($templateKeys)) {
             $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Snippet\UserInterface\Controller\Admin;
 
+use Sulu\Bundle\AdminBundle\Metadata\FormMetadata\FormGroup;
 use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Component\Rest\Exception\EntityNotFoundException;
 use Sulu\Component\Rest\ListBuilder\Doctrine\DoctrineListBuilder;
@@ -100,6 +101,7 @@ final class SnippetController implements SecuredControllerInterface
         $listBuilder->addSelectField($fieldDescriptors['locale']);
         $listBuilder->addSelectField($fieldDescriptors['published']);
         $listBuilder->addSelectField($fieldDescriptors['publishedState']);
+        $listBuilder->addSelectField($fieldDescriptors['templateKey']);
 
         if (isset($fieldDescriptors['ghostLocale'])) {
             $listBuilder->addSelectField($fieldDescriptors['ghostLocale']);
@@ -109,8 +111,10 @@ final class SnippetController implements SecuredControllerInterface
         $groupsParam = $request->query->getString('groups');
         $groupIdentifiers = \array_filter(\explode(',', $groupsParam));
 
+        $groups = $this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE);
+
         $groupTemplateKeys = [];
-        foreach ($this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE) as $group) {
+        foreach ($groups as $group) {
             if (\in_array($group->identifier, $groupIdentifiers, true)) {
                 $groupTemplateKeys = \array_merge($groupTemplateKeys, $group->templates);
             }
@@ -177,6 +181,10 @@ final class SnippetController implements SecuredControllerInterface
         $list = $listRepresentation->toArray();
         foreach ($list['_embedded']['snippets'] as &$item) {
             $item['publishedState'] = WorkflowInterface::WORKFLOW_PLACE_PUBLISHED === ($item['publishedState'] ?? null);
+            $templateKey = $item['templateKey'] ?? null;
+            // prefixed to avoid colliding with a template property of the same name
+            $item['_group'] = $this->resolveGroup($groups, \is_string($templateKey) ? $templateKey : null);
+            unset($item['templateKey']);
         }
 
         return new JsonResponse($this->normalizer->normalize(
@@ -250,6 +258,33 @@ final class SnippetController implements SecuredControllerInterface
         //      Instead of calling the content resolver service which triggers an additional query.
         $dimensionContent = $this->contentManager->resolve($snippet, $dimensionAttributes);
         $normalizedContent = $this->contentManager->normalize($dimensionContent);
+
+        $templateKey = $dimensionContent->getTemplateKey();
+        $ghostLocale = $dimensionContent->getGhostLocale();
+        if (null === $templateKey && null !== $ghostLocale) {
+            // $snippet is already managed by the entity manager for the requested locale, so
+            // fetching it again for $ghostLocale would return the same, already-loaded
+            // dimension contents instead of querying them again. Look up just the template
+            // key for the ghosted locale through the list builder instead.
+            /** @var DoctrineFieldDescriptorInterface[] $ghostFieldDescriptors */
+            $ghostFieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors(SnippetInterface::RESOURCE_KEY);
+            /** @var DoctrineListBuilder $ghostListBuilder */
+            $ghostListBuilder = $this->listBuilderFactory->create(SnippetInterface::class);
+            $ghostListBuilder->setIdField($ghostFieldDescriptors['id']);
+            $ghostListBuilder->addSelectField($ghostFieldDescriptors['templateKey']);
+            $ghostListBuilder->setIds([$id]);
+            $ghostListBuilder->setParameter('locale', $ghostLocale);
+
+            /** @var array{templateKey?: string|null}[] $ghostResult */
+            $ghostResult = $ghostListBuilder->execute();
+            $templateKey = $ghostResult[0]['templateKey'] ?? null;
+        }
+
+        // prefixed to avoid colliding with a template property of the same name
+        $normalizedContent['_group'] = $this->resolveGroup(
+            $this->groupProvider->getGroups(SnippetInterface::TEMPLATE_TYPE),
+            $templateKey,
+        );
 
         return new JsonResponse($this->normalizer->normalize(
             $normalizedContent, // TODO this should just be the snippet entity see comment above
@@ -334,6 +369,22 @@ final class SnippetController implements SecuredControllerInterface
     public function getLocale(Request $request): string
     {
         return $request->query->getString('locale', $request->getLocale());
+    }
+
+    /**
+     * @param array<string, FormGroup> $groups
+     */
+    private function resolveGroup(array $groups, ?string $templateKey): string
+    {
+        if (null !== $templateKey) {
+            foreach ($groups as $group) {
+                if (\in_array($templateKey, $group->templates, true)) {
+                    return $group->identifier;
+                }
+            }
+        }
+
+        return GroupProviderInterface::DEFAULT_GROUP;
     }
 
     private function handleAction(Request $request, string $uuid): ?SnippetInterface // @phpstan-ignore-line

--- a/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
+++ b/packages/snippet/src/UserInterface/Controller/Admin/SnippetController.php
@@ -124,35 +124,11 @@ final class SnippetController implements SecuredControllerInterface
         $requestedTemplateKeys = \array_filter(\explode(',', $templateKeysParam));
         $templateKeys = \array_unique(\array_merge($requestedTemplateKeys, $groupTemplateKeys));
 
-        $templateFilterRequested = [] !== $groupIdentifiers || [] !== $requestedTemplateKeys;
-        if ($templateFilterRequested && 0 === \count($templateKeys)) {
-            // the requested groups/templateKeys did not resolve to any known template key, so the
-            // filter must not be dropped silently (an empty `in()` call has no effect on the query
-            // and would return every snippet instead of none)
-            $listRepresentation = new PaginatedRepresentation(
-                [],
-                SnippetInterface::RESOURCE_KEY,
-                (int) $listBuilder->getCurrentPage(),
-                (int) $listBuilder->getLimit(),
-                0,
-            );
-
-            return new JsonResponse($this->normalizer->normalize(
-                $listRepresentation->toArray(),
-                'json',
-                ['sulu_admin' => true, 'sulu_admin_snippet' => true, 'sulu_admin_snippet_list' => true],
-            ));
-        }
-
-        if (0 !== \count($templateKeys)) {
-            $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);
-        }
-
         $areasParam = $request->query->get('areas');
-        if (null !== $areasParam) {
-            $areas = \explode(',', (string) $areasParam);
+        $areaFilterRequested = null !== $areasParam;
+        if ($areaFilterRequested) {
             $areaTemplateKeys = [];
-            foreach ($areas as $area) {
+            foreach (\explode(',', (string) $areasParam) as $area) {
                 if (!\array_key_exists($area, $this->snippetAreas)) {
                     continue;
                 }
@@ -164,17 +140,28 @@ final class SnippetController implements SecuredControllerInterface
                 $areaTemplateKeys[] = $templateKey;
             }
 
-            if (!empty($areaTemplateKeys)) {
-                $listBuilder->in($fieldDescriptors['templateKey'], $areaTemplateKeys);
-            }
+            // groups/templateKeys and areas each narrow the same templateKey field, so they are
+            // combined into a single set here rather than each issuing their own `in()` call: an
+            // areas filter that resolves to no known template key must still make the whole request
+            // return nothing, not fall back to whatever groups/templateKeys alone would have matched.
+            $templateKeys = [] !== $templateKeys
+                ? \array_intersect($templateKeys, $areaTemplateKeys)
+                : $areaTemplateKeys;
+        }
+
+        $templateFilterRequested = [] !== $groupIdentifiers || [] !== $requestedTemplateKeys || $areaFilterRequested;
+        $filterResolvedToNothing = $templateFilterRequested && 0 === \count($templateKeys);
+
+        if (!$filterResolvedToNothing && 0 !== \count($templateKeys)) {
+            $listBuilder->in($fieldDescriptors['templateKey'], $templateKeys);
         }
 
         $listRepresentation = new PaginatedRepresentation(
-            $listBuilder->execute(),
+            $filterResolvedToNothing ? [] : $listBuilder->execute(),
             SnippetInterface::RESOURCE_KEY,
             (int) $listBuilder->getCurrentPage(),
             (int) $listBuilder->getLimit(),
-            $listBuilder->count(),
+            $filterResolvedToNothing ? 0 : $listBuilder->count(),
         );
 
         /** @var array{_embedded: array{snippets: mixed[][]}} $list */
@@ -184,7 +171,6 @@ final class SnippetController implements SecuredControllerInterface
             $templateKey = $item['templateKey'] ?? null;
             // prefixed to avoid colliding with a template property of the same name
             $item['_group'] = $this->resolveGroup($groups, \is_string($templateKey) ? $templateKey : null);
-            unset($item['templateKey']);
         }
 
         return new JsonResponse($this->normalizer->normalize(

--- a/packages/snippet/tests/Application/config/templates/snippets/snippet-alternate.xml
+++ b/packages/snippet/tests/Application/config/templates/snippets/snippet-alternate.xml
@@ -4,6 +4,7 @@
           xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template.xsd">
 
     <key>snippet-alternate</key>
+    <group>alternate-group</group>
 
     <view>views/snippets/snippet-alternate</view>
     <controller>Sulu\Content\UserInterface\Controller\Website\ContentController::indexAction</controller>

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Admin/Provider/SnippetTemplateSelectProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Admin/Provider/SnippetTemplateSelectProviderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Admin\Provider;
+
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadata;
+use Sulu\Bundle\AdminBundle\Metadata\ListMetadata\ListMetadataProvider;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class SnippetTemplateSelectProviderTest extends SuluTestCase
+{
+    private ListMetadataProvider $listMetadataProvider;
+    private RequestStack $requestStack;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->listMetadataProvider = self::getContainer()->get('sulu_admin.list_metadata_provider');
+        $this->requestStack = self::getContainer()->get('request_stack');
+    }
+
+    public function testGetFilterValuesWithoutTemplatesParamReturnsAllTemplates(): void
+    {
+        // The "templates" query parameter is absent whenever this list metadata is requested outside a
+        // grouped snippet list view, e.g. from a generic snippet_selection overlay. Regression test for a
+        // crash on symfony/expression-language versions that do not support "??" on undefined variables
+        // (the XML expression used to read "templates ?? null").
+        $options = $this->getTemplateKeyFilterOptions(new Request());
+
+        $this->assertSame(['snippet-alternate', 'snippet'], \array_keys($options));
+    }
+
+    public function testGetFilterValuesWithTemplatesParamNarrowsOptions(): void
+    {
+        $options = $this->getTemplateKeyFilterOptions(new Request(['templates' => 'snippet']));
+
+        $this->assertSame(['snippet'], \array_keys($options));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getTemplateKeyFilterOptions(Request $request): array
+    {
+        $this->requestStack->push($request);
+
+        try {
+            /** @var ListMetadata $metadata */
+            $metadata = $this->listMetadataProvider->getMetadata('snippets', 'en', []);
+        } finally {
+            $this->requestStack->pop();
+        }
+
+        foreach ($metadata->getFields() as $field) {
+            if ('templateKey' === $field->getName()) {
+                /** @var array<string, string> $options */
+                $options = $field->getFilterTypeParameters()['options'] ?? [];
+
+                return $options;
+            }
+        }
+
+        $this->fail('Expected a "templateKey" field in the list metadata.');
+    }
+}

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Admin/SnippetAdminTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Admin/SnippetAdminTest.php
@@ -45,6 +45,56 @@ class SnippetAdminTest extends SuluTestCase
         $this->assertContains('sulu_admin.copy', $actionNames);
     }
 
+    public function testConfigureViewsCreatesAViewPerTemplateGroup(): void
+    {
+        $viewCollection = new ViewCollection();
+        $this->getSnippetAdmin()->configureViews($viewCollection);
+
+        $this->assertTrue($viewCollection->has(SnippetAdmin::LIST_VIEW));
+
+        foreach (['default', 'alternate-group'] as $groupIdentifier) {
+            $this->assertTrue($viewCollection->has(SnippetAdmin::LIST_VIEW . '_' . $groupIdentifier));
+            $this->assertTrue($viewCollection->has(SnippetAdmin::ADD_TABS_VIEW . '_' . $groupIdentifier));
+            $this->assertTrue($viewCollection->has(SnippetAdmin::EDIT_TABS_VIEW . '_' . $groupIdentifier));
+        }
+
+        $this->assertFalse($viewCollection->has(SnippetAdmin::EDIT_TABS_VIEW));
+    }
+
+    public function testConfigureViewsRestrictsTheListAndFormToTheTemplatesOfTheGroup(): void
+    {
+        $viewCollection = new ViewCollection();
+        $this->getSnippetAdmin()->configureViews($viewCollection);
+
+        $listView = $viewCollection->get(SnippetAdmin::LIST_VIEW . '_alternate-group')->getView();
+        $this->assertSame(
+            ['templateKeys' => 'snippet-alternate'],
+            $listView->getOption('requestParameters'),
+        );
+        $this->assertSame(
+            ['templates' => 'snippet-alternate'],
+            $listView->getOption('metadataRequestParameters'),
+        );
+
+        $formView = $viewCollection->get(SnippetAdmin::EDIT_TABS_VIEW . '_alternate-group.content')->getView();
+        $this->assertSame(
+            ['templates' => 'snippet-alternate'],
+            $formView->getOption('metadataRequestParameters'),
+        );
+    }
+
+    public function testGetSecurityContextsRegistersAContextPerCustomGroup(): void
+    {
+        /** @var array<string, array<string, array<string, string[]>>> $securityContexts */
+        $securityContexts = $this->getSnippetAdmin()->getSecurityContexts();
+
+        $snippetContexts = $securityContexts[SnippetAdmin::SULU_ADMIN_SECURITY_SYSTEM]['Snippet'] ?? [];
+
+        $this->assertArrayHasKey(SnippetAdmin::SECURITY_CONTEXT, $snippetContexts);
+        $this->assertArrayHasKey(SnippetAdmin::getSnippetSecurityContext('alternate-group'), $snippetContexts);
+        $this->assertArrayNotHasKey(SnippetAdmin::getSnippetSecurityContext('default'), $snippetContexts);
+    }
+
     private function getSnippetAdmin(): SnippetAdmin
     {
         /** @var SnippetAdmin $snippetAdmin */

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Admin/SnippetAreaAdminTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Admin/SnippetAreaAdminTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Admin;
+
+use Sulu\Bundle\AdminBundle\Admin\View\ViewCollection;
+use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
+use Sulu\Snippet\Infrastructure\Sulu\Admin\SnippetAdmin;
+use Sulu\Snippet\Infrastructure\Sulu\Admin\SnippetAreaAdmin;
+
+class SnippetAreaAdminTest extends SuluTestCase
+{
+    public function testConfigureViewsMapsEveryTemplateToItsGroupEditView(): void
+    {
+        /** @var SnippetAreaAdmin $snippetAreaAdmin */
+        $snippetAreaAdmin = self::getContainer()->get('sulu_snippet.snippet_area_admin');
+
+        $viewCollection = new ViewCollection();
+        $snippetAreaAdmin->configureViews($viewCollection);
+
+        $view = $viewCollection->get('sulu_snippet.snippet_areas')->getView();
+
+        $snippetEditViews = $view->getOption('snippetEditViews');
+        $this->assertIsArray($snippetEditViews);
+
+        $this->assertSame(SnippetAdmin::EDIT_TABS_VIEW . '_default', $snippetEditViews['snippet'] ?? null);
+        $this->assertSame(
+            SnippetAdmin::EDIT_TABS_VIEW . '_alternate-group',
+            $snippetEditViews['snippet-alternate'] ?? null,
+        );
+    }
+}

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Content/SnippetSmartContentProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Content/SnippetSmartContentProviderTest.php
@@ -99,12 +99,12 @@ class SnippetSmartContentProviderTest extends SuluTestCase
         ]);
     }
 
-    public function testFindFlatByXmlTemplateKeysIntersectsWithUiTypes(): void
+    public function testFindFlatByXmlTemplateKeysIntersectsWithUiGroups(): void
     {
         $result = $this->smartContentProvider->findFlatBy(
             [
                 ...$this->getDefaultFilters(),
-                ...['locale' => 'en', 'types' => ['snippet']],
+                ...['locale' => 'en', 'types' => ['default']],
             ],
             [],
             ['templateKeys' => 'snippet,snippet-alternate'],
@@ -116,7 +116,7 @@ class SnippetSmartContentProviderTest extends SuluTestCase
             $this->smartContentProvider->countBy(
                 [
                     ...$this->getDefaultFilters(),
-                    ...['locale' => 'en', 'types' => ['snippet']],
+                    ...['locale' => 'en', 'types' => ['default']],
                 ],
                 ['templateKeys' => 'snippet,snippet-alternate'],
             ),
@@ -126,12 +126,12 @@ class SnippetSmartContentProviderTest extends SuluTestCase
         $this->assertContains(self::$snippets['default']->getUuid(), $resultIds);
     }
 
-    public function testFindFlatByUiTypeOutsideXmlTemplateKeysReturnsZero(): void
+    public function testFindFlatByUiGroupOutsideXmlTemplateKeysReturnsZero(): void
     {
         $result = $this->smartContentProvider->findFlatBy(
             [
                 ...$this->getDefaultFilters(),
-                ...['locale' => 'en', 'types' => ['snippet-alternate']],
+                ...['locale' => 'en', 'types' => ['alternate-group']],
             ],
             [],
             ['templateKeys' => 'snippet'],
@@ -143,9 +143,50 @@ class SnippetSmartContentProviderTest extends SuluTestCase
             $this->smartContentProvider->countBy(
                 [
                     ...$this->getDefaultFilters(),
-                    ...['locale' => 'en', 'types' => ['snippet-alternate']],
+                    ...['locale' => 'en', 'types' => ['alternate-group']],
                 ],
                 ['templateKeys' => 'snippet'],
+            ),
+        );
+    }
+
+    public function testFindFlatByXmlGroupsRestrictsTheResult(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy(
+            [
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en'],
+            ],
+            [],
+            ['groups' => 'alternate-group'],
+        );
+
+        $this->assertCount(1, $result);
+
+        $resultIds = \array_map(fn ($snippet) => $snippet['id'], $result);
+        $this->assertContains(self::$snippets['alternate']->getUuid(), $resultIds);
+    }
+
+    public function testFindFlatByUiGroupOutsideXmlGroupsReturnsZero(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy(
+            [
+                ...$this->getDefaultFilters(),
+                ...['locale' => 'en', 'types' => ['default']],
+            ],
+            [],
+            ['groups' => 'alternate-group'],
+        );
+
+        $this->assertCount(0, $result);
+        $this->assertSame(
+            0,
+            $this->smartContentProvider->countBy(
+                [
+                    ...$this->getDefaultFilters(),
+                    ...['locale' => 'en', 'types' => ['default']],
+                ],
+                ['groups' => 'alternate-group'],
             ),
         );
     }

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Content/SnippetSmartContentProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Content/SnippetSmartContentProviderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Content;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfiguration;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -217,6 +218,60 @@ class SnippetSmartContentProviderTest extends SuluTestCase
         $this->assertCount(1, $result);
         $this->assertSame(self::$snippets['alternate']->getUuid(), $result[0]['id']);
         $this->assertSame(1, $this->smartContentProvider->countBy($filters));
+    }
+
+    public function testFindFlatByIncludesGroupAndLocaleForDeepLinking(): void
+    {
+        /** @var array<array{id: string, title: string, group: string, locale: string}> $result */
+        $result = $this->smartContentProvider->findFlatBy([...$this->getDefaultFilters(), ...['locale' => 'en']], []);
+
+        $itemsByUuid = [];
+        foreach ($result as $item) {
+            $itemsByUuid[$item['id']] = $item;
+        }
+
+        // "default" uses the "snippet" template, which is not part of a configured group
+        $defaultItem = $itemsByUuid[self::$snippets['default']->getUuid()];
+        $this->assertSame('default', $defaultItem['group']);
+        $this->assertSame('en', $defaultItem['locale']);
+
+        // "alternate" uses the "snippet-alternate" template, which belongs to the "alternate-group"
+        $alternateItem = $itemsByUuid[self::$snippets['alternate']->getUuid()];
+        $this->assertSame('alternate-group', $alternateItem['group']);
+        $this->assertSame('en', $alternateItem['locale']);
+    }
+
+    public function testFindFlatByReturnsRequestedLocaleNotAHardcodedOne(): void
+    {
+        $germanSnippet = self::createSnippet([
+            'de' => [
+                'live' => [
+                    'template' => 'snippet',
+                    'title' => 'Deutsches Snippet',
+                ],
+            ],
+        ]);
+
+        /** @var array<array{id: string, title: string, group: string, locale: string}> $result */
+        $result = $this->smartContentProvider->findFlatBy([...$this->getDefaultFilters(), ...['locale' => 'de']], []);
+
+        $itemsByUuid = [];
+        foreach ($result as $item) {
+            $itemsByUuid[$item['id']] = $item;
+        }
+
+        $this->assertArrayHasKey($germanSnippet->getUuid(), $itemsByUuid);
+        $this->assertSame('de', $itemsByUuid[$germanSnippet->getUuid()]['locale']);
+    }
+
+    public function testGetConfigurationHasGroupAwareView(): void
+    {
+        /** @var ProviderConfiguration $configuration */
+        $configuration = $this->smartContentProvider->getConfiguration();
+
+        $this->assertSame('sulu_snippet.snippet.edit_tabs_{group}', $configuration->getView());
+        $this->assertSame(['id' => 'id', 'locale' => 'locale'], $configuration->getResultToView());
+        $this->assertSame(['group' => 'group'], $configuration->getResultToViewName());
     }
 
     /**

--- a/packages/snippet/tests/Functional/Infrastructure/Sulu/Search/AdminSnippetReindexProviderTest.php
+++ b/packages/snippet/tests/Functional/Infrastructure/Sulu/Search/AdminSnippetReindexProviderTest.php
@@ -15,6 +15,7 @@ namespace Sulu\Snippet\Tests\Functional\Infrastructure\Sulu\Search;
 
 use CmsIg\Seal\Reindex\ReindexConfig;
 use Doctrine\ORM\EntityManagerInterface;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Bundle\TestBundle\Testing\SetGetPrivatePropertyTrait;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
 use Sulu\Snippet\Domain\Model\SnippetInterface;
@@ -33,7 +34,9 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
     protected function setUp(): void
     {
         $this->entityManager = $this->getEntityManager();
-        $this->provider = new AdminSnippetReindexProvider($this->entityManager);
+        /** @var GroupProviderInterface $groupProvider */
+        $groupProvider = self::getContainer()->get('sulu_admin.metadata_group_provider');
+        $this->provider = new AdminSnippetReindexProvider($this->entityManager, $groupProvider);
         $this->purgeDatabase();
     }
 
@@ -106,6 +109,9 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
                 'title' => 'Test Schnipsel 2',
                 'locale' => 'de',
+                'metadata' => [
+                    'group' => 'default',
+                ],
                 'securityContext' => SnippetAdmin::SECURITY_CONTEXT,
             ],
             [
@@ -116,6 +122,9 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
                 'title' => 'Test Snippet',
                 'locale' => 'en',
+                'metadata' => [
+                    'group' => 'default',
+                ],
                 'securityContext' => SnippetAdmin::SECURITY_CONTEXT,
             ],
             [
@@ -126,6 +135,9 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
                 'createdAt' => (new \DateTimeImmutable($createdAt))->format('c'),
                 'title' => 'Test Snippet 2',
                 'locale' => 'en',
+                'metadata' => [
+                    'group' => 'default',
+                ],
                 'securityContext' => SnippetAdmin::SECURITY_CONTEXT,
             ],
         ];
@@ -136,6 +148,30 @@ class AdminSnippetReindexProviderTest extends SuluTestCase
         $this->assertSame(
             $expectedResult,
             $results,
+        );
+    }
+
+    public function testProvideUsesThePerGroupSecurityContextForGroupedTemplates(): void
+    {
+        $snippet = $this->createSnippet([
+            'en' => [
+                'draft' => [
+                    'template' => 'snippet-alternate',
+                    'title' => 'Alternate Snippet',
+                ],
+            ],
+        ]);
+
+        $config = ReindexConfig::create()->withIndex('admin');
+        /** @var array<array{resourceId: string, metadata: array{group: string}, securityContext: string}> $results */
+        $results = \iterator_to_array($this->provider->provide($config));
+
+        $this->assertCount(1, $results);
+        $this->assertSame($snippet->getUuid(), $results[0]['resourceId']);
+        $this->assertSame(['group' => 'alternate-group'], $results[0]['metadata']);
+        $this->assertSame(
+            SnippetAdmin::getSnippetSecurityContext('alternate-group'),
+            $results[0]['securityContext'],
         );
     }
 

--- a/packages/snippet/tests/Functional/Integration/SnippetAreaControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetAreaControllerTest.php
@@ -76,6 +76,12 @@ class SnippetAreaControllerTest extends SuluTestCase
         ]);
         $this->assertResponseStatusCodeSame(200);
 
+        // the frontend resolves the group-specific edit view from this field right after the PUT response,
+        // so it must be present without requiring a follow-up GET request
+        /** @var array{templateKey?: string} $putResponseContent */
+        $putResponseContent = \json_decode((string) $this->client->getResponse()->getContent(), true) ?? [];
+        $this->assertSame('snippet', $putResponseContent['templateKey'] ?? null);
+
         $this->client->jsonRequest('GET', '/admin/api/snippet-areas?webspaceKey=sulu-io');
         $this->assertResponseSnapshot('snippet_area_cget_partially_filled.json', $this->client->getResponse(), 200);
     }

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -339,6 +339,23 @@ class SnippetControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testGetListWithGroupsFilter(): void
+    {
+        // the created snippets use the "snippet" template, which has no group and therefore lands in "default"
+        $this->client->request('GET', '/admin/api/snippets?locale=en&groups=default');
+        $response = $this->client->getResponse();
+        $this->assertResponseSnapshot('snippet_cget_types_filter_snippet.json', $response, 200);
+
+        $this->client->request('GET', '/admin/api/snippets?locale=en&groups=alternate-group');
+        $response = $this->client->getResponse();
+        $this->assertResponseSnapshot('snippet_cget_types_filter_nonexistent.json', $response, 200);
+
+        $this->client->request('GET', '/admin/api/snippets?locale=en&groups=alternate-group&templateKeys=snippet');
+        $response = $this->client->getResponse();
+        $this->assertResponseSnapshot('snippet_cget_types_filter_snippet.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
     public function testDeleteSingleLocale(string $id): string
     {
         $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=en');

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -356,6 +356,15 @@ class SnippetControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testGetListWithUnknownGroupsFilterReturnsNoResults(): void
+    {
+        // an unknown/typo'd group identifier must not be silently dropped and return every snippet
+        $this->client->request('GET', '/admin/api/snippets?locale=en&groups=does-not-exist');
+        $response = $this->client->getResponse();
+        $this->assertResponseSnapshot('snippet_cget_types_filter_nonexistent.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
     public function testDeleteSingleLocale(string $id): string
     {
         $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=en');

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -476,9 +476,52 @@ class SnippetControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
 
+        /** @var array{id: string, group: string, locale: string} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame($trashItem->getResourceId(), $content['id']);
+        $this->assertSame('default', $content['group']);
+        $this->assertSame('en', $content['locale']);
+
         $this->client->request('GET', '/admin/api/snippets/' . $trashItem->getResourceId() . '?locale=en');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('snippet_post_restore.json', $response, 200);
+    }
+
+    public function testRestoreResolvesConfiguredGroup(): void
+    {
+        self::purgeDatabase();
+
+        $this->client->request('POST', '/admin/api/snippets?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'snippet-alternate',
+            'title' => 'Alternate Restore Test',
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+        /** @var array{id: string} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $id = $content['id'];
+
+        $this->client->request('DELETE', '/admin/api/snippets/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(204, $response);
+
+        $trashRepository = self::getContainer()->get(TrashItemRepositoryInterface::class);
+        $trashItem = $trashRepository->findOneBy([
+            'resourceKey' => SnippetInterface::RESOURCE_KEY,
+            'resourceId' => $id,
+            'restoreType' => null,
+        ]);
+        $this->assertNotNull($trashItem);
+
+        $this->client->request('POST', '/admin/api/trash-items/' . $trashItem->getId() . '?action=restore');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{id: string, group: string, locale: string} $restoreContent */
+        $restoreContent = \json_decode((string) $response->getContent(), true);
+        $this->assertSame($id, $restoreContent['id']);
+        $this->assertSame('alternate-group', $restoreContent['group']);
+        $this->assertSame('en', $restoreContent['locale']);
     }
 
     public function testGetListWithGhostLocaleAndTypesFiltering(): void

--- a/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
+++ b/packages/snippet/tests/Functional/Integration/SnippetControllerTest.php
@@ -365,6 +365,43 @@ class SnippetControllerTest extends SuluTestCase
     }
 
     #[Depends('testPost')]
+    public function testGetListWithAreasFilter(): void
+    {
+        // the "hotel" area (config/templates/snippets/snippet.xml) is assigned to the "snippet" template
+        $this->client->request('GET', '/admin/api/snippets?locale=en&areas=hotel');
+        $response = $this->client->getResponse();
+        $this->assertResponseSnapshot('snippet_cget_types_filter_snippet.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
+    public function testGetListWithUnknownAreasFilterReturnsNoResults(): void
+    {
+        // an unknown/typo'd area identifier must not be silently dropped and return every snippet
+        $this->client->request('GET', '/admin/api/snippets?locale=en&areas=does-not-exist');
+        $response = $this->client->getResponse();
+        $this->assertResponseSnapshot('snippet_cget_types_filter_nonexistent.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
+    public function testGetListWithGroupsAndAreasFilterCombined(): void
+    {
+        // groups and areas narrow the same templateKey field and must intersect: "default" resolves to
+        // the "snippet" template, and the "hotel" area also resolves to "snippet", so the combination
+        // still returns the snippet
+        $this->client->request('GET', '/admin/api/snippets?locale=en&groups=default&areas=hotel');
+        $response = $this->client->getResponse();
+        $this->assertResponseSnapshot('snippet_cget_types_filter_snippet.json', $response, 200);
+
+        // a "groups" filter that resolves to a template key must not be silently combined with an
+        // unrelated, unresolved "areas" filter: previously the areas filter used its own separate
+        // `in()` call and was skipped entirely whenever it resolved to no known template key, so the
+        // groups filter alone would have determined the (wrong) result
+        $this->client->request('GET', '/admin/api/snippets?locale=en&groups=default&areas=does-not-exist');
+        $response = $this->client->getResponse();
+        $this->assertResponseSnapshot('snippet_cget_types_filter_nonexistent.json', $response, 200);
+    }
+
+    #[Depends('testPost')]
     public function testDeleteSingleLocale(string $id): string
     {
         $this->client->request('GET', '/admin/api/snippets/' . $id . '?locale=en');

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_cget.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_cget.json
@@ -12,6 +12,7 @@
                 "published": null,
                 "publishedState": false,
                 "title": "Test Snippet 2",
+                "templateKey": "snippet",
                 "_group": "default"
             }
         ]

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_cget.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_cget.json
@@ -11,8 +11,8 @@
                 "locale": "en",
                 "published": null,
                 "publishedState": false,
-                "templateKey": "snippet",
-                "title": "Test Snippet 2"
+                "title": "Test Snippet 2",
+                "_group": "default"
             }
         ]
     },

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_cget_types_filter_multiple.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_cget_types_filter_multiple.json
@@ -12,6 +12,7 @@
                 "published": null,
                 "publishedState": false,
                 "title": "Test Snippet 2",
+                "templateKey": "snippet",
                 "_group": "default"
             }
         ]

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_cget_types_filter_multiple.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_cget_types_filter_multiple.json
@@ -11,8 +11,8 @@
                 "locale": "en",
                 "published": null,
                 "publishedState": false,
-                "templateKey": "snippet",
-                "title": "Test Snippet 2"
+                "title": "Test Snippet 2",
+                "_group": "default"
             }
         ]
     },

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_cget_types_filter_snippet.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_cget_types_filter_snippet.json
@@ -12,6 +12,7 @@
                 "published": null,
                 "publishedState": false,
                 "title": "Test Snippet 2",
+                "templateKey": "snippet",
                 "_group": "default"
             }
         ]

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_cget_types_filter_snippet.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_cget_types_filter_snippet.json
@@ -11,8 +11,8 @@
                 "locale": "en",
                 "published": null,
                 "publishedState": false,
-                "templateKey": "snippet",
-                "title": "Test Snippet 2"
+                "title": "Test Snippet 2",
+                "_group": "default"
             }
         ]
     },

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_get.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_get.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_get_after_restore.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_get_after_restore.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_get_ghost_locale.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_get_ghost_locale.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": ["en"],
     "changed": "@datetime@",
     "changer" : "@integer@",

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_publish.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_publish.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_restore.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": [
         "en",
         "de"

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_trigger_copy_locale.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_trigger_copy_locale.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": [
         "en",
         "de"

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_post_trigger_unpublish.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_post_trigger_unpublish.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": [
         "en"
     ],

--- a/packages/snippet/tests/Functional/Integration/responses/snippet_put.json
+++ b/packages/snippet/tests/Functional/Integration/responses/snippet_put.json
@@ -1,5 +1,6 @@
 {
     "_hash": "@string@",
+    "_group": "default",
     "availableLocales": [
         "en",
         "de"

--- a/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ValidateSmartContentParamsPass.php
+++ b/src/Sulu/Bundle/AdminBundle/DependencyInjection/Compiler/ValidateSmartContentParamsPass.php
@@ -27,9 +27,10 @@ final class ValidateSmartContentParamsPass implements CompilerPassInterface
 {
     private const DEPRECATED_PARAMS = ['types', 'structureTypes'];
 
-    private const ARTICLE_PROVIDERS = [
+    private const GROUP_PROVIDERS = [
         'articles',
         'articles_page_tree',
+        'snippets',
     ];
 
     private const TEMPLATE_NAMESPACE = 'http://schemas.sulu.io/template/template';
@@ -124,11 +125,11 @@ final class ValidateSmartContentParamsPass implements CompilerPassInterface
             }
         }
 
-        $isArticleProvider = null !== $provider && \in_array($provider, self::ARTICLE_PROVIDERS, true);
+        $isGroupProvider = null !== $provider && \in_array($provider, self::GROUP_PROVIDERS, true);
 
         foreach ($deprecated as $deprecatedName) {
             $replacement = match ($deprecatedName) {
-                'types' => $isArticleProvider ? 'groups' : 'templateKeys',
+                'types' => $isGroupProvider ? 'groups' : 'templateKeys',
                 'structureTypes' => 'templateKeys',
             };
 

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/ValidateSmartContentParamsPassTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/DependencyInjection/Compiler/ValidateSmartContentParamsPassTest.php
@@ -93,6 +93,21 @@ class ValidateSmartContentParamsPassTest extends TestCase
         (new ValidateSmartContentParamsPass())->process($container);
     }
 
+    public function testDeprecatedTypesParamThrowsForSnippetProvider(): void
+    {
+        $dir = $this->createTempTemplateDir();
+        $this->writeTemplateXml($dir, 'bad.xml', 'bad-template', 'my_property', 'snippets', [
+            'types' => 'layout',
+        ]);
+
+        $container = $this->createContainer([$dir]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('param "types" is deprecated, rename to "groups"');
+
+        (new ValidateSmartContentParamsPass())->process($container);
+    }
+
     public function testDeprecatedTypesParamThrowsForPageProvider(): void
     {
         $dir = $this->createTempTemplateDir();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #9060
| License | MIT
| Documentation PR | sulu/sulu-docs#

#### What's in this PR?

Snippets get the same template group mechanism articles already have. A template can declare `<group>blog</group>`, and the admin then renders one list tab per group, filters each tab by its group's template keys, narrows the template dropdown in the add/edit form, and registers a per-group security context `sulu.snippet.snippets_<group>`. Snippets without an explicit group fall into the implicit `default` group, same as before.

This touches every place group-awareness already reaches for articles:

- `SnippetAdmin` builds one list/add/edit view per group, mirroring `ArticleAdmin`.
- The snippet list endpoint accepts a `groups` query parameter, expanded to template keys, alongside the existing `templateKeys` and `areas` filters.
- `snippet_selection` and `single_snippet_selection` selection overlays accept a `groups` param, same as the article selection.
- The snippet smart content provider exposes groups as selectable types and filters by them.
- Admin search indexes the group per snippet and deep-links a search hit into the right group tab.
- The "Default snippets" webspace tab and trash restore now resolve to the correct group's view instead of a view name that stopped existing once groups are in.

Deep links, selection overlays and search were the parts that needed care beyond a straight port: each had its own place where a template key had to be resolved to (or filtered by) a group, and each is covered by a new or extended test.

#### Why?

Snippets and articles share the same underlying content system, but only articles got grouped tabs when that feature landed. Projects with many snippet templates end up with one long, unfiltered list, the same problem articles had before groups.

#### Example Usage

```xml
<snippet xmlns="http://schemas.sulu.io/template/template">
    <key>event</key>
    <group>events</group>
    ...
</snippet>
```

Snippets using the `event` template now show up under a dedicated "Events" tab, filtered to that group's templates, with their own `sulu.snippet.snippets_events` security context.

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
