### PR TITLE
Keep Date values in request bodies and settings

### DIFF
--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/stores/ListStore.js
@@ -1,8 +1,9 @@
 // @flow
-import {action, autorun, computed, intercept, observable, untracked} from 'mobx';
+import {action, autorun, computed, intercept, isArrayLike, observable, untracked} from 'mobx';
 import equals from 'fast-deep-equal';
 import log from 'loglevel';
 import ResourceRequester, {RequestPromise} from '../../../services/ResourceRequester';
+import {transformUrlToDate} from '../../../utils/Date';
 import userStore from '../../../stores/userStore';
 import metadataStore from './metadataStore';
 import type {
@@ -22,6 +23,30 @@ const USER_SETTING_SORT_ORDER = 'sort_order';
 const USER_SETTING_FILTER = 'filter';
 const USER_SETTING_LIMIT = 'limit';
 const USER_SETTING_SCHEMA = 'schema';
+
+function transformFilterValue(value) {
+    if (typeof value === 'string') {
+        return transformUrlToDate(value) || value;
+    }
+
+    if (isArrayLike(value)) {
+        return value.map(transformFilterValue);
+    }
+
+    if (value instanceof Object) {
+        return transformFilterObject(value);
+    }
+
+    return value;
+}
+
+function transformFilterObject(value) {
+    return Object.keys(value).reduce((transformedValue, key) => {
+        transformedValue[key] = transformFilterValue(value[key]);
+
+        return transformedValue;
+    }, {});
+}
 
 export default class ListStore {
     @observable pageCount: ?number = 0;
@@ -74,10 +99,10 @@ export default class ListStore {
         userStore.setPersistentSetting(key, value);
     }
 
-    static getFilterSetting(listKey: string, userSettingsKey: string): string {
+    static getFilterSetting(listKey: string, userSettingsKey: string): Object {
         const key = [USER_SETTING_PREFIX, listKey, userSettingsKey, USER_SETTING_FILTER].join('.');
 
-        return userStore.getPersistentSetting(key);
+        return transformFilterValue(userStore.getPersistentSetting(key));
     }
 
     static setFilterSetting(listKey: string, userSettingsKey: string, value: *) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/containers/List/tests/stores/ListStore.test.js
@@ -107,6 +107,39 @@ test('The filter value should be updated when set from the outside and only a si
         .toHaveBeenCalledWith('sulu_admin.list_store.tests.list_test.filter', {});
 });
 
+test('The filter setting should transform stored date strings back to Date objects', () => {
+    userStore.getPersistentSetting.mockReturnValueOnce({
+        birthday: {from: '1990-01-01 00:00', to: '2005-12-31 00:00'},
+    });
+
+    const filter = ListStore.getFilterSetting('tests', 'list_test');
+
+    expect(userStore.getPersistentSetting).toHaveBeenCalledWith('sulu_admin.list_store.tests.list_test.filter');
+    expect(filter).toEqual({birthday: {from: new Date(1990, 0, 1), to: new Date(2005, 11, 31)}});
+    expect(filter.birthday.from).toBeInstanceOf(Date);
+    expect(filter.birthday.to).toBeInstanceOf(Date);
+});
+
+test('The filter setting should leave values that are not dates untouched', () => {
+    userStore.getPersistentSetting.mockReturnValueOnce({
+        salutation: {eq: 'Dear'},
+        tagId: [1, 2],
+        enabled: {eq: true},
+    });
+
+    expect(ListStore.getFilterSetting('tests', 'list_test')).toEqual({
+        salutation: {eq: 'Dear'},
+        tagId: [1, 2],
+        enabled: {eq: true},
+    });
+});
+
+test('The filter setting should return undefined if nothing was stored', () => {
+    userStore.getPersistentSetting.mockReturnValueOnce(undefined);
+
+    expect(ListStore.getFilterSetting('tests', 'list_test')).toEqual(undefined);
+});
+
 test('The limit value should be updated when set from the outside', () => {
     const listStore = new ListStore('tests', 'tests', 'list_test', {page: observable.box()});
     expect(listStore.limit.get()).toEqual(10);

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/Requester.js
@@ -1,5 +1,6 @@
 // @flow
 import {isArrayLike} from 'mobx';
+import {transformDateForUrl} from '../../utils/Date';
 import RequestPromise from './RequestPromise';
 import type {HandleResponseHook} from './types';
 
@@ -59,6 +60,12 @@ function transformRequestObject(data: Object): Object {
             return transformedData;
         }
 
+        if (value instanceof Date) {
+            transformedData[key] = transformDateForUrl(value);
+
+            return transformedData;
+        }
+
         if (isArrayLike(value)) {
             transformedData[key] = transformRequestArray(value);
 
@@ -79,6 +86,10 @@ function transformRequestObject(data: Object): Object {
 
 function transformRequestArray(data) {
     return data.map((value) => {
+        if (value instanceof Date) {
+            return transformDateForUrl(value);
+        }
+
         if (isArrayLike(value)) {
             return transformRequestArray(value);
         }

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Requester/tests/Requester.test.js
@@ -285,6 +285,58 @@ test('Should execute PATCH request and return JSON', () => {
     return requestPromise;
 });
 
+test('Should execute PATCH request and transform dates instead of serializing them to an empty object', () => {
+    const response = {
+        json: jest.fn(),
+        ok: true,
+    };
+    response.json.mockReturnValue(Promise.resolve({}));
+    const promise = new Promise((resolve) => resolve(response));
+
+    window.fetch = jest.fn();
+    window.fetch.mockReturnValue(promise);
+
+    const requestPromise = Requester.patch('/some-url', {
+        filter: {birthday: {from: new Date(1990, 0, 1), to: new Date(2005, 11, 31)}},
+    });
+
+    expect(window.fetch).toHaveBeenCalledWith('/some-url', {
+        method: 'PATCH',
+        body: JSON.stringify({
+            filter: {birthday: {from: '1990-01-01 00:00', to: '2005-12-31 00:00'}},
+        }),
+        credentials: 'same-origin',
+        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
+    });
+
+    return requestPromise;
+});
+
+test('Should execute POST request and transform dates in arrays', () => {
+    const response = {
+        json: jest.fn(),
+        ok: true,
+    };
+    response.json.mockReturnValue(Promise.resolve({}));
+    const promise = new Promise((resolve) => resolve(response));
+
+    window.fetch = jest.fn();
+    window.fetch.mockReturnValue(promise);
+
+    const requestPromise = Requester.post('/some-url', {dates: [new Date(1990, 0, 1)]});
+
+    expect(window.fetch).toHaveBeenCalledWith('/some-url', {
+        method: 'POST',
+        body: JSON.stringify({dates: ['1990-01-01 00:00']}),
+        credentials: 'same-origin',
+        headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
+        signal: expect.any(AbortSignal),
+    });
+
+    return requestPromise;
+});
+
 test('Should execute DELETE request and return JSON', () => {
     const response = {
         json: jest.fn(),

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/services/Router/Router.js
@@ -4,7 +4,7 @@ import equal from 'fast-deep-equal';
 import log from 'loglevel';
 import {compile} from 'path-to-regexp';
 import {parsePath} from 'history';
-import {transformDateForUrl} from '../../utils/Date';
+import {transformDateForUrl, transformUrlToDate} from '../../utils/Date';
 import routeRegistry from './registries/routeRegistry';
 import resourceViewRegistry from './registries/resourceViewRegistry';
 import Route from './Route';
@@ -26,18 +26,9 @@ function tryParse(value: ?string) {
         return undefined;
     }
 
-    if (value && value.match(/^\d\d\d\d-\d\d-\d\d$/)) {
-        const date = new Date(value + ' 00:00'); // The time is necessary to avoid timezone issues
-        if (date.toString() !== 'Invalid Date') {
-            return date;
-        }
-    }
-
-    if (value && value.match(/^\d\d\d\d-\d\d-\d\d \d\d:\d\d$/)) {
-        const date = new Date(value);
-        if (date.toString() !== 'Invalid Date') {
-            return date;
-        }
+    const date = transformUrlToDate(value);
+    if (date) {
+        return date;
     }
 
     if (isNaN(value)) {

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/index.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/index.js
@@ -3,5 +3,12 @@ import transformDateForUrl from './transformDateForUrl';
 import transformDateToDateTimeString from './transformDateToDateTimeString';
 import transformDateToTimeString from './transformDateToTimeString';
 import transformTimeStringToDate from './transformTimeStringToDate';
+import transformUrlToDate from './transformUrlToDate';
 
-export {transformDateForUrl, transformDateToDateTimeString, transformDateToTimeString, transformTimeStringToDate};
+export {
+    transformDateForUrl,
+    transformDateToDateTimeString,
+    transformDateToTimeString,
+    transformTimeStringToDate,
+    transformUrlToDate,
+};

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/tests/transformUrlToDate.test.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/tests/transformUrlToDate.test.js
@@ -1,0 +1,33 @@
+// @flow
+import transformUrlToDate from '../transformUrlToDate';
+
+test.each([
+    ['1990-01-01', 1990, 0, 1, 0, 0],
+    ['2005-12-31 23:59', 2005, 11, 31, 23, 59],
+    ['2026-09-08 14:50', 2026, 8, 8, 14, 50],
+])('Transform url value "%s"', (value, year, month, day, hour, minute) => {
+    const date = transformUrlToDate(value);
+
+    if (!date) {
+        throw new Error('A date should be returned');
+    }
+
+    expect(date.getFullYear()).toEqual(year);
+    expect(date.getMonth()).toEqual(month);
+    expect(date.getDate()).toEqual(day);
+    expect(date.getHours()).toEqual(hour);
+    expect(date.getMinutes()).toEqual(minute);
+});
+
+test.each([
+    [undefined],
+    [null],
+    [''],
+    ['Dear'],
+    ['1990'],
+    ['01/01/1990'],
+    ['1990-01-01T00:00:00.000Z'],
+    ['1990-13-01'],
+])('Return undefined for "%s"', (value) => {
+    expect(transformUrlToDate(value)).toEqual(undefined);
+});

--- a/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/transformUrlToDate.js
+++ b/src/Sulu/Bundle/AdminBundle/Resources/js/utils/Date/transformUrlToDate.js
@@ -1,0 +1,21 @@
+// @flow
+export default function(value: ?string): ?Date {
+    if (!value || typeof value !== 'string') {
+        return undefined;
+    }
+
+    if (value.match(/^\d\d\d\d-\d\d-\d\d$/)) {
+        // The time is necessary to avoid timezone issues
+        const date = new Date(value + ' 00:00');
+
+        return date.toString() === 'Invalid Date' ? undefined : date;
+    }
+
+    if (value.match(/^\d\d\d\d-\d\d-\d\d \d\d:\d\d$/)) {
+        const date = new Date(value);
+
+        return date.toString() === 'Invalid Date' ? undefined : date;
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #9083
| License | MIT

#### What's in this PR?

`Requester` serializes `Date` values in request bodies with `transformDateForUrl` instead of
turning them into `{}`. `ListStore.getFilterSetting` parses them back with the new
`transformUrlToDate` util, which `Router.tryParse` now uses as well.

#### Why?

`transformRequestObject` rebuilt every object from `Object.keys()`. `Object.keys(new Date())` is
`[]`, so date and datetime filter values reached the server as `{}` and were stored as
`{"birthday":{"from":[],"to":[]}}`. After a full page load the filter chip was empty and the list
returned no rows.

The setting now holds the same representation as the URL, so both paths read and write dates the
same way.
