### PR TITLE
Keep the fields coming from the request options in the list store

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -566,7 +566,12 @@ export default class ListStore {
         options.sortBy = this.sortColumn.get();
         options.sortOrder = this.sortOrder.get();
         options.limit = this.limit.get();
-        options.fields = this.fields;
+        // "fields" can also arrive through the request options, e.g. a selection field asking for
+        // a property its list does not display. Both sets are requested instead of one winning.
+        const requestedFields = typeof options.fields === 'string'
+            ? options.fields.split(',')
+            : (options.fields || []);
+        options.fields = [...new Set([...this.fields, ...requestedFields])];
         if (Object.keys(this.filterQueryOption).length > 0) {
             options.filter = this.filterQueryOption;
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -192,6 +192,43 @@ test('The loading strategy should be called when a request is sent', () => {
     listStore.destroy();
 });
 
+test('The loading strategy should keep a "fields" option coming from the request options', () => {
+    const loadingStrategy = new LoadingStrategy();
+    const structureStrategy = new StructureStrategy();
+    const page = observable.box(1);
+    const locale = observable.box();
+    const listStore = new ListStore(
+        'categories',
+        'categories',
+        'list_test',
+        {
+            page,
+            locale,
+        },
+        {
+            fields: 'key',
+        },
+        undefined
+    );
+    listStore.schema = {};
+
+    listStore.updateLoadingStrategy(loadingStrategy);
+    listStore.updateStructureStrategy(structureStrategy);
+
+    expect(loadingStrategy.load).toHaveBeenCalledWith(
+        'categories',
+        expect.objectContaining({
+            fields: [
+                'id',
+                'key',
+            ],
+        }),
+        undefined
+    );
+
+    listStore.destroy();
+});
+
 test('The user store should be called correctly when changing the schema', () => {
     const page = observable.box(1);
     const locale = observable.box();


### PR DESCRIPTION
Fixes #7666

`ListStore` overwrote `options.fields` with the fields it derives from the visible columns of the list:

```js
options.fields = this.fields;
```

So a `fields` request parameter configured on a selection field never reached the API. @Prokyonn's reading was right, it is just the whole assignment that wins rather than a hard-coded list.

That is what makes the jexl context of a `category_selection` differ between the form and its overlay: the overlay only ever gets what the list schema displays, and asking for another property through `request_parameters` had no effect, which is why the documented workaround is to make `key` permanently visible in `config/lists/categories.xml`.

Both sets are requested now, deduplicated, accepting the value as a string or as an array.

On `2.6` the new test shows the current behaviour drops the option entirely: expected `{"fields": ["id", "key"]}`, received `{"fields": ["id"]}`. The 78 `ListStore` tests pass and eslint is clean.

Targeting `2.6` since that is where the issue was reported and the line is the same on `3.0` and `3.1`.
