### PR TITLE
Fix article trash restore navigating to a removed view

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
+++ b/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
@@ -214,10 +214,11 @@ final class ArticleTrashItemHandler implements
 
     public function getConfiguration(): RestoreConfiguration
     {
+        // the restore response carries no template, so the group of the edit view cannot be resolved
         return new RestoreConfiguration(
             null,
-            ArticleAdmin::EDIT_TABS_VIEW,
-            ['id' => 'id'],
+            ArticleAdmin::LIST_VIEW,
+            [],
             null, // TODO serialization group?
         );
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #9065, #9067
| License | MIT
| Documentation PR |

#### What's in this PR?

Changes `ArticleTrashItemHandler::getConfiguration()` to navigate to the article list view instead of the bare `ArticleAdmin::EDIT_TABS_VIEW` after restoring a trashed article.

#### Why?

Since article template groups (#8124), `ArticleAdmin::EDIT_TABS_VIEW` is only registered with a per-group suffix (`_<group>`). The bare constant no longer resolves to an existing view, so restoring a trashed article from the trash bin navigated to a dead route and threw a JS error instead of redirecting. The restore response carries no `templateKey`, so the group can't be resolved at this point, so this points restore at the list view instead, the same workaround already used for snippet template groups in #9065. A proper fix that lands on the restored article's own edit view, resolving the group server-side, is a separate follow-up PR.

#### Example Usage

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
