### PR TITLE
Decode html entities in the sulu-link href before splitting it

### DIFF
--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -212,7 +212,9 @@ class LinkTag implements TagInterface
      */
     private function getPartsFromHref($href): array
     {
-        $href = (string) $href ?: null;
+        // the href comes from an html attribute, so "#", "?" and "&" may be escaped as entities
+        // and have to be decoded before they can be used as separators
+        $href = $href ? \html_entity_decode((string) $href, \ENT_QUOTES | \ENT_HTML5, 'UTF-8') : null;
 
         /** @var string[] $hrefParts */
         $hrefParts = $href ? \explode('#', $href, 2) : [];

--- a/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
+++ b/src/Sulu/Bundle/MarkupBundle/Markup/LinkTag.php
@@ -212,9 +212,11 @@ class LinkTag implements TagInterface
      */
     private function getPartsFromHref($href): array
     {
-        // the href comes from an html attribute, so "#", "?" and "&" may be escaped as entities
-        // and have to be decoded before they can be used as separators
-        $href = $href ? \html_entity_decode((string) $href, \ENT_QUOTES | \ENT_HTML5, 'UTF-8') : null;
+        // The href comes from an html attribute, so "#", "?" and "&" may be escaped as entities
+        // and have to be decoded before they can be used as separators. Quotes are deliberately
+        // left encoded: the parts are re-appended to the href that parseAll() prints without
+        // escaping, so decoding a quote here would let it break out of the attribute.
+        $href = $href ? \html_entity_decode((string) $href, \ENT_NOQUOTES | \ENT_HTML5, 'UTF-8') : null;
 
         /** @var string[] $hrefParts */
         $hrefParts = $href ? \explode('#', $href, 2) : [];

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -260,6 +260,27 @@ class LinkTagTest extends TestCase
         );
     }
 
+    public function testParseAllWithEscapedAnchor(): void
+    {
+        // twig's escape('html_attr') filter turns the "#" into "&#x23;", which used to be split
+        // on its own "#", leaving a broken uuid and no usable anchor
+        $href = '123-123-123&#x23;my-anchor';
+        $tag = '<sulu-link href="' . $href . '" title="Test-Title" provider="article">Test-Content</sulu-link>';
+
+        $this->providers['article']->preload(['123-123-123'], 'de', true)
+            ->willReturn([new LinkItem('123-123-123', 'Page-Title', '/de/test', true)]);
+
+        $result = $this->linkTag->parseAll(
+            [$tag => ['href' => $href, 'title' => 'Test-Title', 'provider' => 'article', 'content' => 'Test-Content']],
+            'de'
+        );
+
+        $this->assertEquals(
+            [$tag => '<a href="http://sulu.lo/de/test#my-anchor" title="Test-Title">Test-Content</a>'],
+            $result
+        );
+    }
+
     public function testParseAllMultipleTags(): void
     {
         $this->providers['article']->preload(['123-123-123', '312-312-312'], 'de', true)

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -52,6 +52,7 @@ class LinkTagTest extends TestCase
         $providers = $this->providers = [
             'page' => $this->prophesize(LinkProviderInterface::class),
             'article' => $this->prophesize(LinkProviderInterface::class),
+            'external' => $this->prophesize(LinkProviderInterface::class),
         ];
         $this->providerPool = $this->prophesize(LinkProviderPoolInterface::class);
         $this->providerPool->getProvider(Argument::any())->will(
@@ -277,6 +278,65 @@ class LinkTagTest extends TestCase
 
         $this->assertEquals(
             [$tag => '<a href="http://sulu.lo/de/test#my-anchor" title="Test-Title">Test-Content</a>'],
+            $result
+        );
+    }
+
+    public function testParseAllWithEscapedQueryAndAnchor(): void
+    {
+        $href = '123-123-123&#x3F;query=value&#x23;my-anchor';
+        $tag = '<sulu-link href="' . $href . '" provider="article">Test-Content</sulu-link>';
+
+        $this->providers['article']->preload(['123-123-123'], 'de', true)
+            ->willReturn([new LinkItem('123-123-123', 'Page-Title', '/de/test', true)]);
+
+        $result = $this->linkTag->parseAll(
+            [$tag => ['href' => $href, 'provider' => 'article', 'content' => 'Test-Content']],
+            'de'
+        );
+
+        $this->assertEquals(
+            [$tag => '<a href="http://sulu.lo/de/test?query=value#my-anchor">Test-Content</a>'],
+            $result
+        );
+    }
+
+    public function testParseAllWithEncodedAmpersandInQuery(): void
+    {
+        // "&amp;" is how an "&" is written in an html attribute, so it belongs to the query
+        $href = '123-123-123?first=1&amp;second=2';
+        $tag = '<sulu-link href="' . $href . '" provider="article">Test-Content</sulu-link>';
+
+        $this->providers['article']->preload(['123-123-123'], 'de', true)
+            ->willReturn([new LinkItem('123-123-123', 'Page-Title', '/de/test', true)]);
+
+        $result = $this->linkTag->parseAll(
+            [$tag => ['href' => $href, 'provider' => 'article', 'content' => 'Test-Content']],
+            'de'
+        );
+
+        $this->assertEquals(
+            [$tag => '<a href="http://sulu.lo/de/test?first=1&second=2">Test-Content</a>'],
+            $result
+        );
+    }
+
+    public function testParseAllWithExternalUrl(): void
+    {
+        // the external provider hands back the href as the url, so a full url has to survive untouched
+        $href = 'https://example.com/path?first=1#my-anchor';
+        $tag = '<sulu-link href="' . $href . '" provider="external">Test-Content</sulu-link>';
+
+        $this->providers['external']->preload(['https://example.com/path'], 'de', true)
+            ->willReturn([new LinkItem('https://example.com/path', '', 'https://example.com/path', true)]);
+
+        $result = $this->linkTag->parseAll(
+            [$tag => ['href' => $href, 'provider' => 'external', 'content' => 'Test-Content']],
+            'de'
+        );
+
+        $this->assertEquals(
+            [$tag => '<a href="https://example.com/path?first=1#my-anchor">Test-Content</a>'],
             $result
         );
     }

--- a/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
+++ b/src/Sulu/Bundle/MarkupBundle/Tests/Unit/Markup/LinkTagTest.php
@@ -301,6 +301,27 @@ class LinkTagTest extends TestCase
         );
     }
 
+    public function testParseAllKeepsEncodedQuotesEncoded(): void
+    {
+        // parseAll() prints the attributes without escaping, so a decoded quote would break
+        // out of the href and inject an attribute
+        $href = '123-123-123&#x23;a&quot; onmouseover=&quot;alert(1)';
+        $tag = '<sulu-link href="' . $href . '" provider="article">Test-Content</sulu-link>';
+
+        $this->providers['article']->preload(['123-123-123'], 'de', true)
+            ->willReturn([new LinkItem('123-123-123', 'Page-Title', '/de/test', true)]);
+
+        $result = $this->linkTag->parseAll(
+            [$tag => ['href' => $href, 'provider' => 'article', 'content' => 'Test-Content']],
+            'de'
+        );
+
+        $this->assertEquals(
+            [$tag => '<a href="http://sulu.lo/de/test#a&quot; onmouseover=&quot;alert(1)">Test-Content</a>'],
+            $result
+        );
+    }
+
     public function testParseAllWithEncodedAmpersandInQuery(): void
     {
         // "&amp;" is how an "&" is written in an html attribute, so it belongs to the query


### PR DESCRIPTION
Fixes #6955.

Applied the solution you pointed at in the issue: the href is decoded before being split.

One thing worth noting, the symptom is worse than the report suggests. The split happens on the `#` *inside* `&#x23;`, so the uuid becomes `123-123-123&` and the link does not resolve at all, falling back to plain text. The lost anchor is the milder half of it.

I kept the decoding in `getPartsFromHref()` rather than in `HtmlTagExtractor`, where it would have been tempting: `parseAll()` re-emits attributes with `sprintf('%s="%s"')` and no escaping, so decoding them globally would have opened an injection.

The existing data provider could not host the case, because the test harness derives the expected uuid with `preg_split('/[#?]/', $href)` and so reproduces the bug itself. Rather than touch that shared helper I added a dedicated test.

@abdellahrk mentioned looking into this back in February 2025, so apologies if this steps on anything still in progress.
