### PR TITLE
Keep Date values in request bodies and settings

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -23,6 +23,34 @@ const USER_SETTING_FILTER = 'filter';
 const USER_SETTING_LIMIT = 'limit';
 const USER_SETTING_SCHEMA = 'schema';
 
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+// Dates are stored as ISO strings in the user settings and have to be restored as Date objects,
+// because the filter types and the router work with Date objects.
+function reviveDates(value: mixed) {
+    if (typeof value === 'string' && ISO_DATE_REGEX.test(value)) {
+        const date = new Date(value);
+
+        return isNaN(date.getTime()) ? value : date;
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(reviveDates);
+    }
+
+    if (value instanceof Object) {
+        const objectValue: {[string]: mixed} = (value: any);
+
+        return Object.keys(objectValue).reduce((revivedValue, key) => {
+            revivedValue[key] = reviveDates(objectValue[key]);
+
+            return revivedValue;
+        }, {});
+    }
+
+    return value;
+}
+
 export default class ListStore {
     @observable pageCount: ?number = 0;
     @observable selections: Array<Object> = [];
@@ -74,10 +102,10 @@ export default class ListStore {
         userStore.setPersistentSetting(key, value);
     }
 
-    static getFilterSetting(listKey: string, userSettingsKey: string): string {
+    static getFilterSetting(listKey: string, userSettingsKey: string): Object {
         const key = [USER_SETTING_PREFIX, listKey, userSettingsKey, USER_SETTING_FILTER].join('.');
 
-        return userStore.getPersistentSetting(key);
+        return reviveDates(userStore.getPersistentSetting(key));
     }
 
     static setFilterSetting(listKey: string, userSettingsKey: string, value: *) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -107,6 +107,41 @@ test('The filter value should be updated when set from the outside and only a si
         .toHaveBeenCalledWith('sulu_admin.list_store.tests.list_test.filter', {});
 });
 
+test('The filter setting should restore dates as Date objects', () => {
+    userStore.getPersistentSetting.mockReturnValueOnce({
+        birthday: {from: '1990-01-01T00:00:00.000Z', to: '2005-12-31T00:00:00.000Z'},
+    });
+
+    const filter = ListStore.getFilterSetting('tests', 'list_test');
+
+    expect(userStore.getPersistentSetting).toHaveBeenCalledWith('sulu_admin.list_store.tests.list_test.filter');
+    expect(filter).toEqual({
+        birthday: {from: new Date(Date.UTC(1990, 0, 1)), to: new Date(Date.UTC(2005, 11, 31))},
+    });
+    expect(filter.birthday.from).toBeInstanceOf(Date);
+    expect(filter.birthday.to).toBeInstanceOf(Date);
+});
+
+test('The filter setting should leave values that are not dates untouched', () => {
+    userStore.getPersistentSetting.mockReturnValueOnce({
+        salutation: {eq: 'Dear'},
+        tagId: [1, 2],
+        name: {eq: '1990-01-01'},
+    });
+
+    expect(ListStore.getFilterSetting('tests', 'list_test')).toEqual({
+        salutation: {eq: 'Dear'},
+        tagId: [1, 2],
+        name: {eq: '1990-01-01'},
+    });
+});
+
+test('The filter setting should return undefined if nothing was stored', () => {
+    userStore.getPersistentSetting.mockReturnValueOnce(undefined);
+
+    expect(ListStore.getFilterSetting('tests', 'list_test')).toEqual(undefined);
+});
+
 test('The limit value should be updated when set from the outside', () => {
     const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
     expect(listStore.limit.get()).toEqual(10);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -59,6 +59,12 @@ function transformRequestObject(data: Object): Object {
             return transformedData;
         }
 
+        if (value instanceof Date) {
+            transformedData[key] = value;
+
+            return transformedData;
+        }
+
         if (isArrayLike(value)) {
             transformedData[key] = transformRequestArray(value);
 
@@ -79,6 +85,10 @@ function transformRequestObject(data: Object): Object {
 
 function transformRequestArray(data) {
     return data.map((value) => {
+        if (value instanceof Date) {
+            return value;
+        }
+
         if (isArrayLike(value)) {
             return transformRequestArray(value);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -285,6 +285,58 @@ test('Should execute PATCH request and return JSON', () => {
     return requestPromise;
 });
 
+test('Should execute PATCH request and keep dates instead of serializing them to an empty object', () => {
+    const response = {
+        json: jest.fn(),
+        ok: true,
+    };
+    response.json.mockReturnValue(Promise.resolve({}));
+    const promise = new Promise((resolve) => resolve(response));
+
+    window.fetch = jest.fn();
+    window.fetch.mockReturnValue(promise);
+
+    const requestPromise = Requester.patch('/some-url', {
+        filter: {birthday: {from: new Date(Date.UTC(1990, 0, 1)), to: new Date(Date.UTC(2005, 11, 31))}},
+    });
+
+    expect(window.fetch).toHaveBeenCalledWith('/some-url', {
+        method: 'PATCH',
+        body: JSON.stringify({
+            filter: {birthday: {from: '1990-01-01T00:00:00.000Z', to: '2005-12-31T00:00:00.000Z'}},
+        }),
+        credentials: 'same-origin',
+        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
+    });
+
+    return requestPromise;
+});
+
+test('Should execute POST request and keep dates in arrays', () => {
+    const response = {
+        json: jest.fn(),
+        ok: true,
+    };
+    response.json.mockReturnValue(Promise.resolve({}));
+    const promise = new Promise((resolve) => resolve(response));
+
+    window.fetch = jest.fn();
+    window.fetch.mockReturnValue(promise);
+
+    const requestPromise = Requester.post('/some-url', {dates: [new Date(Date.UTC(1990, 0, 1))]});
+
+    expect(window.fetch).toHaveBeenCalledWith('/some-url', {
+        method: 'POST',
+        body: JSON.stringify({dates: ['1990-01-01T00:00:00.000Z']}),
+        credentials: 'same-origin',
+        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
+    });
+
+    return requestPromise;
+});
+
 test('Should execute DELETE request and return JSON', () => {
     const response = {
         json: jest.fn(),


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #9083
| License | MIT

#### What's in this PR?

`Requester` keeps `Date` values in request bodies instead of turning them into `{}`, and
`ListStore.getFilterSetting` restores stored ISO strings as `Date` objects.

#### Why?

`transformRequestObject` rebuilt every object from `Object.keys()`. `Object.keys(new Date())`
is `[]`, so date and datetime filter values reached the server as `{}` and were stored as
`{"birthday":{"from":[],"to":[]}}`. After a full page load the filter chip was empty and the
list returned no rows.

Reviving the value is needed as well, because the filter types and the router work with `Date`
objects, not strings.
