### PR TITLE
Keep non-multilingual field values in the template preview

### DIFF
--- a/packages/content/src/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
+++ b/packages/content/src/Application/ContentDataMapper/DataMapper/TemplateDataMapper.php
@@ -74,7 +74,15 @@ class TemplateDataMapper implements DataMapperInterface
 
         $unlocalizedDimensionContent->setTemplateData($unlocalizedData);
         $localizedDimensionContent->setTemplateKey($template);
-        $localizedDimensionContent->setTemplateData($localizedData);
+
+        // In the preview both parameters are the same dimension content instance, so a plain
+        // overwrite would drop the unlocalized data set above. Merge when they are identical; the
+        // persisted-save path uses distinct instances and stays unaffected.
+        $localizedDimensionContent->setTemplateData(
+            $unlocalizedDimensionContent === $localizedDimensionContent
+                ? \array_merge($unlocalizedData, $localizedData)
+                : $localizedData
+        );
     }
 
     /**

--- a/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
+++ b/packages/content/tests/Unit/Content/Application/ContentDataMapper/DataMapper/TemplateDataMapperTest.php
@@ -165,7 +165,12 @@ class TemplateDataMapperTest extends TestCase
         $templateMapper->map($localizedDimensionContent, $localizedDimensionContent, $data);
 
         $this->assertSame('template-key', $localizedDimensionContent->getTemplateKey());
-        $this->assertSame(['title' => 'Test Localized'], $localizedDimensionContent->getTemplateData());
+        // In the preview the same instance holds both the unlocalized and the localized data, so the
+        // non-multilingual "unlocalizedField" must be kept next to the localized "title" (see #8574).
+        $this->assertSame(
+            ['unlocalizedField' => 'Test Unlocalized', 'title' => 'Test Localized'],
+            $localizedDimensionContent->getTemplateData(),
+        );
     }
 
     public function testMapNestedPropertyData(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | fixes #8574
| Related PRs   | #8997
| License       | MIT

#### What's in this PR?

Non-multilingual fields no longer lose their value in the template preview.

#### Why?

In the preview the same dimension content instance holds both the unlocalized and the localized data. `TemplateDataMapper` wrote the unlocalized data first and then overwrote it with the localized data, dropping every non-multilingual (`multilingual="false"`) field. It now merges the two when both parameters refer to the same instance; the persisted-save path uses distinct instances and stays unaffected.
