### PR TITLE
Remove translations for the dropped bypass transition

### DIFF
--- a/packages/article/translations/admin.de.json
+++ b/packages/article/translations/admin.de.json
@@ -27,7 +27,6 @@
     "sulu_activity.description.articles.workflow_transition.publish": "{userFullName} hat den Artikel \"{resourceTitle}\" veröffentlicht",
     "sulu_activity.description.articles.workflow_transition.unpublish": "{userFullName} hat den Artikel \"{resourceTitle}\" nicht mehr veröffentlicht",
     "sulu_activity.description.articles.workflow_transition.remove_draft": "{userFullName} hat den Entwurf des Artikels \"{resourceTitle}\" verworfen",
-    "sulu_activity.description.articles.workflow_transition.bypass_publish": "{userFullName} hat den Artikel \"{resourceTitle}\" ohne Review veröffentlicht",
     "sulu_activity.description.articles.workflow_transition.request_for_review": "{userFullName} hat ein Review für den Artikel \"{resourceTitle}\" angefragt",
     "sulu_activity.description.articles.workflow_transition.request_for_review_draft": "{userFullName} hat ein Review für den Entwurf des Artikels \"{resourceTitle}\" angefragt",
     "sulu_activity.description.articles.workflow_transition.cancel_review": "{userFullName} hat das Review des Artikels \"{resourceTitle}\" abgebrochen",

--- a/packages/article/translations/admin.en.json
+++ b/packages/article/translations/admin.en.json
@@ -26,7 +26,6 @@
     "sulu_activity.description.articles.workflow_transition.publish": "{userFullName} has published the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.workflow_transition.unpublish": "{userFullName} has unpublished the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.workflow_transition.remove_draft": "{userFullName} has discarded the draft of the article \"{resourceTitle}\"",
-    "sulu_activity.description.articles.workflow_transition.bypass_publish": "{userFullName} has published the article \"{resourceTitle}\" without a review",
     "sulu_activity.description.articles.workflow_transition.request_for_review": "{userFullName} has requested a review for the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.workflow_transition.request_for_review_draft": "{userFullName} has requested a review for the draft of the article \"{resourceTitle}\"",
     "sulu_activity.description.articles.workflow_transition.cancel_review": "{userFullName} has cancelled the review of the article \"{resourceTitle}\"",

--- a/packages/page/translations/admin.de.json
+++ b/packages/page/translations/admin.de.json
@@ -48,7 +48,6 @@
     "sulu_activity.description.pages.workflow_transition.publish": "{userFullName} hat die Seite \"{resourceTitle}\" veröffentlicht",
     "sulu_activity.description.pages.workflow_transition.unpublish": "{userFullName} hat die Seite \"{resourceTitle}\" nicht mehr veröffentlicht",
     "sulu_activity.description.pages.workflow_transition.remove_draft": "{userFullName} hat den Entwurf der Seite \"{resourceTitle}\" verworfen",
-    "sulu_activity.description.pages.workflow_transition.bypass_publish": "{userFullName} hat die Seite \"{resourceTitle}\" ohne Review veröffentlicht",
     "sulu_activity.description.pages.workflow_transition.request_for_review": "{userFullName} hat ein Review für die Seite \"{resourceTitle}\" angefragt",
     "sulu_activity.description.pages.workflow_transition.request_for_review_draft": "{userFullName} hat ein Review für den Entwurf der Seite \"{resourceTitle}\" angefragt",
     "sulu_activity.description.pages.workflow_transition.cancel_review": "{userFullName} hat das Review der Seite \"{resourceTitle}\" abgebrochen",

--- a/packages/page/translations/admin.en.json
+++ b/packages/page/translations/admin.en.json
@@ -48,7 +48,6 @@
     "sulu_activity.description.pages.workflow_transition.publish": "{userFullName} has published the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.workflow_transition.unpublish": "{userFullName} has unpublished the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.workflow_transition.remove_draft": "{userFullName} has discarded the draft of the page \"{resourceTitle}\"",
-    "sulu_activity.description.pages.workflow_transition.bypass_publish": "{userFullName} has published the page \"{resourceTitle}\" without a review",
     "sulu_activity.description.pages.workflow_transition.request_for_review": "{userFullName} has requested a review for the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.workflow_transition.request_for_review_draft": "{userFullName} has requested a review for the draft of the page \"{resourceTitle}\"",
     "sulu_activity.description.pages.workflow_transition.cancel_review": "{userFullName} has cancelled the review of the page \"{resourceTitle}\"",

--- a/packages/snippet/translations/admin.de.json
+++ b/packages/snippet/translations/admin.de.json
@@ -33,7 +33,6 @@
     "sulu_activity.description.snippets.workflow_transition.publish": "{userFullName} hat den Schnipsel \"{resourceTitle}\" veröffentlicht",
     "sulu_activity.description.snippets.workflow_transition.unpublish": "{userFullName} hat den Schnipsel \"{resourceTitle}\" nicht mehr veröffentlicht",
     "sulu_activity.description.snippets.workflow_transition.remove_draft": "{userFullName} hat den Entwurf des Schnipsels \"{resourceTitle}\" verworfen",
-    "sulu_activity.description.snippets.workflow_transition.bypass_publish": "{userFullName} hat das Snippet \"{resourceTitle}\" ohne Review veröffentlicht",
     "sulu_activity.description.snippets.workflow_transition.request_for_review": "{userFullName} hat ein Review für das Snippet \"{resourceTitle}\" angefragt",
     "sulu_activity.description.snippets.workflow_transition.request_for_review_draft": "{userFullName} hat ein Review für den Entwurf des Snippets \"{resourceTitle}\" angefragt",
     "sulu_activity.description.snippets.workflow_transition.cancel_review": "{userFullName} hat das Review des Snippets \"{resourceTitle}\" abgebrochen",

--- a/packages/snippet/translations/admin.en.json
+++ b/packages/snippet/translations/admin.en.json
@@ -32,7 +32,6 @@
     "sulu_activity.description.snippets.workflow_transition.publish": "{userFullName} has published the snippet \"{resourceTitle}\"",
     "sulu_activity.description.snippets.workflow_transition.unpublish": "{userFullName} has unpublished the snippet \"{resourceTitle}\"",
     "sulu_activity.description.snippets.workflow_transition.remove_draft": "{userFullName} has discarded the draft of the snippet \"{resourceTitle}\"",
-    "sulu_activity.description.snippets.workflow_transition.bypass_publish": "{userFullName} has published the snippet \"{resourceTitle}\" without a review",
     "sulu_activity.description.snippets.workflow_transition.request_for_review": "{userFullName} has requested a review for the snippet \"{resourceTitle}\"",
     "sulu_activity.description.snippets.workflow_transition.request_for_review_draft": "{userFullName} has requested a review for the draft of the snippet \"{resourceTitle}\"",
     "sulu_activity.description.snippets.workflow_transition.cancel_review": "{userFullName} has cancelled the review of the snippet \"{resourceTitle}\"",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | #9078
| License | MIT
| Documentation PR | -

#### What's in this PR?

Removes six translation keys that #9078 added and nothing can reach:

- `sulu_activity.description.pages.workflow_transition.bypass_publish`
- `sulu_activity.description.articles.workflow_transition.bypass_publish`
- `sulu_activity.description.snippets.workflow_transition.bypass_publish`

in `en` and `de` each.

#### Why?

An activity description is looked up as
`sulu_activity.description.<resourceKey>.workflow_transition.<transition>`. #9078 dropped the
`bypass_publish` transition before it was merged but kept its translations, so no activity can ever
carry that name and the keys are dead. `lint-translations` only reports keys that are missing, not
keys that are unused, which is why nothing complained.

`sulu_content.workflow_transition_request.bypass_publish` stays: that one labels the review overlay's
button, which still exists and now runs the ordinary `publish` transition.
