### PR TITLE
Track references for single_page_selection and teaser_selection content types

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -2,6 +2,18 @@
 
 For every update follow the [Upgrade Documentation](https://docs.sulu.io/2.x/upgrades/upgrade-2.x.html) steps.
 
+## 2.6.27
+
+### Reference tracking for page and teaser selections
+
+The `single_page_selection` and `teaser_selection` content types now register their targets in the
+reference table, like the snippet and media selections already do. Content that uses these types only
+gets reference rows on its next publish, so refresh existing content once after upgrading:
+
+```bash
+bin/console sulu:reference:refresh
+```
+
 ## 2.6.26
 
 ### Improved reference tracking performance

--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -11,7 +11,8 @@ reference table, like the snippet and media selections already do. Content that 
 gets reference rows on its next publish, so refresh existing content once after upgrading:
 
 ```bash
-bin/console sulu:reference:refresh
+bin/adminconsole sulu:reference:refresh
+bin/websiteconsole sulu:reference:refresh
 ```
 
 ## 2.6.26

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -39123,13 +39123,13 @@ parameters:
 		-
 			message: '#^Cannot access offset ''id'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
 
 		-
 			message: '#^Cannot access offset ''type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 2
 			path: src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -39123,13 +39123,13 @@ parameters:
 		-
 			message: '#^Cannot access offset ''id'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
 
 		-
 			message: '#^Cannot access offset ''type'' on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 2
+			count: 1
 			path: src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
 
 		-

--- a/src/Sulu/Bundle/PageBundle/Content/Types/SinglePageSelection.php
+++ b/src/Sulu/Bundle/PageBundle/Content/Types/SinglePageSelection.php
@@ -12,6 +12,9 @@
 namespace Sulu\Bundle\PageBundle\Content\Types;
 
 use PHPCR\NodeInterface;
+use Sulu\Bundle\PageBundle\Document\BasePageDocument;
+use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollectorInterface;
+use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Component\Content\Compat\PropertyInterface;
 use Sulu\Component\Content\PreResolvableContentTypeInterface;
@@ -20,7 +23,7 @@ use Sulu\Component\Content\SimpleContentType;
 /**
  * ContentType for SinglePageSelection.
  */
-class SinglePageSelection extends SimpleContentType implements PreResolvableContentTypeInterface
+class SinglePageSelection extends SimpleContentType implements PreResolvableContentTypeInterface, ReferenceContentTypeInterface
 {
     public function __construct(
         private ReferenceStoreInterface $referenceStore
@@ -70,5 +73,19 @@ class SinglePageSelection extends SimpleContentType implements PreResolvableCont
         }
 
         $this->referenceStore->add($uuid);
+    }
+
+    public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
+    {
+        $uuid = $property->getValue();
+        if (!\is_string($uuid) || '' === $uuid) {
+            return;
+        }
+
+        $referenceCollector->addReference(
+            BasePageDocument::RESOURCE_KEY,
+            $uuid,
+            $propertyPrefix . $property->getName()
+        );
     }
 }

--- a/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
@@ -23,6 +23,8 @@ use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMapperInterf
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\PropertyMetadataMinMaxValueResolver;
 use Sulu\Bundle\AdminBundle\Metadata\SchemaMetadata\StringMetadata;
 use Sulu\Bundle\PageBundle\Teaser\Provider\TeaserProviderPoolInterface;
+use Sulu\Bundle\ReferenceBundle\Application\Collector\ReferenceCollectorInterface;
+use Sulu\Bundle\ReferenceBundle\Infrastructure\Sulu\ContentType\ReferenceContentTypeInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreInterface;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStoreNotExistsException;
 use Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStorePoolInterface;
@@ -35,7 +37,7 @@ use Sulu\Component\Content\SimpleContentType;
 /**
  * Provides content-type for selecting teasers.
  */
-class TeaserContentType extends SimpleContentType implements PreResolvableContentTypeInterface, PropertyMetadataMapperInterface
+class TeaserContentType extends SimpleContentType implements PreResolvableContentTypeInterface, PropertyMetadataMapperInterface, ReferenceContentTypeInterface
 {
     public function __construct(
         private TeaserProviderPoolInterface $teaserProviderPool,
@@ -128,6 +130,25 @@ class TeaserContentType extends SimpleContentType implements PreResolvableConten
             } catch (ReferenceStoreNotExistsException $exception) {
                 // ignore not existing stores
             }
+        }
+    }
+
+    public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
+    {
+        foreach ($this->getItems($property) as $item) {
+            $type = $item['type'] ?? null;
+            $id = $item['id'] ?? null;
+
+            // the teaser "type" is the provider alias, which matches the resource key of the referenced resource
+            if (!\is_string($type) || '' === $type || (!\is_string($id) && !\is_int($id)) || '' === (string) $id) {
+                continue;
+            }
+
+            $referenceCollector->addReference(
+                $type,
+                (string) $id,
+                $propertyPrefix . $property->getName()
+            );
         }
     }
 

--- a/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
+++ b/src/Sulu/Bundle/PageBundle/Teaser/TeaserContentType.php
@@ -136,6 +136,10 @@ class TeaserContentType extends SimpleContentType implements PreResolvableConten
     public function getReferences(PropertyInterface $property, ReferenceCollectorInterface $referenceCollector, string $propertyPrefix = ''): void
     {
         foreach ($this->getItems($property) as $item) {
+            if (!\is_array($item)) {
+                continue;
+            }
+
             $type = $item['type'] ?? null;
             $id = $item['id'] ?? null;
 

--- a/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/test_page.xml
+++ b/src/Sulu/Bundle/PageBundle/Tests/Application/config/templates/pages/test_page.xml
@@ -45,5 +45,19 @@
                 <title lang="en">Animals</title>
             </meta>
         </property>
+
+        <property name="page" type="single_page_selection">
+            <meta>
+                <title lang="de">Seite</title>
+                <title lang="en">Page</title>
+            </meta>
+        </property>
+
+        <property name="teaser" type="teaser_selection">
+            <meta>
+                <title lang="de">Teaser</title>
+                <title lang="en">Teaser</title>
+            </meta>
+        </property>
     </properties>
 </template>

--- a/src/Sulu/Bundle/PageBundle/Tests/Functional/Reference/Provider/PageReferenceProviderTest.php
+++ b/src/Sulu/Bundle/PageBundle/Tests/Functional/Reference/Provider/PageReferenceProviderTest.php
@@ -81,6 +81,58 @@ class PageReferenceProviderTest extends SuluTestCase
         self::assertSame($snippet->getUuid(), $references[0]->getResourceId());
     }
 
+    public function testUpdatePageAndTeaserReferences(): void
+    {
+        /** @var PageDocument $targetPage */
+        $targetPage = $this->documentManager->create('page');
+        $targetPage->setTitle('Target page');
+        $targetPage->setLocale('en');
+        $targetPage->setStructureType('test_page');
+        $targetPage->setResourceSegment('/target-page');
+        $targetPage->setParent($this->documentManager->find($this->sessionManager->getContentPath('sulu_io')));
+        $targetPage->getStructure()->bind([
+            'title' => 'Target page',
+            'template' => 'test_page',
+            'url' => '/target-page',
+        ]);
+        $this->documentManager->persist($targetPage, 'en');
+        $this->documentManager->publish($targetPage, 'en');
+        $this->documentManager->flush();
+
+        /** @var PageDocument $page */
+        $page = $this->documentManager->create('page');
+        $page->setTitle('Example page');
+        $page->setLocale('en');
+        $page->setStructureType('test_page');
+        $page->setResourceSegment('/example-page-123');
+        $page->setParent($this->documentManager->find($this->sessionManager->getContentPath('sulu_io')));
+
+        $page->getStructure()->bind([
+            'title' => 'Example page',
+            'template' => 'test_page',
+            'url' => '/test',
+            'page' => $targetPage->getUuid(),
+            'teaser' => ['items' => [['type' => 'pages', 'id' => $targetPage->getUuid()]]],
+        ]);
+
+        $this->documentManager->persist($page, 'en');
+        $this->documentManager->publish($page, 'en');
+        $this->documentManager->flush();
+
+        $this->pageReferenceProvider->updateReferences($page, 'en', 'test');
+        $this->getEntityManager()->flush();
+
+        /** @var Reference[] $references */
+        $references = $this->referenceRepository->findBy(['referenceContext' => 'test'], ['referenceProperty' => 'ASC']);
+
+        // one reference from the single_page_selection, one from the teaser_selection, both pointing at the target page
+        $this->assertCount(2, $references);
+        foreach ($references as $reference) {
+            self::assertSame(PageDocument::RESOURCE_KEY, $reference->getResourceKey());
+            self::assertSame($targetPage->getUuid(), $reference->getResourceId());
+        }
+    }
+
     public function testUpdateUnpublishedReferences(): void
     {
         /** @var SnippetDocument $snippet */


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | |
| Related issues/PRs | sulu/SuluArticleBundle#727 sulu/sulu#9076|
| License | MIT
| Documentation PR | |

#### What's in this PR?

`single_page_selection` and `teaser_selection` content types never implemented `ReferenceContentTypeInterface`, unlike the snippet and media selections. That means no `Reference` row was ever written for a page or teaser link, so anything relying on the reference table to know what depends on a given page/article (e.g. republishing a page that teasers another page) never saw that dependency.

- `SinglePageSelection`: implements `getReferences()`, mirroring `SingleSnippetSelection`.
- `TeaserContentType`: implements `getReferences()`, iterating teaser items and using each item's provider alias as the resource key (same value already used by `preResolve()`/reference stores).
- No service/XML wiring needed: the reference writer detects reference content types via `instanceof` at runtime.
- `UPGRADE-2.x.md`: notes the new tracking and that existing content needs a `sulu:reference:refresh` run to backfill.

#### Why?

Pages/teasers referencing other pages silently dropped their dependency in the reference table, so a reference-based republish never fired for them. Same gap also existed in SuluArticleBundle's article selections, fixed in sulu/SuluArticleBundle#727.

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md