### PR TITLE
Type the sort direction handed to the query builder

### DIFF
--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepository.php
@@ -293,7 +293,7 @@ class ContactRepository extends EntityRepository implements ContactRepositoryInt
      * Add sorting to querybuilder.
      *
      * @param QueryBuilder $qb
-     * @param array $sorting
+     * @param array<string, string>|null $sorting column => direction
      * @param string $prefix
      *
      * @return QueryBuilder
@@ -301,7 +301,7 @@ class ContactRepository extends EntityRepository implements ContactRepositoryInt
     private function addSorting($qb, $sorting, $prefix = 'u')
     {
         // Add order by
-        foreach ($sorting as $k => $d) {
+        foreach ($sorting ?? [] as $k => $d) {
             $qb->addOrderBy($prefix . '.' . $k, $d);
         }
 

--- a/src/Sulu/Bundle/ContactBundle/Entity/ContactRepositoryInterface.php
+++ b/src/Sulu/Bundle/ContactBundle/Entity/ContactRepositoryInterface.php
@@ -52,7 +52,7 @@ interface ContactRepositoryInterface extends RepositoryInterface
      *
      * @param int|null $limit Page size for Pagination
      * @param int|null $offset Offset for Pagination
-     * @param array|null $sorting Columns to sort
+     * @param array<string, string>|null $sorting Columns to sort, column => direction
      * @param array|null $where Where clauses
      *
      * @return array

--- a/src/Sulu/Bundle/ContactBundle/Tests/Functional/Entity/ContactRepositoryTest.php
+++ b/src/Sulu/Bundle/ContactBundle/Tests/Functional/Entity/ContactRepositoryTest.php
@@ -103,6 +103,30 @@ class ContactRepositoryTest extends SuluTestCase
         $this->assertEquals('Anne', $result[2]['firstName']);
     }
 
+    public function testFindGetAllWithoutSorting(): void
+    {
+        $contact1 = $this->createContact('Max', 'Mustermann');
+        $contact2 = $this->createContact('Anne', 'Mustermann');
+        $this->em->flush();
+
+        // a PHP warning alone does not fail the suite, so turn it into an exception
+        \set_error_handler(static function(int $severity, string $message): never {
+            throw new \ErrorException($message, 0, $severity);
+        });
+
+        try {
+            $result = $this->contactRepository->findGetAll(null, null, null, []);
+        } finally {
+            \restore_error_handler();
+        }
+
+        $this->assertCount(2, $result);
+        $this->assertEqualsCanonicalizing(
+            ['Max', 'Anne'],
+            \array_column($result, 'firstName')
+        );
+    }
+
     public function testFindGetAllSortByIdAscWithLimit(): void
     {
         $contact1 = $this->createContact('Max', 'Mustermann');

--- a/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
+++ b/src/Sulu/Bundle/MediaBundle/Entity/MediaRepository.php
@@ -238,7 +238,7 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
     /**
      * Extracts filter vars.
      *
-     * @return array
+     * @return array{mixed, mixed, mixed, mixed, mixed, string|null, mixed} collection, systemCollections, types, search, orderBy, orderSort, ids
      */
     private function extractFilterVars(array $filter)
     {
@@ -247,7 +247,8 @@ class MediaRepository extends EntityRepository implements MediaRepositoryInterfa
         $types = \array_key_exists('types', $filter) ? $filter['types'] : null;
         $search = \array_key_exists('search', $filter) ? $filter['search'] : null;
         $orderBy = \array_key_exists('orderBy', $filter) ? $filter['orderBy'] : null;
-        $orderSort = \array_key_exists('orderSort', $filter) ? $filter['orderSort'] : null;
+        // the query builder only takes a string direction
+        $orderSort = isset($filter['orderSort']) && \is_string($filter['orderSort']) ? $filter['orderSort'] : null;
         $ids = \array_key_exists('ids', $filter) ? $filter['ids'] : null;
 
         return [$collection, $systemCollections, $types, $search, $orderBy, $orderSort, $ids];


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets |
| Related issues/PRs |
| License | MIT
| Documentation PR |

#### What's in this PR?

doctrine/orm 3.7.0 (released 2026-09-07) types the second parameter of `QueryBuilder::addOrderBy()`
as `SortDirection|string|null`. The "highest" PHP Lint job now installs it and phpstan rejects the
untyped values in `ContactRepository::addSorting()` and `MediaRepository::findMedia()`.

- `ContactRepository`: the sorting is declared as `array<string, string>` (column => direction)
  down from the interface, and `addSorting()` tolerates `null` as the interface allows.
- `MediaRepository`: `orderSort` is read from the filter as a string.

#### Why?

`3.0` and `3.1` and every open PR fail PHP Lint since the release.
