### PR TITLE
Add group-aware deep links for article smart content

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -24,6 +24,17 @@ Run the new migration to apply the schema change:
 bin/console doctrine:migrations:migrate
 ```
 
+### Group-aware deep links for smart content
+
+`Sulu\Bundle\AdminBundle\SmartContent\Configuration\BuilderInterface::enableView()` gained an optional third parameter
+`?array $resultToViewName`, and `Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfigurationInterface`
+gained the method `getResultToViewName(): ?array`. Together they let a smart content provider navigate to a view name
+with a placeholder (e.g. `{group}`) that gets resolved per item, so clicking a smart content item can deep link into
+the correct template group's edit view.
+
+If you have a custom implementation of one of these interfaces, add the new method.
+`ProviderConfigurationInterface` implementations that do not need group-aware navigation can return `null`.
+
 ## 3.0.8
 
 ### Route value is required when saving routable content

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Sulu\Article\Domain\Model\ArticleDimensionContentInterface;
 use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Article\Infrastructure\Sulu\Admin\ArticleAdmin;
 use Sulu\Article\Infrastructure\Sulu\Content\ResourceLoader\ArticleResourceLoader;
 use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Bundle\AdminBundle\SmartContent\Configuration\Builder;
@@ -137,7 +138,12 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
             ->enableProperties([
                 'title' => 'title',
                 'url' => 'url',
-            ]);
+            ])
+            ->enableView(
+                ArticleAdmin::EDIT_TABS_VIEW . '_{group}',
+                ['id' => 'id', 'locale' => 'locale'],
+                ['group' => 'group'],
+            );
 
         // TODO
         //        if ($this->hasAudienceTargeting) {
@@ -187,7 +193,7 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
      *     changed?: 'asc'|'desc',
      * } $sortBys
      *
-     * @return array<array{id: string, title: string}>
+     * @return array<array{id: string, title: string, group: string, locale: string}>
      */
     public function findFlatBy(array $filters, array $sortBys, array $params = []): array
     {
@@ -217,12 +223,25 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         // we need the distinct here, because joins due to tags/categories can lead to duplicate results
         $queryBuilder->select('DISTINCT ' . $alias . '.uuid as id');
         $queryBuilder->addSelect('filterDimensionContent.title');
+        $queryBuilder->addSelect('filterDimensionContent.templateKey');
         $this->smartContentQueryEnhancer->addOrderBySelects($queryBuilder);
         $this->smartContentQueryEnhancer->addPagination($queryBuilder, $filters['offset'] ?? 0, $filters['limit']);
 
-        /** @var array{id: string, title: string}[] $result */
+        /** @var array{id: string, title: string, templateKey: string|null}[] $result */
         $result = $queryBuilder->getQuery()->getArrayResult();
 
+        foreach ($result as &$item) {
+            $templateKey = $item['templateKey'];
+            $item['group'] = $this->groupProvider->resolveGroup(
+                ArticleInterface::TEMPLATE_TYPE,
+                \is_string($templateKey) ? $templateKey : null,
+            );
+            $item['locale'] = $filters['locale'];
+            unset($item['templateKey']);
+        }
+        unset($item);
+
+        /** @var array{id: string, title: string, group: string, locale: string}[] $result */
         return $result;
     }
 

--- a/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
+++ b/packages/article/src/Infrastructure/Sulu/Content/ArticleSmartContentProvider.php
@@ -230,12 +230,18 @@ readonly class ArticleSmartContentProvider implements SmartContentProviderInterf
         /** @var array{id: string, title: string, templateKey: string|null}[] $result */
         $result = $queryBuilder->getQuery()->getArrayResult();
 
+        // built once and reused for every result, instead of calling getGroups() per item
+        $groupByTemplateKey = [];
+        foreach ($this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE) as $group) {
+            foreach ($group->templates as $template) {
+                $groupByTemplateKey[$template] = $group->identifier;
+            }
+        }
+
         foreach ($result as &$item) {
             $templateKey = $item['templateKey'];
-            $item['group'] = $this->groupProvider->resolveGroup(
-                ArticleInterface::TEMPLATE_TYPE,
-                \is_string($templateKey) ? $templateKey : null,
-            );
+            $item['group'] = (\is_string($templateKey) ? $groupByTemplateKey[$templateKey] ?? null : null)
+                ?? GroupProviderInterface::DEFAULT_GROUP;
             $item['locale'] = $filters['locale'];
             unset($item['templateKey']);
         }

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
@@ -249,6 +249,35 @@ class ArticleSmartContentProviderTest extends SuluTestCase
         }
     }
 
+    public function testFindFlatByIncludesGroupAndLocaleForDeepLinking(): void
+    {
+        $result = $this->smartContentProvider->findFlatBy([...$this->getDefaultFilters(), ...['locale' => 'en']], []);
+
+        $itemsByUuid = [];
+        foreach ($result as $item) {
+            $itemsByUuid[$item['id']] = $item;
+        }
+
+        // "tech1" uses the default "article" template, which is not part of a configured group
+        $defaultItem = $itemsByUuid[self::$articles['tech1']->getUuid()];
+        $this->assertSame('default', $defaultItem['group']);
+        $this->assertSame('en', $defaultItem['locale']);
+
+        // "tech2" uses the "blog" template, which belongs to the "blog-group"
+        $blogItem = $itemsByUuid[self::$articles['tech2']->getUuid()];
+        $this->assertSame('blog-group', $blogItem['group']);
+        $this->assertSame('en', $blogItem['locale']);
+    }
+
+    public function testGetConfigurationHasGroupAwareView(): void
+    {
+        $configuration = $this->smartContentProvider->getConfiguration();
+
+        $this->assertSame('sulu_article.article.edit_tabs_{group}', $configuration->getView());
+        $this->assertSame(['id' => 'id', 'locale' => 'locale'], $configuration->getResultToView());
+        $this->assertSame(['group' => 'group'], $configuration->getResultToViewName());
+    }
+
     /**
      * @return array<string, array{0: string[], 1: string, 2: int}>
      */

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Sulu\Article\Application\Message\ApplyWorkflowTransitionArticleMessage;
 use Sulu\Article\Application\Message\CreateArticleMessage;
 use Sulu\Article\Domain\Model\ArticleInterface;
+use Sulu\Bundle\AdminBundle\SmartContent\Configuration\ProviderConfiguration;
 use Sulu\Bundle\AdminBundle\SmartContent\SmartContentProviderInterface;
 use Sulu\Bundle\CategoryBundle\Entity\CategoryInterface;
 use Sulu\Bundle\TestBundle\Testing\SuluTestCase;
@@ -270,8 +271,28 @@ class ArticleSmartContentProviderTest extends SuluTestCase
         $this->assertSame('en', $blogItem['locale']);
     }
 
+    public function testFindFlatByReturnsRequestedLocaleNotAHardcodedOne(): void
+    {
+        $germanArticle = self::createArticle([
+            'title' => 'Deutscher Artikel',
+            'locale' => 'de',
+        ]);
+
+        /** @var array<array{id: string, title: string, group: string, locale: string}> $result */
+        $result = $this->smartContentProvider->findFlatBy([...$this->getDefaultFilters(), ...['locale' => 'de']], []);
+
+        $itemsByUuid = [];
+        foreach ($result as $item) {
+            $itemsByUuid[$item['id']] = $item;
+        }
+
+        $this->assertArrayHasKey($germanArticle->getUuid(), $itemsByUuid);
+        $this->assertSame('de', $itemsByUuid[$germanArticle->getUuid()]['locale']);
+    }
+
     public function testGetConfigurationHasGroupAwareView(): void
     {
+        /** @var ProviderConfiguration $configuration */
         $configuration = $this->smartContentProvider->getConfiguration();
 
         $this->assertSame('sulu_article.article.edit_tabs_{group}', $configuration->getView());

--- a/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
+++ b/packages/article/tests/Functional/Infrastructure/Sulu/Content/ArticleSmartContentProviderTest.php
@@ -251,6 +251,7 @@ class ArticleSmartContentProviderTest extends SuluTestCase
 
     public function testFindFlatByIncludesGroupAndLocaleForDeepLinking(): void
     {
+        /** @var array<array{id: string, title: string, group: string, locale: string}> $result */
         $result = $this->smartContentProvider->findFlatBy([...$this->getDefaultFilters(), ...['locale' => 'en']], []);
 
         $itemsByUuid = [];

--- a/src/Sulu/Bundle/AdminBundle/Resources/config/serializer/ProviderConfiguration.xml
+++ b/src/Sulu/Bundle/AdminBundle/Resources/config/serializer/ProviderConfiguration.xml
@@ -13,5 +13,6 @@
         <property name="presentAs" type="boolean" expose="true" groups="frontend"/>
         <property name="view" type="string" expose="true" groups="frontend"/>
         <property name="resultToView" type="array" expose="true" groups="frontend"/>
+        <property name="resultToViewName" type="array" expose="true" groups="frontend"/>
     </class>
 </serializer>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/fields/SmartContent.js
@@ -2,8 +2,8 @@
 import React from 'react';
 import {computed, toJS, reaction, when, isArrayLike} from 'mobx';
 import equals from 'fast-deep-equal';
-import jsonpointer from 'json-pointer';
 import SmartContentComponent, {smartContentConfigStore, SmartContentStore} from '../../SmartContent';
+import resolveItemView from '../../../utils/resolveItemView';
 import smartContentStorePool from './smartContentStorePool';
 import type {FieldTypeProps} from '../../../types';
 import type {FilterCriteria, Presentation} from '../../SmartContent/types';
@@ -89,6 +89,10 @@ class SmartContent extends React.Component<Props> {
 
     @computed get resultToView() {
         return smartContentConfigStore.getConfig(this.provider).resultToView;
+    }
+
+    @computed get resultToViewName() {
+        return smartContentConfigStore.getConfig(this.provider).resultToViewName;
     }
 
     constructor(props: Props) {
@@ -193,19 +197,15 @@ class SmartContent extends React.Component<Props> {
     handleItemClick = (itemId: string | number, item: Object) => {
         const {router} = this.props;
 
-        const {resultToView, viewName} = this;
+        const {resultToView, resultToViewName, viewName} = this;
 
         if (!router || !viewName || !resultToView) {
             return;
         }
 
-        router.navigate(
-            viewName,
-            Object.keys(resultToView).reduce((parameters, resultPath) => {
-                parameters[resultToView[resultPath]] = jsonpointer.get(item, '/' + resultPath);
-                return parameters;
-            }, {})
-        );
+        const {parameters, view} = resolveItemView(viewName, resultToView, resultToViewName, item);
+
+        router.navigate(view, parameters);
     };
 
     render() {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Form/tests/fields/SmartContent.test.js
@@ -460,6 +460,52 @@ test('Should navigate to view if item is clicked', () => {
     expect(router.navigate).toHaveBeenLastCalledWith('sulu_media.form', {id: 3});
 });
 
+test('Should navigate to templated view if item with resultToViewName is clicked', () => {
+    const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
+
+    const schemaOptions = {
+        provider: {
+            name: 'provider',
+            value: 'articles',
+        },
+    };
+
+    smartContentConfigStore.getConfig.mockReturnValue({
+        sorting: [],
+        view: 'sulu_article.article.edit_tabs_{group}',
+        resultToView: {id: 'id', locale: 'locale'},
+        resultToViewName: {group: 'group'},
+    });
+
+    const router = new Router();
+
+    const smartContent = mount(
+        <SmartContent
+            {...fieldTypeDefaultProps}
+            formInspector={formInspector}
+            router={router}
+            schemaOptions={schemaOptions}
+        />
+    );
+
+    smartContent.instance().smartContentStore.items = [
+        {id: 1, locale: 'en', group: 'blog-group'},
+        {id: 2, locale: 'de', group: 'default'},
+    ];
+    smartContent.update();
+
+    smartContent.find('MultiItemSelection .content').at(0).simulate('click');
+    expect(router.navigate).toHaveBeenLastCalledWith(
+        'sulu_article.article.edit_tabs_blog-group',
+        {id: 1, locale: 'en'}
+    );
+    smartContent.find('MultiItemSelection .content').at(1).simulate('click');
+    expect(router.navigate).toHaveBeenLastCalledWith(
+        'sulu_article.article.edit_tabs_default',
+        {id: 2, locale: 'de'}
+    );
+});
+
 test('Should call destroy on SmartContentStore when unmounted', () => {
     const formInspector = new FormInspector(new ResourceFormStore(new ResourceStore('test'), 'test'));
 

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/types.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/SmartContent/types.js
@@ -49,6 +49,7 @@ export type SmartContentConfig = {
     limit: boolean,
     presentAs: boolean,
     resultToView?: {[string]: string},
+    resultToViewName?: {[string]: string},
     sorting: Array<Sorting>,
     tags: boolean,
     types: Array<Type>,

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
@@ -109,10 +109,11 @@ class Builder implements BuilderInterface
         return $this;
     }
 
-    public function enableView(string $view, array $resultToView): self
+    public function enableView(string $view, array $resultToView, ?array $resultToViewName = null): self
     {
         $this->configuration->setView($view);
         $this->configuration->setResultToView($resultToView);
+        $this->configuration->setResultToViewName($resultToViewName);
 
         return $this;
     }

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/Builder.php
@@ -109,6 +109,10 @@ class Builder implements BuilderInterface
         return $this;
     }
 
+    /**
+     * @param array<string, string> $resultToView
+     * @param array<string, string>|null $resultToViewName
+     */
     public function enableView(string $view, array $resultToView, ?array $resultToViewName = null): self
     {
         $this->configuration->setView($view);

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/BuilderInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/BuilderInterface.php
@@ -102,11 +102,15 @@ interface BuilderInterface
     /**
      * Defines where the deep link when clicking on a smart content item should navigate to.
      *
+     * The view name may contain placeholders (e.g. "{group}") that get replaced with a value
+     * resolved from the item via $resultToViewName.
+     *
      * @param array<string, string> $resultToView
+     * @param array<string, string>|null $resultToViewName
      *
      * @return BuilderInterface
      */
-    public function enableView(string $view, array $resultToView);
+    public function enableView(string $view, array $resultToView, ?array $resultToViewName = null);
 
     /**
      * Sets default properties to be included when resolving smart content items.

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
@@ -86,6 +86,11 @@ class ProviderConfiguration implements ProviderConfigurationInterface
     /**
      * @var array<string, string>|null
      */
+    private ?array $resultToViewName = null;
+
+    /**
+     * @var array<string, string>|null
+     */
     private ?array $defaultProperties = null;
 
     public function hasDatasource(): bool
@@ -243,6 +248,19 @@ class ProviderConfiguration implements ProviderConfigurationInterface
     public function setResultToView(?array $resultToView): void
     {
         $this->resultToView = $resultToView;
+    }
+
+    public function getResultToViewName(): ?array
+    {
+        return $this->resultToViewName;
+    }
+
+    /**
+     * @param array<string, string>|null $resultToViewName
+     */
+    public function setResultToViewName(?array $resultToViewName): void
+    {
+        $this->resultToViewName = $resultToViewName;
     }
 
     /**

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfiguration.php
@@ -250,6 +250,9 @@ class ProviderConfiguration implements ProviderConfigurationInterface
         $this->resultToView = $resultToView;
     }
 
+    /**
+     * @return array<string, string>|null
+     */
     public function getResultToViewName(): ?array
     {
         return $this->resultToViewName;

--- a/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfigurationInterface.php
+++ b/src/Sulu/Bundle/AdminBundle/SmartContent/Configuration/ProviderConfigurationInterface.php
@@ -109,6 +109,13 @@ interface ProviderConfigurationInterface
     public function getResultToView(): ?array;
 
     /**
+     * Returns the mapping from smart content item properties to placeholders in the view name.
+     *
+     * @return array<string, string>|null
+     */
+    public function getResultToViewName(): ?array;
+
+    /**
      * Returns default properties to include when resolving items.
      *
      * @return array<string, string>|null

--- a/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
+++ b/src/Sulu/Bundle/AdminBundle/Tests/Unit/SmartContent/Configuration/BuilderTest.php
@@ -176,6 +176,23 @@ class BuilderTest extends TestCase
 
         $this->assertSame('edit_form', $configuration->getView());
         $this->assertSame(['id' => 'id'], $configuration->getResultToView());
+        $this->assertNull($configuration->getResultToViewName());
+    }
+
+    public function testViewWithResultToViewName(): void
+    {
+        $builder = Builder::create();
+
+        $this->assertSame(
+            $builder,
+            $builder->enableView('edit_form_{group}', ['id' => 'id'], ['group' => 'group']),
+        );
+
+        $configuration = $builder->getConfiguration();
+
+        $this->assertSame('edit_form_{group}', $configuration->getView());
+        $this->assertSame(['id' => 'id'], $configuration->getResultToView());
+        $this->assertSame(['group' => 'group'], $configuration->getResultToViewName());
     }
 
     public function testTypes(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | yes
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs | #9066
| License | MIT
| Documentation PR |

#### What's in this PR?

Clicking an article row in a smart-content field now navigates to that article's group-aware edit view, the same way `article_selection`/`single_article_selection` do in #9066.

The smart-content deep-link plumbing (`ProviderConfigurationInterface::getView()`/`getResultToView()`, `SmartContent.js`'s `handleItemClick`) already existed and is used by pages, media, contacts and accounts, but nothing wired it up for articles, and it had no way to express a group placeholder in the view name (articles register one edit view per template group, e.g. `sulu_article.article.edit_tabs_blog`). This PR:

- adds an optional third parameter `$resultToViewName` to `BuilderInterface::enableView()`, and a matching `ProviderConfigurationInterface::getResultToViewName()`, so a view name can contain such a placeholder, resolved per item
- has `SmartContent.js` resolve the view via the shared `resolveItemView` utility (added by #9066, now merged) instead of a bespoke `resultToView`-only reducer
- has `ArticleSmartContentProvider` call `enableView(ArticleAdmin::EDIT_TABS_VIEW . '_{group}', ['id' => 'id', 'locale' => 'locale'], ['group' => 'group'])` and resolve each item's `group`/`locale` in `findFlatBy()`, building a template-key-to-group lookup once per call from `GroupProvider::getGroups()` (not per item, to avoid re-fetching and re-sorting the groups for every result)

The two interface changes are a BC break for any custom `BuilderInterface` or `ProviderConfigurationInterface` implementation, documented in `UPGRADE-3.x.md`.

#### Why?

Found while testing #9066: article `smart_content` fields showed articles as plain, unclickable text, unlike the selection fields right next to them on the same form.

#### Example Usage

```xml
<property name="articleSmartContent" type="smart_content">
    <params>
        <param name="provider" value="articles"/>
    </params>
</property>
```

Clicking an article row in this field now opens that article's edit view directly, in the correct group tab.

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
