### PR TITLE
Keep a falsy scalar value when setting data on a media

### DIFF
--- a/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
+++ b/src/Sulu/Bundle/MediaBundle/Media/Manager/MediaManager.php
@@ -489,7 +489,10 @@ class MediaManager implements MediaManagerInterface
     protected function setDataToMedia(Media $media, $data, $user)
     {
         foreach ($data as $attribute => $value) {
+            // a scalar is applied whenever it carries something, so that a title of "0" or a
+            // numeric value of 0 is not mistaken for an absent one
             if ($value
+                || (\is_scalar($value) && '' !== $value)
                 || 'tags' === $attribute
                 || 'size' === $attribute
                 || 'description' === $attribute

--- a/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Unit/Media/Manager/MediaManagerTest.php
@@ -509,6 +509,35 @@ class MediaManagerTest extends TestCase
         $mediaManager->delete(1, true);
     }
 
+    public function testSaveKeepsAFalsyScalarTitle(): void
+    {
+        /** @var ObjectProphecy<UploadedFile> $uploadedFile */
+        $uploadedFile = $this->prophesize(UploadedFile::class)->willBeConstructedWith([__DIR__ . \DIRECTORY_SEPARATOR . 'test.txt', 1, null, null, 1, true]);
+        $uploadedFile->getClientOriginalName()->willReturn('test.txt');
+        $uploadedFile->getPathname()->willReturn('');
+        $uploadedFile->getSize()->willReturn('123');
+        $uploadedFile->getMimeType()->willReturn('img');
+
+        $user = $this->prophesize(User::class)->willImplement(UserInterface::class);
+        $this->userRepository->findUserById(1)->willReturn($user);
+
+        $this->mediaRepository->createNew()->willReturn(new Media());
+
+        $this->storage->save('', 'test.txt')->shouldBeCalled();
+        $this->mediaPropertiesProvider
+            ->provide($uploadedFile->reveal())
+            ->willReturn([])
+            ->shouldBeCalled();
+
+        $this->pathCleaner->cleanup(Argument::any())->willReturn('test');
+
+        $this->domainEventCollector->collect(Argument::type(MediaCreatedEvent::class))->shouldBeCalled();
+
+        $media = $this->mediaManager->save($uploadedFile->reveal(), ['locale' => 'en', 'title' => '0'], 1);
+
+        $this->assertSame('0', $media->getTitle());
+    }
+
     #[\PHPUnit\Framework\Attributes\DataProvider('provideSpecialCharacterFileName')]
     public function testSpecialCharacterFileName(string $fileName, string $cleanUpArgument, string $cleanUpResult, string $extension): void
     {


### PR DESCRIPTION
Fixes #9056

`setDataToMedia()` decided whether to apply an attribute by its truthiness, with a list of thirteen attribute names exempted from that check. `title` is not on it, so `"0"` was read as an absent value and the previous title stayed, with a 200 and no message.

A scalar is now applied whenever it carries something:

```php
if ($value
    || (\is_scalar($value) && '' !== $value)
    || 'tags' === $attribute
    // ...
```

`null`, empty strings, arrays and objects keep behaving exactly as before. I kept it that narrow on purpose: widening to `null !== $value` would also let an empty array clear `formats` or `properties`, which is beyond what this issue reports.

@mamazu, the numeric case you raised is covered by the same line, and `focusPointX` and `focusPointY` turn out to be on the exemption list already, so those two were never affected. Grouping the thirteen exemptions by type is a good idea but a bigger change, happy to look at it separately.

The new unit test fails on `2.6` with `Failed asserting that null is identical to '0'`. The 22 tests of `MediaManagerTest` pass.

Targeting `2.6` since the code is the same on `2.6`, `3.0` and `3.1` as you noted.
