### PR TITLE
Navigate to the restored article's edit view after trash restore

### DIFF
--- a/packages/article/src/Infrastructure/Sulu/Trash/ArticleRestoreResult.php
+++ b/packages/article/src/Infrastructure/Sulu/Trash/ArticleRestoreResult.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Article\Infrastructure\Sulu\Trash;
+
+/**
+ * @internal
+ */
+final class ArticleRestoreResult
+{
+    public function __construct(
+        private string $id,
+        private string $group,
+        private string $locale,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+}

--- a/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
+++ b/packages/article/src/Infrastructure/Sulu/Trash/ArticleTrashItemHandler.php
@@ -23,6 +23,7 @@ use Sulu\Article\Domain\Model\ArticleInterface;
 use Sulu\Article\Domain\Repository\ArticleRepositoryInterface;
 use Sulu\Article\Infrastructure\Sulu\Admin\ArticleAdmin;
 use Sulu\Bundle\ActivityBundle\Application\Collector\DomainEventCollectorInterface;
+use Sulu\Bundle\AdminBundle\Metadata\GroupProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfiguration;
 use Sulu\Bundle\TrashBundle\Application\RestoreConfigurationProvider\RestoreConfigurationProviderInterface;
 use Sulu\Bundle\TrashBundle\Application\TrashItemHandler\RestoreTrashItemHandlerInterface;
@@ -53,6 +54,7 @@ final class ArticleTrashItemHandler implements
         private ContentMergerInterface $contentMerger,
         private iterable $articleMappers,
         private DomainEventCollectorInterface $domainEventCollector,
+        private GroupProviderInterface $groupProvider,
     ) {
     }
 
@@ -169,6 +171,8 @@ final class ArticleTrashItemHandler implements
         $allLocales = [];
         /** @var string|null $articleTitle */
         $articleTitle = null;
+        /** @var string|null $templateKey */
+        $templateKey = null;
         Assert::isArray($dimensionContents, 'Expected dimensionContents to be an array');
         foreach ($dimensionContents as $dimensionContentData) {
             Assert::isArray($dimensionContentData, 'Expected dimensionContentData to be an array');
@@ -183,12 +187,20 @@ final class ArticleTrashItemHandler implements
                 $allLocales[] = $dimensionContentData['locale'];
             }
 
+            if (null === $templateKey && \array_key_exists('template', $dimensionContentData) && $dimensionContentData['template']) {
+                Assert::string($dimensionContentData['template']);
+                $templateKey = $dimensionContentData['template'];
+            }
+
             foreach ($this->articleMappers as $articleMapper) {
                 $articleMapper->mapArticleData($article, $dimensionContentData);
             }
         }
 
         $context = $allLocales ? ['locales' => $allLocales] : [];
+
+        Assert::notEmpty($allLocales, 'Expected to find at least one restored locale for the article.');
+        $result = new ArticleRestoreResult($article->getUuid(), $this->resolveGroup($templateKey), $allLocales[0]);
 
         if ('translation' === $trashItem->getRestoreType()) {
             foreach ($allLocales as $locale) {
@@ -199,7 +211,7 @@ final class ArticleTrashItemHandler implements
                 ));
             }
 
-            return $article;
+            return $result;
         }
 
         $this->domainEventCollector->collect(new ArticleRestoredEvent(
@@ -209,16 +221,35 @@ final class ArticleTrashItemHandler implements
             $restoreData,
         ));
 
-        return $article;
+        return $result;
     }
 
     public function getConfiguration(): RestoreConfiguration
     {
         return new RestoreConfiguration(
             null,
-            ArticleAdmin::EDIT_TABS_VIEW,
-            ['id' => 'id'],
-            null, // TODO serialization group?
+            ArticleAdmin::EDIT_TABS_VIEW . '_{group}',
+            ['id' => 'id', 'locale' => 'locale'],
+            null,
+            ['group' => 'group'],
         );
+    }
+
+    private function resolveGroup(?string $templateKey): string
+    {
+        if (null === $templateKey) {
+            return GroupProviderInterface::DEFAULT_GROUP;
+        }
+
+        // resolve the template key -> group identifier mapping once instead of per item,
+        // to avoid re-fetching and re-sorting the groups for every single result
+        $groupByTemplateKey = [];
+        foreach ($this->groupProvider->getGroups(ArticleInterface::TEMPLATE_TYPE) as $group) {
+            foreach ($group->templates as $template) {
+                $groupByTemplateKey[$template] = $group->identifier;
+            }
+        }
+
+        return $groupByTemplateKey[$templateKey] ?? GroupProviderInterface::DEFAULT_GROUP;
     }
 }

--- a/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
+++ b/packages/article/src/Infrastructure/Symfony/HttpKernel/SuluArticleBundle.php
@@ -446,6 +446,7 @@ final class SuluArticleBundle extends AbstractBundle
                     new Reference('sulu_content.content_merger'),
                     tagged_iterator('sulu_article.article_mapper'),
                     new Reference('sulu_activity.domain_event_collector'),
+                    new Reference('sulu_admin.metadata_group_provider'),
                 ])
                 ->tag('sulu_trash.store_trash_item_handler')
                 ->tag('sulu_trash.restore_trash_item_handler')

--- a/packages/article/tests/Functional/Integration/ArticleControllerTest.php
+++ b/packages/article/tests/Functional/Integration/ArticleControllerTest.php
@@ -620,9 +620,54 @@ class ArticleControllerTest extends SuluTestCase
         $response = $this->client->getResponse();
         $this->assertHttpStatusCode(200, $response);
 
+        /** @var array{id: string, group: string, locale: string} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $this->assertSame($trashItem->getResourceId(), $content['id']);
+        $this->assertSame('default', $content['group']);
+        $this->assertSame('en', $content['locale']);
+
         $this->client->request('GET', '/admin/api/articles/' . $trashItem->getResourceId() . '?locale=en');
         $response = $this->client->getResponse();
         $this->assertResponseSnapshot('article_post_restore.json', $response, 200);
+    }
+
+    public function testRestoreResolvesConfiguredGroup(): void
+    {
+        self::purgeDatabase();
+
+        $this->client->request('POST', '/admin/api/articles?locale=en&action=publish', [], [], [], \json_encode([
+            'template' => 'blog',
+            'title' => 'Blog Restore Test',
+            'url' => '/blog-restore-test',
+            'mainWebspace' => 'sulu-io',
+        ]) ?: null);
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(201, $response);
+        /** @var array{id: string} $content */
+        $content = \json_decode((string) $response->getContent(), true);
+        $id = $content['id'];
+
+        $this->client->request('DELETE', '/admin/api/articles/' . $id . '?locale=en');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(204, $response);
+
+        $trashRepository = self::getContainer()->get(TrashItemRepositoryInterface::class);
+        $trashItem = $trashRepository->findOneBy([
+            'resourceKey' => ArticleInterface::RESOURCE_KEY,
+            'resourceId' => $id,
+            'restoreType' => null,
+        ]);
+        $this->assertNotNull($trashItem);
+
+        $this->client->request('POST', '/admin/api/trash-items/' . $trashItem->getId() . '?action=restore');
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode(200, $response);
+
+        /** @var array{id: string, group: string, locale: string} $restoreContent */
+        $restoreContent = \json_decode((string) $response->getContent(), true);
+        $this->assertSame($id, $restoreContent['id']);
+        $this->assertSame('blog-group', $restoreContent['group']);
+        $this->assertSame('en', $restoreContent['locale']);
     }
 
     public function testGetListWithTemplateFiltering(): void

--- a/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfiguration.php
+++ b/src/Sulu/Bundle/TrashBundle/Application/RestoreConfigurationProvider/RestoreConfiguration.php
@@ -40,19 +40,28 @@ class RestoreConfiguration
     private $resultSerializationGroups;
 
     /**
+     * @var array<string, string>|null
+     */
+    #[Groups(['frontend'])]
+    private $resultToViewName;
+
+    /**
      * @param array<string, string>|null $resultToView
      * @param array<string>|null $resultSerializationGroups
+     * @param array<string, string>|null $resultToViewName
      */
     public function __construct(
         ?string $form = null,
         ?string $view = null,
         ?array $resultToView = null,
-        ?array $resultSerializationGroups = null
+        ?array $resultSerializationGroups = null,
+        ?array $resultToViewName = null
     ) {
         $this->form = $form;
         $this->view = $view;
         $this->resultToView = $resultToView;
         $this->resultSerializationGroups = $resultSerializationGroups;
+        $this->resultToViewName = $resultToViewName;
     }
 
     public function getForm(): ?string
@@ -79,5 +88,13 @@ class RestoreConfiguration
     public function getResultSerializationGroups(): ?array
     {
         return $this->resultSerializationGroups;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    public function getResultToViewName(): ?array
+    {
+        return $this->resultToViewName;
     }
 }

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/types.js
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/types.js
@@ -3,5 +3,6 @@
 export type RestoreConfiguration = {|
     form?: string,
     resultToView?: {[string]: string},
+    resultToViewName?: {[string]: string},
     view?: string,
 |};

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/views/List/itemActions/RestoreItemAction.js
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/views/List/itemActions/RestoreItemAction.js
@@ -43,17 +43,29 @@ export default class RestoreItemAction extends AbstractListItemAction {
             id: this.idToBeRestored,
         })
             .then(action((response) => {
-                const {view, resultToView = {}} = this.restoreConfiguration || {};
+                const {view, resultToView, resultToViewName} = this.restoreConfiguration || {};
+                const definiteResultToView = resultToView || {};
 
                 this.restoring = false;
                 this.idToBeRestored = undefined;
                 this.resourceKeyToBeRestored = undefined;
 
                 if (view) {
+                    let resolvedView = view;
+
+                    if (resultToViewName) {
+                        Object.keys(resultToViewName).forEach((resultPath) => {
+                            resolvedView = resolvedView.replace(
+                                `{${resultToViewName[resultPath]}}`,
+                                `${jsonpointer.get(response, '/' + resultPath)}`
+                            );
+                        });
+                    }
+
                     this.router.navigate(
-                        view,
-                        Object.keys(resultToView).reduce((parameters, resultPath) => {
-                            parameters[resultToView[resultPath]] = jsonpointer.get(response, '/' + resultPath);
+                        resolvedView,
+                        Object.keys(definiteResultToView).reduce((parameters, resultPath) => {
+                            parameters[definiteResultToView[resultPath]] = jsonpointer.get(response, '/' + resultPath);
                             return parameters;
                         }, {})
                     );

--- a/src/Sulu/Bundle/TrashBundle/Resources/js/views/List/itemActions/tests/RestoreItemAction.test.js
+++ b/src/Sulu/Bundle/TrashBundle/Resources/js/views/List/itemActions/tests/RestoreItemAction.test.js
@@ -183,6 +183,30 @@ test('Send request and navigate to view if dialog is confirmed and view is confi
     });
 });
 
+test('Send request and navigate to resolved view if resultToViewName is configured', () => {
+    RestoreItemAction.restoreConfigurationMapping.test = {
+        view: 'test-view_{group}',
+        resultToView: {id: 'id'},
+        resultToViewName: {group: 'group'},
+    };
+
+    const postPromise = Promise.resolve({id: '1234-1234-1234', group: 'press'});
+    ResourceRequester.post.mockReturnValue(postPromise);
+
+    const itemAction = createItemAction();
+
+    const onClick = itemAction.getItemActionConfig({id: 'id-1234', resourceKey: 'test'}).onClick;
+    if (!onClick) {
+        throw new Error('The onClick callback should not be undefined in this case');
+    }
+    onClick('id-1234', 1);
+    mount(itemAction.getNode()).find(Dialog).props().onConfirm();
+
+    return postPromise.then(() => {
+        expect(itemAction.router.navigate).toHaveBeenLastCalledWith('test-view_press', {id: '1234-1234-1234'});
+    });
+});
+
 test('Display RestoreFormOverlay if onClick callback is fired', () => {
     RestoreItemAction.restoreConfigurationMapping.test = {form: 'foo'};
     const itemAction = createItemAction();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #
| Related issues/PRs | #9068, #9067
| License | MIT
| Documentation PR |

#### What's in this PR?

Adds a `resultToViewName` field to `RestoreConfiguration`, so a trash restore's target view name can carry a `{token}` placeholder that gets resolved from a field in the restore response before the frontend navigates. `ArticleTrashItemHandler` now uses it: it resolves the restored article's group server-side and navigates straight to that group's edit view, instead of the group-tab list added as a stopgap in #9068.

#### Why?

#9068 fixed article trash restore navigating to a dead route (since #8124 removed the ungrouped edit view), but only got the user back to the article list, not the restored article itself. The restore response carried no group information to resolve the group-specific edit view. This adds that: `ArticleTrashItemHandler::restore()` now returns a small `id`/`group`/`locale` result (all `RestoreItemAction` ever reads from the response) instead of the full article entity, with the group resolved via the same template-key-to-group lookup already used by `ArticleSmartContentProvider`.

The `resultToViewName` mechanism itself is generic and mirrors the placeholder resolution already shipped for smart-content deep links (#9067), so any other resource's `RestoreConfigurationProvider` can use it too.

#### Example Usage

```php
public function getConfiguration(): RestoreConfiguration
{
    return new RestoreConfiguration(
        null,
        ArticleAdmin::EDIT_TABS_VIEW . '_{group}',
        ['id' => 'id', 'locale' => 'locale'],
        null,
        ['group' => 'group'],
    );
}
```

#### To Do

- [ ] Create a documentation PR
- [ ] Add breaking changes to UPGRADE.md
