### PR TITLE
Collapse attribute groups by default and move their labels to the core catalogue

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/CollapsibleCollection.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/CollapsibleCollection.js
@@ -62,8 +62,8 @@ class CollapsibleCollection<T: CollapsibleConfig> extends React.Component<Props<
             expandedCollapsibles.splice(value.length);
         }
 
-        // A collapsible is expanded when it enters the collection.
-        expandedCollapsibles.push(...new Array(value.length - expandedCollapsibles.length).fill(true));
+        // A collapsible is collapsed when it enters the collection.
+        expandedCollapsibles.push(...new Array(value.length - expandedCollapsibles.length).fill(false));
     };
 
     @action handleCollapse = (index: number) => {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/README.md
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/README.md
@@ -2,7 +2,7 @@ The collapsible collection renders a `Collapsible` for every entry of its `value
 their expanded state. Every entry needs a `title` and may bring a `subtitle`, the content of a
 collapsible comes from the `renderCollapsibleContent` callback. As soon as there is more than one
 entry, a control to collapse or expand all of them at once is shown. Every collapsible starts
-expanded.
+collapsed.
 
 The collapsibles are sorted by dragging their handle, which reorders `value` and reports the new
 order through `onChange`.

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/CollapsibleCollection.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/CollapsibleCollection.test.js
@@ -45,18 +45,18 @@ function getCollapsible(title: string) {
     return screen.getByText(title).closest('section');
 }
 
-test('Render two expanded collapsibles', () => {
+test('Render two collapsed collapsibles', () => {
     const {container} = renderCollapsibleCollection();
 
     expect(container).toMatchSnapshot();
 });
 
-test('Render all collapsibles expanded by default', () => {
+test('Render all collapsibles collapsed by default', () => {
     renderCollapsibleCollection();
 
-    expect(screen.getByText('General content')).toBeInTheDocument();
-    expect(screen.getByText('Marketing content')).toBeInTheDocument();
-    expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
+    expect(screen.queryByText('General content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.expand_all')).toBeInTheDocument();
 });
 
 test('Render the title and the subtitle of every collapsible', () => {
@@ -72,24 +72,13 @@ test('Call the renderCollapsibleContent callback with the value, the index and t
     const renderSpy = jest.fn((collapsible) => <div>{collapsible.title} content</div>);
     renderCollapsibleCollection({renderCollapsibleContent: renderSpy});
 
-    expect(renderSpy).toHaveBeenCalledWith(TWO_COLLAPSIBLES[0], 0, true);
-    expect(renderSpy).toHaveBeenCalledWith(TWO_COLLAPSIBLES[1], 1, true);
+    expect(renderSpy).toHaveBeenCalledWith(TWO_COLLAPSIBLES[0], 0, false);
+    expect(renderSpy).toHaveBeenCalledWith(TWO_COLLAPSIBLES[1], 1, false);
 });
 
-test('Clicking collapse all should collapse every collapsible and flip the toggle', async() => {
+test('Clicking expand all should expand every collapsible and flip the toggle', async() => {
     const {user} = renderCollapsibleCollection();
 
-    await user.click(screen.getByText('sulu_admin.collapse_all'));
-
-    expect(screen.queryByText('General content')).not.toBeInTheDocument();
-    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
-    expect(screen.getByText('sulu_admin.expand_all')).toBeInTheDocument();
-});
-
-test('Clicking expand all should expand every collapsible again', async() => {
-    const {user} = renderCollapsibleCollection();
-
-    await user.click(screen.getByText('sulu_admin.collapse_all'));
     await user.click(screen.getByText('sulu_admin.expand_all'));
 
     expect(screen.getByText('General content')).toBeInTheDocument();
@@ -97,32 +86,42 @@ test('Clicking expand all should expand every collapsible again', async() => {
     expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
 });
 
-test('Collapsing a single collapsible should leave the other ones untouched', async() => {
+test('Clicking collapse all should collapse every collapsible again', async() => {
     const {user} = renderCollapsibleCollection();
 
-    await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
+    await user.click(screen.getByText('sulu_admin.expand_all'));
+    await user.click(screen.getByText('sulu_admin.collapse_all'));
 
     expect(screen.queryByText('General content')).not.toBeInTheDocument();
-    expect(screen.getByText('Marketing content')).toBeInTheDocument();
-    expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
+    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.expand_all')).toBeInTheDocument();
 });
 
-test('Expanding a single collapsible again should render its content', async() => {
+test('Expanding a single collapsible should leave the other ones untouched', async() => {
     const {user} = renderCollapsibleCollection();
 
-    await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
     await user.click(within(getCollapsible('General')).getByLabelText('su-expand-vertical'));
 
     expect(screen.getByText('General content')).toBeInTheDocument();
+    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
 });
 
-test('Show the expand all toggle when every collapsible was collapsed individually', async() => {
+test('Collapsing a single collapsible again should hide its content', async() => {
     const {user} = renderCollapsibleCollection();
 
+    await user.click(within(getCollapsible('General')).getByLabelText('su-expand-vertical'));
     await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
-    await user.click(within(getCollapsible('Marketing')).getByLabelText('su-collapse-vertical'));
 
-    expect(screen.getByText('sulu_admin.expand_all')).toBeInTheDocument();
+    expect(screen.queryByText('General content')).not.toBeInTheDocument();
+});
+
+test('Show the collapse all toggle as soon as one collapsible was expanded individually', async() => {
+    const {user} = renderCollapsibleCollection();
+
+    await user.click(within(getCollapsible('General')).getByLabelText('su-expand-vertical'));
+
+    expect(screen.getByText('sulu_admin.collapse_all')).toBeInTheDocument();
 });
 
 test('Do not render the collapse all toggle for a single collapsible', () => {
@@ -148,7 +147,7 @@ test('Render the actions and call their callback with the index of the collapsib
     await user.click(within(getCollapsible('Marketing')).getByLabelText('Delete'));
 
     expect(deleteSpy).toHaveBeenCalledWith(1);
-    expect(screen.getByText('Marketing content')).toBeInTheDocument();
+    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
 });
 
 test('Render a drag handle for every collapsible', () => {
@@ -173,7 +172,7 @@ test('Sorting a collapsible should reorder the value and move its expanded state
         value,
     });
 
-    await user.click(within(getCollapsible('General')).getByLabelText('su-collapse-vertical'));
+    await user.click(within(getCollapsible('General')).getByLabelText('su-expand-vertical'));
 
     act(() => {
         ref.current.handleSortEnd({newIndex: 2, oldIndex: 0});
@@ -184,9 +183,9 @@ test('Sorting a collapsible should reorder the value and move its expanded state
 
     rerenderCollapsibleCollection({value: [{title: 'Marketing'}, {title: 'Shipping'}, {title: 'General'}]});
 
-    expect(screen.queryByText('General content')).not.toBeInTheDocument();
-    expect(screen.getByText('Marketing content')).toBeInTheDocument();
-    expect(screen.getByText('Shipping content')).toBeInTheDocument();
+    expect(screen.getByText('General content')).toBeInTheDocument();
+    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shipping content')).not.toBeInTheDocument();
 });
 
 test('Render the given texts instead of the default translations', async() => {
@@ -198,11 +197,11 @@ test('Render the given texts instead of the default translations', async() => {
     });
 
     expect(screen.getByText('Add attributes')).toBeInTheDocument();
-    expect(screen.getByText('Collapse all groups')).toBeInTheDocument();
-
-    await user.click(screen.getByText('Collapse all groups'));
-
     expect(screen.getByText('Expand all groups')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Expand all groups'));
+
+    expect(screen.getByText('Collapse all groups')).toBeInTheDocument();
 });
 
 test('Do not render an add button when no onAddClick callback is given', () => {
@@ -226,26 +225,26 @@ test('Render the given add button text instead of the default translation', () =
     expect(screen.getByText('Add attributes')).toBeInTheDocument();
 });
 
-test('An appended collapsible should start expanded while collapsed siblings stay collapsed', async() => {
+test('An appended collapsible should start collapsed while expanded siblings stay expanded', async() => {
     const {rerenderCollapsibleCollection, user} = renderCollapsibleCollection();
 
-    await user.click(screen.getByText('sulu_admin.collapse_all'));
+    await user.click(screen.getByText('sulu_admin.expand_all'));
 
     rerenderCollapsibleCollection({value: [...TWO_COLLAPSIBLES, {title: 'Shipping'}]});
 
-    expect(screen.getByText('Shipping content')).toBeInTheDocument();
-    expect(screen.queryByText('General content')).not.toBeInTheDocument();
-    expect(screen.queryByText('Marketing content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Shipping content')).not.toBeInTheDocument();
+    expect(screen.getByText('General content')).toBeInTheDocument();
+    expect(screen.getByText('Marketing content')).toBeInTheDocument();
 });
 
 test('A removed collapsible should not leave its expanded state behind', async() => {
     const value = [{title: 'General'}, {title: 'Marketing'}, {title: 'Shipping'}];
     const {rerenderCollapsibleCollection, user} = renderCollapsibleCollection({value});
 
-    await user.click(within(getCollapsible('Shipping')).getByLabelText('su-collapse-vertical'));
+    await user.click(within(getCollapsible('Shipping')).getByLabelText('su-expand-vertical'));
 
     rerenderCollapsibleCollection({value: [{title: 'General'}, {title: 'Marketing'}]});
     rerenderCollapsibleCollection({value});
 
-    expect(screen.getByText('Shipping content')).toBeInTheDocument();
+    expect(screen.queryByText('Shipping content')).not.toBeInTheDocument();
 });

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/__snapshots__/CollapsibleCollection.test.js.snap
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/components/CollapsibleCollection/tests/__snapshots__/CollapsibleCollection.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Render two expanded collapsibles 1`] = `
+exports[`Render two collapsed collapsibles 1`] = `
 <div>
   <section
     class="collapsibleCollection"
@@ -14,12 +14,12 @@ exports[`Render two expanded collapsibles 1`] = `
       >
         <span
           aria-hidden="true"
-          class="su-collapse-vertical collapsibleCollectionActionButtonIcon"
+          class="su-expand-vertical collapsibleCollectionActionButtonIcon"
         />
         <span
           class="collapsibleCollectionActionButtonText"
         >
-          sulu_admin.collapse_all
+          sulu_admin.expand_all
         </span>
       </button>
     </div>
@@ -30,7 +30,7 @@ exports[`Render two expanded collapsibles 1`] = `
       class="sortableCollapsibleList"
     >
       <section
-        class="collapsible expanded"
+        class="collapsible"
         role="switch"
       >
         <div
@@ -61,28 +61,20 @@ exports[`Render two expanded collapsibles 1`] = `
               class="spacer"
             />
             <button
-              aria-expanded="true"
+              aria-expanded="false"
               class="toggle"
               type="button"
             >
               <span
-                aria-label="su-collapse-vertical"
-                class="su-collapse-vertical"
+                aria-label="su-expand-vertical"
+                class="su-expand-vertical"
               />
             </button>
           </header>
-          <article
-            class="children"
-          >
-            <div>
-              General
-               content
-            </div>
-          </article>
         </div>
       </section>
       <section
-        class="collapsible expanded"
+        class="collapsible"
         role="switch"
       >
         <div
@@ -113,24 +105,16 @@ exports[`Render two expanded collapsibles 1`] = `
               class="spacer"
             />
             <button
-              aria-expanded="true"
+              aria-expanded="false"
               class="toggle"
               type="button"
             >
               <span
-                aria-label="su-collapse-vertical"
-                class="su-collapse-vertical"
+                aria-label="su-expand-vertical"
+                class="su-expand-vertical"
               />
             </button>
           </header>
-          <article
-            class="children"
-          >
-            <div>
-              Marketing
-               content
-            </div>
-          </article>
         </div>
       </section>
     </div>

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Product/ProductFamilyAttributes/ProductFamilyAttributes.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Product/ProductFamilyAttributes/ProductFamilyAttributes.js
@@ -32,8 +32,8 @@ type Props = {|
 |};
 
 const COLUMNS: Array<FieldColumn> = [
-    {name: 'required', title: 'sulu_product.attribute_required', type: 'checkbox'},
-    {name: 'variantSpecific', title: 'sulu_product.attribute_variant', type: 'checkbox'},
+    {name: 'required', title: 'sulu_admin.attribute_required', type: 'checkbox'},
+    {name: 'variantSpecific', title: 'sulu_admin.attribute_variant', type: 'checkbox'},
 ];
 
 /**
@@ -104,7 +104,7 @@ class ProductFamilyAttributes extends React.Component<Props> {
 
                 return {
                     ...group,
-                    subtitle: translate('sulu_product.attribute_count', {count: group.entries.length}),
+                    subtitle: translate('sulu_admin.attribute_count', {count: group.entries.length}),
                 };
             })
             .sort((a, b) => a.title.localeCompare(b.title));
@@ -125,7 +125,7 @@ class ProductFamilyAttributes extends React.Component<Props> {
     renderHeaderCells(): Array<Object> {
         const cells = [
             <Table.HeaderCell className={attributeGroupTableStyles.labelCell} key="label">
-                {translate('sulu_product.attribute')}
+                {translate('sulu_admin.attribute')}
             </Table.HeaderCell>,
             ...COLUMNS.map((column) => (
                 <Table.HeaderCell className={attributeGroupTableStyles.fieldCell} key={column.name}>
@@ -240,7 +240,7 @@ class ProductFamilyAttributes extends React.Component<Props> {
             <Fragment>
                 <CollapsibleCollection
                     actions={this.collapsibleActions}
-                    addButtonText={translate('sulu_product.add_attributes_overlay_title')}
+                    addButtonText={translate('sulu_admin.choose_attributes')}
                     movable={false}
                     onAddClick={this.props.disabled ? undefined : this.handleAddClick}
                     onChange={this.handleCollectionChange}
@@ -256,7 +256,7 @@ class ProductFamilyAttributes extends React.Component<Props> {
                     open={this.overlayOpen}
                     preSelectedItems={this.selectedItems}
                     resourceKey={this.props.resourceKey}
-                    title={translate('sulu_product.add_attributes_overlay_title')}
+                    title={translate('sulu_admin.choose_attributes')}
                 />
             </Fragment>
         );

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Product/ProductFamilyAttributes/tests/ProductFamilyAttributes.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/Product/ProductFamilyAttributes/tests/ProductFamilyAttributes.test.js
@@ -131,6 +131,13 @@ function renderControlled(value = VALUE, onChange = jest.fn()) {
     return {...view, store};
 }
 
+// Every card starts collapsed, so a test that reads the rows opens the cards first.
+async function expandAllCards() {
+    for (const toggle of screen.getAllByLabelText('su-expand-vertical')) {
+        await userEvent.click(toggle);
+    }
+}
+
 function getRow(name: string) {
     // $FlowFixMe
     return screen.getByText(name).closest('tr');
@@ -154,8 +161,9 @@ test('loads the selected attributes from the resource', () => {
     expect(MultiSelectionStore).toHaveBeenCalledWith('attributes', ['a3', 'a1', 'a2'], expect.anything(), 'ids');
 });
 
-test('renders the flag columns through the registered checkbox field type', () => {
+test('renders the flag columns through the registered checkbox field type', async() => {
     renderComponent();
+    await expandAllCards();
 
     expect(fieldRegistry.get).toHaveBeenCalledWith('checkbox');
     expect(within(getRow('Size')).getAllByRole('checkbox')).toHaveLength(2);
@@ -169,8 +177,9 @@ test('orders group cards alphabetically by group name', () => {
     expect(headings).toEqual(['General', 'Marketing']);
 });
 
-test('orders attributes inside a group by position', () => {
+test('orders attributes inside a group by position', async() => {
     renderComponent();
+    await expandAllCards();
 
     // Collapsible's root is <section role="switch">, so this scopes the query to one card.
     const general = screen.getByText('General').closest('[role="switch"]');
@@ -189,20 +198,21 @@ test('renders no cards and no collapse toggle when the value is empty', () => {
 test('shows the attribute count per group', () => {
     renderComponent();
 
-    expect(screen.getByText('sulu_product.attribute_count:{"count":2}')).toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.attribute_count:{"count":2}')).toBeInTheDocument();
 });
 
 test('skips an id whose attribute no longer resolves', () => {
     renderComponent([...VALUE, {id: 'gone', required: false, variantSpecific: false}]);
 
     expect(screen.queryByText('gone')).not.toBeInTheDocument();
-    expect(screen.getByText('sulu_product.attribute_count:{"count":2}')).toBeInTheDocument();
+    expect(screen.getByText('sulu_admin.attribute_count:{"count":2}')).toBeInTheDocument();
 });
 
 test('toggling required emits the updated value', async() => {
     const handleChange = jest.fn();
 
     renderComponent(VALUE, handleChange);
+    await expandAllCards();
 
     await userEvent.click(within(getRow('Size')).getAllByRole('checkbox')[0]);
 
@@ -217,6 +227,7 @@ test('toggling variant emits the updated value', async() => {
     const handleChange = jest.fn();
 
     renderComponent(VALUE, handleChange);
+    await expandAllCards();
 
     await userEvent.click(within(getRow('Size')).getAllByRole('checkbox')[1]);
 
@@ -231,6 +242,7 @@ test('removing a row emits the value without it', async() => {
     const handleChange = jest.fn();
 
     renderComponent(VALUE, handleChange);
+    await expandAllCards();
 
     await userEvent.click(within(getRow('Size')).getByRole('button', {name: 'sulu_admin.delete'}));
 
@@ -258,7 +270,7 @@ test('confirming the overlay replaces the selection, keeping flags of entries al
 
     const {store} = renderControlled(VALUE, handleChange);
 
-    await userEvent.click(screen.getByText('sulu_product.add_attributes_overlay_title'));
+    await userEvent.click(screen.getByText('sulu_admin.choose_attributes'));
     await userEvent.click(screen.getByText('confirm-overlay'));
 
     expect(store.set).toHaveBeenCalledWith(mockOverlayItems);
@@ -272,8 +284,9 @@ test('confirming the overlay replaces the selection, keeping flags of entries al
 test('renders the overlay rows without a reload', async() => {
     const {store} = renderControlled();
 
-    await userEvent.click(screen.getByText('sulu_product.add_attributes_overlay_title'));
+    await userEvent.click(screen.getByText('sulu_admin.choose_attributes'));
     await userEvent.click(screen.getByText('confirm-overlay'));
+    await expandAllCards();
 
     expect(screen.queryByText('Marketing')).not.toBeInTheDocument();
     expect(within(getCard('General')).getByText('Colour')).toBeInTheDocument();

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.de.json
@@ -283,5 +283,10 @@
     "sulu_admin.link_target_blank": "_blank",
     "sulu_admin.link_target_self": "_self",
     "sulu_admin.link_target_parent": "_parent",
-    "sulu_admin.link_target_top": "_top"
+    "sulu_admin.link_target_top": "_top",
+    "sulu_admin.attribute": "Attribut",
+    "sulu_admin.attribute_required": "Erforderlich",
+    "sulu_admin.attribute_variant": "Variante",
+    "sulu_admin.choose_attributes": "Attribute auswählen",
+    "sulu_admin.attribute_count": "{count} {count, plural, =1 {Attribut} other {Attribute}}"
 }

--- a/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
+++ b/src/Sulu/Bundle/AdminBundle/Resources/translations/admin.en.json
@@ -283,5 +283,10 @@
     "sulu_admin.link_target_blank": "_blank",
     "sulu_admin.link_target_self": "_self",
     "sulu_admin.link_target_parent": "_parent",
-    "sulu_admin.link_target_top": "_top"
+    "sulu_admin.link_target_top": "_top",
+    "sulu_admin.attribute": "Attribute",
+    "sulu_admin.attribute_required": "Required",
+    "sulu_admin.attribute_variant": "Variant",
+    "sulu_admin.choose_attributes": "Choose attributes",
+    "sulu_admin.attribute_count": "{count} {count, plural, =1 {attribute} other {attributes}}"
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs | #9063, #9080
| License | MIT
| Documentation PR |

#### What's in this PR?

Follow-ups to the `product_family_attributes` field from #9063:

- `CollapsibleCollection` starts every collapsible collapsed
- The add button and the overlay say "Choose attributes,, like the other selection overlays.
- The container's labels move into the core catalogue as `sulu_admin.*` keys. They were
  `sulu_product.*` keys that only `sulu/product-bundle` defines.

#### Why?

The field ships in core, so its defaults and labels should be complete without the bundle.
