### PR TITLE
Load the current file version with the medias assigned to a contact or account

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -2,6 +2,17 @@
 
 For every update follow the [Upgrade Documentation](https://docs.sulu.io/2.x/upgrades/upgrade-2.x.html) steps.
 
+## 2.6.27
+
+### MediaRepositoryInterface has changed
+
+A new method has been added to the `MediaRepositoryInterface`:
+
+- `findMediaWithCurrentFileVersion`
+
+It returns the medias together with the file version they currently point at, so that reading
+that version does not cost one query per media.
+
 ## 2.6.26
 
 ### Improved reference tracking performance

--- a/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/AccountManager.php
@@ -253,11 +253,7 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
      */
     public function setMedias(Account $account, $mediaIds)
     {
-        $foundMedias = [];
-        if (\count($mediaIds) > 0) {
-            /** @var MediaInterface[] $foundMedias */
-            $foundMedias = $this->mediaRepository->findById($mediaIds);
-        }
+        $foundMedias = $this->mediaRepository->findMediaWithCurrentFileVersion($mediaIds);
         $foundMediaIds = \array_map(
             fn (MediaInterface $mediaEntity) => $mediaEntity->getId(),
             $foundMedias
@@ -266,14 +262,25 @@ class AccountManager extends AbstractContactManager implements DataProviderRepos
             throw new EntityNotFoundException($this->mediaRepository->getClassName(), \reset($missingMediaIds));
         }
 
+        $removedMedias = [];
         foreach ($account->getMedias() as $media) {
             if (!\in_array($media->getId(), $foundMediaIds)) {
-                $account->removeMedia($media);
-
-                $this->domainEventCollector->collect(
-                    new AccountMediaRemovedEvent($account, $media)
-                );
+                $removedMedias[] = $media;
             }
+        }
+
+        // the removed medias come from the account itself, so their file version is loaded
+        // here too: the domain events below read its meta
+        $this->mediaRepository->findMediaWithCurrentFileVersion(
+            \array_map(fn (MediaInterface $mediaEntity) => $mediaEntity->getId(), $removedMedias)
+        );
+
+        foreach ($removedMedias as $media) {
+            $account->removeMedia($media);
+
+            $this->domainEventCollector->collect(
+                new AccountMediaRemovedEvent($account, $media)
+            );
         }
 
         foreach ($foundMedias as $media) {

--- a/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
+++ b/src/Sulu/Bundle/ContactBundle/Contact/ContactManager.php
@@ -628,12 +628,7 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
      */
     private function setMedias(ContactInterface $contact, $mediaIds)
     {
-        /** @var MediaInterface[] $foundMedias */
-        $foundMedias = [];
-        if (\count($mediaIds) > 0) {
-            /** @var MediaInterface[] $foundMedias */
-            $foundMedias = $this->mediaRepository->findById($mediaIds);
-        }
+        $foundMedias = $this->mediaRepository->findMediaWithCurrentFileVersion($mediaIds);
         /** @var int[] $foundMediaIds */
         $foundMediaIds = \array_map(
             function(MediaInterface $mediaEntity) {
@@ -646,14 +641,27 @@ class ContactManager extends AbstractContactManager implements DataProviderRepos
             throw new EntityNotFoundException($this->mediaRepository->getClassName(), \reset($missingMediaIds));
         }
 
+        $removedMedias = [];
         foreach ($contact->getMedias() as $media) {
             if (!\in_array($media->getId(), $foundMediaIds)) {
-                $contact->removeMedia($media);
-
-                $this->domainEventCollector->collect(
-                    new ContactMediaRemovedEvent($contact, $media)
-                );
+                $removedMedias[] = $media;
             }
+        }
+
+        // the removed medias come from the contact itself, so their file version is loaded
+        // here too: the domain events below read its meta
+        $this->mediaRepository->findMediaWithCurrentFileVersion(
+            \array_map(function(MediaInterface $mediaEntity) {
+                return $mediaEntity->getId();
+            }, $removedMedias)
+        );
+
+        foreach ($removedMedias as $media) {
+            $contact->removeMedia($media);
+
+            $this->domainEventCollector->collect(
+                new ContactMediaRemovedEvent($contact, $media)
+            );
         }
 
         foreach ($foundMedias as $media) {

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -480,6 +480,29 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             ->getArrayResult();
     }
 
+    public function findMediaWithCurrentFileVersion(array $ids): array
+    {
+        if (0 === \count($ids)) {
+            return [];
+        }
+
+        // the file versions are joined on the version the file points at, so the collection
+        // is hydrated with the single version the callers read, instead of being loaded
+        // lazily once per media
+        /** @var MediaInterface[] */
+        return $this->createQueryBuilder('media')
+            ->leftJoin('media.files', 'file')
+            ->leftJoin('file.fileVersions', 'fileVersion', Join::WITH, 'fileVersion.version = file.version')
+            ->leftJoin('fileVersion.defaultMeta', 'fileVersionDefaultMeta')
+            ->addSelect('file')
+            ->addSelect('fileVersion')
+            ->addSelect('fileVersionDefaultMeta')
+            ->where('media.id IN (:mediaIds)')
+            ->setParameter('mediaIds', $ids)
+            ->getQuery()
+            ->getResult();
+    }
+
     public function setAccessControlQueryEnhancer(AccessControlQueryEnhancerInterface $accessControlQueryEnhancer)
     {
         $this->accessControlQueryEnhancer = $accessControlQueryEnhancer;

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\MediaBundle\Entity;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Join;
@@ -486,6 +487,9 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             return [];
         }
 
+        // callers pass whatever the request carried, so the keys are dropped to keep a list
+        $ids = \array_values($ids);
+
         // the file versions are joined on the version the file points at, so the collection
         // is hydrated with the single version the callers read, instead of being loaded
         // lazily once per media
@@ -498,7 +502,9 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
             ->addSelect('fileVersion')
             ->addSelect('fileVersionDefaultMeta')
             ->where('media.id IN (:mediaIds)')
-            ->setParameter('mediaIds', $ids)
+            // the type is passed explicitly so the list is expanded into one placeholder
+            // per id, without relying on what the DBAL version in use infers from the value
+            ->setParameter('mediaIds', $ids, Connection::PARAM_INT_ARRAY)
             ->getQuery()
             ->getResult();
     }

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepositoryInterface.php
@@ -107,4 +107,15 @@ interface MediaRepositoryInterface extends RepositoryInterface
      * @return array<array{id: int, resourceKey: string, depth: int}>
      */
     public function findMediaResourcesByCollection(int $collectionId, bool $includeDescendantCollections = true): array;
+
+    /**
+     * Finds the medias with the given ids, with the file version they currently point at
+     * already loaded. Use it when the medias are only needed to read that file version,
+     * to avoid loading the versions of each media separately.
+     *
+     * @param array<int> $ids
+     *
+     * @return MediaInterface[]
+     */
+    public function findMediaWithCurrentFileVersion(array $ids): array;
 }

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -581,8 +581,12 @@ class MediaRepositoryTest extends SuluTestCase
         $media1 = $this->createMedia('test-1', 'test-1', $collection);
         $media2 = $this->createMedia('test-2', 'test-2', $collection);
 
+        $this->assertInstanceOf(Media::class, $media1);
+        $this->assertInstanceOf(Media::class, $media2);
+
         // the second version is the one the file points at, the first one must not be loaded
         $file = $media1->getFiles()[0];
+        $this->assertInstanceOf(File::class, $file);
         $file->setVersion(2);
         $file->addFileVersion($this->createFileVersion($file, 2, 'test-1-version-2'));
 
@@ -602,15 +606,21 @@ class MediaRepositoryTest extends SuluTestCase
         $this->assertArrayHasKey($mediaId1, $result);
         $this->assertArrayHasKey($mediaId2, $result);
 
-        $fileVersions = $result[$mediaId1]->getFiles()[0]->getFileVersions();
+        $loadedFile = $result[$mediaId1]->getFiles()[0];
+        $this->assertInstanceOf(File::class, $loadedFile);
+
+        $fileVersions = $loadedFile->getFileVersions();
         $this->assertInstanceOf(PersistentCollection::class, $fileVersions);
         $this->assertTrue($fileVersions->isInitialized());
         $this->assertCount(1, $fileVersions);
 
-        $latestFileVersion = $result[$mediaId1]->getFiles()[0]->getLatestFileVersion();
+        $latestFileVersion = $loadedFile->getLatestFileVersion();
         $this->assertNotNull($latestFileVersion);
         $this->assertSame(2, $latestFileVersion->getVersion());
-        $this->assertSame('test-1-version-2', $latestFileVersion->getDefaultMeta()->getTitle());
+
+        $defaultMeta = $latestFileVersion->getDefaultMeta();
+        $this->assertNotNull($defaultMeta);
+        $this->assertSame('test-1-version-2', $defaultMeta->getTitle());
     }
 
     public function testFindMediaWithCurrentFileVersionWithoutIds(): void

--- a/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
+++ b/src/Sulu/Bundle/MediaBundle/Tests/Functional/Entity/MediaRepositoryTest.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\MediaBundle\Tests\Functional\Entity;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\PersistentCollection;
 use Sulu\Bundle\ContactBundle\Entity\Contact;
 use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\CollectionMeta;
@@ -208,6 +209,34 @@ class MediaRepositoryTest extends SuluTestCase
         $this->em->persist($formatOptions);
 
         return $media;
+    }
+
+    private function createFileVersion(File $file, int $version, string $title): FileVersion
+    {
+        $fileVersion = new FileVersion();
+        $fileVersion->setVersion($version);
+        $fileVersion->setName($title . '.jpeg');
+        $fileVersion->setMimeType('image/jpg');
+        $fileVersion->setFile($file);
+        $fileVersion->setSize(1124214);
+        $fileVersion->setDownloadCounter(0);
+        $fileVersion->setChanged(new \DateTime('1937-04-20'));
+        $fileVersion->setCreated(new \DateTime('1937-04-20'));
+        $fileVersion->setStorageOptions(['segment' => '1', 'fileName' => $title . '.jpeg']);
+
+        $fileVersionMeta = new FileVersionMeta();
+        $fileVersionMeta->setLocale('en-gb');
+        $fileVersionMeta->setTitle($title);
+        $fileVersionMeta->setDescription('decription');
+        $fileVersionMeta->setFileVersion($fileVersion);
+
+        $fileVersion->addMeta($fileVersionMeta);
+        $fileVersion->setDefaultMeta($fileVersionMeta);
+
+        $this->em->persist($fileVersion);
+        $this->em->persist($fileVersionMeta);
+
+        return $fileVersion;
     }
 
     private function createUser(?RoleInterface $role = null)
@@ -541,6 +570,52 @@ class MediaRepositoryTest extends SuluTestCase
         $this->assertCount(2, $result);
         $this->assertEquals($media1->getId(), $result[0]->getId());
         $this->assertEquals($media3->getId(), $result[1]->getId());
+    }
+
+    public function testFindMediaWithCurrentFileVersion(): void
+    {
+        $collection = $this->createCollection('default');
+
+        $this->em->flush();
+
+        $media1 = $this->createMedia('test-1', 'test-1', $collection);
+        $media2 = $this->createMedia('test-2', 'test-2', $collection);
+
+        // the second version is the one the file points at, the first one must not be loaded
+        $file = $media1->getFiles()[0];
+        $file->setVersion(2);
+        $file->addFileVersion($this->createFileVersion($file, 2, 'test-1-version-2'));
+
+        $this->em->flush();
+
+        $mediaId1 = $media1->getId();
+        $mediaId2 = $media2->getId();
+
+        $this->em->clear();
+
+        $result = [];
+        foreach ($this->mediaRepository->findMediaWithCurrentFileVersion([$mediaId1, $mediaId2]) as $media) {
+            $result[$media->getId()] = $media;
+        }
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey($mediaId1, $result);
+        $this->assertArrayHasKey($mediaId2, $result);
+
+        $fileVersions = $result[$mediaId1]->getFiles()[0]->getFileVersions();
+        $this->assertInstanceOf(PersistentCollection::class, $fileVersions);
+        $this->assertTrue($fileVersions->isInitialized());
+        $this->assertCount(1, $fileVersions);
+
+        $latestFileVersion = $result[$mediaId1]->getFiles()[0]->getLatestFileVersion();
+        $this->assertNotNull($latestFileVersion);
+        $this->assertSame(2, $latestFileVersion->getVersion());
+        $this->assertSame('test-1-version-2', $latestFileVersion->getDefaultMeta()->getTitle());
+    }
+
+    public function testFindMediaWithCurrentFileVersionWithoutIds(): void
+    {
+        $this->assertSame([], $this->mediaRepository->findMediaWithCurrentFileVersion([]));
     }
 
     public function testFindMediaForUserWithoutPermissions(): void


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #9074
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

`MediaRepository::findMediaWithCurrentFileVersion()` loads medias together with the file version they currently point at, and `ContactManager::setMedias()` / `AccountManager::setMedias()` use it for the medias they assign **and** for the ones they remove.

#### Why?

Assigning or unassigning medias on a contact or an account issued one `SELECT ... FROM me_file_versions WHERE idFiles = ?` per media, from the activity log: the domain events read `getFiles()[0]->getLatestFileVersion()->getDefaultMeta()`, and `File::$fileVersions` is a lazy one-to-many.

One thing about the issue's own suggestion, which is why this PR is a bit larger than "swap `findById()` for a fetch-join". That only covers half of it. The removed medias do not come from `findById()`, they come from `$contact->getMedias()`, so their file versions stay lazy either way. On the reported case (2 medias added and 2 removed, 4 queries), swapping the finder alone removes 2 of the 4. Both sides are handled here.

On the shape, @mamazu wrote "the best way would be to use a repository to only load the version that is currently active", which is what the new method does: it joins `file.fileVersions` on `fileVersion.version = file.version` plus `defaultMeta`, and nothing else. It uses `leftJoin` rather than the `innerJoin` of `findMedia()` on purpose: a media without a file version stays in the result instead of turning the assignment into an `EntityNotFoundException`.

Adding the method to `MediaRepositoryInterface` is documented in `UPGRADE-2.x.md`.

#### Testing

`MediaRepositoryTest` gains two tests. The meaningful assertion is `$fileVersions->isInitialized()` after an `em->clear()`, since that is exactly what the lazy load was, plus a media with two versions to check only the current one is hydrated.

I could not run the functional suite or PHPStan here: both need the test kernel to boot, and this machine has no PDO driver and no `ext-gd`. `php -l` and php-cs-fixer are green (0 of 31), the rest is for the CI.

#### To Do

- [ ] Create a documentation PR
- [x] Add breaking changes to UPGRADE.md
